### PR TITLE
feat: auto-refresh model pricing from LiteLLM at runtime

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,9 +36,11 @@ npm-workspaces monorepo (`packages/*`):
 - **NEVER write to `~/.claude` or `~/.codex`.** They are read-only data sources.
 - All app-owned state lives in **`~/.claudescope/`** (override: `CLAUDESCOPE_HOME`):
   the DuckDB index, a user-editable `pricing.json` (seeded from a shipped
-  default; `loadPricing` falls back to the default if the copy is missing), the
-  daemon PID file, and logs. State lives outside the package dir so global
-  installs survive upgrades — do not move it back into the package.
+  default; `loadPricing` falls back to the default if the copy is missing),
+  `pricing.fetched.json` (runtime-fetched rates snapshot, auto-refreshed daily
+  from LiteLLM, or manually via `claudescope pricing update`), the daemon PID
+  file, and logs. State lives outside the package dir so global installs survive
+  upgrades — do not move it back into the package.
 
 ## Commands
 
@@ -52,7 +54,7 @@ npm run typecheck   # tsc -b across all packages
 npm run bundle      # assemble the single publishable package into dist/
 ```
 
-The shipped CLI (after install) is `claudescope {start|stop|status|restart|logs|open|update}`.
+The shipped CLI (after install) is `claudescope {start|stop|status|restart|logs|open|update|pricing update}`.
 
 ## Distribution model
 
@@ -112,8 +114,10 @@ The CLI `update` command (`cli.ts`) detects the install method and defers to
   a session renders as tool/terminal/file blocks plus a final result. Expected,
   not a bug. Older Junie sessions also lack a recorded `cwd` (no `projectDir` in
   `index.jsonl`) and group under the `(unknown — Junie)` project bucket.
-- **Cost is a local estimate** from token usage × `pricing.json` rates; not real
-  billing. Computed once at index time and stored.
+- **Cost is a local estimate** from token usage × rates; not real billing.
+  Computed once at index time and stored. Rates auto-refresh daily from LiteLLM
+  at runtime (`pricing.fetched.json`); `pricing.json` is the fallback/override
+  layer for families and the default rate.
 - **Release is maintainer-only** and tag-triggered (npm Trusted Publishing /
   OIDC). See `CONTRIBUTING.md`.
 

--- a/README.md
+++ b/README.md
@@ -38,10 +38,11 @@ Claudescope works whether you use one agent or all three. Adding another is just
 
 > **Privacy:** Everything runs locally on `127.0.0.1`. The app **never** writes to
 > `~/.claude`, `~/.codex`, or `~/.junie` — all are read-only sources. Its only persistent
-> state lives in `~/.claudescope/` — a DuckDB index and a copy of the pricing
-> file, both safe to delete anytime. The sole outbound request is an optional
-> daily check for a newer published version (`claudescope update`); nothing about
-> your transcripts ever leaves your machine.
+> state lives in `~/.claudescope/` — a DuckDB index, a copy of the pricing file, and
+> a cached pricing snapshot (`pricing.fetched.json`), all safe to delete anytime. The
+> sole outbound requests are an optional daily check for a newer published version
+> (`claudescope update`) and an optional daily pricing refresh (`claudescope pricing
+> update`); nothing about your transcripts ever leaves your machine.
 
 ---
 
@@ -139,8 +140,9 @@ claudescope restart    # restart it
 claudescope status     # is it running? is an update available?
 claudescope open       # open the running app in your browser
 claudescope logs -f    # tail the server log
-claudescope update     # upgrade to the latest published version and restart
-claudescope help       # full usage
+claudescope update          # upgrade to the latest published version and restart
+claudescope pricing update  # fetch current model prices (LiteLLM) into the local rate table
+claudescope help            # full usage
 
 # options: --port <n>   (default 4317, or $PORT)
 #          --no-open    (don't open the browser on start)
@@ -205,13 +207,24 @@ cost = ( input_tokens          × input_rate
 The per-event cost is computed once at index time and stored, so analytics is
 just a `SUM` over events; a project/session total is the sum of its events.
 
-Rates live in `~/.claudescope/pricing.json` (seeded on first run from the copy
-shipped with the package; when running from source, `packages/server/pricing.json`).
-A model id resolves in this order:
-exact `models` entry → **family** match (`opus` / `sonnet` / `haiku` / `gpt`
-substring) → `default`. The family step means version- or date-suffixed ids (e.g.
-`claude-haiku-4-5-20251001`, or a Codex `gpt-5.x-codex` id) still price correctly.
-Shipped rates (USD per 1M tokens, from Anthropic and OpenAI published API pricing):
+Rates are resolved in a layered lookup:
+
+1. **Fetched exact id** — `~/.claudescope/pricing.fetched.json` (auto-refreshed
+   daily from [LiteLLM's community price table](https://github.com/BerriAI/litellm/blob/main/model_prices_and_context_window.json),
+   covering Anthropic, OpenAI, Gemini, xAI, Mistral, and DeepSeek models).
+2. **Local exact id** — `~/.claudescope/pricing.json` (seeded on first run from
+   the shipped default; user-editable; takes precedence over the fetched snapshot
+   for any id it defines explicitly).
+3. **Family match** — `opus` / `sonnet` / `haiku` / `gemini` / `gpt` substring in
+   the model id → the matching family rate from `pricing.json`.
+4. **Default** — the `default` entry in `pricing.json`.
+
+The family step means version- or date-suffixed ids (e.g. `claude-haiku-4-5-20251001`,
+`gpt-5.x-codex`, `gemini-2.5-flash`) still price correctly. `pricing.json` is the
+user-editable fallback and override layer for families and the default rate; the
+fetched snapshot provides exact per-model rates for all known models.
+
+Shipped fallback rates (USD per 1M tokens):
 
 | family / model      | input | output | cache write (5m) | cache read |
 | ------------------- | ----- | ------ | ---------------- | ---------- |
@@ -219,20 +232,21 @@ Shipped rates (USD per 1M tokens, from Anthropic and OpenAI published API pricin
 | Opus 4.1 / 4        | $15   | $75    | $18.75           | $1.50      |
 | Sonnet 4.x          | $3    | $15    | $3.75            | $0.30      |
 | Haiku 4.5           | $1    | $5     | $1.25            | $0.10      |
+| Gemini 2.5 Pro-class| $1.25 | $10    | —                | $0.31      |
 | GPT-5               | $0.63 | $5     | —                | $0.13      |
 | GPT-5.4             | $2.50 | $15    | —                | $0.50      |
 | GPT-5.5             | $5    | $30    | —                | $0.50      |
 | `<synthetic>`       | $0    | $0     | $0               | $0         |
 
-- Edit `~/.claudescope/pricing.json` to update prices or add models, then re-index
-  (`POST /api/reindex` or `claudescope restart`) to recompute.
-- Or run **`npm run update-pricing`** to refresh `pricing.json` from Anthropic's
-  published pricing page. There's no official pricing *API*, so this is a
-  best-effort scrape (it validates what it parses and won't write garbage) —
-  review the diff afterwards. Use `--dry-run` to preview without writing.
-- The `opus`/`sonnet`/`haiku`/`gpt` family rules use **current** pricing; the
-  deprecated Opus 4 / 4.1 ($15/$75) and specific GPT-5 versions are pinned via
-  exact `models` entries. Add an exact entry to override any specific model.
+- Rates **auto-refresh daily** in the background while the server runs. Run
+  `claudescope pricing update` to force a refresh at any time. New rates apply
+  to newly indexed events; existing indexed costs are unchanged.
+- Edit `~/.claudescope/pricing.json` to override families, the default rate, or
+  pin specific model prices. Re-index (`POST /api/reindex` or `claudescope
+  restart`) to recompute stored costs at the new rates.
+- The `opus`/`sonnet`/`haiku`/`gemini`/`gpt` family rules use **current**
+  pricing; the deprecated Opus 4 / 4.1 ($15/$75) and specific GPT-5 versions are
+  pinned via exact `models` entries. Add an exact entry to override any model.
 
 > **Caveat:** these are **list-price estimates** — they ignore any discounts,
 > service tier, or batch pricing, and the cache-write rate assumes the 5-minute

--- a/docs/plans/0010-runtime-pricing-refresh.md
+++ b/docs/plans/0010-runtime-pricing-refresh.md
@@ -1,6 +1,6 @@
 # 0010 — Runtime pricing refresh from LiteLLM
 
-- **Status:** in-progress
+- **Status:** done
 - **Date:** 2026-06-10
 - **PR:** [#9](https://github.com/vladar107/claudescope/pull/9)
 

--- a/docs/plans/0010-runtime-pricing-refresh.md
+++ b/docs/plans/0010-runtime-pricing-refresh.md
@@ -1,0 +1,117 @@
+# 0010 — Runtime pricing refresh from LiteLLM
+
+- **Status:** in-progress
+- **Date:** 2026-06-10
+- **PR:** <link, once opened>
+
+## Context
+
+Model prices change and new models appear far more often than claudescope
+releases. Today the only rate source is the shipped `pricing.json`, seeded once
+into `~/.claudescope/pricing.json` and never refreshed — so existing installs
+estimate costs with stale rates, and any model missing from the file silently
+falls back to family/default rates. The maintainer-side
+`scripts/update-pricing.mjs` scrapes Anthropic's docs page (Claude only,
+fragile HTML parse) and requires a release to reach users. Junie sessions can
+additionally run on non-Anthropic/non-OpenAI providers (e.g. Gemini), which
+today always fall to the default rate.
+
+## Goal
+
+Decouple pricing from releases: the app fetches current rates at runtime from
+LiteLLM's community-maintained pricing JSON, refreshes them automatically while
+the daemon runs, and exposes a manual `claudescope pricing update` CLI command.
+Historical (already-indexed) costs stay as-is.
+
+## Decisions
+
+- **Source: LiteLLM `model_prices_and_context_window.json`** (raw GitHub, no
+  auth) — machine-readable, covers all major providers, updated within days of
+  new models. Rejected: scraping Anthropic docs at runtime (fragile, breaks for
+  all users at once, Claude-only); hosting a curated file in this repo (still
+  needs the maintainer to notice price changes).
+- **Provider allowlist, not the full file** — keep models whose
+  `litellm_provider` ∈ {anthropic, openai, gemini, xai, mistral, deepseek} and
+  `mode === "chat"` (~500–800 models), skipping Bedrock/Azure/Vertex duplicates
+  and non-chat models that bare transcript model ids would never match.
+- **Latest snapshot only, stored as a file** — `~/.claudescope/pricing.fetched.json`
+  (`{ fetchedAt, models }`). Not in DuckDB: the index is a disposable derived
+  cache and pricing must survive rebuilds. No rate history: LiteLLM has none,
+  and per-event costs are already frozen at index time.
+- **Precedence: fetched exact id → local exact id → local family substring →
+  local default.** Implemented as a per-model merge (`fetched.models` over
+  `local.models`); `families`/`default` always come from the local file
+  (LiteLLM has no such concepts). The shipped default remains the bottom
+  fallback when no files exist.
+- **mtime-keyed `loadPricing()` cache instead of an API endpoint** — the CLI
+  command and the daemon timer both just write the file; the daemon picks up
+  changes on its next reindex poll (≤15 s). Rejected: a `POST /api/pricing/
+  refresh` endpoint + CLI→daemon plumbing (more moving parts for the same
+  outcome).
+- **Cost via a DuckDB pricing join table** — at ~800 models the current inline
+  `CASE` in `buildCostExpr` becomes a multi-thousand-branch expression; a small
+  pricing table joined at projection time (exact id → family → default
+  fallback) is the clean shape. Persisted-cost semantics are unchanged.
+- **Fail-safe refresh** — validate everything parsed (finite, ≥ 0, sanity cap,
+  ≥ 1 anthropic + ≥ 1 openai model); on any failure abort without writing and
+  keep last-known rates. Failures log at warn level (daemon) / stderr (CLI).
+- **Accepted imprecision** — refreshed rates apply to newly indexed events
+  only; a full index rebuild re-prices history at current rates. Costs are
+  estimates by design.
+
+## Approach
+
+1. **Wave 1 — refresh core.** Shared `FetchedPricing` type; config constants
+   (`FETCHED_PRICING_PATH`, `PRICING_REFRESH_INTERVAL_MS`,
+   `LITELLM_PRICING_URL`, provider allowlist); new
+   `packages/server/src/data/pricing-refresh.ts` with a pure
+   `mapLiteLLM(json)` (per-token → per-MTok, missing cache fields → 0) and
+   `refreshPricing()` (fetch → map → validate → atomic write). Fixture-based
+   unit tests, no network.
+2. **Wave 2a — merge + server wiring.** `loadPricing()` merges shipped default
+   ← user `pricing.json` ← `pricing.fetched.json` with an mtime-keyed cache;
+   cost computation moves from the inline CASE to a pricing join table; server
+   boot refreshes in the background when the snapshot is missing/stale (>24 h)
+   plus a 24 h interval timer (unref + onClose cleanup, warn on failure —
+   same pattern as auto-reindex).
+3. **Wave 2b — CLI + docs.** `claudescope pricing update` (direct in-process
+   fetch; prints model count, fetchedAt, path, changed-rate count); help text;
+   `gemini` family added to the shipped `pricing.json`; README + CLAUDE.md
+   updates.
+4. **Wrap-up.** Review, `npm test`, `npm run typecheck`.
+
+## Files affected
+
+- `packages/shared/src/pricing.ts` — add `FetchedPricing` type.
+- `packages/server/src/config.ts` — fetched-pricing path, refresh interval,
+  LiteLLM URL, provider allowlist.
+- `packages/server/src/data/pricing-refresh.ts` — new: fetch/map/validate/write.
+- `packages/server/src/data/pricing.ts` — layered merge + mtime-keyed cache.
+- `packages/server/src/data/index.ts` — pricing join table replaces the inline
+  cost CASE.
+- `packages/server/src/index.ts` — boot-time + interval auto-refresh.
+- `packages/server/src/cli.ts` — `pricing update` command + help.
+- `packages/server/pricing.json` — add `gemini` family rates.
+- `packages/server/test/` — mapper unit tests; merge/invalidation tests.
+- `README.md`, `CLAUDE.md` — document the fetched layer and the command.
+
+## Testing
+
+- Unit: `mapLiteLLM` against an inline LiteLLM-shaped fixture (happy path,
+  malformed entries skipped, validation aborts, per-token → per-MTok math).
+- Unit/integration: `loadPricing` precedence and mtime invalidation via
+  temp-dir `PRICING_PATH`/`FETCHED_PRICING_PATH`; cost join produces the same
+  values the CASE did for exact/family/default matches.
+- `npm test` and `npm run typecheck` green; no test touches the network or
+  real `~/.claude*` dirs.
+
+## Risks / open questions
+
+- LiteLLM schema drift breaks the mapper → strict validation + abort-without-
+  write; users keep last-known rates indefinitely (warn log). Worst case
+  equals today's behavior.
+- LiteLLM rates can lag or differ from official pricing — accepted; costs are
+  local estimates.
+- `scripts/update-pricing.mjs` stays as maintainer tooling for the shipped
+  fallback file; could later be replaced by the same LiteLLM mapper
+  (follow-up).

--- a/docs/plans/0010-runtime-pricing-refresh.md
+++ b/docs/plans/0010-runtime-pricing-refresh.md
@@ -2,7 +2,7 @@
 
 - **Status:** in-progress
 - **Date:** 2026-06-10
-- **PR:** <link, once opened>
+- **PR:** [#9](https://github.com/vladar107/claudescope/pull/9)
 
 ## Context
 

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -34,3 +34,4 @@ decision, or a change worth explaining before doing. Skip it for one-line fixes.
 | 0007 | [UI redesign: multi-agent, light/dark, responsive nav](./0007-ui-redesign-multi-agent.md) | done |
 | 0008 | [Junie connector](./0008-junie-connector.md) | done |
 | 0009 | [Homebrew + Nix distribution](./0009-homebrew-nix-distribution.md) | done |
+| 0010 | [runtime pricing refresh](./0010-runtime-pricing-refresh.md) | in-progress |

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -34,4 +34,4 @@ decision, or a change worth explaining before doing. Skip it for one-line fixes.
 | 0007 | [UI redesign: multi-agent, light/dark, responsive nav](./0007-ui-redesign-multi-agent.md) | done |
 | 0008 | [Junie connector](./0008-junie-connector.md) | done |
 | 0009 | [Homebrew + Nix distribution](./0009-homebrew-nix-distribution.md) | done |
-| 0010 | [runtime pricing refresh](./0010-runtime-pricing-refresh.md) | in-progress |
+| 0010 | [runtime pricing refresh](./0010-runtime-pricing-refresh.md) | done |

--- a/packages/server/pricing.json
+++ b/packages/server/pricing.json
@@ -12,6 +12,7 @@
     "opus": { "input": 5, "output": 25, "cacheWrite": 6.25, "cacheRead": 0.5 },
     "sonnet": { "input": 3, "output": 15, "cacheWrite": 3.75, "cacheRead": 0.3 },
     "haiku": { "input": 1, "output": 5, "cacheWrite": 1.25, "cacheRead": 0.1 },
+    "gemini": { "input": 1.25, "output": 10, "cacheWrite": 0, "cacheRead": 0.31 },
     "gpt": { "input": 2.5, "output": 15, "cacheWrite": 0, "cacheRead": 0.5 }
   },
   "default": { "input": 3, "output": 15, "cacheWrite": 3.75, "cacheRead": 0.3 }

--- a/packages/server/src/cli.ts
+++ b/packages/server/src/cli.ts
@@ -28,6 +28,7 @@ import { createInterface } from 'node:readline/promises';
 import { parseArgs } from 'node:util';
 import { fileURLToPath } from 'node:url';
 import { APP_VERSION, CLAUDE_PROJECTS_DIR, CLAUDESCOPE_HOME, PORT as DEFAULT_PORT } from './config.js';
+import { refreshPricing } from './data/pricing-refresh.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 /** The server bundle, a sibling of this CLI in the published package. */
@@ -338,6 +339,27 @@ async function maybeNotifyUpdate(force: boolean): Promise<void> {
   }
 }
 
+/** Run a one-shot pricing refresh and print a concise summary. */
+async function pricingUpdate(): Promise<void> {
+  try {
+    const { modelCount, changed, path } = await refreshPricing();
+    console.log(`✓ Pricing updated: ${modelCount} models (${changed} changed) → ${path}`);
+    console.log('  A running server picks up the new rates automatically (newly indexed events).');
+  } catch (err) {
+    console.error(`✗ Pricing update failed: ${err instanceof Error ? err.message : String(err)}`);
+    console.error('  Existing rates are unchanged.');
+    process.exitCode = 1;
+  }
+}
+
+/** Print brief usage for the pricing subcommand. */
+function pricingHelp(): void {
+  console.log(`Usage: claudescope pricing <subcommand>
+
+Subcommands:
+  update    Fetch current model prices (LiteLLM) into the local rate table`);
+}
+
 function help(): void {
   console.log(`claudescope v${APP_VERSION} — local viewer for Claude Code transcripts
 
