### PR TITLE
fix: tolerate malformed JSON lines when indexing transcripts

### DIFF
--- a/packages/server/src/connectors/claude-code.ts
+++ b/packages/server/src/connectors/claude-code.ts
@@ -18,8 +18,14 @@ import { sqlString } from '../db/duckdb.js';
 import type { SessionData, SubagentSource } from '../data/session-loader.js';
 import type { AgentConnector, AuxProjections, DiscoveredFile } from './types.js';
 
-/** Shared `read_ndjson` options for the line-delimited Claude transcripts. */
-const READ_OPTS = `union_by_name=true, format='newline_delimited', maximum_object_size=268435456`;
+/**
+ * Shared `read_ndjson` options for the line-delimited Claude transcripts.
+ * `ignore_errors=true` makes DuckDB skip a malformed/partial line (e.g. a
+ * transcript written mid-flush, or one with an unescaped control character)
+ * instead of failing the whole file read — which would otherwise abort the
+ * entire reindex. The JS session-detail parser tolerates such lines too.
+ */
+const READ_OPTS = `union_by_name=true, format='newline_delimited', maximum_object_size=268435456, ignore_errors=true`;
 
 /**
  * SQL extracting FTS-searchable plain text from a `message` JSON value.

--- a/packages/server/src/connectors/claude-code/claude-code.ts
+++ b/packages/server/src/connectors/claude-code/claude-code.ts
@@ -13,10 +13,10 @@
 import { existsSync, readdirSync, readFileSync, statSync } from 'node:fs';
 import { basename, join } from 'node:path';
 import type { RawEvent } from '@claudescope/shared';
-import { CLAUDE_PROJECTS_DIR } from '../config.js';
-import { sqlString } from '../db/duckdb.js';
-import type { SessionData, SubagentSource } from '../data/session-loader.js';
-import type { AgentConnector, AuxProjections, DiscoveredFile } from './types.js';
+import { CLAUDE_PROJECTS_DIR } from '../../config.js';
+import { sqlString } from '../../db/duckdb.js';
+import type { SessionData, SubagentSource } from '../../data/session-loader.js';
+import type { AgentConnector, AuxProjections, DiscoveredFile } from '../types.js';
 
 /**
  * Shared `read_ndjson` options for the line-delimited Claude transcripts.

--- a/packages/server/src/connectors/codex/codex.ts
+++ b/packages/server/src/connectors/codex/codex.ts
@@ -70,7 +70,7 @@ function eventsProjectionSql(filePath: string): string {
       file_path, session_id, uuid, parent_uuid, role, type, ts, cwd, git_branch,
       model, input_tokens, output_tokens, cache_read_tokens, cache_write_tokens,
       service_tier, is_sidechain, tool_use_count, text_content
-    FROM read_ndjson(${path}, format='newline_delimited', maximum_object_size=268435456, columns={
+    FROM read_ndjson(${path}, format='newline_delimited', maximum_object_size=268435456, ignore_errors=true, columns={
       file_path:'VARCHAR', session_id:'VARCHAR', uuid:'VARCHAR', parent_uuid:'VARCHAR',
       role:'VARCHAR', type:'VARCHAR', ts:'TIMESTAMP', cwd:'VARCHAR', git_branch:'VARCHAR',
       model:'VARCHAR', input_tokens:'BIGINT', output_tokens:'BIGINT', cache_read_tokens:'BIGINT',

--- a/packages/server/src/connectors/junie/junie.ts
+++ b/packages/server/src/connectors/junie/junie.ts
@@ -78,7 +78,7 @@ function eventsProjectionSql(filePath: string): string {
       file_path, session_id, uuid, parent_uuid, role, type, ts, cwd, git_branch,
       model, input_tokens, output_tokens, cache_read_tokens, cache_write_tokens,
       service_tier, is_sidechain, tool_use_count, text_content
-    FROM read_ndjson(${path}, format='newline_delimited', maximum_object_size=268435456, columns={
+    FROM read_ndjson(${path}, format='newline_delimited', maximum_object_size=268435456, ignore_errors=true, columns={
       file_path:'VARCHAR', session_id:'VARCHAR', uuid:'VARCHAR', parent_uuid:'VARCHAR',
       role:'VARCHAR', type:'VARCHAR', ts:'TIMESTAMP', cwd:'VARCHAR', git_branch:'VARCHAR',
       model:'VARCHAR', input_tokens:'BIGINT', output_tokens:'BIGINT', cache_read_tokens:'BIGINT',
@@ -94,7 +94,7 @@ function auxProjections(filePath: string): AuxProjections {
   return {
     titles: `
       SELECT session_id, last(title) AS title
-      FROM read_ndjson(${path}, format='newline_delimited', maximum_object_size=268435456,
+      FROM read_ndjson(${path}, format='newline_delimited', maximum_object_size=268435456, ignore_errors=true,
         columns={session_id:'VARCHAR', title:'VARCHAR'})
       WHERE session_id IS NOT NULL AND title IS NOT NULL AND title <> ''
       GROUP BY session_id`,

--- a/packages/server/src/connectors/registry.ts
+++ b/packages/server/src/connectors/registry.ts
@@ -4,7 +4,7 @@
  */
 
 import type { AgentConnector } from './types.js';
