### PR TITLE
feat: Homebrew and Nix distribution channels

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ permissions:
   contents: read
 
 jobs:
-  ci:
+  test:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,8 +47,14 @@ jobs:
 
   # Build the Nix flake so a broken flake or a stale npmDepsHash is caught on PRs,
   # not first at release time. (Needs npmDepsHash filled in — see CONTRIBUTING.)
+  # Matrix covers the platforms users install on: Linux x64, macOS arm64 (macos-14)
+  # and Intel (macos-13). npmDepsHash is OS-independent, so all three share it.
   nix:
-    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-14, macos-13]
+    runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout
         uses: actions/checkout@v6

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,13 +47,15 @@ jobs:
 
   # Build the Nix flake so a broken flake or a stale npmDepsHash is caught on PRs,
   # not first at release time. (Needs npmDepsHash filled in — see CONTRIBUTING.)
-  # Matrix covers the platforms users install on: Linux x64, macOS arm64 (macos-14)
-  # and Intel (macos-13). npmDepsHash is OS-independent, so all three share it.
+  # Matrix covers the platforms users install on: Linux x64 and macOS arm64
+  # (macos-14). Intel macOS (macos-13) is omitted — GitHub is deprecating Intel
+  # runners (they queue indefinitely), and the darwin-x64 build path is identical
+  # to arm64 bar the binding dir. npmDepsHash is OS-independent, shared by both.
   nix:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-14, macos-13]
+        os: [ubuntu-latest, macos-14]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,3 +44,15 @@ jobs:
 
       - name: Test
         run: npm test
+
+  # Build the Nix flake so a broken flake or a stale npmDepsHash is caught on PRs,
+  # not first at release time. (Needs npmDepsHash filled in — see CONTRIBUTING.)
+  nix:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+      - name: Install Nix
+        uses: DeterminateSystems/nix-installer-action@main
+      - name: Build the flake
+        run: nix build .#claudescope -L

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,20 +1,78 @@
 name: Release
 
-# Publish to npm when a version tag is pushed. Tags are the only release
-# trigger — never publish from a laptop. Create one with:
+# Publish when a version tag is pushed. Tags are the only release trigger — never
+# publish from a laptop. Create one with:
 #   npm version patch   # bumps package.json + creates the vX.Y.Z tag
 #   git push --follow-tags
+#
+# Flow: validate (gate) → create GitHub Release → publish channels.
+# npm and nix run in parallel; brew runs after npm (its formula points at the
+# published npm tarball). Each channel is an independent job, so a failure in one
+# (e.g. nix) does not block the others — re-run just that job.
 on:
   push:
     tags: ['v*']
 
+# Least privilege by default; jobs widen only what they need.
 permissions:
-  contents: write # create the GitHub Release from the tag
-  id-token: write # OIDC token for npm Trusted Publishing + provenance
+  contents: read
 
 jobs:
-  release:
+  # Gate: the tag must match the package version and the suite must pass before
+  # anything ships. `npm publish` is irreversible, so this guards every channel.
+  validate:
     runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      # Guard against a tag that doesn't match the version in package.json, so the
+      # published version always equals the tag.
+      - name: Verify tag matches package version
+        run: |
+          TAG="${GITHUB_REF_NAME#v}"
+          PKG="$(node -p "require('./package.json').version")"
+          if [ "$TAG" != "$PKG" ]; then
+            echo "::error::Tag v$TAG does not match package.json version $PKG"
+            exit 1
+          fi
+
+      - name: Test
+        run: npm test
+
+  # Mirror the curated, human-written tag annotation (from `npm version -m`) to a
+  # GitHub Release — verbatim, never auto-generated. Runs before the channels.
+  release:
+    needs: validate
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write # create the GitHub Release from the tag
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Create GitHub Release
+        run: gh release create "$GITHUB_REF_NAME" --verify-tag --title "$GITHUB_REF_NAME" --notes-from-tag
+        env:
+          GH_TOKEN: ${{ github.token }}
+
+  # Channel: npm. Auth comes from the OIDC id-token via npm Trusted Publishing —
+  # no NPM_TOKEN secret; provenance is generated automatically under OIDC.
+  npm:
+    needs: release
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write # OIDC token for npm Trusted Publishing + provenance
+      contents: read
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -34,32 +92,70 @@ jobs:
       - name: Upgrade npm for trusted publishing
         run: npm install -g npm@latest
 
