### PR TITLE
perf(bench): statistical gate over interleaved A/B samples

### DIFF
--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -50,6 +50,8 @@ jobs:
         run: npm ci
 
       - name: Bench (5 interleaved A/B rounds)
+        # NOTE: the base side runs main's harness — only pass flags that main's
+        # run.ts already understands; a new flag needs a two-step rollout.
         run: |
           for i in 1 2 3 4 5; do
             # Alternate which side goes first to cancel order bias on top of drift.
@@ -59,7 +61,7 @@ jobs:
               # --if-present: on the PR that introduces the suite, base has no
               # bench script yet → no base files → compare no-ops (bootstrap).
               (cd "$side" && npm run bench --if-present -- \
-                --out "$GITHUB_WORKSPACE/$name-$i.json" --scale 2 --runs 2 --round "$i")
+                --out "$GITHUB_WORKSPACE/$name-$i.json" --scale 2 --runs 2)
             done
           done
 

--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -63,7 +63,7 @@ jobs:
             done
           done
 
-      - name: Compare (gate: >10% pooled regression AND p < 0.01 on headline)
+      - name: Compare (fail on >10% pooled headline regression with p < 0.01)
         working-directory: pr
         run: |
           args=()

--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -1,10 +1,13 @@
 name: Performance
 
-# Same-runner A/B perf gate. On each PR, bench the PR head and the target branch
-# back-to-back on the SAME VM, then compare medians — this cancels most runner
-# variance, which a stored baseline across different VMs cannot. Fails if a
-# headline metric regresses beyond the threshold. PR-only: the A/B needs both
-# sides, and there is no diff to gate on a plain push to main.
+# Interleaved same-runner A/B perf gate. On each PR, bench the PR head and the
+# target branch in ALTERNATING short rounds on the SAME VM (base,cand / cand,base
+# / …), then pool the raw samples per side and gate with a Mann-Whitney test.
+# Alternation cancels the temporal drift that a sequential A-then-B cannot
+# (shared runners routinely drift ~10-15% between two long blocks), and the
+# statistical gate means a FAIL requires both a >10% pooled-median regression
+# AND p < 0.01 — not a lucky/unlucky pair of medians. PR-only: the A/B needs
+# both sides, and there is no diff to gate on a plain push to main.
 on:
   pull_request:
     branches: [main]
@@ -38,30 +41,35 @@ jobs:
           cache: npm
           cache-dependency-path: pr/package-lock.json
 
-      - name: Bench candidate (PR head)
+      - name: Install deps (PR head)
         working-directory: pr
-        run: |
-          npm ci
-          npm run bench -- --out "$GITHUB_WORKSPACE/candidate.json"
+        run: npm ci
 
-      - name: Bench base (target branch)
+      - name: Install deps (base)
         working-directory: base
-        run: |
-          npm ci
-          # --if-present: on the PR that introduces the suite, base has no bench
-          # script yet → no base file → compare no-ops (bootstrap).
-          npm run bench --if-present -- --out "$GITHUB_WORKSPACE/base.json"
+        run: npm ci
 
-      - name: Compare (fail on >20% headline regression)
+      - name: Bench (5 interleaved A/B rounds)
+        run: |
+          for i in 1 2 3 4 5; do
+            # Alternate which side goes first to cancel order bias on top of drift.
+            if [ $((i % 2)) -eq 1 ]; then order="base pr"; else order="pr base"; fi
+            for side in $order; do
+              if [ "$side" = pr ]; then name=cand; else name=base; fi
+              # --if-present: on the PR that introduces the suite, base has no
+              # bench script yet → no base files → compare no-ops (bootstrap).
+              (cd "$side" && npm run bench --if-present -- \
+                --out "$GITHUB_WORKSPACE/$name-$i.json" --scale 2 --runs 2 --round "$i")
+            done
+          done
+
+      - name: Compare (gate: >10% pooled regression AND p < 0.01 on headline)
         working-directory: pr
-        # Threshold is 20% here, not the local default of 10%. The two benches run
-        # sequentially, so same-runner A/B cancels fixed hardware differences but
-        # NOT temporal drift — GitHub shared runners routinely vary ~10-15% in the
-        # minute between the two runs (observed: every metric skewing uniformly).
-        # 20% catches real regressions (a non-native ingestion rewrite would be
-        # multiples slower) without flaking on runner noise; use `npm run bench`
-        # locally on a stable machine for fine-grained (~1%) checks.
-        run: npm run bench:compare -- --base "$GITHUB_WORKSPACE/base.json" --candidate "$GITHUB_WORKSPACE/candidate.json" --threshold 20
+        run: |
+          args=()
+          for f in "$GITHUB_WORKSPACE"/base-*.json; do [ -e "$f" ] && args+=(--base "$f"); done
+          for f in "$GITHUB_WORKSPACE"/cand-*.json; do [ -e "$f" ] && args+=(--candidate "$f"); done
+          npm run bench:compare -- "${args[@]}" --threshold 10
 
       - name: Upload perf results
         if: always()
@@ -69,6 +77,6 @@ jobs:
         with:
           name: perf-results
           path: |
-            candidate.json
-            base.json
+            cand-*.json
+            base-*.json
           if-no-files-found: ignore