-import { claudeCodeConnector } from './claude-code.js';
+import { claudeCodeConnector } from './claude-code/claude-code.js';
 import { codexConnector } from './codex/codex.js';
 import { junieConnector } from './junie/junie.js';
 

--- a/packages/server/src/data/index.ts
+++ b/packages/server/src/data/index.ts
@@ -266,28 +266,36 @@ async function doReindex(): Promise<ReindexResponse> {
       continue; // unchanged
     }
 
-    await loadFile(conn, connector, file, costExpr);
+    // Isolate per-file failures: a file DuckDB can't read at all (beyond the
+    // per-line `ignore_errors` tolerance) must not abort the whole reindex and
+    // wedge every other session. Skip it (its `files` row keeps the old mtime,
+    // so a later edit retries it) and carry on.
+    try {
+      await loadFile(conn, connector, file, costExpr);
 
-    // Determine the session id from loaded events (filename usually matches,
-    // but the event sessionId is authoritative).
-    const sidRows = await queryRows(
-      conn,
-      `SELECT session_id FROM events WHERE file_path = ${sqlString(file.path)} LIMIT 1`,
-    );
-    const sessionId = sidRows.length > 0 ? String(sidRows[0]?.session_id ?? '') : null;
-    const cwdRows = await queryRows(
-      conn,
-      `SELECT cwd FROM events WHERE file_path = ${sqlString(file.path)} AND cwd IS NOT NULL LIMIT 1`,
-    );
-    const cwd = cwdRows.length > 0 ? String(cwdRows[0]?.cwd ?? '') : null;
+      // Determine the session id from loaded events (filename usually matches,
+      // but the event sessionId is authoritative).
+      const sidRows = await queryRows(
+        conn,
+        `SELECT session_id FROM events WHERE file_path = ${sqlString(file.path)} LIMIT 1`,
+      );
+      const sessionId = sidRows.length > 0 ? String(sidRows[0]?.session_id ?? '') : null;
+      const cwdRows = await queryRows(
+        conn,
+        `SELECT cwd FROM events WHERE file_path = ${sqlString(file.path)} AND cwd IS NOT NULL LIMIT 1`,
+      );
+      const cwd = cwdRows.length > 0 ? String(cwdRows[0]?.cwd ?? '') : null;
 
-    await conn.run(`
-      INSERT OR REPLACE INTO files (path, mtime_ms, size_bytes, session_id, project_cwd, connector_id, indexed_at)
-      VALUES (${sqlString(file.path)}, ${file.mtimeMs}, ${file.size},
-              ${sessionId ? sqlString(sessionId) : 'NULL'},
-              ${cwd ? sqlString(cwd) : 'NULL'}, ${sqlString(connector.id)}, now())
-    `);
-    reindexed += 1;
+      await conn.run(`
+        INSERT OR REPLACE INTO files (path, mtime_ms, size_bytes, session_id, project_cwd, connector_id, indexed_at)
+        VALUES (${sqlString(file.path)}, ${file.mtimeMs}, ${file.size},
+                ${sessionId ? sqlString(sessionId) : 'NULL'},
+                ${cwd ? sqlString(cwd) : 'NULL'}, ${sqlString(connector.id)}, now())
+      `);
+      reindexed += 1;
+    } catch (err) {
+      console.warn(`claudescope: skipping unreadable transcript ${file.path}:`, err);
+    }
   }
 
   // Nothing changed on disk: skip the (relatively expensive) derived-table and

--- a/packages/server/test/api.integration.test.ts
+++ b/packages/server/test/api.integration.test.ts
@@ -72,13 +72,19 @@ function writeFixtures(): string[] {
   ]));
   writeFileSync(join(wfA, 'agent-wwww.meta.json'), JSON.stringify({ agentType: 'workflow-subagent' }));
 
-  // Second project / session.
+  // Second project / session — deliberately includes a MALFORMED line mid-file:
+  // a string with an invalid JSON backslash escape (`\p`, as in an un-doubled
+  // path or a `\p{…}` regex). DuckDB's strict reader rejects it at the `p`;
+  // `ignore_errors=true` must skip just that line and still index the surrounding
+  // valid events. Without the fix, the whole reindex throws and the suite fails.
   const sessB = join(projB, 'sessB.jsonl');