-      # Guard against a tag that doesn't match the version in package.json, so
-      # the published version always equals the tag.
-      - name: Verify tag matches package version
-        run: |
-          TAG="${GITHUB_REF_NAME#v}"
-          PKG="$(node -p "require('./package.json').version")"
-          if [ "$TAG" != "$PKG" ]; then
-            echo "::error::Tag v$TAG does not match package.json version $PKG"
-            exit 1
-          fi
-
-      - name: Test
-        run: npm test
-
       - name: Assemble the publishable package
         run: npm run bundle
 
-      # Auth comes from the OIDC id-token via npm Trusted Publishing — no
-      # NPM_TOKEN secret. Provenance is generated automatically under OIDC.
       - name: Publish to npm
         run: npm publish --access public
         working-directory: dist
 
-      # Mirror the curated, human-written tag annotation (from `npm version -m`)
-      # to a GitHub Release — verbatim, never auto-generated.
-      - name: Create GitHub Release
-        run: gh release create "$GITHUB_REF_NAME" --verify-tag --title "$GITHUB_REF_NAME" --notes-from-tag
+  # Channel: nix. The flake builds from the tagged source, so this verifies that
+  # `nix run github:vladar107/claudescope` works at this tag (nothing to push —
+  # Nix pins by git commit). Independent of npm; failure here blocks no other
+  # channel. Requires npmDepsHash in flake.nix to be current — see CONTRIBUTING.
+  nix:
+    needs: release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Install Nix
+        uses: DeterminateSystems/nix-installer-action@main
+
+      - name: Build the flake
+        run: nix build .#claudescope -L
+
+  # Channel: brew. Points the tap at the just-published npm tarball, so it must run
+  # after npm. Pushes to the separate vladar107/homebrew-tap repo, which needs a
+  # cross-repo PAT (github.token can't push elsewhere) — secret HOMEBREW_TAP_TOKEN.
+  brew:
+    needs: npm
+    runs-on: ubuntu-latest
+    steps:
+      - name: Update Homebrew tap
         env:
-          GH_TOKEN: ${{ github.token }}
+          TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+        run: |
+          VERSION="${GITHUB_REF_NAME#v}"
+          TARBALL="https://registry.npmjs.org/@vladar107/claudescope/-/claudescope-${VERSION}.tgz"
+          curl -fsSL "$TARBALL" -o pkg.tgz
+          SHA256="$(shasum -a 256 pkg.tgz | cut -d ' ' -f 1)"
+          git clone "https://x-access-token:${TAP_TOKEN}@github.com/vladar107/homebrew-tap.git" tap
+          mkdir -p tap/Formula
+          cat > tap/Formula/claudescope.rb <<EOF
+          class Claudescope < Formula
+            desc "Local, read-only viewer for AI coding-agent transcripts"
+            homepage "https://github.com/vladar107/claudescope"
+            url "${TARBALL}"
+            sha256 "${SHA256}"
+            license "MIT"
+
+            depends_on "node"
+
+            def install
+              system "npm", "install", *std_npm_args
+              bin.install_symlink Dir["#{libexec}/bin/*"]
+            end
+
+            test do
+              assert_match version.to_s, shell_output("#{bin}/claudescope version")
+            end
+          end
+          EOF
+          cd tap
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add Formula/claudescope.rb
+          git commit -m "claudescope ${VERSION}"
+          git push

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,6 +65,18 @@ bundle time** via esbuild `define` (`__CLAUDESCOPE_VERSION__`) — never hardcod
 it. Publish metadata (keywords, repo, etc.) is sourced from the **root**
 `package.json`; edit it there, not in `bundle.mjs`.
 