--- a/packages/server/perf/compare.ts
+++ b/packages/server/perf/compare.ts
@@ -1,23 +1,35 @@
 /**
- * Compare two perf result files (base vs candidate) and gate on regression of
- * the HEADLINE metrics. Used by the same-runner A/B CI job: both files are
- * produced on the same VM moments apart, so most machine variance cancels and a
- * tight-ish threshold is meaningful.
+ * Compare pooled perf samples (base vs candidate) and gate on a statistically
+ * significant regression of the HEADLINE metrics.
  *
- *   npm run bench:compare -- --base base.json --candidate cand.json [--threshold 10]
+ * Accepts multiple result files per side — one per interleaved CI round, so
+ * temporal runner drift hits both arms alike and cancels in the pooled test:
  *
- * Bootstrap: if the base file is missing/empty (e.g. `main` predates the suite),
- * there is nothing to compare against — print a notice and exit 0.
+ *   npm run bench:compare -- --base b1.json --base b2.json \
+ *     --candidate c1.json --candidate c2.json [--threshold 10]
+ *
+ * A headline metric FAILS only when ALL hold:
+ *   1. the pooled candidate median regresses more than the threshold,
+ *   2. a one-sided Mann-Whitney U test confirms the shift (p < 0.01),
+ *   3. the metric is above the significance floor.
+ * A noisy baseline (CV > 12%) demotes FAIL to "inconclusive" — visible in the
+ * summary, but it does not fail the build on a pathological runner day.
+ *
+ * Bootstrap: with no base files (e.g. `main` predates the suite) there is
+ * nothing to compare — print a notice and exit 0. Base files without raw
+ * samples (schema v1) can't back a statistical gate, so the comparison is
+ * rendered advisory-only and also exits 0.
  */
 
 import { appendFileSync, readFileSync } from 'node:fs';
 import { parseArgs } from 'node:util';
 import type { BenchResult, Metric } from './types.js';