@@ -351,6 +373,7 @@ Commands:
   open             Open the running app in your browser
   logs [-f]        Print the server log (-f / --follow to tail it)
   update [-y]      Upgrade to the latest published version and restart
+  pricing update   Fetch current model prices (LiteLLM) into the local rate table
   help             Show this help
   version          Print the installed version
 
@@ -407,6 +430,15 @@ async function main(): Promise<void> {
     case 'update':
       await update(Boolean(values.yes));
       break;
+    case 'pricing': {
+      const sub = positionals[1];
+      if (sub === 'update') {
+        await pricingUpdate();
+      } else {
+        pricingHelp();
+      }
+      break;
+    }
     case 'version':
       console.log(APP_VERSION);
       break;

--- a/packages/server/src/config.ts
+++ b/packages/server/src/config.ts
@@ -97,6 +97,33 @@ export const DEFAULT_PRICING_PATH = firstExisting(
 export const PRICING_PATH = process.env.PRICING_PATH ?? join(CLAUDESCOPE_HOME, 'pricing.json');
 
 /**
+ * App-owned snapshot of runtime-fetched rates (from LiteLLM). Stored alongside
+ * the other app state so it survives index rebuilds, which discard the DuckDB
+ * cache. Override with FETCHED_PRICING_PATH (used by tests to point at a
+ * throwaway temp dir).
+ */
+export const FETCHED_PRICING_PATH =
+  process.env.FETCHED_PRICING_PATH ?? join(CLAUDESCOPE_HOME, 'pricing.fetched.json');
+
+/**
+ * Source for runtime pricing refresh: LiteLLM's community-maintained,
+ * machine-readable price table (raw GitHub, no auth). Override with
+ * LITELLM_PRICING_URL.
+ */
+export const LITELLM_PRICING_URL =
+  process.env.LITELLM_PRICING_URL ??
+  'https://raw.githubusercontent.com/BerriAI/litellm/main/model_prices_and_context_window.json';
+
+/**
+ * How often (ms) the daemon re-fetches pricing from LiteLLM. Set
+ * PRICING_REFRESH_INTERVAL_MS=0 to disable. Default 24h. (The timer itself is
+ * wired up in a later wave; this constant only declares the interval.)
+ */
+export const PRICING_REFRESH_INTERVAL_MS = Number(
+  process.env.PRICING_REFRESH_INTERVAL_MS ?? 24 * 60 * 60 * 1000,
+);
+
+/**
  * Built web assets served in production. Resolved for both the bundled layout
  * (`<pkg>/web` next to the server bundle) and the dev layout
  * (`packages/web/dist`). Override with WEB_DIST_DIR.

--- a/packages/server/src/data/index.ts
+++ b/packages/server/src/data/index.ts
@@ -31,36 +31,86 @@ export function isIndexReady(): boolean {
   return ready;
 }
 
+/** The four rate fields, in canonical → SQL-column order. */
+const RATE_FIELDS = [
+  ['input', 'input', 'input_tokens'],
+  ['output', 'output', 'output_tokens'],
+  ['cacheWrite', 'cache_write', 'cache_write_tokens'],
+  ['cacheRead', 'cache_read', 'cache_read_tokens'],
+] as const satisfies readonly (readonly [keyof PricingConfig['models'][string], string, string])[];
+
+/** Alias the per-file projection gets when joined against {@link pricing_rates}. */
+const EVENTS_ALIAS = 'ev';
+
+/** Alias the {@link pricing_rates} join table gets in the cost expression. */
+const RATES_ALIAS = 'pr';
+
 /**
- * Build the per-event cost expression (USD) from the pricing config. Costs are
- * computed in SQL via a big CASE over the model id so the value is persisted on
- * each event row and analytics can simply SUM it. Rates are USD per 1M tokens.
+ * (Re)create and populate the `pricing_rates` join table from the merged
+ * pricing's exact-id model rates. At a few hundred rows this is cheap, so we
+ * just recreate it once per reindex run (never per file). The cost expression
+ * (see {@link buildCostExpr}) LEFT JOINs each event's `model` against this table
+ * for the exact-id rate, falling back to family/default in SQL.
+ */
+async function syncPricingTable(conn: DuckDBConnection, pricing: PricingConfig): Promise<void> {
+  await conn.run('DROP TABLE IF EXISTS pricing_rates');
+  await conn.run(`
+    CREATE TABLE pricing_rates (
+      model       VARCHAR PRIMARY KEY,
+      input       DOUBLE,
+      output      DOUBLE,
+      cache_write DOUBLE,
+      cache_read  DOUBLE
+    )
+  `);
+
+  const rows = Object.entries(pricing.models);
+  if (rows.length === 0) return;
+  const values = rows
+    .map(
+      ([model, r]) =>
+        `(${sqlString(model)}, ${r.input}, ${r.output}, ${r.cacheWrite}, ${r.cacheRead})`,
+    )
+    .join(', ');
+  await conn.run(`INSERT INTO pricing_rates VALUES ${values}`);
+}
+
+/**
+ * Build the per-event cost expression (USD). Costs are computed in SQL so the
+ * value is persisted on each event row and analytics can simply SUM it. Rates
+ * are USD per 1M tokens.
+ *
+ * Per rate field the value is `COALESCE(exact-id join rate, family substring
+ * match, default literal)`: the exact id comes from the {@link pricing_rates}
+ * join table (aliased {@link RATES_ALIAS}), the family match is a small CASE
+ * over `pricing.families` (a handful of branches), and the default is a literal.
  * Operates on the canonical token columns, so it is agent-agnostic.
+ *
+ * The caller must LEFT JOIN the projection against `pricing_rates ${RATES_ALIAS}`
+ * on the model column (see {@link loadFile}).
  */
 function buildCostExpr(pricing: PricingConfig): string {
-  const rateExpr = (field: keyof PricingConfig['models'][string]): string => {
+  const rateExpr = (field: keyof PricingConfig['models'][string], column: string): string => {
     const cases: string[] = [];
-    // Exact model ids win first.
-    for (const [model, rates] of Object.entries(pricing.models)) {
-      cases.push(`WHEN model = ${sqlString(model)} THEN ${rates[field]}`);
-    }
-    // Then family substring matches (opus/sonnet/haiku), so any version or
-    // date-suffixed id still resolves.
+    // Family substring matches (opus/sonnet/haiku/…), so any version or
+    // date-suffixed id still resolves when no exact-id row joined.
     for (const [family, rates] of Object.entries(pricing.families ?? {})) {
       const pat = sqlString(`%${family.toLowerCase()}%`);
-      cases.push(`WHEN lower(model) LIKE ${pat} THEN ${rates[field]}`);
+      cases.push(`WHEN lower(${EVENTS_ALIAS}.model) LIKE ${pat} THEN ${rates[field]}`);
     }
-    cases.push(`ELSE ${pricing.default[field]}`);
-    return `CASE ${cases.join(' ')} END`;
+    const familyExpr =
+      cases.length > 0 ? `CASE ${cases.join(' ')} ELSE ${pricing.default[field]} END` : `${pricing.default[field]}`;
+    // Exact-id rate (join) wins; then family; then default.
+    return `COALESCE(${RATES_ALIAS}.${column}, ${familyExpr})`;
   };
 
   // Cost is only attributable to assistant events (the ones carrying usage).
+  const terms = RATE_FIELDS.map(
+    ([field, column, tokenCol]) => `COALESCE(${EVENTS_ALIAS}.${tokenCol}, 0) * ${rateExpr(field, column)}`,
+  );
   return `
     (
-      COALESCE(input_tokens, 0)       * ${rateExpr('input')}      +
-      COALESCE(output_tokens, 0)      * ${rateExpr('output')}     +
-      COALESCE(cache_write_tokens, 0) * ${rateExpr('cacheWrite')} +
-      COALESCE(cache_read_tokens, 0)  * ${rateExpr('cacheRead')}
+      ${terms.join(' +\n      ')}
     ) / 1000000.0`;
 }
 
@@ -82,17 +132,22 @@ async function loadFile(
   await connector.prepare?.(file.path);
   await conn.run(`DELETE FROM events WHERE file_path = ${path}`);
 
+  // The cost expression references the projected token/model columns plus the
+  // pricing_rates join (aliased `pr` — see buildCostExpr). LEFT JOIN on the
+  // model column so events whose model has no exact-id row fall through to the
+  // family/default CASE; the table is recreated each reindex (syncPricingTable).
   await conn.run(`
     INSERT INTO events
     SELECT
-      file_path, session_id, uuid, parent_uuid, role, type, ts, cwd, git_branch,
-      model, input_tokens, output_tokens, cache_read_tokens, cache_write_tokens,
-      service_tier, is_sidechain, tool_use_count,
+      ev.file_path, ev.session_id, ev.uuid, ev.parent_uuid, ev.role, ev.type, ev.ts, ev.cwd, ev.git_branch,
+      ev.model, ev.input_tokens, ev.output_tokens, ev.cache_read_tokens, ev.cache_write_tokens,
+      ev.service_tier, ev.is_sidechain, ev.tool_use_count,
       ${costExpr} AS cost_usd,
-      text_content
+      ev.text_content
     FROM (
       ${connector.eventsProjectionSql(file.path)}
-    )
+    ) AS ev
+    LEFT JOIN pricing_rates ${RATES_ALIAS} ON ${RATES_ALIAS}.model = ev.model
   `);
 
   const aux = connector.auxProjections(file.path);
@@ -232,6 +287,9 @@ async function doReindex(): Promise<ReindexResponse> {
   const start = Date.now();
   const conn = await getConnection();
   const pricing = loadPricing();
+  // Refresh the pricing join table (cheap; recreated once per run) before any
+  // file loads so the cost expression's exact-id join sees current rates.
+  await syncPricingTable(conn, pricing);
   const costExpr = buildCostExpr(pricing);
 
   // Discover across every registered connector, tagging each file with its owner.

--- a/packages/server/src/data/pricing-refresh.ts
+++ b/packages/server/src/data/pricing-refresh.ts
@@ -1,0 +1,198 @@
+/**
+ * Runtime pricing refresh from LiteLLM.
+ *
+ * Fetches LiteLLM's community-maintained price table, maps the allowlisted
+ * chat/responses models to our per-MTok {@link ModelRates} shape, validates the
+ * result, and atomically writes a {@link FetchedPricing} snapshot to
+ * {@link FETCHED_PRICING_PATH}. The snapshot survives index rebuilds and is
+ * layered over the local `pricing.json` by the loader (wired in a later wave).
+ *
+ * Pure mappers/validators are exported for unit testing. This module has no
+ * import-time side effects and never touches DuckDB.
+ */
+
+import { mkdirSync, readFileSync, renameSync, writeFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import type { FetchedPricing, ModelRates } from '@claudescope/shared';
+import { FETCHED_PRICING_PATH, LITELLM_PRICING_URL } from '../config.js';
+
+/**
+ * Providers whose models we keep. Bare transcript model ids only ever match
+ * these "first-party" providers; Bedrock/Azure/Vertex/router duplicates use
+ * provider-prefixed ids that would never match and are dropped.
+ */
+const ALLOWED_PROVIDERS = new Set([
+  'anthropic',
+  'openai',
+  'gemini',
+  'xai',
+  'mistral',
+  'deepseek',
+]);
+
+/**
+ * LiteLLM `mode` values we treat as chat-style. `responses` covers OpenAI's
+ * Responses-API models (e.g. `gpt-5-codex`, `o3-pro`) that transcripts do use.
+ */
+const CHAT_MODES = new Set(['chat', 'responses']);
+
+/** Convert per-token USD to per-MTok USD. */
+const PER_MTOK = 1_000_000;
+
+/** Reject any rate above this (USD per MTok) as a parse error / bad data. */
+const SANITY_CAP = 10_000;
+
+/** Network timeout for the fetch; the file is a few MB. */
+const FETCH_TIMEOUT_MS = 30_000;
+
+/** Shape of a single LiteLLM entry we read (other fields ignored). */
+interface LiteLLMEntry {
+  litellm_provider?: unknown;
+  mode?: unknown;
+  input_cost_per_token?: unknown;
+  output_cost_per_token?: unknown;
+  cache_creation_input_token_cost?: unknown;
+  cache_read_input_token_cost?: unknown;
+}
+
+/** A finite, non-negative number within the sanity cap, else `null`. */
+function toRate(value: unknown): number | null {
+  if (typeof value !== 'number' || !Number.isFinite(value) || value < 0) return null;
+  const rate = value * PER_MTOK;
+  return rate <= SANITY_CAP ? rate : null;
+}
+
+/** An optional cache rate: missing/undefined → 0; invalid/out-of-range → null. */
+function toCacheRate(value: unknown): number | null {
+  if (value === undefined || value === null) return 0;
+  return toRate(value);
+}
+
+/**
+ * Map a parsed LiteLLM JSON object to our per-MTok rate table. Pure; exported
+ * for tests.
+ *
+ * Keeps entries whose `litellm_provider` is allowlisted and whose `mode` is
+ * chat-style. Provider-prefixed keys (e.g. `gemini/gemini-2.5-pro`) are skipped
+ * — transcripts store bare model ids, and the bare id is present for these
+ * providers. Individual entries with missing/invalid input or output cost (or
+ * any rate over the sanity cap) are skipped, not fatal. Missing cache fields
+ * default to 0.
+ */
+export function mapLiteLLM(json: unknown): Record<string, ModelRates> {
+  const out: Record<string, ModelRates> = {};
+  if (typeof json !== 'object' || json === null) return out;
+
+  for (const [id, raw] of Object.entries(json as Record<string, unknown>)) {
+    if (id === 'sample_spec') continue;
+    if (id.includes('/')) continue; // skip provider-prefixed duplicates
+    if (typeof raw !== 'object' || raw === null) continue;
+
+    const entry = raw as LiteLLMEntry;
+    if (typeof entry.litellm_provider !== 'string' || !ALLOWED_PROVIDERS.has(entry.litellm_provider)) {
+      continue;
+    }
+    if (typeof entry.mode !== 'string' || !CHAT_MODES.has(entry.mode)) continue;
+
+    const input = toRate(entry.input_cost_per_token);
+    const output = toRate(entry.output_cost_per_token);
+    const cacheWrite = toCacheRate(entry.cache_creation_input_token_cost);
+    const cacheRead = toCacheRate(entry.cache_read_input_token_cost);
+    // Skip entries that fail any rate check rather than failing the whole map.
+    if (input === null || output === null || cacheWrite === null || cacheRead === null) {
+      continue;
+    }
+
+    out[id] = { input, output, cacheWrite, cacheRead };
+  }
+
+  return out;
+}
+
+/**
+ * Throw unless the mapped table looks usable: at least one anthropic and one
+ * openai model survived. We track this by id pattern so other providers
+ * disappearing upstream never aborts the refresh. Exported for tests.
+ */
+export function validateFetched(models: Record<string, ModelRates>): void {
+  const ids = Object.keys(models);
+  const hasAnthropic = ids.some((id) => id.startsWith('claude'));
+  const hasOpenai = ids.some((id) => /^(gpt|o\d|chatgpt|codex)/.test(id));
+  if (!hasAnthropic || !hasOpenai) {
+    const missing = [!hasAnthropic && 'anthropic', !hasOpenai && 'openai'].filter(Boolean).join(', ');
+    throw new Error(
+      `Fetched pricing failed validation: no ${missing} model survived mapping ` +
+        `(${ids.length} model(s) total). LiteLLM schema may have drifted.`,
+    );
+  }
+}
+
+/** Read the previous snapshot, tolerating a missing or corrupt file. */
+function readPreviousModels(path: string): Record<string, ModelRates> {
+  try {
+    const parsed = JSON.parse(readFileSync(path, 'utf8')) as FetchedPricing;
+    return parsed?.models ?? {};
+  } catch {
+    return {};
+  }
+}
+
+/** Count model ids whose rates differ from (or are absent in) the previous set. */
+function countChanged(
+  next: Record<string, ModelRates>,
+  prev: Record<string, ModelRates>,
+): number {
+  let changed = 0;
+  for (const [id, rates] of Object.entries(next)) {
+    const before = prev[id];
+    if (
+      !before ||
+      before.input !== rates.input ||
+      before.output !== rates.output ||
+      before.cacheWrite !== rates.cacheWrite ||
+      before.cacheRead !== rates.cacheRead
+    ) {
+      changed += 1;
+    }
+  }
+  return changed;
+}
+
+/**
+ * Fetch LiteLLM pricing, map + validate it, and atomically write the snapshot.
+ *
+ * On any failure (network, non-OK response, parse error, validation) this
+ * throws and the existing snapshot file is left untouched, so callers fall back
+ * to last-known rates. Returns a summary of the write.
+ */
+export async function refreshPricing(): Promise<{
+  fetchedAt: string;
+  modelCount: number;
+  changed: number;
+  path: string;
+}> {
+  const res = await fetch(LITELLM_PRICING_URL, {
+    signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+  });
+  if (!res.ok) {
+    throw new Error(`Pricing fetch failed: ${res.status} ${res.statusText}`);
+  }
+
+  const json: unknown = await res.json();
+  const models = mapLiteLLM(json);
+  validateFetched(models);
+
+  const prev = readPreviousModels(FETCHED_PRICING_PATH);
+  const changed = countChanged(models, prev);
+
+  const fetchedAt = new Date().toISOString();
+  const snapshot: FetchedPricing = { fetchedAt, models };
+
+  // Atomic write: stage to a temp file in the same dir, then rename over target.
+  mkdirSync(dirname(FETCHED_PRICING_PATH), { recursive: true });
+  const tmp = join(dirname(FETCHED_PRICING_PATH), `.pricing.fetched.${process.pid}.tmp`);
+  writeFileSync(tmp, `${JSON.stringify(snapshot, null, 2)}\n`);
+  renameSync(tmp, FETCHED_PRICING_PATH);
+
+  return { fetchedAt, modelCount: Object.keys(models).length, changed, path: FETCHED_PRICING_PATH };
+}

--- a/packages/server/src/data/pricing.ts
+++ b/packages/server/src/data/pricing.ts
@@ -1,24 +1,82 @@
 /**
- * Pricing loader + cost computation.
+ * Pricing loader.
  *
- * Placeholder: loads the user-editable {@link PRICING_PATH} JSON and computes
- * per-event USD cost from token usage. `<synthetic>` resolves to $0.
+ * Loads a layered {@link PricingConfig}: a base layer (the user-editable
+ * {@link PRICING_PATH}, falling back to the shipped {@link DEFAULT_PRICING_PATH})
+ * with an optional overlay of runtime-fetched rates from
+ * {@link FETCHED_PRICING_PATH}. Fetched rates win per exact model id; `families`
+ * and `default` always come from the base layer (LiteLLM has no such concepts).
+ *
+ * The result is cached and keyed on the (mtime, existence) of both files, so an
+ * edit to either — e.g. a `claudescope pricing update` rewriting the fetched
+ * snapshot — is picked up on the next call (the reindex poll calls this every
+ * ~15s) without restarting. A missing or corrupt fetched file is silently
+ * ignored, leaving base-only behavior.
  */
 
-import { existsSync, readFileSync } from 'node:fs';
-import type { PricingConfig } from '@claudescope/shared';
-import { DEFAULT_PRICING_PATH, PRICING_PATH } from '../config.js';
+import { existsSync, readFileSync, statSync } from 'node:fs';
+import type { FetchedPricing, PricingConfig } from '@claudescope/shared';
+import { DEFAULT_PRICING_PATH, FETCHED_PRICING_PATH, PRICING_PATH } from '../config.js';
 
-let cached: PricingConfig | null = null;
+/** Sentinel mtime for a file that does not exist. */
+const ABSENT = -1;
+
+/** A cache key tracking the (existence, mtime) of both pricing layers. */
+interface CacheKey {
+  baseMtime: number;
+  fetchedMtime: number;
+}
+
+let cached: { key: CacheKey; config: PricingConfig } | null = null;
+
+/** stat a path for its mtime, returning {@link ABSENT} when it doesn't exist. */
+function mtimeOf(path: string): number {
+  try {
+    return statSync(path).mtimeMs;
+  } catch {
+    return ABSENT;
+  }
+}
+
+/** Read + parse the fetched snapshot, tolerating a missing or corrupt file. */
+function readFetched(path: string): FetchedPricing | null {
+  try {
+    const parsed = JSON.parse(readFileSync(path, 'utf8')) as FetchedPricing;
+    if (parsed && typeof parsed === 'object' && parsed.models && typeof parsed.models === 'object') {
+      return parsed;
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
 
 /**
- * Load (and cache) the pricing configuration from disk. Prefers the
- * user-editable copy in the state dir, falling back to the shipped default so a
- * fresh checkout (or a run before the state dir was seeded) still has rates.
+ * Load (and cache) the layered pricing configuration from disk. Re-reads only
+ * when either layer's file mtime or existence changed since the last call.
  */
 export function loadPricing(): PricingConfig {
-  if (cached) return cached;
-  const path = existsSync(PRICING_PATH) ? PRICING_PATH : DEFAULT_PRICING_PATH;
-  cached = JSON.parse(readFileSync(path, 'utf8')) as PricingConfig;
-  return cached;
+  const basePath = existsSync(PRICING_PATH) ? PRICING_PATH : DEFAULT_PRICING_PATH;
+  const key: CacheKey = {
+    baseMtime: mtimeOf(basePath),
+    fetchedMtime: mtimeOf(FETCHED_PRICING_PATH),
+  };
+
+  if (cached && cached.key.baseMtime === key.baseMtime && cached.key.fetchedMtime === key.fetchedMtime) {
+    return cached.config;
+  }
+
+  const base = JSON.parse(readFileSync(basePath, 'utf8')) as PricingConfig;
+
+  // Overlay fetched rates per exact id; families/default stay from the base.
+  let config = base;
+  if (key.fetchedMtime !== ABSENT) {
+    const fetched = readFetched(FETCHED_PRICING_PATH);
+    if (fetched) {
+      config = { ...base, models: { ...base.models, ...fetched.models } };
+    }
+  }
+
+  cached = { key, config };
+  return config;
 }

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -3,21 +3,43 @@
  * (in production) serves the built web assets from disk.
  */
 
-import { existsSync } from 'node:fs';
+import { existsSync, readFileSync } from 'node:fs';
 import { spawn } from 'node:child_process';
 import Fastify from 'fastify';
 import fastifyStatic from '@fastify/static';
+import type { FetchedPricing } from '@claudescope/shared';
 import {
   APP_VERSION,
   CLAUDE_PROJECTS_DIR,
+  FETCHED_PRICING_PATH,
   OPEN_BROWSER,
   PORT,
+  PRICING_REFRESH_INTERVAL_MS,
   REINDEX_INTERVAL_MS,
   WEB_DIST_DIR,
   ensureStateDir,
 } from './config.js';
 import { registerRoutes } from './routes/index.js';
 import { reindex } from './data/index.js';
+import { refreshPricing } from './data/pricing-refresh.js';
+
+/** How old a fetched-pricing snapshot may be before a boot refresh fires. */
+const PRICING_STALE_MS = 24 * 60 * 60 * 1000;
+
+/**
+ * Whether the fetched-pricing snapshot is missing, unparsable, or older than
+ * {@link PRICING_STALE_MS} — i.e. worth refreshing on boot.
+ */
+function pricingSnapshotIsStale(): boolean {
+  try {
+    const snapshot = JSON.parse(readFileSync(FETCHED_PRICING_PATH, 'utf8')) as FetchedPricing;
+    const fetchedAt = Date.parse(snapshot?.fetchedAt ?? '');
+    if (!Number.isFinite(fetchedAt)) return true;
+    return Date.now() - fetchedAt > PRICING_STALE_MS;
+  } catch {
+    return true; // missing or corrupt → refresh
+  }
+}
 
 /** Open a URL in the user's default browser (best-effort, cross-platform). */
 function openBrowser(url: string): void {
@@ -71,6 +93,31 @@ async function main(): Promise<void> {
     }, REINDEX_INTERVAL_MS);
     timer.unref(); // don't keep the process alive solely for the timer
     app.addHook('onClose', async () => clearInterval(timer));
+  }
+
+  // Auto-refresh pricing from LiteLLM: once at boot when the snapshot is
+  // missing/stale (>24h), then on an interval so long-running daemons track new
+  // models and rate changes. Set PRICING_REFRESH_INTERVAL_MS=0 to disable both
+  // (no network calls). No explicit cache-bust is needed: loadPricing's mtime
+  // cache picks up the rewritten file on the next reindex poll. Never blocks
+  // startup; failures are non-fatal — the loader falls back to last-known /
+  // shipped rates.
+  if (PRICING_REFRESH_INTERVAL_MS > 0) {
+    const runPricingRefresh = (): void => {
+      refreshPricing()
+        .then((res) =>
+          app.log.info(
+            { modelCount: res.modelCount, changed: res.changed },
+            'pricing refresh complete',
+          ),
+        )
+        .catch((err) => app.log.warn({ err }, 'pricing refresh failed — keeping last-known rates'));
+    };
+
+    if (pricingSnapshotIsStale()) runPricingRefresh();
+    const pricingTimer = setInterval(runPricingRefresh, PRICING_REFRESH_INTERVAL_MS);
+    pricingTimer.unref();
+    app.addHook('onClose', async () => clearInterval(pricingTimer));
   }
 
   // In production, serve the built SPA. In dev, Vite serves it and proxies /api.

--- a/packages/server/test/pricing-refresh.test.ts
+++ b/packages/server/test/pricing-refresh.test.ts
@@ -1,0 +1,232 @@
+/**
+ * Unit tests for the runtime pricing refresh. Fixture-based; no network.
+ *
+ * The fixture mirrors the real LiteLLM `model_prices_and_context_window.json`
+ * shape (per-token USD costs, `litellm_provider`, `mode`, a `sample_spec` key)
+ * and exercises mapping, validation, and the end-to-end `refreshPricing` write
+ * with `fetch` stubbed and FETCHED_PRICING_PATH pointed at a temp dir. The env
+ * override is set before importing the module, since config.ts reads env at
+ * import time.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+// --- temp snapshot location (decided before the module under test imports) ---
+const work = mkdtempSync(join(tmpdir(), 'claudescope-pricing-'));
+const fetchedPath = join(work, 'pricing.fetched.json');
+process.env.FETCHED_PRICING_PATH = fetchedPath;
+
+const { mapLiteLLM, validateFetched, refreshPricing } = await import('../src/data/pricing-refresh.js');
+
+/** A LiteLLM-shaped fixture covering every mapping branch. */
+const LITELLM = {
+  sample_spec: {
+    input_cost_per_token: 0.0,
+    output_cost_per_token: 0.0,
+    litellm_provider: 'one of https://docs.litellm.ai/docs/providers',
+    mode: 'chat',
+  },
+  // anthropic chat model with all four rates present.
+  'claude-sonnet-4-5': {
+    litellm_provider: 'anthropic',
+    mode: 'chat',
+    input_cost_per_token: 3e-6,
+    output_cost_per_token: 15e-6,
+    cache_creation_input_token_cost: 3.75e-6,
+    cache_read_input_token_cost: 0.3e-6,
+  },
+  // openai chat model missing cache fields (one null, one absent) → 0.
+  'gpt-5': {
+    litellm_provider: 'openai',
+    mode: 'chat',
+    input_cost_per_token: 1.25e-6,
+    output_cost_per_token: 10e-6,
+    cache_read_input_token_cost: 0.125e-6,
+    cache_creation_input_token_cost: null,
+  },
+  // openai responses-mode model (e.g. Codex) — must be kept.
+  'gpt-5-codex': {
+    litellm_provider: 'openai',
+    mode: 'responses',
+    input_cost_per_token: 1.25e-6,
+    output_cost_per_token: 10e-6,
+  },
+  // provider-prefixed duplicate — must be skipped (bare id stored in transcripts).
+  'gemini/gemini-2.5-pro': {
+    litellm_provider: 'gemini',
+    mode: 'chat',
+    input_cost_per_token: 1.25e-6,
+    output_cost_per_token: 10e-6,
+  },
+  // non-allowlisted provider — skipped.
+  'bedrock-claude': {
+    litellm_provider: 'bedrock',
+    mode: 'chat',
+    input_cost_per_token: 3e-6,
+    output_cost_per_token: 15e-6,
+  },
+  // non-chat mode — skipped.
+  'text-embedding-3-small': {
+    litellm_provider: 'openai',
+    mode: 'embedding',
+    input_cost_per_token: 0.02e-6,
+    output_cost_per_token: 0,
+  },
+  // malformed: missing output cost — skipped without throwing.
+  'mistral-broken': {
+    litellm_provider: 'mistral',
+    mode: 'chat',
+    input_cost_per_token: 2e-6,
+  },
+  // sanity-cap violation ($10,001 per MTok input) — skipped.
+  'xai-absurd': {
+    litellm_provider: 'xai',
+    mode: 'chat',
+    input_cost_per_token: 0.010001,
+    output_cost_per_token: 1e-6,
+  },
+};
+
+describe('mapLiteLLM', () => {
+  const rates = mapLiteLLM(LITELLM);
+
+  it('maps per-token to per-MTok and keeps all four rates', () => {
+    expect(rates['claude-sonnet-4-5']).toEqual({
+      input: 3,
+      output: 15,
+      cacheWrite: 3.75,
+      cacheRead: 0.3,
+    });
+  });
+
+  it('defaults missing/null cache fields to 0', () => {
+    expect(rates['gpt-5']).toEqual({ input: 1.25, output: 10, cacheWrite: 0, cacheRead: 0.125 });
+  });
+
+  it('keeps responses-mode models (e.g. Codex)', () => {
+    expect(rates['gpt-5-codex']).toEqual({ input: 1.25, output: 10, cacheWrite: 0, cacheRead: 0 });
+  });
+
+  it('skips provider-prefixed duplicate keys', () => {
+    expect(rates['gemini/gemini-2.5-pro']).toBeUndefined();
+  });
+
+  it('skips non-allowlisted providers', () => {
+    expect(rates['bedrock-claude']).toBeUndefined();
+  });
+
+  it('skips non-chat modes', () => {
+    expect(rates['text-embedding-3-small']).toBeUndefined();
+  });
+
+  it('skips malformed entries (missing output cost) without throwing', () => {
+    expect(rates['mistral-broken']).toBeUndefined();
+  });
+
+  it('skips sanity-cap violations', () => {
+    expect(rates['xai-absurd']).toBeUndefined();
+  });
+
+  it('ignores the sample_spec key', () => {
+    expect(rates.sample_spec).toBeUndefined();
+  });
+});
+
+describe('validateFetched', () => {
+  it('passes when both anthropic and openai survive', () => {
+    expect(() => validateFetched(mapLiteLLM(LITELLM))).not.toThrow();
+  });
+
+  it('throws when no anthropic model survives', () => {
+    expect(() => validateFetched({ 'gpt-5': { input: 1, output: 2, cacheWrite: 0, cacheRead: 0 } })).toThrow(
+      /anthropic/,
+    );
+  });
+
+  it('throws when no openai model survives', () => {
+    expect(() =>
+      validateFetched({ 'claude-sonnet-4-5': { input: 1, output: 2, cacheWrite: 0, cacheRead: 0 } }),
+    ).toThrow(/openai/);
+  });
+});
+
+describe('refreshPricing', () => {
+  const ok = (body: unknown) =>
+    ({ ok: true, status: 200, statusText: 'OK', json: async () => body }) as unknown as Response;
+
+  beforeEach(() => {
+    if (existsSync(fetchedPath)) rmSync(fetchedPath);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('writes a FetchedPricing snapshot with fetchedAt + models', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => ok(LITELLM)));
+
+    const result = await refreshPricing();
+    expect(result.path).toBe(fetchedPath);
+    expect(result.modelCount).toBe(3); // claude-sonnet-4-5, gpt-5, gpt-5-codex
+    expect(result.changed).toBe(3); // no previous snapshot → all changed
+
+    const snapshot = JSON.parse(readFileSync(fetchedPath, 'utf8'));
+    expect(typeof snapshot.fetchedAt).toBe('string');
+    expect(snapshot.fetchedAt).toBe(result.fetchedAt);
+    expect(snapshot.models['claude-sonnet-4-5']).toEqual({
+      input: 3,
+      output: 15,
+      cacheWrite: 3.75,
+      cacheRead: 0.3,
+    });
+  });
+
+  it('counts only changed rates on a second run', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => ok(LITELLM)));
+    await refreshPricing();
+
+    // Alter exactly one model's rate; the others are identical.
+    const altered = {
+      ...LITELLM,
+      'gpt-5': { ...LITELLM['gpt-5'], output_cost_per_token: 20e-6 },
+    };
+    vi.stubGlobal('fetch', vi.fn(async () => ok(altered)));
+
+    const result = await refreshPricing();
+    expect(result.changed).toBe(1);
+    expect(result.modelCount).toBe(3);
+  });
+
+  it('leaves an existing snapshot untouched when the fetch is invalid', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => ok(LITELLM)));
+    await refreshPricing();
+    const before = readFileSync(fetchedPath, 'utf8');
+
+    // A valid HTTP response whose body fails validation (no anthropic/openai).
+    vi.stubGlobal('fetch', vi.fn(async () => ok({ sample_spec: {} })));
+    await expect(refreshPricing()).rejects.toThrow();
+
+    expect(readFileSync(fetchedPath, 'utf8')).toBe(before);
+  });
+
+  it('throws and writes nothing on a non-OK response', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => ({ ok: false, status: 503, statusText: 'Service Unavailable' }) as Response),
+    );
+    await expect(refreshPricing()).rejects.toThrow(/503/);
+    expect(existsSync(fetchedPath)).toBe(false);
+  });
+});
+
+// Best-effort cleanup of the temp dir after the suite.
+process.on('exit', () => {
+  try {
+    rmSync(work, { recursive: true, force: true });
+  } catch {
+    // ignore
+  }
+});