+**Other channels wrap this npm package** — no separate artifacts. **Homebrew**
+(formula in the separate `vladar107/homebrew-tap` repo) and a **Nix flake**
+(`flake.nix` at the repo root, builds from source via `buildNpmPackage`) both
+install `@vladar107/claudescope` under the hood and let npm/Nix resolve the native
+`@duckdb/node-api` binary. `release.yml` runs as independent jobs (validate →
+create release → npm ∥ nix, then brew after npm): it bumps the Homebrew formula
+(needs the `HOMEBREW_TAP_TOKEN` secret) and verifies the flake builds. A failure
+in one channel doesn't block the others. The flake's `npmDepsHash` only changes
+when deps change, not per version.
+The CLI `update` command (`cli.ts`) detects the install method and defers to
+`brew`/`nix` instead of `npm install -g` for those installs. See `CONTRIBUTING.md`.
+
 ## Conventions
 
 - **Code style:** match the surrounding code — TypeScript, ESM, existing naming

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -88,7 +88,33 @@ npm version minor -m "%s
 git push --follow-tags   # the tag triggers .github/workflows/release.yml
 ```
 
-The release workflow verifies the tag matches `package.json`, runs the tests,
-runs `npm run bundle`, publishes `dist/`, and creates a GitHub Release from the
-tag's curated message. We follow [SemVer](https://semver.org). Do not re-tag an
-already-published version (the publish step will fail).
+The release workflow runs as independent jobs: a **`validate`** gate (tag matches
+`package.json` + tests) → **create the GitHub Release** → then the channels. `npm`
+(bundle + publish) and `nix` (flake build) run in parallel; **`brew`** runs after
+`npm` because its formula points at the published npm tarball. Because the channels
+are independent jobs, a failure in one (e.g. a stale Nix hash) does **not** block
+the others — just re-run that job. We follow [SemVer](https://semver.org). Do not
+re-tag an already-published version (the publish step will fail).
+
+### Distribution channels
+
+Homebrew and Nix both **wrap the published npm package** — no separate build
+artifacts. They're kept in sync automatically:
+
+- **Homebrew** — the release job rewrites `Formula/claudescope.rb` in the separate
+  [`vladar107/homebrew-tap`](https://github.com/vladar107/homebrew-tap) repo,
+  pointing it at the new npm tarball + sha256. This cross-repo push needs a
+  fine-grained PAT with `contents: write` on that repo, stored as the
+  **`HOMEBREW_TAP_TOKEN`** secret (`github.token` cannot push to another repo).
+- **Nix** — `flake.nix` lives at the repo root and builds from source, so Nix pins
+  by git commit; there's no URL/hash to bump per release. The one value to maintain
+  is **`npmDepsHash`**, and only **when dependencies change** (a version-only bump
+  doesn't touch it). Refresh it before tagging:
+
+  ```bash
+  nix run nixpkgs#prefetch-npm-deps -- package-lock.json   # prints the new hash
+  ```
+
+  Paste the printed hash into `flake.nix`. A stale hash fails the `nix` job (on
+  PRs and at release), but since channels are independent it only breaks the Nix
+  channel — npm and Homebrew still publish.

--- a/README.md
+++ b/README.md
@@ -114,6 +114,20 @@ Try it without installing:
 npx @vladar107/claudescope
 ```
 