+import { cv, iqr, mannWhitneyGreater, median } from './stats.js';
 
 const { values } = parseArgs({
   options: {
-    base: { type: 'string' },
-    candidate: { type: 'string' },
+    base: { type: 'string', multiple: true },
+    candidate: { type: 'string', multiple: true },
     threshold: { type: 'string', default: '10' },
     'min-ms': { type: 'string', default: '25' },
   },
@@ -27,22 +39,28 @@ const threshold = Math.max(0, Number(values.threshold));
 // Significance floor: a latency metric is too small to gate on a relative %
 // once it's down in the noise (GC/JIT/IO jitter dwarfs the signal). Below this
 // it's reported but never fails — a regression that actually matters pushes the
-// value above the floor anyway.
+// value above the floor anyway. Batched sampling keeps headline metrics above it.
 const minMs = Math.max(0, Number(values['min-ms']));
+// One-sided Mann-Whitney significance level for the gate.
+const ALPHA = 0.01;
+// Pooled-baseline CV above which a regression verdict is only "inconclusive".
+const MAX_BASE_CV = 0.12;
 
-function load(path: string | undefined): BenchResult | null {
-  if (!path) return null;
-  try {
-    const parsed = JSON.parse(readFileSync(path, 'utf8')) as BenchResult;
-    if (!parsed.metrics?.length) return null;
-    return parsed;
-  } catch {
-    return null;
+function load(paths: string[] | undefined): BenchResult[] {
+  const out: BenchResult[] = [];
+  for (const path of paths ?? []) {
+    try {
+      const parsed = JSON.parse(readFileSync(path, 'utf8')) as BenchResult;
+      if (parsed.metrics?.length) out.push(parsed);
+    } catch {
+      /* unreadable file — treat as absent */
+    }
   }
+  return out;
 }
 
-const base = load(values.base);
-const candidate = load(values.candidate);
+const baseFiles = load(values.base);
+const candFiles = load(values.candidate);
 
 /** Append markdown to the GitHub Actions job summary, if running in CI. */
 function writeJobSummary(md: string): void {
@@ -50,60 +68,101 @@ function writeJobSummary(md: string): void {
   if (path) appendFileSync(path, md + '\n');
 }
 
-if (!candidate) {
-  console.error('✗ No candidate results to compare. Did the bench run produce a result file?');
+if (candFiles.length === 0) {
+  console.error('✗ No candidate results to compare. Did the bench run produce result files?');
   process.exit(1);
 }
-if (!base) {
+if (baseFiles.length === 0) {
   const msg = 'No baseline to compare against (bootstrap) — regression gate skipped.';
   console.log(`ℹ ${msg}`);
   writeJobSummary(`## ⚡ Performance\n\nℹ️ ${msg}`);
   process.exit(0);
 }
 
-const baseById = new Map<string, Metric>(base.metrics.map((m) => [m.id, m]));
+// Schema-v1 base files carry a single aggregated value and no raw samples —
+// a statistical gate is impossible, so render the table advisory-only.
+const advisory = baseFiles.some((f) => f.meta.schemaVersion === undefined);
 
-/** Signed regression percentage: positive = candidate is worse (slower) than base. */
-function regressionPct(b: Metric, c: Metric): number {
-  if (b.value === 0) return 0;
-  const deltaPct = ((c.value - b.value) / b.value) * 100;
-  return b.betterIsLower ? deltaPct : -deltaPct;
+/** Pool each side's raw samples per metric id (v1 metrics fall back to [value]). */
+function pool(files: BenchResult[]): Map<string, { metric: Metric; samples: number[] }> {
+  const out = new Map<string, { metric: Metric; samples: number[] }>();
+  for (const file of files) {
+    for (const m of file.metrics) {
+      const entry = out.get(m.id) ?? { metric: m, samples: [] };
+      entry.samples.push(...(m.samples?.length ? m.samples : [m.value]));
+      out.set(m.id, entry);
+    }
+  }
+  return out;
 }
+
+const basePool = pool(baseFiles);
+const candPool = pool(candFiles);
 
 interface Row {
   metric: Metric;
-  base: number;
+  baseMed: number;
+  baseIqr: number;
+  candMed: number;
+  candIqr: number;
+  /** Signed regression %: positive = candidate is worse than base. */
   reg: number;
+  /** One-sided M-W p-value that the candidate is worse. */
+  p: number;
+  baseCv: number;
   belowFloor: boolean;
-  verdict: 'FAIL' | 'noise' | 'ok';
+  verdict: 'FAIL' | 'inconclusive' | 'ok';
 }
 
 const rows: Row[] = [];
 let failed = false;
-for (const c of candidate.metrics) {
-  const b = baseById.get(c.id);
-  if (!b) continue;
-  const reg = regressionPct(b, c);
-  // Latency metrics below the significance floor are reported, never gated.
-  const belowFloor = c.unit === 'ms' && Math.max(b.value, c.value) < minMs;
-  const regressed = c.headline && reg > threshold && !belowFloor;
-  if (regressed) failed = true;
-  const verdict: Row['verdict'] = regressed
-    ? 'FAIL'
-    : belowFloor && c.headline && reg > threshold
-      ? 'noise'
-      : 'ok';
-  rows.push({ metric: c, base: b.value, reg, belowFloor, verdict });
+for (const [id, cand] of candPool) {
+  const base = basePool.get(id);
+  if (!base) continue;
+  const m = cand.metric;
+  const baseMed = median(base.samples);
+  const candMed = median(cand.samples);
+  const deltaPct = baseMed === 0 ? 0 : ((candMed - baseMed) / baseMed) * 100;
+  const reg = m.betterIsLower ? deltaPct : -deltaPct;
+  // Direction of "worse": larger for latency, smaller for throughput.
+  const p = m.betterIsLower
+    ? mannWhitneyGreater(base.samples, cand.samples)
+    : mannWhitneyGreater(cand.samples, base.samples);
+  const baseCv = cv(base.samples);
+  const belowFloor = m.unit === 'ms' && Math.max(baseMed, candMed) < minMs;
+  const significant = m.headline && reg > threshold && p < ALPHA && !belowFloor && !advisory;
+  let verdict: Row['verdict'] = 'ok';
+  if (significant) {
+    verdict = baseCv > MAX_BASE_CV ? 'inconclusive' : 'FAIL';
+    if (verdict === 'FAIL') failed = true;
+  }
+  rows.push({
+    metric: m,
+    baseMed,
+    baseIqr: iqr(base.samples),
+    candMed,
+    candIqr: iqr(cand.samples),
+    reg,
+    p,
+    baseCv,
+    belowFloor,
+    verdict,
+  });
 }
 
 // --- console (CI logs) ------------------------------------------------------
-console.log(`Perf comparison (threshold ${threshold}% on headline metrics, * = headline):\n`);
+console.log(
+  `Perf comparison (gate: headline Δ > ${threshold}% AND p < ${ALPHA}; * = headline; ` +
+    `${baseFiles.length} base / ${candFiles.length} candidate file(s))${advisory ? ' — ADVISORY (v1 base)' : ''}:\n`,
+);
 for (const r of rows) {
   const sign = r.reg >= 0 ? '+' : '';
   console.log(
-    `  ${r.metric.headline ? '*' : ' '} ${r.metric.id.padEnd(28)} base=${r.base
+    `  ${r.metric.headline ? '*' : ' '} ${r.metric.id.padEnd(30)} base=${r.baseMed
       .toFixed(2)
-      .padStart(10)}  cand=${r.metric.value.toFixed(2).padStart(10)}  ${(sign + r.reg.toFixed(1) + '%').padStart(9)}  ${r.verdict}`,
+      .padStart(10)}  cand=${r.candMed.toFixed(2).padStart(10)}  ${(sign + r.reg.toFixed(1) + '%').padStart(9)}  p=${r.p
+      .toFixed(3)
+      .padStart(5)}  ${r.verdict}`,
   );
 }
 
@@ -112,38 +171,47 @@ function fmtValue(unit: string, value: number): string {
   if (unit === 'events/s') return Math.round(value).toLocaleString('en-US');
   return value.toFixed(2);
 }
+function fmtCell(unit: string, med: number, spread: number): string {
+  return `${fmtValue(unit, med)} ±${fmtValue(unit, spread)}`;
+}
 function deltaCell(reg: number): string {
   const arrow = Math.abs(reg) < 0.05 ? '■' : reg > 0 ? '▲' : '▼';
   return `${arrow} ${reg >= 0 ? '+' : '-'}${Math.abs(reg).toFixed(1)}%`;
 }
 function verdictIcon(r: Row): string {
   if (r.verdict === 'FAIL') return '⚠️';
-  if (r.verdict === 'noise') return '💤';
+  if (r.verdict === 'inconclusive') return '❓';
+  if (r.belowFloor) return '💤';
   return r.reg < -5 ? '🚀' : '✅';
 }
 function mdTable(subset: Row[]): string {
-  const head = '| Metric | Baseline | This PR | Δ vs base |    |\n|---|--:|--:|--:|:--:|';
+  const head =
+    '| Metric | Baseline | This PR | Δ vs base | p | base CV |    |\n|---|--:|--:|--:|--:|--:|:--:|';
   const body = subset
     .map(
       (r) =>
-        `| ${r.metric.label} (${r.metric.unit}) | ${fmtValue(r.metric.unit, r.base)} | ${fmtValue(
+        `| ${r.metric.label} (${r.metric.unit}) | ${fmtCell(r.metric.unit, r.baseMed, r.baseIqr)} | ${fmtCell(
           r.metric.unit,
-          r.metric.value,
-        )} | ${deltaCell(r.reg)} | ${verdictIcon(r)} |`,
+          r.candMed,
+          r.candIqr,
+        )} | ${deltaCell(r.reg)} | ${r.p.toFixed(3)} | ${(r.baseCv * 100).toFixed(1)}% | ${verdictIcon(r)} |`,
     )
     .join('\n');
   return `${head}\n${body}`;
 }
 
 const headline = rows.filter((r) => r.metric.headline);
-const m = candidate.meta;
-const banner = failed
-  ? `## ⚡ Performance: ⚠️ headline regression > ${threshold}%`
-  : '## ⚡ Performance: ✅ no headline regression';
+const m = candFiles[0].meta;
+const banner = advisory
+  ? '## ⚡ Performance: ℹ️ advisory only (baseline lacks per-sample data)'
+  : failed
+    ? `## ⚡ Performance: ⚠️ significant headline regression > ${threshold}%`
+    : '## ⚡ Performance: ✅ no significant headline regression';
 const summary = [
   banner,
   '',
-  `baseline (\`main\`) vs candidate (PR) · gate ${threshold}% on headline · floor ${minMs} ms`,
+  `baseline (\`main\`) vs candidate (PR), ${baseFiles.length}+${candFiles.length} interleaved runs pooled · ` +
+    `gate Δ > ${threshold}% AND Mann-Whitney p < ${ALPHA} on headline · floor ${minMs} ms`,
   '',
   '### Key metrics',
   '',
@@ -153,13 +221,18 @@ const summary = [
   mdTable(rows),
   '\n</details>',
   '',
-  `<sub>Δ vs base: ▲ positive = slower/worse, ▼ = faster. ✅ within gate · ⚠️ regressed · 💤 below ${minMs} ms floor (ignored) · 🚀 >5% faster. Corpus: ${m.totalEvents.toLocaleString('en-US')} events · ${(m.totalBytes / 1e6).toFixed(1)} MB · scale ${m.scale} · runs ${m.runs}.</sub>`,
+  `<sub>Values are pooled median ±IQR. Δ vs base: ▲ positive = slower/worse, ▼ = faster. ` +
+    `✅ within gate · ⚠️ significant regression · ❓ regression but baseline too noisy (CV > ${MAX_BASE_CV * 100}%) · ` +
+    `💤 below ${minMs} ms floor · 🚀 >5% faster. ` +
+    `Corpus: ${m.totalEvents.toLocaleString('en-US')} events · ${(m.totalBytes / 1e6).toFixed(1)} MB · scale ${m.scale} · runs ${m.runs}/file.</sub>`,
 ].join('\n');
 writeJobSummary(summary);
 
 if (failed) {
-  console.error(`\n✗ Performance regression: a headline metric regressed more than ${threshold}%.`);
+  console.error(
+    `\n✗ Performance regression: a headline metric regressed more than ${threshold}% with p < ${ALPHA}.`,
+  );
   process.exit(1);
 }
-console.log('\n✓ No headline regression beyond threshold.');
+console.log(advisory ? '\nℹ Advisory comparison only (no gate).' : '\n✓ No significant headline regression.');
 process.exit(0);

--- a/packages/server/perf/run.ts
+++ b/packages/server/perf/run.ts
@@ -3,7 +3,7 @@
  * throwaway temp dir, runs the hot-path scenarios (warmup + median-of-N), and
  * writes a result JSON + prints a human table.
  *
- *   npm run bench -- --out result.json [--scale 1] [--runs 5] [--round N]
+ *   npm run bench -- --out result.json [--scale 1] [--runs 5]
  *
  * Env vars are set BEFORE importing any server module (config binds the DB path
  * at import time), mirroring test/api.integration.test.ts.
@@ -21,14 +21,11 @@ const { values } = parseArgs({
     out: { type: 'string', default: 'perf-result.json' },
     scale: { type: 'string', default: '1' },
     runs: { type: 'string', default: '5' },
-    // Interleaved CI round number — recorded in result meta only.
-    round: { type: 'string' },
   },
 });
 
 const scale = Math.max(1, Number(values.scale));
 const runs = Math.max(1, Number(values.runs));
-const round = values.round !== undefined ? Number(values.round) : undefined;
 const outPath = resolve(String(values.out));
 
 // --- temp locations (decided before any server module is imported) ----------
@@ -84,7 +81,6 @@ async function main(): Promise<void> {
       node: process.version,
       scale,
       runs,
-      ...(round !== undefined ? { round } : {}),
       totalEvents: info.totalEvents,
       totalBytes: info.totalBytes,
     },

--- a/packages/server/perf/run.ts
+++ b/packages/server/perf/run.ts
@@ -3,7 +3,7 @@
  * throwaway temp dir, runs the hot-path scenarios (warmup + median-of-N), and
  * writes a result JSON + prints a human table.
  *
- *   npm run bench -- --out result.json [--scale 1] [--runs 5]
+ *   npm run bench -- --out result.json [--scale 1] [--runs 5] [--round N]
  *
  * Env vars are set BEFORE importing any server module (config binds the DB path
  * at import time), mirroring test/api.integration.test.ts.
@@ -21,11 +21,14 @@ const { values } = parseArgs({
     out: { type: 'string', default: 'perf-result.json' },
     scale: { type: 'string', default: '1' },
     runs: { type: 'string', default: '5' },
+    // Interleaved CI round number — recorded in result meta only.
+    round: { type: 'string' },
   },
 });
 
 const scale = Math.max(1, Number(values.scale));
 const runs = Math.max(1, Number(values.runs));
+const round = values.round !== undefined ? Number(values.round) : undefined;
 const outPath = resolve(String(values.out));
 
 // --- temp locations (decided before any server module is imported) ----------
@@ -76,10 +79,12 @@ async function main(): Promise<void> {
 
   const result: BenchResult = {
     meta: {
+      schemaVersion: 2,
       timestamp: new Date().toISOString(),
       node: process.version,
       scale,
       runs,
+      ...(round !== undefined ? { round } : {}),
       totalEvents: info.totalEvents,
       totalBytes: info.totalBytes,
     },

--- a/packages/server/perf/scenarios.ts
+++ b/packages/server/perf/scenarios.ts
@@ -2,6 +2,11 @@
  * Perf scenarios over the real server hot paths. Imported dynamically by run.ts
  * AFTER the temp env vars are set, so the transitive server imports (config,
  * duckdb, index) bind to the throwaway database.
+ *
+ * Fast operations are measured in BATCHES (one sample = N timed iterations) so
+ * every gated sample lands well above shared-runner jitter — a 2ms no-op
+ * reindex is unmeasurable on a noisy VM, but 50 of them (~100-200ms) are not.
+ * Raw samples are kept on each metric for the comparator's statistical gate.
  */
 
 import { rmSync, utimesSync } from 'node:fs';
@@ -14,15 +19,33 @@ import { assembleThread, buildSubagentRuns } from '../src/data/parser.js';
 import { registerRoutes } from '../src/routes/index.js';
 import type { CorpusInfo } from './fixtures.js';
 import type { Metric } from './types.js';
+import { median, percentile } from './stats.js';
+
+// Iterations per batch sample, sized so one batch ≈ 100ms+ even on fast runs.
+const NOOP_ITERS = 50;
+const SINGLE_FILE_ITERS = 10;
+const SEARCH_ITERS = 25;
+const ANALYTICS_ITERS = 10;
+const SESSION_LOAD_ITERS = 3;
 
 const metric = (
   id: string,
   label: string,
   unit: string,
-  value: number,
+  samples: number[],
   headline: boolean,
   betterIsLower: boolean,
-): Metric => ({ id, label, unit, value, headline, betterIsLower });
+  itersPerSample = 1,
+): Metric => ({
+  id,
+  label,
+  unit,
+  value: median(samples),
+  headline,
+  betterIsLower,
+  samples,
+  itersPerSample,
+});
 
 async function timeit(fn: () => Promise<unknown> | unknown): Promise<number> {
   const t = process.hrtime.bigint();
@@ -37,16 +60,17 @@ async function samples(fn: () => Promise<unknown> | unknown, runs: number, warmu
   return out;
 }
 
-const median = (xs: number[]): number => {
-  const s = [...xs].sort((a, b) => a - b);
-  const m = Math.floor(s.length / 2);
-  return s.length % 2 ? s[m] : (s[m - 1] + s[m]) / 2;
-};
-const percentile = (xs: number[], p: number): number => {
-  const s = [...xs].sort((a, b) => a - b);
-  const idx = Math.min(s.length - 1, Math.max(0, Math.ceil((p / 100) * s.length) - 1));
-  return s[idx];
-};
+/** One sample = `iters` timed iterations of `fn`; 2 warmup batches (JIT + caches). */
+async function batchedSamples(
+  fn: () => Promise<unknown> | unknown,
+  iters: number,
+  runs: number,
+): Promise<number[]> {
+  const batch = async () => {
+    for (let i = 0; i < iters; i++) await fn();
+  };
+  return samples(batch, runs, 2);
+}
 
 function discardDb(): void {
   for (const suffix of ['', '.wal', '.tmp']) {
@@ -62,57 +86,80 @@ export async function runAllScenarios(
   const metrics: Metric[] = [];
 
   // 1. Cold full index build — discard DB + rebuild each sample. Leaves a built
-  //    index for the warm scenarios below.
+  //    index for the warm scenarios below. One build is seconds long at CI
+  //    scale, so each build is its own (unbatched) sample.
   const coldFn = async () => {
     await closeConnection();
     discardDb();
     await reindex();
   };
   const cold = await samples(coldFn, runs);
-  const coldMs = median(cold);
-  metrics.push(metric('cold_index.events_per_sec', 'Cold index throughput', 'events/s', info.totalEvents / (coldMs / 1000), true, false));
-  metrics.push(metric('cold_index.mb_per_sec', 'Cold index throughput', 'MB/s', info.totalBytes / 1e6 / (coldMs / 1000), false, false));
-  metrics.push(metric('cold_index.wall_ms', 'Cold index build', 'ms', coldMs, false, true));
+  metrics.push(
+    metric('cold_index.events_per_sec', 'Cold index throughput', 'events/s', cold.map((ms) => info.totalEvents / (ms / 1000)), true, false),
+  );
+  metrics.push(
+    metric('cold_index.mb_per_sec', 'Cold index throughput', 'MB/s', cold.map((ms) => info.totalBytes / 1e6 / (ms / 1000)), false, false),
+  );
+  metrics.push(metric('cold_index.wall_ms', 'Cold index build', 'ms', cold, false, true));
 
   // 2. No-op reindex — nothing changed on disk; must stay cheap (runs every 15s).
-  const noop = await samples(() => reindex(), runs);
-  metrics.push(metric('noop_reindex.wall_ms', 'No-op reindex', 'ms', median(noop), true, true));
+  const noop = await batchedSamples(() => reindex(), NOOP_ITERS, runs);
+  metrics.push(
+    metric('noop_reindex.batch_ms', `No-op reindex ×${NOOP_ITERS}`, 'ms', noop, true, true, NOOP_ITERS),
+  );
 
   // 3. Single-file-change reindex — bump one session file's mtime, reindex.
-  const oneFile = await samples(async () => {
+  const oneFile = await batchedSamples(async () => {
     const now = new Date();
     utimesSync(info.largeSessionFile, now, now);
     await reindex();
-  }, runs);
-  metrics.push(metric('single_file_reindex.wall_ms', 'Single-file reindex', 'ms', median(oneFile), false, true));
+  }, SINGLE_FILE_ITERS, runs);
+  metrics.push(
+    metric('single_file_reindex.batch_ms', `Single-file reindex ×${SINGLE_FILE_ITERS}`, 'ms', oneFile, false, true, SINGLE_FILE_ITERS),
+  );
 
   // Build the app for route-level scenarios (faithful to production queries).
   const app = Fastify();
   await registerRoutes(app);
   await app.ready();
   try {
-    // 4. Search (BM25 FTS).
+    // 4. Search (BM25 FTS) — batched for the gate, plus a short unbatched pass
+    //    so per-call p50/p95 stay visible (informational: a p95 over a handful
+    //    of ~15ms calls is structurally jitter and must never gate).
     const searchUrl = `/api/search?q=${encodeURIComponent(info.searchTerm)}`;
-    const search = await samples(() => app.inject({ method: 'GET', url: searchUrl }), Math.max(runs, 10));
-    metrics.push(metric('search.p95_ms', 'Search BM25 p95', 'ms', percentile(search, 95), true, true));
-    metrics.push(metric('search.p50_ms', 'Search BM25 p50', 'ms', median(search), false, true));
+    const searchCall = () => app.inject({ method: 'GET', url: searchUrl });
+    const search = await batchedSamples(searchCall, SEARCH_ITERS, runs);
+    metrics.push(
+      metric('search.batch_ms', `Search BM25 ×${SEARCH_ITERS}`, 'ms', search, true, true, SEARCH_ITERS),
+    );
+    const searchSingles = await samples(searchCall, Math.max(runs, 10));
+    metrics.push(metric('search.p95_ms', 'Search BM25 p95', 'ms', [percentile(searchSingles, 95)], false, true));
+    metrics.push(metric('search.p50_ms', 'Search BM25 p50', 'ms', [median(searchSingles)], false, true));
 
     // 5. Analytics aggregations.
     for (const groupBy of ['day', 'project', 'model'] as const) {
-      const a = await samples(() => app.inject({ method: 'GET', url: `/api/analytics?groupBy=${groupBy}` }), runs);
-      metrics.push(metric(`analytics.${groupBy}_ms`, `Analytics (${groupBy})`, 'ms', median(a), false, true));
+      const a = await batchedSamples(
+        () => app.inject({ method: 'GET', url: `/api/analytics?groupBy=${groupBy}` }),
+        ANALYTICS_ITERS,
+        runs,
+      );
+      metrics.push(
+        metric(`analytics.${groupBy}_batch_ms`, `Analytics (${groupBy}) ×${ANALYTICS_ITERS}`, 'ms', a, false, true, ANALYTICS_ITERS),
+      );
     }
   } finally {
     await app.close();
   }
 
   // 6. Session detail load + thread/subagent assembly on the large session.
-  const load = await samples(async () => {
+  const load = await batchedSamples(async () => {
     const data = await loadSessionData(info.largeSessionId);
     const thread = assembleThread(data.mainEvents);
     buildSubagentRuns(thread, data.subagents);
-  }, runs);
-  metrics.push(metric('session_load.wall_ms', 'Session load + assemble', 'ms', median(load), false, true));
+  }, SESSION_LOAD_ITERS, runs);
+  metrics.push(
+    metric('session_load.batch_ms', `Session load + assemble ×${SESSION_LOAD_ITERS}`, 'ms', load, false, true, SESSION_LOAD_ITERS),
+  );
 
   return metrics;
 }

--- a/packages/server/perf/stats.ts
+++ b/packages/server/perf/stats.ts
@@ -1,0 +1,74 @@
+/**
+ * Pure statistics helpers for the perf suite. No server/DuckDB imports — used
+ * by both scenarios.ts (sampling) and compare.ts (gating), and compare.ts must
+ * stay importable without pulling in the index.
+ */
+
+export const median = (xs: number[]): number => {
+  const s = [...xs].sort((a, b) => a - b);
+  const m = Math.floor(s.length / 2);
+  return s.length % 2 ? s[m] : (s[m - 1] + s[m]) / 2;
+};
+
+export const percentile = (xs: number[], p: number): number => {
+  const s = [...xs].sort((a, b) => a - b);
+  const idx = Math.min(s.length - 1, Math.max(0, Math.ceil((p / 100) * s.length) - 1));
+  return s[idx];
+};
+
+/** Interquartile range — robust spread for the ±IQR display. */
+export const iqr = (xs: number[]): number => percentile(xs, 75) - percentile(xs, 25);
+
+/** Coefficient of variation (stddev / mean); 0 for empty or zero-mean samples. */
+export function cv(xs: number[]): number {
+  if (xs.length < 2) return 0;
+  const m = xs.reduce((a, b) => a + b, 0) / xs.length;
+  if (m === 0) return 0;
+  const variance = xs.reduce((a, b) => a + (b - m) ** 2, 0) / (xs.length - 1);
+  return Math.sqrt(variance) / Math.abs(m);
+}
+
+/** Standard normal CDF (Zelen & Severo / A&S 7.1.26, |err| < 7.5e-8). */
+function normalCdf(z: number): number {
+  const t = 1 / (1 + 0.2316419 * Math.abs(z));
+  const d = 0.3989422804014327 * Math.exp((-z * z) / 2);
+  const p =
+    d * t * (0.31938153 + t * (-0.356563782 + t * (1.781477937 + t * (-1.821255978 + t * 1.330274429))));
+  return z > 0 ? 1 - p : p;
+}
+
+/**
+ * One-sided Mann-Whitney U test: p-value for the alternative "samples in `y`
+ * are stochastically GREATER than samples in `x`". Normal approximation with
+ * midranks, tie correction, and continuity correction — fine for the pooled
+ * sample sizes the suite produces (~10+ per side). Returns 1 (no evidence)
+ * when a side is empty or every value is tied.
+ */
+export function mannWhitneyGreater(x: number[], y: number[]): number {
+  const n1 = x.length;
+  const n2 = y.length;
+  if (n1 === 0 || n2 === 0) return 1;
+  const all = [...x.map((v) => ({ v, isY: false })), ...y.map((v) => ({ v, isY: true }))].sort(
+    (a, b) => a.v - b.v,
+  );
+  const n = n1 + n2;
+  const ranks = new Array<number>(n);
+  let tieAdj = 0;
+  for (let i = 0; i < n; ) {
+    let j = i;
+    while (j + 1 < n && all[j + 1].v === all[i].v) j++;
+    const midrank = (i + j + 2) / 2; // ranks are 1-based
+    for (let k = i; k <= j; k++) ranks[k] = midrank;
+    const ties = j - i + 1;
+    if (ties > 1) tieAdj += ties ** 3 - ties;
+    i = j + 1;
+  }
+  let rankSumY = 0;
+  for (let k = 0; k < n; k++) if (all[k].isY) rankSumY += ranks[k];
+  const u = rankSumY - (n2 * (n2 + 1)) / 2;
+  const mu = (n1 * n2) / 2;
+  const sigma2 = ((n1 * n2) / 12) * (n + 1 - tieAdj / (n * (n - 1)));
+  if (sigma2 <= 0) return 1; // all values identical
+  const z = (u - mu - 0.5) / Math.sqrt(sigma2);
+  return 1 - normalCdf(z);
+}

--- a/packages/server/perf/types.ts
+++ b/packages/server/perf/types.ts
@@ -33,8 +33,6 @@ export interface BenchResult {
     node: string;
     scale: number;
     runs: number;
-    /** Interleaved CI round this file came from (absent for local runs). */
-    round?: number;
     totalEvents: number;
     totalBytes: number;
   };

--- a/packages/server/perf/types.ts
+++ b/packages/server/perf/types.ts
@@ -9,19 +9,32 @@ export interface Metric {
   /** Human label for the table. */
   label: string;
   unit: string;
+  /** Display value: median of `samples`. */
   value: number;
   /** Headline metrics gate CI; the rest are informational. */
   headline: boolean;
   /** True when a lower value is better (latency); false for throughput. */
   betterIsLower: boolean;
+  /**
+   * Raw per-sample values in `unit`. The comparator pools these across result
+   * files (one per interleaved CI round) for the statistical gate. Absent in
+   * schema-v1 files, which compare.ts treats as advisory-only.
+   */
+  samples: number[];
+  /** How many timed iterations each sample aggregates (1 = unbatched). */
+  itersPerSample: number;
 }
 
 export interface BenchResult {
   meta: {
+    /** Result-file format version; bumped when `samples` were added. */
+    schemaVersion: number;
     timestamp: string;
     node: string;
     scale: number;
     runs: number;
+    /** Interleaved CI round this file came from (absent for local runs). */
+    round?: number;
     totalEvents: number;
     totalBytes: number;
   };

--- a/packages/server/test/stats.test.ts
+++ b/packages/server/test/stats.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest';
+import { cv, iqr, mannWhitneyGreater, median, percentile } from '../perf/stats.js';
+
+describe('median / percentile / iqr / cv', () => {
+  it('computes median for odd and even lengths', () => {
+    expect(median([3, 1, 2])).toBe(2);
+    expect(median([4, 1, 3, 2])).toBe(2.5);
+  });
+
+  it('computes percentiles on the sorted samples', () => {
+    const xs = [10, 20, 30, 40, 50, 60, 70, 80, 90, 100];
+    expect(percentile(xs, 50)).toBe(50);
+    expect(percentile(xs, 95)).toBe(100);
+  });
+
+  it('iqr is the 75th minus the 25th percentile', () => {
+    expect(iqr([1, 2, 3, 4])).toBe(3 - 1);
+  });
+
+  it('cv is stddev over mean, 0 for constant or tiny samples', () => {
+    expect(cv([5])).toBe(0);
+    expect(cv([5, 5, 5, 5])).toBe(0);
+    // mean 10, sample stddev 2 → CV 0.2
+    expect(cv([8, 10, 12, 10])).toBeCloseTo(Math.sqrt(8 / 3) / 10, 5);
+  });
+});
+
+describe('mannWhitneyGreater', () => {
+  it('detects a clearly shifted candidate (p < 0.01 with 10v10 separated samples)', () => {
+    const base = [100, 101, 102, 103, 104, 105, 106, 107, 108, 109];
+    const cand = [130, 131, 132, 133, 134, 135, 136, 137, 138, 139];
+    expect(mannWhitneyGreater(base, cand)).toBeLessThan(0.01);
+  });
+
+  it('reports no evidence when the candidate is faster', () => {
+    const base = [130, 131, 132, 133, 134];
+    const cand = [100, 101, 102, 103, 104];
+    expect(mannWhitneyGreater(base, cand)).toBeGreaterThan(0.9);
+  });
+
+  it('returns 1 for fully tied or empty samples', () => {
+    expect(mannWhitneyGreater([5, 5, 5], [5, 5, 5])).toBe(1);
+    expect(mannWhitneyGreater([], [1, 2, 3])).toBe(1);
+  });
+
+  it('overlapping same-distribution samples are not significant', () => {
+    const base = [10, 12, 11, 13, 12, 11, 10, 13, 12, 11];
+    const cand = [11, 12, 10, 13, 11, 12, 13, 10, 12, 11];
+    expect(mannWhitneyGreater(base, cand)).toBeGreaterThan(0.1);
+  });
+});


### PR DESCRIPTION
## Problem

The perf suite measures noise, not signal — verified from the logs of 8 recent CI runs (June 2026):

- `search.p95_ms` swung **−28.5%…+35.4%** on PRs that never touched search logic.
- `noop_reindex.wall_ms` ranged **1.65–4.5ms** (+111% swings) — *below the suite's own 25ms significance floor*, so it could only ever produce alarming 💤 "noise" verdicts, never gate.
- Dead-gate bug: of the three headline metrics, two (`noop_reindex.wall_ms`, `search.p95_ms` at 13–20ms) sit under the floor and can never fail; the only gateable metric, `cold_index.events_per_sec`, drifted ~16% A/A on identical code — just under the 20% threshold.

Root causes: 5 samples / 1 warmup with raw samples discarded, sequential A-then-B blocks on a temporally drifting shared runner, and operations measured in the 2–20ms range where VM jitter is the same order as the signal.

## Redesign

1. **Batched sampling** (`scenarios.ts`): fast scenarios time N iterations per sample — `noop_reindex` ×50, `search` ×25, `analytics` ×10, `single_file_reindex` ×10, `session_load` ×3 — so every gated sample lands ~100ms+, above runner jitter. Raw samples ship in the result file (`schemaVersion: 2`). Headline set: `cold_index.events_per_sec`, `noop_reindex.batch_ms`, `search.batch_ms`; `search.p95_ms` is demoted to informational (a p95 over ten ~5ms calls is structurally jitter).
2. **Interleaved A/B** (`perf.yml`): 5 short alternating base/candidate rounds on the same VM (odd rounds base-first, even candidate-first), at `--scale 2 --runs 2` → 10 pooled samples per side. Temporal drift hits both arms alike and cancels.
3. **Statistical gate** (`compare.ts` + new pure `stats.ts`): pools samples across rounds; FAIL requires **pooled median regression > 10% AND one-sided Mann-Whitney U p < 0.01 AND above floor**. A noisy baseline (CV > 12%) demotes FAIL to ❓ "inconclusive" (visible, doesn't fail). The job summary now shows median ±IQR, Δ%, p, and base CV per metric. v1-schema baselines (this PR's own CI run) render advisory-only and exit 0 — the existing bootstrap pattern.

## Validation

- **A/A** (identical code, 2 files/side pooled): headline deltas ≤2.5%, all ✅, exit 0.
- **Injected 30% slowdown** at CI pool size (10 samples/side): all three headline metrics FAIL with p < 0.001, exit 1. Informational metrics regress visibly but don't gate.
- **Bootstrap paths**: v1 base → advisory, exit 0; no base files → notice, exit 0.
- New `stats.test.ts` unit-tests median/percentile/IQR/CV and the Mann-Whitney implementation (separation, reverse direction, ties, same-distribution overlap). `npm test` (116) + `npm run typecheck` green.

CI cost: ~6–7 min (vs ~3–4) for the PR-only perf job, with `cancel-in-progress` already set.

Note: this PR's own perf run shows the advisory banner (base lacks per-sample data) — the gate arms on the first PR after this merges.

Part of [plan 0011](docs/plans/0011-performance-search-scroll-bench.md) (workstream C; plan doc lands in #10).
