### PR TITLE
chore(log): downgrade auto-reindex poll failure to warn

### DIFF
--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -64,7 +64,10 @@ async function main(): Promise<void> {
             );
           }
         })
-        .catch((err) => app.log.error({ err }, 'auto-reindex failed'));
+        // A background poll failing is non-fatal — the server keeps serving the
+        // existing index — so warn rather than error (avoids error-level spam
+        // every interval when, e.g., a single file is briefly unreadable).
+        .catch((err) => app.log.warn({ err }, 'auto-reindex failed'));
     }, REINDEX_INTERVAL_MS);
     timer.unref(); // don't keep the process alive solely for the timer
     app.addHook('onClose', async () => clearInterval(timer));


### PR DESCRIPTION
The interval **auto-reindex** is a non-fatal background poll — when it fails, the server keeps serving the existing index. Logging it at `error` (level 50) was too severe and spammed the log every interval (e.g. while a single file is briefly unreadable), as seen in a user's `claudescope logs -f`.

Downgrade that one catch to `warn`. The **one-shot initial index build** failure keeps `error` level, since it's significant and not recurring.

Pairs with #7 (which makes a malformed line skip-able): together, a corrupt transcript no longer aborts the reindex, and any residual background hiccup logs as a warning rather than an error.

## Test plan
- `npm run typecheck` green. (Logging-only change; no behavioral test.)