### PR TITLE
perf(web): clamp huge tool outputs and mount turns progressively

### DIFF
--- a/packages/web/src/components/ClampedText.tsx
+++ b/packages/web/src/components/ClampedText.tsx
@@ -1,0 +1,47 @@
+import { useState } from 'react';
+import { MAX_TEXT_CHARS, clampCut, clampLabel } from './limits.js';
+
+export interface ClampedTextProps {
+  text: string;
+  /** Chars rendered before the "Show all" affordance. */
+  limit?: number;
+  /** Force full rendering (e.g. an in-session search match is in the tail). */
+  forceExpand?: boolean;
+  /** className for the wrapping <pre> (e.g. `tv-pre`, `tv-code-plain`). */
+  className?: string;
+  /** Wrap the text in a <code> element (matches the code-style <pre> sinks). */
+  code?: boolean;
+}
+
+/**
+ * Plain-text <pre> that clamps huge payloads: content over `limit` renders only
+ * its head (cut at a line boundary) plus a "Show all" button, so a multi-MB
+ * tool output never lands in the DOM unasked. Small text renders exactly like
+ * the plain <pre>/<code> it replaces.
+ */
+export function ClampedText({
+  text,
+  limit = MAX_TEXT_CHARS,
+  forceExpand = false,
+  className,
+  code = false,
+}: ClampedTextProps) {
+  const [userExpanded, setUserExpanded] = useState(false);
+  const expanded = userExpanded || forceExpand || text.length <= limit;
+  const shown = expanded ? text : text.slice(0, clampCut(text, limit));
+
+  return (
+    <>
+      <pre className={className}>{code ? <code>{shown}</code> : shown}</pre>
+      {expanded ? null : (
+        <button
+          type="button"
+          className="tv-linkbtn tv-clamp-more"
+          onClick={() => setUserExpanded(true)}
+        >
+          Show all ({clampLabel(text)})
+        </button>
+      )}
+    </>
+  );
+}

--- a/packages/web/src/components/Markdown.tsx
+++ b/packages/web/src/components/Markdown.tsx
@@ -1,7 +1,9 @@
-import { memo, type ReactNode } from 'react';
+import { memo, useState, type ReactNode } from 'react';
 import ReactMarkdown, { type Components } from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import { CodeBlock } from './CodeBlock.js';