-  writeFileSync(sessB, jsonl([
-    { type: 'ai-title', sessionId: 'sessB', aiTitle: 'Session B' },
-    { type: 'user', sessionId: 'sessB', uuid: 'b-u1', parentUuid: null, cwd: '/tmp/projB', timestamp: '2026-01-02T09:00:00.000Z', isSidechain: false, message: { role: 'user', content: 'hello from project B' } },
-    { type: 'assistant', sessionId: 'sessB', uuid: 'b-a1', parentUuid: 'b-u1', cwd: '/tmp/projB', timestamp: '2026-01-02T09:00:05.000Z', isSidechain: false, message: { role: 'assistant', model: 'claude-opus-4-7', content: [{ type: 'text', text: 'hi B' }], usage: { input_tokens: 200, output_tokens: 100 } } },
-  ]));
+  const sessBLines = [
+    JSON.stringify({ type: 'ai-title', sessionId: 'sessB', aiTitle: 'Session B' }),
+    JSON.stringify({ type: 'user', sessionId: 'sessB', uuid: 'b-u1', parentUuid: null, cwd: '/tmp/projB', timestamp: '2026-01-02T09:00:00.000Z', isSidechain: false, message: { role: 'user', content: 'hello from project B' } }),
+    '{"type":"assistant","sessionId":"sessB","message":{"role":"assistant","content":"C:\\path\\to"}}',
+    JSON.stringify({ type: 'assistant', sessionId: 'sessB', uuid: 'b-a1', parentUuid: 'b-u1', cwd: '/tmp/projB', timestamp: '2026-01-02T09:00:05.000Z', isSidechain: false, message: { role: 'assistant', model: 'claude-opus-4-7', content: [{ type: 'text', text: 'hi B' }], usage: { input_tokens: 200, output_tokens: 100 } } }),
+  ];
+  writeFileSync(sessB, sessBLines.join('\n') + '\n');
 
   return [sessA, agentA, join(subA, 'agent-aaaa.meta.json'), agentW, join(wfA, 'agent-wwww.meta.json'), sessB];
 }
@@ -145,6 +151,16 @@ describe('GET /api/sessions', () => {
   it('filters by project id', async () => {
     const sessions = (await get(`/api/sessions?project=${projBId}`)).json();
     expect(sessions.map((s: { id: string }) => s.id)).toEqual(['sessB']);
+  });
+
+  // Regression: sessB's transcript contains a malformed JSON line (invalid `\p`
+  // escape). The indexer must skip just that line, not abort the whole reindex.
+  it('indexes a session despite a malformed line in its transcript', async () => {
+    const detail = (await get('/api/sessions/sessB')).json();
+    expect(detail.meta.id).toBe('sessB');
+    // The two valid turns around the corrupt line are present; the bad line is
+    // dropped (not surfaced as a phantom turn).
+    expect(detail.thread.map((t: { role: string }) => t.role)).toEqual(['user', 'assistant']);
   });
 });
 


### PR DESCRIPTION
## Problem

A user's index build crashed with:

> `auto-reindex failed` … `Invalid Input Error: Malformed JSON in file "…​.jsonl", at byte 5984 in line 12430: unexpected character.`

DuckDB's `read_ndjson` fails the **entire file** on a single malformed line, and because `loadFile` throws, the **whole reindex** aborts — so the user's index never builds at all (every session lost, not just the one bad line).

The offending byte was `p` in a path-like context, i.e. an **invalid JSON backslash escape `\p`** (an un-doubled path or a `\p{…}` regex written without JSON encoding). JSON only allows `\" \\ \/ \b \f \n \r \t \uXXXX`, so a strict parser rejects it.

## Fix (skip, don't repair)

- **`ignore_errors=true`** on every `read_ndjson` (Claude / Codex / Junie) — DuckDB skips just the malformed line and indexes the rest of the file. The JS session-detail parser already tolerated such lines.
- **Per-file guard** in the reindex loop — a wholly-unreadable file can only drop itself, never abort the whole index.
- **Regression test** — a transcript with an invalid `\p` escape mid-file; the suite's index build would throw without the fix.

DuckDB has no "lenient escape" mode, and repairing genuinely-invalid JSON is guesswork with little upside (the line is absent from search/analytics either way), so skipping is deliberate.

## Also: connector layout consistency

Moved `connectors/claude-code.ts` → `connectors/claude-code/claude-code.ts` so all three connectors live in a folder (`claude-code/`, `codex/`, `junie/`). Pure move + import-path fixes, no behavior change.

## Test plan
- `npm test` (85/85) + `npm run typecheck` green.