--- a/packages/server/test/pricing.test.ts
+++ b/packages/server/test/pricing.test.ts
@@ -1,0 +1,212 @@
+/**
+ * Tests for the layered pricing loader and the cost join.
+ *
+ * Two parts:
+ *  - loadPricing precedence + mtime-keyed cache invalidation, driven by temp
+ *    PRICING_PATH / FETCHED_PRICING_PATH files (env set before the module under
+ *    test imports, since config.ts reads env at import time).
+ *  - an end-to-end cost check: a synthetic Claude transcript is indexed into a
+ *    throwaway DuckDB, and per-event `cost_usd` is verified against an exact-id
+ *    join rate, a family fallback, and the default fallback.
+ *
+ * No network, no real ~/.claude* dirs.
+ */
+
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  rmSync,
+  utimesSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import type { FastifyInstance } from 'fastify';
+import type { PricingConfig } from '@claudescope/shared';
+
+// --- temp locations (decided before any server module is imported) ----------
+const work = mkdtempSync(join(tmpdir(), 'claudescope-pricing-merge-'));
+const pricingPath = join(work, 'pricing.json');
+const fetchedPath = join(work, 'pricing.fetched.json');
+const projectsDir = join(work, 'projects');
+const dbPath = join(work, 'index.duckdb');
+
+process.env.PRICING_PATH = pricingPath;
+process.env.FETCHED_PRICING_PATH = fetchedPath;
+process.env.CLAUDE_PROJECTS_DIR = projectsDir;
+process.env.CODEX_SESSIONS_DIR = join(work, 'codex-empty');
+process.env.JUNIE_SESSIONS_DIR = join(work, 'junie-empty');
+process.env.DUCKDB_PATH = dbPath;
+process.env.CLAUDESCOPE_HOME = join(work, 'home');
+process.env.REINDEX_INTERVAL_MS = '0';
+process.env.PRICING_REFRESH_INTERVAL_MS = '0';
+
+/** A base pricing config with one exact model, families, and a default. */
+const BASE: PricingConfig = {
+  models: {
+    'claude-opus-4-8': { input: 15, output: 75, cacheWrite: 18.75, cacheRead: 1.5 },
+    'only-in-base': { input: 9, output: 9, cacheWrite: 9, cacheRead: 9 },
+  },
+  families: {
+    sonnet: { input: 3, output: 15, cacheWrite: 3.75, cacheRead: 0.3 },
+  },
+  default: { input: 1, output: 2, cacheWrite: 0, cacheRead: 0 },
+};
+
+const writeJson = (path: string, value: unknown): void =>
+  writeFileSync(path, `${JSON.stringify(value, null, 2)}\n`);
+
+/**
+ * Force a file's mtime forward to a strictly-increasing value so the loader's
+ * mtime-keyed cache busts even when two rewrites land in the same millisecond.
+ */
+let mtimeTick = Math.floor(Date.now() / 1000);
+const bumpMtime = (path: string): void => {
+  mtimeTick += 2;
+  utimesSync(path, mtimeTick, mtimeTick);
+};
+
+const { loadPricing } = await import('../src/data/pricing.js');
+
+describe('loadPricing — layered merge', () => {
+  beforeAll(() => {
+    writeJson(pricingPath, BASE);
+    if (existsSync(fetchedPath)) rmSync(fetchedPath);
+  });
+
+  it('returns the base config when no fetched snapshot exists', () => {
+    const cfg = loadPricing();
+    expect(cfg.models['claude-opus-4-8']).toEqual(BASE.models['claude-opus-4-8']);
+    expect(cfg.families).toEqual(BASE.families);
+    expect(cfg.default).toEqual(BASE.default);
+  });
+
+  it('lets fetched rates win per exact id, keeps base-only models, base families/default', () => {
+    writeJson(fetchedPath, {
+      fetchedAt: new Date().toISOString(),
+      models: {
+        // overrides the base exact id
+        'claude-opus-4-8': { input: 20, output: 100, cacheWrite: 25, cacheRead: 2 },
+        // a model only the fetched layer knows about
+        'gpt-5-codex': { input: 1.25, output: 10, cacheWrite: 0, cacheRead: 0 },
+      },
+    });
+
+    const cfg = loadPricing();
+    // fetched wins on the shared id
+    expect(cfg.models['claude-opus-4-8']).toEqual({ input: 20, output: 100, cacheWrite: 25, cacheRead: 2 });
+    // base-only model survives the merge
+    expect(cfg.models['only-in-base']).toEqual(BASE.models['only-in-base']);
+    // fetched-only model is present
+    expect(cfg.models['gpt-5-codex']).toEqual({ input: 1.25, output: 10, cacheWrite: 0, cacheRead: 0 });
+    // families/default always come from the base layer
+    expect(cfg.families).toEqual(BASE.families);
+    expect(cfg.default).toEqual(BASE.default);
+  });
+
+  it('ignores a corrupt fetched file (base-only, no throw)', () => {
+    writeFileSync(fetchedPath, '{ this is not json');
+    bumpMtime(fetchedPath);
+    const cfg = loadPricing();
+    expect(cfg.models['claude-opus-4-8']).toEqual(BASE.models['claude-opus-4-8']);
+    expect(cfg.models['gpt-5-codex']).toBeUndefined();
+  });
+
+  it('re-reads when the fetched file mtime changes (cache invalidation)', () => {
+    writeJson(fetchedPath, {
+      fetchedAt: new Date().toISOString(),
+      models: { 'claude-opus-4-8': { input: 1, output: 1, cacheWrite: 1, cacheRead: 1 } },
+    });
+    bumpMtime(fetchedPath);
+    const cfg = loadPricing();
+    expect(cfg.models['claude-opus-4-8']).toEqual({ input: 1, output: 1, cacheWrite: 1, cacheRead: 1 });
+
+    // Rewrite with new rates and bump mtime again → reload must reflect them.
+    writeJson(fetchedPath, {
+      fetchedAt: new Date().toISOString(),
+      models: { 'claude-opus-4-8': { input: 7, output: 8, cacheWrite: 9, cacheRead: 10 } },
+    });
+    bumpMtime(fetchedPath);
+    const reloaded = loadPricing();
+    expect(reloaded.models['claude-opus-4-8']).toEqual({ input: 7, output: 8, cacheWrite: 9, cacheRead: 10 });
+  });
+});
+
+describe('cost via the pricing join table', () => {
+  let app: FastifyInstance;
+  let closeConnection: () => Promise<void>;
+  let queryRows: (conn: unknown, sql: string) => Promise<Record<string, unknown>[]>;
+  let getConnection: () => Promise<unknown>;
+
+  const jsonl = (events: unknown[]): string =>
+    events.map((e) => JSON.stringify(e)).join('\n') + '\n';
+
+  beforeAll(async () => {
+    // Base pricing for the cost test: an exact id, a family substring, a default.
+    writeJson(pricingPath, BASE);
+    // Fetched layer overrides the exact-id rate to prove the join uses it.
+    writeJson(fetchedPath, {
+      fetchedAt: new Date().toISOString(),
+      models: { 'claude-opus-4-8': { input: 30, output: 150, cacheWrite: 0, cacheRead: 0 } },
+    });
+    bumpMtime(fetchedPath);
+
+    const proj = join(projectsDir, 'enc-projX');
+    mkdirSync(proj, { recursive: true });
+    const base = { sessionId: 'sessX', cwd: '/tmp/projX', isSidechain: false };
+    writeFileSync(
+      join(proj, 'sessX.jsonl'),
+      jsonl([
+        // exact-id match → fetched rate (input 30): 100 * 30 / 1e6 = 0.003
+        { ...base, type: 'assistant', uuid: 'x1', parentUuid: null, timestamp: '2026-01-01T10:00:00.000Z', message: { role: 'assistant', model: 'claude-opus-4-8', content: [{ type: 'text', text: 'a' }], usage: { input_tokens: 100, output_tokens: 0 } } },
+        // family match (sonnet, input 3): 100 * 3 / 1e6 = 0.0003
+        { ...base, type: 'assistant', uuid: 'x2', parentUuid: 'x1', timestamp: '2026-01-01T10:00:05.000Z', message: { role: 'assistant', model: 'claude-sonnet-4-5-20251001', content: [{ type: 'text', text: 'b' }], usage: { input_tokens: 100, output_tokens: 0 } } },
+        // default fallback (input 1): 100 * 1 / 1e6 = 0.0001
+        { ...base, type: 'assistant', uuid: 'x3', parentUuid: 'x2', timestamp: '2026-01-01T10:00:10.000Z', message: { role: 'assistant', model: 'some-unknown-model', content: [{ type: 'text', text: 'c' }], usage: { input_tokens: 100, output_tokens: 0 } } },
+      ]),
+    );
+
+    const Fastify = (await import('fastify')).default;
+    const { reindex } = await import('../src/data/index.js');
+    ({ getConnection, queryRows } = await import('../src/db/duckdb.js'));
+    ({ closeConnection } = await import('../src/db/duckdb.js'));
+
+    app = Fastify();
+    await reindex();
+    await app.ready();
+  });
+
+  afterAll(async () => {
+    await app?.close();
+    await closeConnection?.();
+  });
+
+  const costOf = async (uuid: string): Promise<number> => {
+    const conn = await getConnection();
+    const rows = await queryRows(conn, `SELECT cost_usd FROM events WHERE uuid = '${uuid}'`);
+    return Number(rows[0]?.cost_usd);
+  };
+
+  it('uses the exact-id (fetched) rate from the join table', async () => {
+    expect(await costOf('x1')).toBeCloseTo((100 * 30) / 1e6, 12);
+  });
+
+  it('falls back to a family rate when no exact id joins', async () => {
+    expect(await costOf('x2')).toBeCloseTo((100 * 3) / 1e6, 12);
+  });
+
+  it('falls back to the default rate when neither id nor family matches', async () => {
+    expect(await costOf('x3')).toBeCloseTo((100 * 1) / 1e6, 12);
+  });
+});
+
+// Best-effort cleanup of the temp dir after the suite.
+process.on('exit', () => {
+  try {
+    rmSync(work, { recursive: true, force: true });
+  } catch {
+    // ignore
+  }
+});