+import { ClampedText } from './ClampedText.js';
+import { MAX_MARKDOWN_CHARS } from './limits.js';
 
 export interface MarkdownProps {
   /** Markdown source to render. */
@@ -13,6 +15,8 @@ export interface MarkdownProps {
   markdown?: boolean;
   /** Extra className appended to the wrapper. */
   className?: string;
+  /** Fully expand clamped text (e.g. an in-session search match is in the tail). */
+  forceExpand?: boolean;
 }
 
 /**
@@ -55,11 +59,30 @@ const components: Components = {
  * enabled, so content is sanitized by default. Falls back to a <pre> block when
  * `markdown` is false.
  */
-function MarkdownImpl({ children, markdown = true, className }: MarkdownProps) {
+function MarkdownImpl({ children, markdown = true, className, forceExpand = false }: MarkdownProps) {
+  // Huge sources never hit the markdown parser unless the reader opts in.
+  const [parseAnyway, setParseAnyway] = useState(false);
   const cls = className ? `tv-md ${className}` : 'tv-md';
 
   if (!markdown) {
-    return <pre className={`tv-pre ${className ?? ''}`.trim()}>{children}</pre>;
+    return (
+      <ClampedText
+        className={`tv-pre ${className ?? ''}`.trim()}
+        text={children}
+        forceExpand={forceExpand}
+      />
+    );
+  }
+
+  if (children.length > MAX_MARKDOWN_CHARS && !parseAnyway) {
+    return (
+      <div className={cls}>
+        <ClampedText className="tv-pre" text={children} forceExpand={forceExpand} />
+        <button type="button" className="tv-linkbtn tv-clamp-more" onClick={() => setParseAnyway(true)}>
+          Render as markdown anyway
+        </button>
+      </div>
+    );
   }
 
   return (

--- a/packages/web/src/components/ThinkingBlock.tsx
+++ b/packages/web/src/components/ThinkingBlock.tsx
@@ -30,7 +30,7 @@ export function ThinkingBlock({ thinking, defaultOpen = false, forceOpen = false
       title="Thinking"
     >
       {hasText ? (
-        <Markdown>{thinking}</Markdown>
+        <Markdown forceExpand={forceOpen}>{thinking}</Markdown>
       ) : (
         <p className="tv-muted" style={{ fontStyle: 'italic', margin: 0 }}>
           Thinking content isn’t stored in the transcript (only a signature).

--- a/packages/web/src/components/ToolBlock.tsx
+++ b/packages/web/src/components/ToolBlock.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react';
 import type { ContentBlock, ToolInteraction } from '@claudescope/shared';
 import { Collapsible } from './Collapsible.js';
 import { CodeBlock } from './CodeBlock.js';
+import { ClampedText } from './ClampedText.js';
 import { Markdown } from './Markdown.js';
 import { LineDiff } from './LineDiff.js';
 import { extOf, MAX_HIGHLIGHT } from './diff.js';
@@ -39,14 +40,10 @@ function stringifyInput(input: unknown): string {
   }
 }
 
-/** Syntax-highlighted code, falling back to plain text for large payloads. */
-function Code({ code, lang }: { code: string; lang?: string }) {
+/** Syntax-highlighted code, falling back to clamped plain text for large payloads. */
+function Code({ code, lang, forceExpand = false }: { code: string; lang?: string; forceExpand?: boolean }) {
   if (code.length > MAX_HIGHLIGHT) {
-    return (
-      <pre className="tv-code-plain">
-        <code>{code}</code>
-      </pre>
-    );
+    return <ClampedText className="tv-code-plain" text={code} code forceExpand={forceExpand} />;
   }
   return <CodeBlock code={code} lang={lang} />;
 }
@@ -60,16 +57,26 @@ function FileHeader({ path, note }: { path: string; note?: string }) {
   );
 }
 
-/** Render normalized tool_result content blocks. Text/JSON shown as text. */
-function renderResultBlocks(blocks: ContentBlock[]) {
+/** Render normalized tool_result content blocks. Text/JSON shown as (clamped) text. */
+function renderResultBlocks(blocks: ContentBlock[], forceExpand: boolean) {
   return blocks.map((block, i) => {
-    if (block.type === 'text') return <Markdown key={i} markdown={false}>{block.text}</Markdown>;
-    if (block.type === 'thinking') return <Markdown key={i} markdown={false}>{block.thinking}</Markdown>;
-    return <Markdown key={i} markdown={false}>{stringifyInput(block)}</Markdown>;
+    if (block.type === 'text')
+      return <Markdown key={i} markdown={false} forceExpand={forceExpand}>{block.text}</Markdown>;
+    if (block.type === 'thinking')
+      return <Markdown key={i} markdown={false} forceExpand={forceExpand}>{block.thinking}</Markdown>;
+    return <Markdown key={i} markdown={false} forceExpand={forceExpand}>{stringifyInput(block)}</Markdown>;
   });
 }
 
-function ResultSection({ tool, isError }: { tool: ToolInteraction; isError: boolean }) {
+function ResultSection({
+  tool,
+  isError,
+  forceExpand,
+}: {
+  tool: ToolInteraction;
+  isError: boolean;
+  forceExpand: boolean;
+}) {
   if (!tool.result) {
     return (
       <div className="tv-tool__section">
@@ -80,13 +87,21 @@ function ResultSection({ tool, isError }: { tool: ToolInteraction; isError: bool
   return (
     <div className="tv-tool__section">
       <p className="tv-tool__section-label">{isError ? 'Result (error)' : 'Result'}</p>
-      {renderResultBlocks(tool.result.content)}
+      {renderResultBlocks(tool.result.content, forceExpand)}
     </div>
   );
 }
 
 /** Tool-specific body: diffs for edits, highlighted code for files/commands. */
-function ToolBody({ tool, isError }: { tool: ToolInteraction; isError: boolean }) {
+function ToolBody({
+  tool,
+  isError,
+  forceOpen,
+}: {
+  tool: ToolInteraction;
+  isError: boolean;
+  forceOpen: boolean;
+}) {
   const input = asRecord(tool.input);
 
   switch (tool.name) {
@@ -100,7 +115,7 @@ function ToolBody({ tool, isError }: { tool: ToolInteraction; isError: boolean }
             newText={str(input.new_string) ?? ''}
             lang={extOf(fp)}
           />
-          <ResultSection tool={tool} isError={isError} />
+          <ResultSection tool={tool} isError={isError} forceExpand={forceOpen} />
         </>
       );
     }
@@ -123,7 +138,7 @@ function ToolBody({ tool, isError }: { tool: ToolInteraction; isError: boolean }
               </div>
             );
           })}
-          <ResultSection tool={tool} isError={isError} />
+          <ResultSection tool={tool} isError={isError} forceExpand={forceOpen} />
         </>
       );
     }
@@ -132,8 +147,8 @@ function ToolBody({ tool, isError }: { tool: ToolInteraction; isError: boolean }
       return (
         <>
           {fp ? <FileHeader path={fp} /> : null}
-          <Code code={str(input.content) ?? ''} lang={extOf(fp)} />
-          <ResultSection tool={tool} isError={isError} />
+          <Code code={str(input.content) ?? ''} lang={extOf(fp)} forceExpand={forceOpen} />
+          <ResultSection tool={tool} isError={isError} forceExpand={forceOpen} />
         </>
       );
     }
@@ -143,7 +158,11 @@ function ToolBody({ tool, isError }: { tool: ToolInteraction; isError: boolean }
       return (
         <>
           {fp ? <FileHeader path={fp} /> : null}
-          {tool.result ? <Code code={text} lang={extOf(fp)} /> : <ResultSection tool={tool} isError={isError} />}
+          {tool.result ? (
+            <Code code={text} lang={extOf(fp)} forceExpand={forceOpen} />
+          ) : (
+            <ResultSection tool={tool} isError={isError} forceExpand={forceOpen} />
+          )}
         </>
       );
     }
@@ -154,13 +173,11 @@ function ToolBody({ tool, isError }: { tool: ToolInteraction; isError: boolean }
           {str(input.description) ? (
             <p className="tv-tool__section-label tv-muted">{str(input.description)}</p>
           ) : null}
-          <Code code={str(input.command) ?? ''} lang="bash" />
+          <Code code={str(input.command) ?? ''} lang="bash" forceExpand={forceOpen} />
           {out ? (
             <div className="tv-tool__section">
               <p className="tv-tool__section-label">{isError ? 'Output (error)' : 'Output'}</p>
-              <pre className="tv-code-plain">
-                <code>{out}</code>
-              </pre>
+              <ClampedText className="tv-code-plain" text={out} code forceExpand={forceOpen} />
             </div>
           ) : null}
         </>
@@ -171,9 +188,9 @@ function ToolBody({ tool, isError }: { tool: ToolInteraction; isError: boolean }
         <>
           <div className="tv-tool__section">
             <p className="tv-tool__section-label">Input</p>
-            <Code code={stringifyInput(tool.input)} lang="json" />
+            <Code code={stringifyInput(tool.input)} lang="json" forceExpand={forceOpen} />
           </div>
-          <ResultSection tool={tool} isError={isError} />
+          <ResultSection tool={tool} isError={isError} forceExpand={forceOpen} />
         </>
       );
   }
@@ -205,7 +222,7 @@ export function ToolBlock({ tool, defaultOpen = false, forceOpen = false }: Tool
         ) : null
       }
     >
-      <ToolBody tool={tool} isError={isError} />
+      <ToolBody tool={tool} isError={isError} forceOpen={forceOpen} />
     </Collapsible>
   );
 }

--- a/packages/web/src/components/index.ts
+++ b/packages/web/src/components/index.ts
@@ -1,6 +1,7 @@
 /** Reusable rendering + UI components shared across feature pages. */
 
 export { Markdown, type MarkdownProps } from './Markdown.js';
+export { ClampedText, type ClampedTextProps } from './ClampedText.js';
 export { CodeBlock, type CodeBlockProps } from './CodeBlock.js';
 export { Collapsible, type CollapsibleProps } from './Collapsible.js';
 export { ToolBlock, type ToolBlockProps } from './ToolBlock.js';

--- a/packages/web/src/components/limits.ts
+++ b/packages/web/src/components/limits.ts
@@ -1,0 +1,28 @@
+/** Size limits that keep huge transcript payloads from freezing the DOM. */
+
+/** Plain-text content above this many chars renders clamped behind "Show all". */
+export const MAX_TEXT_CHARS = 50_000;
+
+/**
+ * Markdown source above this many chars skips remark parsing entirely (a
+ * multi-MB pasted log must never hit the markdown parser) and renders as
+ * clamped plain text with an opt-in to parse anyway.
+ */
+export const MAX_MARKDOWN_CHARS = 100_000;
+
+/** Where to cut clamped text: the last newline before `limit`, if it isn't
+ * pathologically early (single-line blobs cut mid-line at the limit). */
+export function clampCut(text: string, limit: number): number {
+  const nl = text.lastIndexOf('\n', limit);
+  return nl > limit / 2 ? nl : limit;
+}
+
+/** Human label for the hidden remainder, e.g. "2.4 MB, ~38,000 lines". */
+export function clampLabel(text: string): string {
+  const bytes = text.length;
+  const size =
+    bytes >= 1e6 ? `${(bytes / 1e6).toFixed(1)} MB` : `${Math.max(1, Math.round(bytes / 1e3))} KB`;
+  let lines = 1;
+  for (let i = 0; i < text.length; i++) if (text.charCodeAt(i) === 10) lines++;
+  return `${size}, ~${lines.toLocaleString('en-US')} lines`;
+}

--- a/packages/web/src/pages/session/SessionPage.tsx
+++ b/packages/web/src/pages/session/SessionPage.tsx
@@ -5,7 +5,8 @@ import { api, ApiError } from '../../api/client.js';
 import { AgentBadge, CostBadge, ErrorBox, Spinner, TokenChips } from '../../components';
 import { formatBytes, formatDateTime, shortModel } from '../browse/format.js';
 import { hasRenderableContent } from './blocks.js';
-import { SubagentBlock, SubagentJumpMenu, ThreadList, useHashTarget } from './ThreadView.js';
+import { SubagentBlock, SubagentJumpMenu, ThreadList } from './ThreadView.js';
+import { useProgressiveMount } from './useProgressiveMount.js';
 import { ChangesetPanel } from './ChangesetPanel.js';
 import { buildChangeset } from './changeset.js';
 import { ExportMenu } from './ExportMenu.js';
@@ -92,25 +93,6 @@ export function SessionPage() {
     return () => window.removeEventListener('keydown', onKeyDown);
   }, [refresh]);
 
-  // Scroll to the #<uuid> anchor once the thread has rendered (deep-link). Only
-  // fire on the first load for a given session — a soft refresh swaps `data` but
-  // must not yank a deep-linked reader away from their place.
-  const hashScrolledForId = useRef<string | null>(null);
-  useEffect(() => {
-    if (!data || !id) return;
-    if (hashScrolledForId.current === id) return;
-    hashScrolledForId.current = id;
-    const hash = window.location.hash.slice(1);
-    if (!hash) return;
-    const el = document.getElementById(hash);
-    if (el) {
-      el.scrollIntoView({ block: 'center' });
-      el.classList.add('is-targeted');
-      const timer = window.setTimeout(() => el.classList.remove('is-targeted'), 2400);
-      return () => window.clearTimeout(timer);
-    }
-  }, [data, id]);
-
   if (!id) return <ErrorBox error="Missing session id" />;
   if (loading) return <Spinner size="lg" label="Loading session…" />;
   if (error) return <ErrorBox error={error} onRetry={() => setReloadKey((k) => k + 1)} />;
@@ -130,7 +112,6 @@ function SessionView({
 }) {
   const { meta, thread, subagents } = data;
   const title = meta.title || 'Untitled session';
-  const hashTarget = useHashTarget();
   const [searchParams] = useSearchParams();
 
   // Only render turns that actually carry visible content.
@@ -154,6 +135,55 @@ function SessionView({
     return map;
   }, [subagents]);
   const orphanSubagents = useMemo(() => subagents.filter((s) => !s.toolUseId), [subagents]);
+
+  // Mount turns progressively: the first chunk renders immediately, the rest
+  // stream in during idle time, so a huge session never blocks the first paint
+  // behind one giant React commit.
+  const { visibleItems, allMounted, mounted, ensureMounted } = useProgressiveMount(items);
+
+  // subagentId → uuid of the top-level turn its run renders under. Used to
+  // mount the right turn before navigating to a match/anchor inside a nested
+  // subagent (orphan runs render after the list and are always mounted).
+  const spawnTurnBySubagentId = useMemo(() => {
+    const map = new Map<string, string>();
+    for (const item of items) {
+      for (const block of item.blocks) {
+        if (block.kind !== 'tool') continue;
+        for (const run of subagentsByToolUseId.get(block.id) ?? []) map.set(run.agentId, item.uuid);
+      }
+    }
+    return map;
+  }, [items, subagentsByToolUseId]);
+
+  // Scroll to the #<anchor> deep-link once its turn is mounted. Only on the
+  // first load for a given session — a soft refresh swaps `data` but must not
+  // yank a deep-linked reader away from their place.
+  const hashScrolledForId = useRef<string | null>(null);
+  useEffect(() => {
+    if (hashScrolledForId.current === meta.id) return;
+    const hash = window.location.hash.slice(1);
+    if (!hash) {
+      hashScrolledForId.current = meta.id;
+      return;
+    }
+    const el = document.getElementById(hash);
+    if (!el) {
+      // Target not in the DOM yet: request its turn and retry as turns mount.
+      if (allMounted) {
+        hashScrolledForId.current = meta.id; // never going to appear — give up
+        return;
+      }
+      const agentId = hash.startsWith('subagent-') ? hash.slice('subagent-'.length) : undefined;
+      const target = agentId ? spawnTurnBySubagentId.get(agentId) : hash;
+      if (target) ensureMounted(target);
+      return;
+    }
+    hashScrolledForId.current = meta.id;
+    el.scrollIntoView({ block: 'center' });
+    el.classList.add('is-targeted');
+    const timer = window.setTimeout(() => el.classList.remove('is-targeted'), 2400);
+    return () => window.clearTimeout(timer);
+  }, [meta.id, mounted, allMounted, spawnTurnBySubagentId, ensureMounted]);
 
   // Cheap (no diffing): just groups edits by file, for the tab count.
   const changes = useMemo(() => buildChangeset(thread, subagents), [thread, subagents]);
@@ -195,16 +225,22 @@ function SessionView({
   const reveal = useMemo(() => revealForMatch(activeMatch), [activeMatch]);
 
   // Highlight the active match within its (now-revealed) block. Scoped to one
-  // block, so it stays cheap. Re-run on a short delay to catch async code blocks.
+  // block, so it stays cheap. Re-run on a short delay to catch async code
+  // blocks, and on `mounted` growth in case the match's turn wasn't in the
+  // DOM yet (progressive mounting).
   useEffect(() => {
     const container = threadRef.current;
     clearHighlights();
     if (!container || !activeMatch) return;
+    const anchorUuid = activeMatch.subagentId
+      ? spawnTurnBySubagentId.get(activeMatch.subagentId) // undefined → orphan section, always mounted
+      : activeMatch.turnUuid;
+    if (anchorUuid) ensureMounted(anchorUuid);
     const run = () => highlightMatchInBlock(container, activeMatch, debouncedQuery);
     run();
     const t = window.setTimeout(run, 200);
     return () => window.clearTimeout(t);
-  }, [activeMatch, debouncedQuery]);
+  }, [activeMatch, debouncedQuery, mounted, spawnTurnBySubagentId, ensureMounted]);
 
   // Clear highlights when leaving the session.
   useEffect(() => clearHighlights, []);
@@ -228,7 +264,8 @@ function SessionView({
 
   // Memoize the (expensive) thread subtree so switching tabs — which only
   // changes `tab` — doesn't re-render hundreds of turns / re-parse markdown.
-  // It recomputes only when the data or the finder's reveal/hash actually change.
+  // It recomputes only when the data or the finder's reveal actually change
+  // (and Turn/ThreadBlockView are memoized, so even then most turns bail out).
   const threadView = useMemo(
     () => (
       <SessionSearchContext.Provider value={reveal}>
@@ -236,11 +273,10 @@ function SessionView({
           {items.length === 0 ? (
             <p className="tv-muted">This session has no renderable messages.</p>
           ) : (
-            <ThreadList
-              items={items}
-              subagentsByToolUseId={subagentsByToolUseId}
-              hashTarget={hashTarget}
-            />
+            <ThreadList items={visibleItems} subagentsByToolUseId={subagentsByToolUseId} />
+          )}
+          {allMounted ? null : (
+            <p className="tv-muted">Rendering {items.length - visibleItems.length} more turns…</p>
           )}
 
           {orphanSubagents.length > 0 ? (
@@ -250,14 +286,14 @@ function SessionView({
                 <span className="tv-muted"> (not linked to a tool call)</span>
               </h2>
               {orphanSubagents.map((run) => (
-                <SubagentBlock key={run.agentId} run={run} hashTarget={hashTarget} />
+                <SubagentBlock key={run.agentId} run={run} />
               ))}
             </section>
           ) : null}
         </div>
       </SessionSearchContext.Provider>
     ),
-    [reveal, items, subagentsByToolUseId, hashTarget, orphanSubagents],
+    [reveal, items, visibleItems, allMounted, subagentsByToolUseId, orphanSubagents],
   );
 
   return (

--- a/packages/web/src/pages/session/SessionPage.tsx
+++ b/packages/web/src/pages/session/SessionPage.tsx
@@ -5,13 +5,13 @@ import { api, ApiError } from '../../api/client.js';
 import { AgentBadge, CostBadge, ErrorBox, Spinner, TokenChips } from '../../components';
 import { formatBytes, formatDateTime, shortModel } from '../browse/format.js';
 import { hasRenderableContent } from './blocks.js';
-import { SubagentBlock, SubagentJumpMenu, ThreadList } from './ThreadView.js';
+import { SubagentBlock, SubagentJumpMenu, ThreadList, useHashTarget } from './ThreadView.js';
 import { useProgressiveMount } from './useProgressiveMount.js';
 import { ChangesetPanel } from './ChangesetPanel.js';
 import { buildChangeset } from './changeset.js';
 import { ExportMenu } from './ExportMenu.js';
 import { SessionSearchContext } from './SearchContext.js';
-import { buildMatches, revealForMatch, type RoleFilter } from './search.js';
+import { buildMatches, revealForMatch, type FinderMatch, type RoleFilter } from './search.js';
 import { SessionFinder } from './SessionFinder.js';
 import { highlightMatchInBlock, clearHighlights } from './finderDom.js';
 import './session.css';
@@ -155,6 +155,21 @@ function SessionView({
     return map;
   }, [items, subagentsByToolUseId]);
 
+  // Post-load hash navigation (subagent jump menu, time anchors): the target's
+  // turn may not be mounted yet, in which case the native hash scroll (and a
+  // nested SubagentBlock's own open-on-hash effect) has nothing to land on —
+  // request mounting and let those take over once the element exists.
+  const hashTarget = useHashTarget();
+  useEffect(() => {
+    if (!hashTarget || allMounted) return;
+    if (document.getElementById(hashTarget)) return;
+    const agentId = hashTarget.startsWith('subagent-')
+      ? hashTarget.slice('subagent-'.length)
+      : undefined;
+    const target = agentId ? spawnTurnBySubagentId.get(agentId) : hashTarget;
+    if (target) ensureMounted(target);
+  }, [hashTarget, allMounted, mounted, spawnTurnBySubagentId, ensureMounted]);
+
   // Scroll to the #<anchor> deep-link once its turn is mounted. Only on the
   // first load for a given session — a soft refresh swaps `data` but must not
   // yank a deep-linked reader away from their place.
@@ -181,8 +196,10 @@ function SessionView({
     hashScrolledForId.current = meta.id;
     el.scrollIntoView({ block: 'center' });
     el.classList.add('is-targeted');
-    const timer = window.setTimeout(() => el.classList.remove('is-targeted'), 2400);
-    return () => window.clearTimeout(timer);
+    // Fire-and-forget: this effect re-runs as idle mounting grows `mounted`,
+    // so a cleanup-managed timer would be cleared before it fires and leave
+    // the highlight stuck on. Removing a class on a detached node is harmless.
+    window.setTimeout(() => el.classList.remove('is-targeted'), 2400);
   }, [meta.id, mounted, allMounted, spawnTurnBySubagentId, ensureMounted]);
 
   // Cheap (no diffing): just groups edits by file, for the tab count.
@@ -227,16 +244,26 @@ function SessionView({
   // Highlight the active match within its (now-revealed) block. Scoped to one
   // block, so it stays cheap. Re-run on a short delay to catch async code
   // blocks, and on `mounted` growth in case the match's turn wasn't in the
-  // DOM yet (progressive mounting).
+  // DOM yet (progressive mounting). Once highlighted, later `mounted` growth
+  // must NOT re-run it — highlightMatchInBlock scrolls to the match, and
+  // re-running per idle tick would keep yanking the reader back to it.
+  const highlighted = useRef<{ match: FinderMatch; query: string } | null>(null);
   useEffect(() => {
+    const done = highlighted.current;
+    if (done && done.match === activeMatch && done.query === debouncedQuery) return;
     const container = threadRef.current;
     clearHighlights();
+    highlighted.current = null;
     if (!container || !activeMatch) return;
     const anchorUuid = activeMatch.subagentId
       ? spawnTurnBySubagentId.get(activeMatch.subagentId) // undefined → orphan section, always mounted
       : activeMatch.turnUuid;
     if (anchorUuid) ensureMounted(anchorUuid);
-    const run = () => highlightMatchInBlock(container, activeMatch, debouncedQuery);
+    const run = () => {
+      if (highlightMatchInBlock(container, activeMatch, debouncedQuery)) {
+        highlighted.current = { match: activeMatch, query: debouncedQuery };
+      }
+    };
     run();
     const t = window.setTimeout(run, 200);
     return () => window.clearTimeout(t);

--- a/packages/web/src/pages/session/ThreadView.tsx
+++ b/packages/web/src/pages/session/ThreadView.tsx
@@ -1,6 +1,6 @@
-import { Fragment, useContext, useEffect, useRef, useState } from 'react';
-import type { SubagentRun, ThreadItem } from '@claudescope/shared';
-import { Collapsible, TokenChips } from '../../components';
+import { Fragment, memo, useContext, useEffect, useRef, useState } from 'react';
+import type { SubagentRun, ThreadBlock, ThreadItem } from '@claudescope/shared';
+import { ClampedText, Collapsible, TokenChips } from '../../components';
 import { formatDateTime, shortModel } from '../browse/format.js';
 import { ThreadBlockView, hasRenderableContent } from './blocks.js';
 import { classifySystemText } from './text.js';
@@ -29,42 +29,37 @@ export function useHashTarget(): string {
 export function ThreadList({
   items,
   subagentsByToolUseId,
-  hashTarget,
 }: {
   items: ThreadItem[];
   /** tool_use id → the subagent run(s) it spawned (Workflow fans out to many). */
   subagentsByToolUseId?: Map<string, SubagentRun[]>;
-  hashTarget: string;
 }) {
   return (
     <>
       {items.map((item) => (
-        <Turn
-          key={item.uuid}
-          item={item}
-          subagentsByToolUseId={subagentsByToolUseId}
-          hashTarget={hashTarget}
-        />
+        <Turn key={item.uuid} item={item} subagentsByToolUseId={subagentsByToolUseId} />
       ))}
     </>
   );
 }
 
-function Turn({
+/**
+ * Memoized: turns are immutable for the life of a session payload, so finder
+ * steps and hash changes never re-render the whole list — the reveal context
+ * is read in {@link RevealableBlock} below, and the hash in SubagentBlock.
+ */
+const Turn = memo(function Turn({
   item,
   subagentsByToolUseId,
-  hashTarget,
 }: {
   item: ThreadItem;
   subagentsByToolUseId?: Map<string, SubagentRun[]>;
-  hashTarget: string;
 }) {
   // Harness-injected user turns (task notifications, bash I/O, slash-command
   // output) are noise in the conversation — collapse them behind a label.
   const systemLabel = item.role === 'user' ? classifySystemTurn(item) : null;
   if (systemLabel) return <SystemTurn item={item} label={systemLabel} />;
 
-  const { blockIds } = useContext(SessionSearchContext);
   const roleClass = item.role === 'user' ? 'tv-turn--user' : 'tv-turn--assistant';
   const sidechainClass = item.isSidechain ? ' tv-turn--sidechain' : '';
 
@@ -94,14 +89,11 @@ function Turn({
           {item.blocks.map((block, i) => {
             const runs =
               block.kind === 'tool' ? subagentsByToolUseId?.get(block.id) : undefined;
-            const blockId = blockRevealId(item.uuid, i);
             return (
               <Fragment key={i}>
-                <div className="tv-block" data-block-id={blockId}>
-                  <ThreadBlockView block={block} forceOpen={blockIds.has(blockId)} />
-                </div>
+                <RevealableBlock blockId={blockRevealId(item.uuid, i)} block={block} />
                 {runs?.map((run) => (
-                  <SubagentBlock key={run.agentId} run={run} hashTarget={hashTarget} />
+                  <SubagentBlock key={run.agentId} run={run} />
                 ))}
               </Fragment>
             );
@@ -109,6 +101,20 @@ function Turn({
         </div>
       </div>
     </article>
+  );
+});
+
+/**
+ * Thin per-block wrapper that subscribes to the finder reveal context, so a
+ * finder step re-renders only these wrappers — the memoized ThreadBlockView
+ * bails out everywhere except the block whose `forceOpen` actually flipped.
+ */
+function RevealableBlock({ blockId, block }: { blockId: string; block: ThreadBlock }) {
+  const { blockIds } = useContext(SessionSearchContext);
+  return (
+    <div className="tv-block" data-block-id={blockId}>
+      <ThreadBlockView block={block} forceOpen={blockIds.has(blockId)} />
+    </div>
   );
 }
 
@@ -146,7 +152,7 @@ function SystemTurn({ item, label }: { item: ThreadItem; label: string }) {
             ) : null
           }
         >
-          <pre className="tv-system-turn__pre">{text}</pre>
+          <ClampedText className="tv-system-turn__pre" text={text} />
         </Collapsible>
       </div>
     </article>
@@ -158,8 +164,9 @@ function SystemTurn({ item, label }: { item: ThreadItem; label: string }) {
  * default; opens (and scrolls into view) when the location hash targets it, so
  * the "Subagents" jump menu and deep-links land on an expanded run.
  */
-export function SubagentBlock({ run, hashTarget }: { run: SubagentRun; hashTarget: string }) {
+export function SubagentBlock({ run }: { run: SubagentRun }) {
   const anchor = subagentAnchor(run.agentId);
+  const hashTarget = useHashTarget();
   const { subagentIds } = useContext(SessionSearchContext);
   const forceOpen = subagentIds.has(run.agentId);
   const [open, setOpen] = useState(false);
@@ -200,7 +207,7 @@ export function SubagentBlock({ run, hashTarget }: { run: SubagentRun; hashTarge
           {items.length === 0 ? (
             <p className="tv-muted">No renderable messages in this subagent run.</p>
           ) : (
-            <ThreadList items={items} hashTarget={hashTarget} />
+            <ThreadList items={items} />
           )}
         </div>
       </Collapsible>

--- a/packages/web/src/pages/session/blocks.tsx
+++ b/packages/web/src/pages/session/blocks.tsx
@@ -1,3 +1,4 @@
+import { memo } from 'react';
 import type { ThreadBlock } from '@claudescope/shared';
 import { Markdown, ThinkingBlock, ToolBlock } from '../../components';
 import { stripImageMarkers } from './text.js';
@@ -8,8 +9,12 @@ import { stripImageMarkers } from './text.js';
  * - thinking: collapsible muted block
  * - tool: paired tool_use + tool_result (handles missing result + is_error)
  * - attachment: unknown/rich block (e.g. image) surfaced safely
+ *
+ * Memoized: blocks are immutable for the life of a session payload, so when a
+ * finder step re-renders the thread via context, only the block whose
+ * `forceOpen` flipped actually recomputes.
  */
-export function ThreadBlockView({
+export const ThreadBlockView = memo(function ThreadBlockView({
   block,
   forceOpen = false,
 }: {
@@ -20,7 +25,7 @@ export function ThreadBlockView({
   switch (block.kind) {
     case 'text': {
       const text = stripImageMarkers(block.text);
-      return text ? <Markdown>{text}</Markdown> : null;
+      return text ? <Markdown forceExpand={forceOpen}>{text}</Markdown> : null;
     }
     case 'thinking':
       return <ThinkingBlock thinking={block.thinking} forceOpen={forceOpen} />;
@@ -29,7 +34,7 @@ export function ThreadBlockView({
     case 'attachment':
       return <AttachmentView attachment={block.attachment} />;
   }
-}
+});
 
 /**
  * Best-effort rendering for attachment blocks. Image blocks (the observed

--- a/packages/web/src/pages/session/finderDom.ts
+++ b/packages/web/src/pages/session/finderDom.ts
@@ -59,19 +59,22 @@ export function clearHighlights(): void {
  * Highlight the active match within its block and scroll it into view. Tints
  * all occurrences in that block, emphasizing the active one. Best-effort: any
  * DOM/Range error is swallowed so the finder can never crash the page.
+ *
+ * Returns true once the match was found and highlighted, so callers can stop
+ * retrying (the block may not be in the DOM yet under progressive mounting).
  */
 export function highlightMatchInBlock(
   container: HTMLElement,
   match: FinderMatch,
   query: string,
-): void {
+): boolean {
   try {
     const el = container.querySelector<HTMLElement>(
       `[data-block-id="${CSS.escape(match.blockId)}"]`,
     );
-    if (!el) return;
+    if (!el) return false;
     const ranges = collectRanges(el, query);
-    if (ranges.length === 0) return;
+    if (ranges.length === 0) return false;
     const active = ranges[Math.min(match.occurrenceInBlock, ranges.length - 1)]!;
     const reg = registry();
     if (reg) {
@@ -79,7 +82,9 @@ export function highlightMatchInBlock(
       reg.set('cs-find-active', makeHighlight([active]));
     }
     active.startContainer.parentElement?.scrollIntoView({ block: 'center', behavior: 'smooth' });
+    return true;
   } catch {
     /* never let the finder crash the reader */
+    return false;
   }
 }

--- a/packages/web/src/pages/session/session.css
+++ b/packages/web/src/pages/session/session.css
@@ -81,7 +81,9 @@
      that are off-screen (keeping them in the DOM, so anchors, the finder, and
      jump-to still work). `auto` caches each turn's real height once measured. */
   content-visibility: auto;
-  contain-intrinsic-size: auto 140px;
+  /* Closer to the median rendered turn height — a low estimate makes the
+     scrollbar jump as real heights replace it during fast scrolling. */
+  contain-intrinsic-size: auto 280px;
 }
 
 .tv-turn__gutter {

--- a/packages/web/src/pages/session/useProgressiveMount.ts
+++ b/packages/web/src/pages/session/useProgressiveMount.ts
@@ -1,0 +1,74 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import type { ThreadItem } from '@claudescope/shared';
+
+/** Turns mounted in the first React commit — enough to fill several screens. */
+export const INITIAL_TURNS = 80;
+/** Turns added per idle tick / per ensureMounted overshoot. */
+export const CHUNK_TURNS = 50;
+
+/**
+ * Pure mount-count math: the count needed so the turn at `index` is mounted,
+ * overshooting by a chunk so nearby navigation doesn't immediately re-grow.
+ */
+export function mountCountFor(index: number, current: number, total: number): number {
+  if (index < current) return current;
+  return Math.min(index + CHUNK_TURNS, total);
+}
+
+/**
+ * Mount a huge turn list progressively: the first {@link INITIAL_TURNS} render
+ * immediately (one cheap commit instead of a multi-second one for thousands of
+ * turns), and the rest stream in during browser idle time. `ensureMounted`
+ * synchronously extends the window for deep links and finder navigation.
+ *
+ * The count is monotonic — a soft refresh that appends turns never unmounts
+ * what's already on screen (turns are keyed by uuid).
+ */
+export function useProgressiveMount(items: ThreadItem[]): {
+  visibleItems: ThreadItem[];
+  allMounted: boolean;
+  /** Number of currently mounted turns — effects that wait for a turn's DOM to appear should depend on it. */
+  mounted: number;
+  /** Make the turn with this uuid mountable now (unknown uuids mount everything — safe fallback). */
+  ensureMounted: (uuid: string) => void;
+} {
+  const total = items.length;
+  const [mounted, setMounted] = useState(() => Math.min(INITIAL_TURNS, total));
+  const allMounted = mounted >= total;
+
+  const indexByUuid = useMemo(() => {
+    const map = new Map<string, number>();
+    items.forEach((item, i) => map.set(item.uuid, i));
+    return map;
+  }, [items]);
+
+  // Stream the remaining turns in during idle time (Safari lacks
+  // requestIdleCallback — fall back to a short timeout).
+  useEffect(() => {
+    if (allMounted) return;
+    const grow = () => setMounted((c) => Math.min(c + CHUNK_TURNS, total));
+    if (typeof window.requestIdleCallback === 'function') {
+      const handle = window.requestIdleCallback(grow);
+      return () => window.cancelIdleCallback(handle);
+    }
+    const handle = window.setTimeout(grow, 50);
+    return () => window.clearTimeout(handle);
+  }, [allMounted, mounted, total]);
+
+  const ensureMounted = useCallback(
+    (uuid: string) => {
+      const index = indexByUuid.get(uuid);
+      // Unknown uuid (e.g. a turn inside a subagent thread) — mount everything
+      // rather than silently never reaching the target.
+      setMounted((c) => (index === undefined ? total : mountCountFor(index, c, total)));
+    },
+    [indexByUuid, total],
+  );
+
+  const visibleItems = useMemo(
+    () => (allMounted ? items : items.slice(0, mounted)),
+    [items, mounted, allMounted],
+  );
+
+  return { visibleItems, allMounted, mounted, ensureMounted };
+}

--- a/packages/web/src/pages/session/useProgressiveMount.ts
+++ b/packages/web/src/pages/session/useProgressiveMount.ts
@@ -29,7 +29,7 @@ export function useProgressiveMount(items: ThreadItem[]): {
   allMounted: boolean;
   /** Number of currently mounted turns — effects that wait for a turn's DOM to appear should depend on it. */
   mounted: number;
-  /** Make the turn with this uuid mountable now (unknown uuids mount everything — safe fallback). */
+  /** Make the turn with this uuid mountable now (unknown uuids grow by a chunk per call). */
   ensureMounted: (uuid: string) => void;
 } {
   const total = items.length;
@@ -58,9 +58,13 @@ export function useProgressiveMount(items: ThreadItem[]): {
   const ensureMounted = useCallback(
     (uuid: string) => {
       const index = indexByUuid.get(uuid);
-      // Unknown uuid (e.g. a turn inside a subagent thread) — mount everything
-      // rather than silently never reaching the target.
-      setMounted((c) => (index === undefined ? total : mountCountFor(index, c, total)));
+      // Unknown uuid (e.g. a turn inside a subagent thread, or a stale anchor):
+      // grow by a chunk rather than mounting everything at once — callers retry
+      // on `mounted` growth, so this walks to allMounted without reintroducing
+      // the one-giant-commit freeze.
+      setMounted((c) =>
+        index === undefined ? Math.min(c + CHUNK_TURNS, total) : mountCountFor(index, c, total),
+      );
     },
     [indexByUuid, total],
   );

--- a/packages/web/src/styles/global.css
+++ b/packages/web/src/styles/global.css
@@ -658,6 +658,13 @@ button {
   overflow-x: auto;
 }
 
+/* "Show all (2.4 MB)" affordance under clamped text (ClampedText). */
+.tv-clamp-more {
+  display: block;
+  margin-top: var(--tv-space-2);
+  font-size: var(--tv-fs-sm);
+}
+
 /* Search-result <mark> highlights from server snippets. */
 mark {
   background: var(--tv-mark-bg);

--- a/packages/web/test/clamp.test.ts
+++ b/packages/web/test/clamp.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest';
+import { clampCut, clampLabel } from '../src/components/limits.js';
+import { CHUNK_TURNS, mountCountFor } from '../src/pages/session/useProgressiveMount.js';
+
+describe('clampCut', () => {
+  it('cuts at the last line boundary before the limit', () => {
+    const text = 'aaaa\nbbbb\ncccc\ndddd';
+    // limit 12 → last \n at or before index 12 is index 9
+    expect(clampCut(text, 12)).toBe(9);
+  });
+
+  it('cuts mid-line at the limit for single-line blobs', () => {
+    const text = 'x'.repeat(100);
+    expect(clampCut(text, 40)).toBe(40);
+  });
+
+  it('ignores a pathologically early newline', () => {
+    const text = 'ab\n' + 'x'.repeat(200);
+    // only newline is at index 2, below limit/2 → cut at the limit instead
+    expect(clampCut(text, 100)).toBe(100);
+  });
+});
+
+describe('clampLabel', () => {
+  it('reports KB and line count for small text', () => {
+    expect(clampLabel('a'.repeat(2000) + '\nb')).toBe('2 KB, ~2 lines');
+  });
+
+  it('reports MB for large text', () => {
+    expect(clampLabel('a'.repeat(2_400_000))).toBe('2.4 MB, ~1 lines');
+  });
+});
+
+describe('mountCountFor', () => {
+  it('keeps the current count when the index is already mounted', () => {
+    expect(mountCountFor(10, 80, 500)).toBe(80);
+  });
+
+  it('overshoots the target index by a chunk, capped at total', () => {
+    expect(mountCountFor(200, 80, 500)).toBe(200 + CHUNK_TURNS);
+    expect(mountCountFor(490, 80, 500)).toBe(500);
+  });
+});


### PR DESCRIPTION
## Problem

On very large sessions (a 150MB JSONL was reported) the session page scrolls with visible jank — items appear with a delay. Three causes, all client-side (the server fetch is fine: a 30MB session serves its ~20MB JSON in ~0.4s locally):

1. **One giant React commit**: `ThreadList` mounts every turn at once; on thousands of turns that's a multi-second main-thread block before first paint, and CSS `content-visibility: auto` only defers layout, not JS.
2. **Unbounded DOM payloads**: expanded tool results render fully — a multi-MB Bash output or Read result mounts a multi-MB `<pre>` (only Shiki had a 60KB guard; the plain fallback had none). Huge pasted logs also went through the markdown parser.
3. **Whole-list re-renders**: every finder step (new reveal context) and every hash change re-rendered all turns, and the 140px `contain-intrinsic-size` estimate made the scrollbar jump as real heights replaced it.

## Change

- **`ClampedText`** (new): renders only the head (~50KB, cut at a line boundary) of oversized plain text behind a "Show all (N MB, ~M lines)" button. Applied at every unbounded sink: tool result blocks, Bash output, Read/Write code fallbacks, default tool input, attachments, system turns. `Markdown` sources >100KB skip remark entirely (clamped text + "Render as markdown anyway"). The finder's `forceOpen` reveal force-expands clamps, so matches in hidden tails stay highlightable.
- **`useProgressiveMount`** (new): first ~80 turns render immediately, the rest stream in via `requestIdleCallback` (timeout fallback); `ensureMounted(uuid)` extends the window synchronously for deep links and finder navigation — nested-subagent matches resolve to their spawn turn, orphan runs are always mounted. The deep-link scroll effect moved into `SessionView` and retries as turns mount instead of giving up if the anchor isn't in the first chunk.
- **Re-render hygiene**: `Turn` and `ThreadBlockView` are memoized; the reveal context is read in a thin per-block wrapper (`RevealableBlock`) and `SubagentBlock` tracks the location hash itself — finder steps and hash changes now re-render only thin wrappers, with memoized block views bailing out. Also fixes a hooks-order violation in `Turn` (`useContext` after a conditional return).
- `contain-intrinsic-size` raised 140px → 280px (closer to the median turn) to reduce scroll-anchoring jumps.

No new dependencies. Windowed virtualization (react-virtuoso et al.) was considered and rejected for now — `content-visibility` already skips off-screen layout, and windowing breaks anchors/finder/Cmd+F for unmounted turns. It remains the fallback if this proves insufficient.

## Invariants kept

- Finder matches are computed from data, so clamped tails still match; navigation mounts + force-expands the target block (existing 200ms highlight retry covers async mounts).
- `#uuid` and `#subagent-…` deep links land once their turn mounts (effect retries on mount growth).
- Changes tab and Export are pure data consumers — untouched.
- Native Cmd+F over the full DOM works again once idle mounting completes.

## Tests

- New `clamp.test.ts`: clamp cut-point boundaries, size labels, mount-window math.
- `npm test` (115) + `npm run typecheck` + production `npm run build` green; smoke-tested the built server (`/api/projects`, SPA, 30MB session fetch).
- Manual verification recommended on the real 28MB/150MB sessions: initial paint, fast-scroll trace, expanding a clamped block, finder next/prev across far-apart matches.

Part of [plan 0011](docs/plans/0011-performance-search-scroll-bench.md) (workstream B; plan doc lands in #10). Companion PRs: #10 (finder corpus), #11 (perf-suite statistics).