+### Other install methods
+
+```bash
+# Homebrew (macOS / Linux)
+brew install vladar107/tap/claudescope
+
+# Nix (any platform) — run without installing, or add to a profile
+nix run github:vladar107/claudescope
+nix profile install github:vladar107/claudescope
+```
+
+All channels wrap the same package; `claudescope update` detects how you
+installed it and points you at the right upgrade command.
+
 ### Commands
 
 ```bash

--- a/docs/plans/0009-homebrew-nix-distribution.md
+++ b/docs/plans/0009-homebrew-nix-distribution.md
@@ -1,0 +1,94 @@
+# 0009 — Homebrew + Nix distribution
+
+- **Status:** in-progress <!-- proposed | in-progress | done | superseded | abandoned -->
+- **Date:** 2026-06-09
+- **PR:** <link, once opened>
+
+## Context
+
+Claudescope ships only as the npm package `@vladar107/claudescope` (`npm i -g` /
+`npx`). Users reach for their platform's default package manager — Homebrew on
+macOS, Nix for a reproducible cross-platform path. We want both, without a second
+build pipeline. The one native dependency, `@duckdb/node-api`, ships its
+per-platform prebuilt binaries as npm `optionalDependencies` (macOS x64/arm64,
+Linux x64/arm64), so wrapping the npm package lets npm/Nix resolve the right
+binary automatically.
+
+## Goal
+
+`brew install vladar107/tap/claudescope` and `nix run github:vladar107/claudescope`
+both work; each release auto-syncs the Homebrew formula; and `claudescope update`
+tells brew/nix users the correct upgrade command instead of corrupting the install
+with `npm install -g`.
+
+## Decisions
+
+- **Wrap the npm package, not self-contained binaries** — lowest effort, reuses
+  the tag-triggered npm release, native binary auto-resolved. Rejected SEA/`pkg`
+  binaries (heavier CI matrix, fiddly native-file packaging) — revisit only if a
+  no-Node install (e.g. WinGet) is wanted later.
+- **Channels: Homebrew + Nix only** — Scoop/WinGet/AUR deferred.
+- **Homebrew tap repo named `homebrew-tap`** → `vladar107/tap/claudescope`.
+  Rejected `homebrew-claudescope` (forces the awkward doubled
+  `vladar107/claudescope/claudescope`).
+- **`flake.nix` at the repo root** — required: a subdir flake's `self` can't reach
+  the parent monorepo for `buildNpmPackage { src = self; }`. Footprint is the two
+  standard flake files only; all logic stays inline (no `nix/` dir, no scripts).
+- **`update` detects & defers** — classify install method from the bundle's
+  realpath (`/nix/store/`, Homebrew Cellar) and print the manager's upgrade command.
+- **Sync automated in `release.yml` as independent jobs** — validate → create
+  release → npm ∥ nix, then brew after npm (it consumes the published npm tarball).
+  Independent jobs so one channel's failure doesn't block the rest. Rejected a
+  single linear job / a pre-publish Nix gate (a broken flake would block npm).
+
+## Approach
+
+1. **`packages/server/src/cli.ts`** — add `detectInstallMethod()` (realpath →
+   `brew` | `nix` | `npm`) and branch `update()` to defer for brew/nix.
+2. **`flake.nix`** (+ `flake.lock`) at root — `buildNpmPackage`, `src = self`,
+   `npmBuildScript = "bundle"`, custom `installPhase` that installs `dist/` and
+   vendors `node_modules/@duckdb` beside `cli.js`, `autoPatchelfHook` +
+   `stdenv.cc.cc.lib` on Linux for the prebuilt `.node`, `makeWrapper` over
+   `nodejs_22`. Exposes `packages.default`, `apps.default`, `checks.default`.
+3. **`Formula/claudescope.rb`** in the separate `vladar107/homebrew-tap` repo —
+   `depends_on "node"` + `system "npm", "install", *std_npm_args`.
+4. **`.github/workflows/release.yml`** — independent jobs: `validate` (tag-match +
+   tests) → `release` (create GitHub Release) → `npm` (bundle + publish) ∥ `nix`
+   (`nix build .#claudescope` verify), then `brew` after `npm` (rewrites the
+   formula with the published tarball + sha256 and pushes to the tap repo via
+   `HOMEBREW_TAP_TOKEN`). A failure in one channel doesn't block the others.
+   **`ci.yml`** — a `nix` job builds the flake on PRs.
+5. **Docs** — README install methods, CONTRIBUTING (tap, token, `npmDepsHash`
+   refresh), CLAUDE.md distribution note.
+
+## Files affected
+
+- `packages/server/src/cli.ts` — install-method detection + `update()` branch.
+- `flake.nix`, `flake.lock` (new) — Nix package/app/check.
+- `Formula/claudescope.rb` (new, **separate `homebrew-tap` repo**) — npm wrapper.
+- `.github/workflows/release.yml`, `.github/workflows/ci.yml` — gate + tap sync.
+- `README.md`, `CONTRIBUTING.md`, `CLAUDE.md` — install + maintainer docs.
+
+## Testing
+
+- `npm run typecheck` + `npm test` (cli.ts change stays type-clean). ✅
+- Nix (machine with Nix): `nix build .#` → `./result/bin/claudescope version`;
+  `nix run .#` boots :4317. Run on macOS (arm64) + Linux (x64) for the
+  autoPatchelf / DuckDB-binding load path. **Bootstrap step:** first build with
+  `npmDepsHash = lib.fakeHash` prints the real hash to paste into `flake.nix`.
+- Homebrew (local): `brew install --build-from-source ./Formula/claudescope.rb` →
+  `claudescope version`, `brew test`. Then a real release pushes to the tap.
+- `update` deferral: install via brew/nix and confirm it prints the manager's
+  command and does not run npm.
+
+## Risks / open questions
+
+- **Nix `@duckdb/node-bindings-*` optional dep** — fetching the right host-platform
+  binding through `buildNpmPackage` + loading the `.node` after autoPatchelf is the
+  known friction point; validate on both OSes early.
+- **`npmDepsHash` is `lib.fakeHash` until bootstrapped** — the `nix` job (PRs and
+  release) fails until a maintainer fills the real hash. Because release channels
+  are independent jobs, this only breaks the Nix channel — npm and Homebrew still
+  publish. Bootstrap before relying on the Nix channel.
+- **`HOMEBREW_TAP_TOKEN`** secret + the `vladar107/homebrew-tap` repo must exist
+  before the tap-sync step succeeds.

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -33,3 +33,4 @@ decision, or a change worth explaining before doing. Skip it for one-line fixes.
 | 0006 | [multi-agent UX](./0006-multi-agent-ux.md) | done |
 | 0007 | [UI redesign: multi-agent, light/dark, responsive nav](./0007-ui-redesign-multi-agent.md) | done |
 | 0008 | [Junie connector](./0008-junie-connector.md) | done |