--- a/packages/shared/src/pricing.ts
+++ b/packages/shared/src/pricing.ts
@@ -14,6 +14,14 @@ export interface ModelRates {
   cacheRead: number;
 }
 
+/** Snapshot of rates fetched at runtime (e.g. from LiteLLM). */
+export interface FetchedPricing {
+  /** ISO timestamp of the successful fetch. */
+  fetchedAt: string;
+  /** Per-model rate table, keyed by exact model id. */
+  models: Record<string, ModelRates>;
+}
+
 export interface PricingConfig {
   /** Per-model rate table, keyed by exact model id (highest precedence). */
   models: Record<string, ModelRates>;


### PR DESCRIPTION
## Summary

Decouples pricing from releases: rates are now fetched at runtime from [LiteLLM's community price table](https://github.com/BerriAI/litellm/blob/main/model_prices_and_context_window.json) instead of being frozen into the shipped `pricing.json`.

- **Fetched snapshot**: `~/.claudescope/pricing.fetched.json` — ~150 models (anthropic, openai, gemini, xai, mistral, deepseek; chat + responses modes), per-token → per-MTok mapping, validated (≥1 Claude + ≥1 GPT model, sanity cap), atomic write; any failure aborts without touching the previous snapshot.
- **Auto-refresh**: at boot when the snapshot is missing/older than 24h, then every 24h while the daemon runs. `PRICING_REFRESH_INTERVAL_MS=0` disables all refresh network calls.
- **Manual refresh**: new `claudescope pricing update` CLI command (prints model count / changed count / path).
- **Layered lookup**: fetched exact id → local `pricing.json` exact id → family substring → default. `pricing.json` stays the user-editable fallback for families, the default rate, and models missing from LiteLLM; `loadPricing()` uses an mtime-keyed cache so file changes apply within one reindex poll, no restart needed.
- **Cost via join table**: the per-model inline SQL CASE is replaced by a `pricing_rates` DuckDB table (recreated per reindex) with `COALESCE(exact → family → default)`. Schema signature unchanged — existing indexes survive; historical event costs stay frozen at index time (accepted: costs are estimates).
- Adds a `gemini` family fallback (Junie sessions can run on non-Anthropic/OpenAI providers).

Plan: [docs/plans/0010-runtime-pricing-refresh.md](./docs/plans/0010-runtime-pricing-refresh.md)

## Testing

- `npm run typecheck` clean; 108/108 tests (23 new, fixture-based, no network).
- Live smoke test in a throwaway `CLAUDESCOPE_HOME`: first run fetched 152 models (152 changed), second run reported 0 changed; failure path leaves the snapshot untouched.