### PR TITLE
perf(web): precompute in-session finder corpus once per session

### DIFF
--- a/docs/plans/0011-performance-search-scroll-bench.md
+++ b/docs/plans/0011-performance-search-scroll-bench.md
@@ -1,0 +1,152 @@
+# 0011 — Performance: in-session search, huge-session scrolling, perf-suite redesign
+
+- **Status:** in-progress
+- **Date:** 2026-06-10
+- **PR:** <links per workstream, once opened>
+
+## Context
+
+Three confirmed performance problems:
+
+1. **In-session search is laggy on a ~28MB session.** The finder is fully
+   client-side; every debounced keystroke re-walked the entire thread +
+   subagents, calling `blockText()` which `JSON.stringify`s every tool input
+   and `.toLowerCase()`s every block (`packages/web/src/pages/session/search.ts`).
+   On 28MB that is ~56MB+ of fresh string allocation per query. Highlighting is
+   already cheap (CSS Custom Highlight API, scoped to the active block).
+2. **Scrolling a ~150MB session is janky; items appear with delay.**
+   `GET /api/sessions/:id` returns the whole parsed session in one JSON
+   response; `ThreadList` mounts every turn in one React commit with no
+   virtualization — the only mitigation is CSS `content-visibility: auto;
+   contain-intrinsic-size: auto 140px`, whose 140px estimate badly
+   underestimates real turn heights. Expanded tool results render fully into
+   the DOM with no truncation. (Collapsed `Collapsible` bodies are *not*
+   mounted, so the cost is the initial commit + per-turn lazy layout +
+   unbounded expansion.)
+3. **The perf suite measures noise — confirmed from CI logs (8 runs, June
+   2026).** `search.p95_ms` swung −28.5%…+35.4% on PRs not touching search;
+   `noop_reindex.wall_ms` ranged 1.65–4.5ms (+111% swings) — *below the
+   suite's own 25ms floor*. Dead-gate bug: in `packages/server/perf/compare.ts`,
+   `ms`-unit metrics under the floor can only ever produce alarming "noise"
+   verdicts, never gate; the only metric that can actually fail CI is
+   `cold_index.events_per_sec`, whose A/A spread (~16%) sits just under the
+   20% threshold. Root causes: 5 samples / 1 warmup, raw samples discarded,
+   sequential A-then-B blocks on a drifting shared runner, fixtures too small
+   (timings 2–20ms ≈ VM jitter).
+
+## Goal
+
+Search inside a large session responds in milliseconds after the first query;
+a 150MB session scrolls without long main-thread tasks; the perf gate fails
+only on statistically significant regressions and stops emitting false "noise"
+verdicts. No new dependencies.
+
+## Decisions
+
+- **Search: precompute a lowercased corpus once per session, scan strings per
+  query** — rejected a Web Worker (no infra; structured-clone cost; scans over
+  a prebuilt corpus are fast enough) and incremental query refinement
+  (complexity without measurable benefit; backspace/filter changes would
+  invalidate it).
+- **Scrolling: clamp + progressive mount, not windowed virtualization** —
+  react-virtuoso/@tanstack/react-virtual rejected for now: new dependency,
+  variable/huge item heights, and the finder/anchor flows need target turns
+  mounted. `content-visibility: auto` already skips off-screen layout; the
+  remaining costs are the single giant React commit (fixed by chunked
+  mounting) and unbounded expanded tool output (fixed by clamping).
+  Server-side truncation/pagination rejected: breaks finder/changeset
+  contracts; revisit only if load time (not scroll) remains the pain.
+- **Perf suite: keep a failing gate, make it statistical** — full advisory
+  mode rejected (plan 0003's purpose is a gate). Interleaved A/B rounds cancel
+  temporal runner drift (the dominant noise); batched samples push every gated
+  number above jitter; Mann-Whitney U + threshold + floor make FAIL mean
+  something.
+
+## Approach
+
+### A — In-session search (smallest, first)
+
+1. `search.ts`: split `buildMatches` into `buildSearchCorpus(thread, subagents,
+   subagentsByToolUseId): CorpusEntry[]` (render-order walk, one entry per
+   non-empty block: `{blockId, turnUuid, subagentId?, role, text}` with `text`
+   pre-lowercased; no role filtering) and `findMatches(corpus, query, filter)`
+   (trim+lowercase query once, `indexOf` loop per entry). `buildMatches`
+   remains as the one-shot composition; `occurrenceInBlock` semantics and
+   `finderDom.ts` unchanged.
+2. `SessionPage.tsx`: corpus memo built lazily only while a non-empty debounced
+   query exists (non-searching readers pay nothing; memory drops when the query
+   clears); matches memo scans the corpus per query/filter change.
+3. Tests: corpus order/lowercasing/skip-empty; `findMatches(corpus, …)` ≡
+   `buildMatches(…)`; role filter at scan time; JSON tool input searchable.
+
+### C — Perf suite (second)
+
+1. `types.ts`: `Metric` gains `samples: number[]` + `itersPerSample`;
+   `BenchResult.meta` gains `schemaVersion: 2`, `round?`.
+2. New `perf/stats.ts` (pure, no server imports): `median`, `percentile`,
+   `iqr`, `cv`, `mannWhitneyUOneSided` (normal approximation, tie-corrected).
+3. `scenarios.ts`: `batched(fn, iters)` helper so each sample times N
+   iterations — `noop_reindex` ×50, `search` ×25, `analytics` ×10,
+   `single_file_reindex` ×10, `session_load` ×3; warmup 2 for batched
+   scenarios. Headline set becomes `cold_index.events_per_sec`,
+   `noop_reindex.batch_ms`, `search.batch_ms`; `search.p95_ms` demoted to
+   informational.
+4. `run.ts`: accept `--round <n>` (meta only); CI runs `--scale 2`.
+5. `compare.ts`: accept multiple base/candidate files, pool samples per metric.
+   Gate: FAIL only if pooled candidate median regresses > threshold (10%) AND
+   Mann-Whitney one-sided p < 0.01 AND above floor. Base CV > 12% →
+   "inconclusive" (visible, doesn't fail). v1-schema base files → advisory,
+   exit 0 (bootstrap). Summary shows median ±IQR, Δ%, p, CV, verdict.
+6. `perf.yml`: 5 interleaved rounds alternating side order (odd rounds
+   base-first), each writing `base-$i.json`/`cand-$i.json`; compare with
+   `--threshold 10`. Job ~6–7 min (vs ~3–4).
+
+### B — Scrolling (largest, last)
+
+1. New `components/ClampedText.tsx` (`{text, limit≈50k chars, forceExpand?}`):
+   under limit renders `<pre><code>` as today; over limit renders the head cut
+   at a line boundary + "Show all (N MB, ~M lines)"; `forceExpand` (finder
+   reveal) overrides. Applied at every unbounded-text sink: `ToolBlock.tsx`
+   plain-`<pre>` fallback / Bash output / stringified input, `Markdown.tsx`
+   `markdown={false}` path, `ThreadView.tsx` `SystemTurn`. Plus a size gate in
+   `Markdown.tsx`: >~100k chars never hits remark (ClampedText + "Render as
+   markdown anyway").
+2. New `pages/session/useProgressiveMount.ts`: mount first ~80 turns, grow ~50
+   per `requestIdleCallback` until done; `ensureMounted(uuid)` for deep links
+   and finder navigation; monotonic across soft refresh. `ThreadList` renders
+   `visibleItems` (top level only).
+3. Re-commit hygiene: `React.memo` on `Turn`; fix the hooks-rule violation
+   (`useContext` after conditional return); `contain-intrinsic-size: auto 280px`.
+
+## Files affected
+
+- `packages/web/src/pages/session/search.ts`, `SessionPage.tsx`,
+  `packages/web/test/search.test.ts` — workstream A.
+- `packages/server/perf/{types,stats,scenarios,run,compare}.ts`,
+  `.github/workflows/perf.yml` — workstream C.
+- `packages/web/src/components/{ClampedText.tsx,limits.ts,ToolBlock.tsx,Markdown.tsx}`,
+  `packages/web/src/pages/session/{useProgressiveMount.ts,ThreadView.tsx,SessionPage.tsx,blocks.tsx,session.css}`
+  — workstream B.
+
+## Testing
+
+- `npm run typecheck` + `npm test` per workstream.
+- A: DevTools Performance — first query shows one corpus-build task; subsequent
+  edits/filter toggles are millisecond-scale; finder behavior identical.
+- C: A/A validation (workflow on a no-op diff: all `ok`, p ≥ 0.01); injected
+  ~30% slowdown on a scratch branch must FAIL with p < 0.01; bootstrap PR
+  renders advisory and exits 0.
+- B: before/after Chrome traces on the same large session — no >200ms task
+  during fast scroll; expanding a multi-MB tool block <100ms; deep links,
+  finder navigation (incl. clamped tails), changes tab unchanged.
+
+## Risks / open questions
+
+- Corpus duplicates session text lowercased (~1× transcript size) while a
+  search is active — acceptable; freed when the query clears.
+- Clamping changes UX for huge outputs (head + "Show all"); finder must
+  force-expand clamps when a match lands in the hidden tail.
+- Interleaved rounds raise perf CI to ~6–7 min; acceptable for a PR-only job
+  with cancel-in-progress.
+- If scroll jank persists after B, the documented fallback is windowed
+  virtualization (new dependency, needs explicit approval).

--- a/docs/plans/0011-performance-search-scroll-bench.md
+++ b/docs/plans/0011-performance-search-scroll-bench.md
@@ -1,8 +1,8 @@
 # 0011 — Performance: in-session search, huge-session scrolling, perf-suite redesign
 
-- **Status:** in-progress
+- **Status:** done
 - **Date:** 2026-06-10
-- **PR:** <links per workstream, once opened>
+- **PR:** [#10](https://github.com/vladar107/claudescope/pull/10) (search), [#11](https://github.com/vladar107/claudescope/pull/11) (perf suite), [#12](https://github.com/vladar107/claudescope/pull/12) (scrolling)
 
 ## Context
 

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -35,4 +35,4 @@ decision, or a change worth explaining before doing. Skip it for one-line fixes.
 | 0008 | [Junie connector](./0008-junie-connector.md) | done |
 | 0009 | [Homebrew + Nix distribution](./0009-homebrew-nix-distribution.md) | done |
 | 0010 | [runtime pricing refresh](./0010-runtime-pricing-refresh.md) | done |
-| 0011 | [performance: search, scrolling, bench](./0011-performance-search-scroll-bench.md) | in-progress |
+| 0011 | [performance: search, scrolling, bench](./0011-performance-search-scroll-bench.md) | done |

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -35,3 +35,4 @@ decision, or a change worth explaining before doing. Skip it for one-line fixes.
 | 0008 | [Junie connector](./0008-junie-connector.md) | done |
 | 0009 | [Homebrew + Nix distribution](./0009-homebrew-nix-distribution.md) | done |
 | 0010 | [runtime pricing refresh](./0010-runtime-pricing-refresh.md) | done |
+| 0011 | [performance: search, scrolling, bench](./0011-performance-search-scroll-bench.md) | in-progress |

--- a/packages/web/src/pages/session/SessionPage.tsx
+++ b/packages/web/src/pages/session/SessionPage.tsx
@@ -11,7 +11,13 @@ import { ChangesetPanel } from './ChangesetPanel.js';
 import { buildChangeset } from './changeset.js';
 import { ExportMenu } from './ExportMenu.js';
 import { SessionSearchContext } from './SearchContext.js';
-import { buildMatches, revealForMatch, type FinderMatch, type RoleFilter } from './search.js';
+import {
+  buildSearchCorpus,
+  findMatches,
+  revealForMatch,
+  type FinderMatch,
+  type RoleFilter,
+} from './search.js';
 import { SessionFinder } from './SessionFinder.js';
 import { highlightMatchInBlock, clearHighlights } from './finderDom.js';
 import './session.css';
@@ -227,10 +233,19 @@ function SessionView({
     return () => window.clearTimeout(t);
   }, [query]);
 
+  // Searchable corpus, built lazily on the first non-empty query (readers who
+  // never search pay nothing) and kept until the query clears or `data` swaps.
+  // Query/filter changes then only re-run the cheap string scan below.
+  const searching = debouncedQuery.length > 0;
+  const corpus = useMemo(
+    () => (searching ? buildSearchCorpus(thread, subagents, subagentsByToolUseId) : null),
+    [searching, thread, subagents, subagentsByToolUseId],
+  );
+
   // Ordered match list, computed from data (collapsed content included).
   const matches = useMemo(
-    () => buildMatches(thread, subagents, subagentsByToolUseId, debouncedQuery, roleFilter),
-    [thread, subagents, subagentsByToolUseId, debouncedQuery, roleFilter],
+    () => (corpus ? findMatches(corpus, debouncedQuery, roleFilter) : []),
+    [corpus, debouncedQuery, roleFilter],
   );
   const count = matches.length;
 

--- a/packages/web/src/pages/session/search.ts
+++ b/packages/web/src/pages/session/search.ts
@@ -5,6 +5,11 @@
  * producing an ordered list of occurrences. The UI reveals and highlights only
  * the ACTIVE match's block at a time — never all of them — so a common word
  * can't expand the whole transcript at once.
+ *
+ * Text extraction is split from scanning: `buildSearchCorpus` walks the thread
+ * once and pre-lowercases every block's text (tool inputs are JSON.stringify'd
+ * exactly once), so each query change only runs cheap `indexOf` scans over
+ * plain strings instead of re-serializing the whole transcript.
  */
 
 import type { SubagentRun, ThreadBlock, ThreadItem } from '@claudescope/shared';
@@ -62,42 +67,72 @@ export interface RevealSets {
 const matchesRole = (role: string, filter: RoleFilter): boolean =>
   filter === 'all' || role === filter;
 
-function pushTurnMatches(
+/** One searchable block, with its text extracted and lowercased exactly once. */
+export interface CorpusEntry {
+  /** `<turnUuid>:<blockIndex>` — also the DOM `data-block-id` of the block. */
+  blockId: string;
+  turnUuid: string;
+  /** agentId if this block lives inside a subagent run. */
+  subagentId?: string;
+  /** The owning turn's role, so the role filter can apply at scan time. */
+  role: string;
+  /** Lowercased `blockText(block)`. */
+  text: string;
+}
+
+function pushTurnEntries(
   turn: ThreadItem,
   subagentId: string | undefined,
-  q: string,
-  filter: RoleFilter,
-  out: FinderMatch[],
+  out: CorpusEntry[],
 ): void {
-  if (!matchesRole(turn.role, filter)) return;
   turn.blocks.forEach((block, i) => {
     const text = blockText(block).toLowerCase();
-    let from = 0;
-    let occ = 0;
-    let idx = text.indexOf(q, from);
-    while (idx !== -1) {
-      out.push({
-        blockId: blockRevealId(turn.uuid, i),
-        turnUuid: turn.uuid,
-        ...(subagentId ? { subagentId } : {}),
-        occurrenceInBlock: occ,
-      });
-      occ += 1;
-      from = idx + q.length;
-      idx = text.indexOf(q, from);
-    }
+    if (!text) return; // attachments etc. — nothing to search
+    out.push({
+      blockId: blockRevealId(turn.uuid, i),
+      turnUuid: turn.uuid,
+      ...(subagentId ? { subagentId } : {}),
+      role: turn.role,
+      text,
+    });
   });
 }
 
 /**
- * Build the ordered match list, walking in render order: each main-thread turn,
- * and — right after a tool call that spawned subagents — that tool's subagent
- * runs (which render nested there). Orphan subagents come last.
+ * Flatten the transcript into searchable entries, walking in render order: each
+ * main-thread turn, and — right after a tool call that spawned subagents — that
+ * tool's subagent runs (which render nested there). Orphan subagents come last.
+ * Role filtering is NOT applied here so the corpus survives filter changes.
  */
-export function buildMatches(
+export function buildSearchCorpus(
   thread: ThreadItem[],
   subagents: SubagentRun[],
   subagentsByToolUseId: Map<string, SubagentRun[]>,
+): CorpusEntry[] {
+  const out: CorpusEntry[] = [];
+  const nested = new Set<string>();
+  for (const turn of thread) {
+    pushTurnEntries(turn, undefined, out);
+    for (const block of turn.blocks) {
+      if (block.kind !== 'tool') continue;
+      const runs = subagentsByToolUseId.get(block.id);
+      if (!runs) continue;
+      for (const run of runs) {
+        nested.add(run.agentId);
+        for (const t of run.thread) pushTurnEntries(t, run.agentId, out);
+      }
+    }
+  }
+  for (const run of subagents) {
+    if (nested.has(run.agentId)) continue;
+    for (const t of run.thread) pushTurnEntries(t, run.agentId, out);
+  }
+  return out;
+}
+
+/** Scan a prebuilt corpus for a query — the only work that runs per keystroke. */
+export function findMatches(
+  corpus: CorpusEntry[],
   query: string,
   filter: RoleFilter,
 ): FinderMatch[] {
@@ -105,24 +140,35 @@ export function buildMatches(
   const q = query.trim().toLowerCase();
   if (!q) return out;
 
-  const nested = new Set<string>();
-  for (const turn of thread) {
-    pushTurnMatches(turn, undefined, q, filter, out);
-    for (const block of turn.blocks) {
-      if (block.kind !== 'tool') continue;
-      const runs = subagentsByToolUseId.get(block.id);
-      if (!runs) continue;
-      for (const run of runs) {
-        nested.add(run.agentId);
-        for (const t of run.thread) pushTurnMatches(t, run.agentId, q, filter, out);
-      }
+  for (const entry of corpus) {
+    if (!matchesRole(entry.role, filter)) continue;
+    let from = 0;
+    let occ = 0;
+    let idx = entry.text.indexOf(q, from);
+    while (idx !== -1) {
+      out.push({
+        blockId: entry.blockId,
+        turnUuid: entry.turnUuid,
+        ...(entry.subagentId ? { subagentId: entry.subagentId } : {}),
+        occurrenceInBlock: occ,
+      });
+      occ += 1;
+      from = idx + q.length;
+      idx = entry.text.indexOf(q, from);
     }
   }
-  for (const run of subagents) {
-    if (nested.has(run.agentId)) continue;
-    for (const t of run.thread) pushTurnMatches(t, run.agentId, q, filter, out);
-  }
   return out;
+}
+
+/** One-shot corpus build + scan. Prefer caching the corpus via `buildSearchCorpus`. */
+export function buildMatches(
+  thread: ThreadItem[],
+  subagents: SubagentRun[],
+  subagentsByToolUseId: Map<string, SubagentRun[]>,
+  query: string,
+  filter: RoleFilter,
+): FinderMatch[] {
+  return findMatches(buildSearchCorpus(thread, subagents, subagentsByToolUseId), query, filter);
 }
 
 /** The (minimal) reveal sets needed to make a single match visible. */

--- a/packages/web/test/search.test.ts
+++ b/packages/web/test/search.test.ts
@@ -1,6 +1,12 @@
 import { describe, expect, it } from 'vitest';
 import type { SubagentRun, ThreadItem } from '@claudescope/shared';
-import { blockText, buildMatches, revealForMatch } from '../src/pages/session/search.js';
+import {
+  blockText,
+  buildMatches,
+  buildSearchCorpus,
+  findMatches,
+  revealForMatch,
+} from '../src/pages/session/search.js';
 
 function turn(uuid: string, role: 'user' | 'assistant', blocks: ThreadItem['blocks']): ThreadItem {
   return { uuid, parentUuid: null, role, timestamp: '2026-01-01T00:00:00Z', isSidechain: false, blocks };
@@ -70,6 +76,74 @@ describe('buildMatches', () => {
   it('is empty for a blank query and case-insensitive otherwise', () => {
     expect(buildMatches(thread, [], noMap, '  ', 'all')).toHaveLength(0);
     expect(buildMatches(thread, [], noMap, 'NEEDLE', 'all')).toHaveLength(3);
+  });
+});
+
+describe('buildSearchCorpus / findMatches', () => {
+  const nestedRun: SubagentRun = {
+    agentId: 'n1',
+    agentType: 'Explore',
+    description: 'd',
+    messageCount: 1,
+    toolCallCount: 0,
+    totalTokens: 0,
+    thread: [turn('nu1', 'assistant', [{ kind: 'text', type: 'text', text: 'Nested Needle' }])],
+  };
+  const orphanRun: SubagentRun = {
+    agentId: 'o1',
+    agentType: 'Explore',
+    description: 'd',
+    messageCount: 1,
+    toolCallCount: 0,
+    totalTokens: 0,
+    thread: [turn('ou1', 'assistant', [{ kind: 'text', type: 'text', text: 'orphan needle' }])],
+  };
+  const thread: ThreadItem[] = [
+    turn('t1', 'user', [
+      { kind: 'text', type: 'text', text: 'Needle One' },
+      { kind: 'attachment', attachment: { type: 'image' } },
+    ]),
+    turn('t2', 'assistant', [
+      {
+        kind: 'tool',
+        id: 'tool-1',
+        name: 'Agent',
+        input: { prompt: 'find the needle' },
+      },
+    ]),
+  ];
+  const byToolUse = new Map<string, SubagentRun[]>([['tool-1', [nestedRun]]]);
+
+  it('flattens in render order, lowercases text, and skips empty blocks', () => {
+    const corpus = buildSearchCorpus(thread, [orphanRun], byToolUse);
+    expect(corpus.map((e) => e.blockId)).toEqual(['t1:0', 't2:0', 'nu1:0', 'ou1:0']);
+    expect(corpus[0]).toMatchObject({ role: 'user', text: 'needle one' });
+    expect(corpus[2]).toMatchObject({ subagentId: 'n1', text: 'nested needle' });
+    // t1:1 (attachment) has no text and is omitted entirely.
+    expect(corpus.some((e) => e.blockId === 't1:1')).toBe(false);
+  });
+
+  it('makes JSON tool input searchable via the corpus', () => {
+    const corpus = buildSearchCorpus(thread, [], noMap);
+    const m = findMatches(corpus, 'find the needle', 'all');
+    expect(m).toHaveLength(1);
+    expect(m[0]).toMatchObject({ blockId: 't2:0' });
+  });
+
+  it('matches buildMatches output for the same inputs', () => {
+    const corpus = buildSearchCorpus(thread, [orphanRun], byToolUse);
+    for (const filter of ['all', 'user', 'assistant'] as const) {
+      expect(findMatches(corpus, 'needle', filter)).toEqual(
+        buildMatches(thread, [orphanRun], byToolUse, 'needle', filter),
+      );
+    }
+  });
+
+  it('applies the role filter at scan time on an unfiltered corpus', () => {
+    const corpus = buildSearchCorpus(thread, [orphanRun], byToolUse);
+    expect(findMatches(corpus, 'needle', 'all')).toHaveLength(4);
+    expect(findMatches(corpus, 'needle', 'user')).toHaveLength(1);
+    expect(findMatches(corpus, 'needle', 'assistant')).toHaveLength(3);
   });
 });
 


### PR DESCRIPTION
## Problem

In-session search is laggy on large sessions (reported on a 28MB transcript). The finder re-walked the entire thread + all subagents on every debounced query change, and `blockText()` re-`JSON.stringify`'d every tool input and `.toLowerCase()`'d every block each time — roughly 2× the transcript size in fresh string allocations per keystroke, all on the main thread.

## Change

- Split `buildMatches` in `packages/web/src/pages/session/search.ts` into:
  - `buildSearchCorpus(thread, subagents, subagentsByToolUseId)` — one render-order walk producing `{blockId, turnUuid, subagentId?, role, text}` entries with text extracted + lowercased exactly once (empty blocks skipped, no role filtering so the corpus survives filter changes);
  - `findMatches(corpus, query, filter)` — the only per-query work: a plain `indexOf` scan over prebuilt strings.
- `SessionPage.tsx` builds the corpus lazily (only while a non-empty debounced query exists), so readers who never search pay nothing and the memory is released when the query clears. Role-filter changes now re-run only the cheap scan.
- `buildMatches` remains as the one-shot composition; `FinderMatch`/`occurrenceInBlock` semantics and `finderDom.ts` highlighting are unchanged.

## Tests

- Existing `buildMatches` suite passes unchanged (now exercises the composition).
- New cases: corpus render-order/lowercasing/empty-block skipping, `findMatches(corpus, …)` ≡ `buildMatches(…)`, role filtering at scan time on an unfiltered corpus, JSON tool input searchability.
- `npm run typecheck` + `npm test` (89 tests) green.

Part of [plan 0011](docs/plans/0011-performance-search-scroll-bench.md) (workstream A of 3).