+| 0009 | [Homebrew + Nix distribution](./0009-homebrew-nix-distribution.md) | in-progress |

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1780749050,
+        "narHash": "sha256-3av0pIjlOWQ6rDbNOmpUSvbNnJkGORQKKjb4LtCZsIY=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "a799d3e3886da994fa307f817a6bc705ae538eeb",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -30,7 +30,7 @@
           #   nix run nixpkgs#prefetch-npm-deps -- package-lock.json
           # A version-only bump does NOT change this. Placeholder = lib.fakeHash:
           # the first real `nix build` prints the correct value to paste in here.
-          npmDepsHash = lib.fakeHash;
+          npmDepsHash = "sha256-jQsMvQK4qVuZSL+yB9W0z1Dw9HUt9+Go0QxVwAY5FrU=";
 
           nodejs = node;
 

--- a/flake.nix
+++ b/flake.nix
@@ -15,6 +15,16 @@
         inherit (pkgs) lib;
         node = pkgs.nodejs_22;
 
+        # The DuckDB binding for THIS platform — the only one we ship. The npm
+        # dep closure fetches every platform's binary (incl. a musl Linux variant
+        # autoPatchelf can't satisfy on glibc nixpkgs), so we copy just this one.
+        # nixpkgs is glibc by default, so we never want the *-musl bindings.
+        duckdbBinding =
+          if pkgs.stdenv.isDarwin then
+            (if pkgs.stdenv.isAarch64 then "darwin-arm64" else "darwin-x64")
+          else
+            (if pkgs.stdenv.isAarch64 then "linux-arm64" else "linux-x64");
+
         claudescope = pkgs.buildNpmPackage {
           pname = "claudescope";
           # Single source of truth: the version comes from the root package.json,
@@ -53,11 +63,15 @@
             mkdir -p $out/lib/claudescope
             cp -R dist/. $out/lib/claudescope/
 
-            # The bundle keeps @duckdb/node-api external, so its package (and the
-            # host-platform @duckdb/node-bindings-* binary) must sit beside cli.js
-            # at runtime. autoPatchelfHook then fixes the .node on Linux.
+            # The bundle keeps @duckdb/node-api external, so it (the dispatcher
+            # @duckdb/node-bindings, and this platform's prebuilt binary) must sit
+            # beside cli.js at runtime. Copy ONLY the matching binding — shipping
+            # other platforms' binaries is dead weight, and the musl Linux one
+            # would fail autoPatchelfHook below. autoPatchelf then fixes the .node.
             mkdir -p $out/lib/claudescope/node_modules/@duckdb
-            cp -R node_modules/@duckdb/. $out/lib/claudescope/node_modules/@duckdb/
+            cp -R node_modules/@duckdb/node-api $out/lib/claudescope/node_modules/@duckdb/
+            cp -R node_modules/@duckdb/node-bindings $out/lib/claudescope/node_modules/@duckdb/
+            cp -R node_modules/@duckdb/node-bindings-${duckdbBinding} $out/lib/claudescope/node_modules/@duckdb/
 
             # Wrap the CLI with the pinned Node and put coreutils on PATH (the
             # `logs -f` command shells out to `tail`).

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,95 @@
+{
+  description = "Local, read-only viewer for AI coding-agent transcripts (Claude Code, Codex, Junie)";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs =
+    { self, nixpkgs, flake-utils }:
+    flake-utils.lib.eachDefaultSystem (
+      system:
+      let
+        pkgs = import nixpkgs { inherit system; };
+        inherit (pkgs) lib;
+        node = pkgs.nodejs_22;
+
+        claudescope = pkgs.buildNpmPackage {
+          pname = "claudescope";
+          # Single source of truth: the version comes from the root package.json,
+          # the same value esbuild bakes into the bundle at build time.
+          version = (builtins.fromJSON (builtins.readFile ./package.json)).version;
+
+          # Build from the monorepo itself — this is why the flake must live at the
+          # repo root (a subdir flake's `self` can't reach the parent sources).
+          src = self;
+
+          # Fixed-output hash of the npm dependency closure (from package-lock.json).
+          # Refresh after any dependency change with:
+          #   nix run nixpkgs#prefetch-npm-deps -- package-lock.json
+          # A version-only bump does NOT change this. Placeholder = lib.fakeHash:
+          # the first real `nix build` prints the correct value to paste in here.
+          npmDepsHash = lib.fakeHash;
+
+          nodejs = node;
+
+          # `npm run bundle` assembles dist/ (server + CLI + web + pricing default).
+          npmBuildScript = "bundle";
+
+          # We install dist/ ourselves rather than the default `npm install` layout.
+          dontNpmInstall = true;
+
+          nativeBuildInputs =
+            [ pkgs.makeWrapper ]
+            # The prebuilt DuckDB .node is a downloaded ELF on Linux; patch its
+            # interpreter/rpath against nixpkgs. macOS dylib needs no patching.
+            ++ lib.optionals pkgs.stdenv.isLinux [ pkgs.autoPatchelfHook ];
+          buildInputs = lib.optionals pkgs.stdenv.isLinux [ pkgs.stdenv.cc.cc.lib ];
+
+          installPhase = ''
+            runHook preInstall
+
+            mkdir -p $out/lib/claudescope
+            cp -R dist/. $out/lib/claudescope/
+
+            # The bundle keeps @duckdb/node-api external, so its package (and the
+            # host-platform @duckdb/node-bindings-* binary) must sit beside cli.js
+            # at runtime. autoPatchelfHook then fixes the .node on Linux.
+            mkdir -p $out/lib/claudescope/node_modules/@duckdb
+            cp -R node_modules/@duckdb/. $out/lib/claudescope/node_modules/@duckdb/
+
+            # Wrap the CLI with the pinned Node and put coreutils on PATH (the
+            # `logs -f` command shells out to `tail`).
+            makeWrapper ${node}/bin/node $out/bin/claudescope \
+              --add-flags $out/lib/claudescope/cli.js \
+              --prefix PATH : ${lib.makeBinPath [ pkgs.coreutils ]}
+
+            runHook postInstall
+          '';
+
+          meta = {
+            description = "Local, read-only viewer for AI coding-agent transcripts";
+            homepage = "https://github.com/vladar107/claudescope";
+            license = lib.licenses.mit;
+            mainProgram = "claudescope";
+            platforms = [ "x86_64-linux" "aarch64-linux" "x86_64-darwin" "aarch64-darwin" ];
+          };
+        };
+      in
+      {
+        packages.default = claudescope;
+        packages.claudescope = claudescope;
+
+        apps.default = {
+          type = "app";
+          program = "${claudescope}/bin/claudescope";
+        };
+
+        # `nix flake check` smoke test: the CLI starts and reports its version.
+        checks.default = pkgs.runCommand "claudescope-version" { } ''
+          ${claudescope}/bin/claudescope version > "$out"
+        '';
+      }
+    );
+}

--- a/packages/server/src/cli.ts
+++ b/packages/server/src/cli.ts
@@ -19,6 +19,7 @@ import {
   mkdirSync,
   openSync,
   readFileSync,
+  realpathSync,
   rmSync,
   writeFileSync,
 } from 'node:fs';
@@ -216,13 +217,49 @@ async function confirm(question: string, defaultYes: boolean): Promise<boolean> 
   }
 }
 
+type InstallMethod = 'brew' | 'nix' | 'npm';
+
+/** Classify how this CLI was installed from where its bundle resides. Homebrew
+ *  symlinks the bin out of the Cellar's libexec (realpath resolves it back); Nix
+ *  installs under /nix/store; everything else (npm global, npx) is treated as npm. */
+function detectInstallMethod(): InstallMethod {
+  let p = __dirname;
+  try {
+    p = realpathSync(__dirname);
+  } catch {
+    /* keep __dirname if the path can't be resolved */
+  }
+  if (p.includes('/nix/store/')) return 'nix';
+  // Match the formula's Cellar dir specifically (…/Cellar/claudescope/<version>/…),
+  // not a generic "homebrew" — a plain `npm i -g` under Homebrew's own Node lives
+  // at …/homebrew/lib/node_modules/… and must NOT be mistaken for a brew install.
+  if (/[\\/]Cellar[\\/]claudescope[\\/]/.test(p)) return 'brew';
+  return 'npm';
+}
+
 /** Upgrade the global install to the latest published version and restart.
  *  Resolves the target version and confirms before installing; `--yes` (or a
- *  non-interactive stdin) skips the prompt. Installs the hardcoded package only. */
+ *  non-interactive stdin) skips the prompt. Installs the hardcoded package only.
+ *  For package-manager-managed installs (brew/nix), defers to that manager. */
 async function update(skipConfirm: boolean): Promise<void> {
   const latest = await getLatestVersion(true);
   if (latest && !isNewer(latest, APP_VERSION)) {
     console.log(`✓ Already on the latest version (v${APP_VERSION}).`);
+    return;
+  }
+
+  // Running `npm install -g` over a brew-/nix-managed install would corrupt it —
+  // defer to the manager's own upgrade command instead.
+  const method = detectInstallMethod();
+  if (method === 'brew') {
+    console.log('claudescope was installed via Homebrew.');
+    console.log('  Run: brew upgrade vladar107/tap/claudescope');
+    return;
+  }
+  if (method === 'nix') {
+    console.log('claudescope was installed via Nix.');
+    console.log('  Run: nix profile upgrade claudescope');
+    console.log('  (flake users: re-run `nix run --refresh github:vladar107/claudescope`)');
     return;
   }
   if (!latest) {


### PR DESCRIPTION
## What

Adds two new distribution channels that **wrap the published npm package** (no separate build artifacts):

- **Homebrew** (macOS + Linux) — `brew install vladar107/tap/claudescope`
- **Nix flake** (any platform) — `nix run github:vladar107/claudescope`

npm resolves the one native dep (`@duckdb/node-api`) automatically; the Nix flake patches the prebuilt `.node` on Linux via `autoPatchelfHook`.

## Changes

- **`cli.ts`** — `claudescope update` detects the install method (`brew`/`nix`/`npm`) and defers to the correct upgrade command instead of running `npm install -g` (which would corrupt a brew/nix-managed install). Brew is matched on the precise `Cellar/claudescope` path so a plain `npm i -g` under Homebrew's *Node* isn't misclassified.
- **`flake.nix`** (repo root) — `buildNpmPackage` building from source; vendors `@duckdb` beside the bundle and wraps the CLI with pinned `nodejs_22`.
- **`release.yml`** — restructured into independent jobs: `validate` (tag-match + tests) → `release` (create GitHub Release) → `npm` ∥ `nix`, then `brew` after `npm`. A failure in one channel no longer blocks the others.
- **`ci.yml`** — builds the flake on PRs.
- Docs (README/CONTRIBUTING/CLAUDE.md) + plan [`docs/plans/0009`](docs/plans/0009-homebrew-nix-distribution.md).

## Maintainer setup required before releases use these channels

See the PR comment / CONTRIBUTING — needs the `homebrew-tap` repo, a `HOMEBREW_TAP_TOKEN` secret, and a one-time `npmDepsHash` bootstrap.

## Test plan

- `npm test` (84/84) + `npm run typecheck` green.
- Nix/Homebrew require a Nix machine / `brew` to validate end-to-end (see plan 0009 Testing).