### PR TITLE
fix(web): load Shiki grammars on demand for any bundled language

### DIFF
--- a/packages/web/src/components/CodeBlock.tsx
+++ b/packages/web/src/components/CodeBlock.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
 import { useTheme } from '../theme/ThemeProvider.js';
-import { getHighlighter, normalizeLang, shikiThemeFor } from './highlighter.js';
+import { getHighlighter, resolveLang, shikiThemeFor } from './highlighter.js';
 
 export interface CodeBlockProps {
   /** Raw source code (already de-fenced). */
@@ -11,19 +11,19 @@ export interface CodeBlockProps {
 
 /**
  * Highlights a code block with Shiki. Renders an unhighlighted <pre> first,
- * then swaps in highlighted HTML once the (lazy) highlighter resolves. If Shiki
- * fails to load or doesn't know the language, the plain <pre> stays — so this
- * component is always safe to render.
+ * then swaps in highlighted HTML once the (lazy) highlighter — and, if needed,
+ * the on-demand grammar for `lang` — resolves. If Shiki fails to load or
+ * doesn't know the language, the plain <pre> stays — so this component is
+ * always safe to render.
  */
 export function CodeBlock({ code, lang }: CodeBlockProps) {
   const [html, setHtml] = useState<string | null>(null);
-  const resolved = normalizeLang(lang);
   const { resolvedTheme } = useTheme();
 
   useEffect(() => {
     let cancelled = false;
-    getHighlighter()
-      .then((hl) => {
+    Promise.all([getHighlighter(), resolveLang(lang)])
+      .then(([hl, resolved]) => {
         if (cancelled || !hl) return;
         const out = hl.codeToHtml(code, { lang: resolved, theme: shikiThemeFor(resolvedTheme) });
         if (!cancelled) setHtml(out);
@@ -34,7 +34,7 @@ export function CodeBlock({ code, lang }: CodeBlockProps) {
     return () => {
       cancelled = true;
     };
-  }, [code, resolved, resolvedTheme]);
+  }, [code, lang, resolvedTheme]);
 
   if (html) {
     // Shiki output is trusted (we generated it from the code string).

--- a/packages/web/src/components/highlighter.ts
+++ b/packages/web/src/components/highlighter.ts
@@ -1,14 +1,17 @@
 /**
  * Lazy, shared Shiki highlighter. Loading the full grammar/theme set is heavy,
  * so we create a single highlighter instance on first use and reuse it. A small
- * curated language set keeps the bundle reasonable; unknown languages fall back
- * to plaintext. All failures are swallowed so the caller can render plain text.
+ * curated set is preloaded so common languages highlight without a flash; any
+ * other language Shiki bundles is grammar-loaded on demand the first time it
+ * appears (each grammar is its own lazy chunk), and only truly unknown
+ * languages fall back to plaintext. All failures are swallowed so the caller
+ * can render plain text.
  */
 
 import type { BundledLanguage, Highlighter, SpecialLanguage } from 'shiki';
 
-/** Languages we ship grammars for. Anything else renders as plaintext. */
-const LANGS = [
+/** Grammars preloaded with the highlighter; everything else loads on demand. */
+const PRELOADED_LANGS = [
   'typescript',
   'javascript',
   'tsx',
@@ -45,20 +48,26 @@ export function getHighlighter(): Promise<Highlighter | null> {
   if (!highlighterPromise) {
     highlighterPromise = import('shiki')
       .then(({ createHighlighter }) =>
-        createHighlighter({ themes: [...THEMES], langs: [...LANGS] }),
+        createHighlighter({ themes: [...THEMES], langs: [...PRELOADED_LANGS] }),
       )
       .catch(() => null);
   }
   return highlighterPromise;
 }
 
-/** Normalize a fenced-code language hint to one of our supported grammars. */
+/**
+ * Normalize a language hint (markdown fence tag or file extension) to a Shiki
+ * grammar id. Purely an alias map — whether the grammar exists is decided by
+ * {@link resolveLang} against Shiki's bundled registry.
+ */
 export function normalizeLang(lang: string | undefined): string {
   if (!lang) return 'text';
   const l = lang.toLowerCase();
   const alias: Record<string, string> = {
     ts: 'typescript',
     js: 'javascript',
+    mjs: 'javascript',
+    cjs: 'javascript',
     sh: 'bash',
     zsh: 'bash',
     shell: 'bash',
@@ -67,9 +76,55 @@ export function normalizeLang(lang: string | undefined): string {
     md: 'markdown',
     rs: 'rust',
     golang: 'go',
+    kt: 'kotlin',
+    kts: 'kotlin',
+    h: 'c',
+    cc: 'cpp',
+    cxx: 'cpp',
+    hpp: 'cpp',
+    hh: 'cpp',
+    cs: 'csharp',
+    rb: 'ruby',
+    m: 'objective-c',
+    mm: 'objective-cpp',
+    pl: 'perl',
+    ex: 'elixir',
+    exs: 'elixir',
+    erl: 'erlang',
+    hs: 'haskell',
+    gradle: 'groovy',
+    gql: 'graphql',
   };
-  const resolved = alias[l] ?? l;
-  return (LANGS as readonly string[]).includes(resolved) ? resolved : 'text';
+  return alias[l] ?? l;
+}
+
+// Grammar loads in flight or settled, so each language is requested once.
+const langLoads = new Map<string, Promise<unknown>>();
+
+/**
+ * Resolve a language hint to a grammar the shared highlighter can actually
+ * use, loading it on demand from Shiki's bundle when it isn't preloaded.
+ * Resolves to 'text' for unknown languages or on any load failure.
+ */
+export async function resolveLang(lang: string | undefined): Promise<string> {
+  const hl = await getHighlighter();
+  if (!hl) return 'text';
+  const id = normalizeLang(lang);
+  if (id === 'text' || id === 'txt' || id === 'plaintext') return 'text';
+  if (hl.getLoadedLanguages().includes(id)) return id;
+  try {
+    const { bundledLanguages } = await import('shiki');
+    if (!(id in bundledLanguages)) return 'text';
+    let load = langLoads.get(id);
+    if (!load) {
+      load = hl.loadLanguage(id as BundledLanguage).catch(() => {});
+      langLoads.set(id, load);
+    }
+    await load;
+    return hl.getLoadedLanguages().includes(id) ? id : 'text';
+  } catch {
+    return 'text';
+  }
 }
 
 function escapeHtml(s: string): string {
@@ -89,7 +144,7 @@ export async function highlightLines(
   const hl = await getHighlighter();
   if (!hl) return null;
   try {
-    const resolved = normalizeLang(lang) as BundledLanguage | SpecialLanguage;
+    const resolved = (await resolveLang(lang)) as BundledLanguage | SpecialLanguage;
     const { tokens } = hl.codeToTokens(code, { lang: resolved, theme: shikiThemeFor(theme) });
     return tokens.map((line) =>
       line


### PR DESCRIPTION
## Problem

Kotlin code renders as plaintext — and so does Swift, C, C++, C#, Ruby, PHP, Scala, and anything else outside the curated 18-grammar list in `highlighter.ts`. `normalizeLang` gated every language hint against that list and silently fell back to `text`, for both markdown fences and file-extension hints from Read/Write/Edit tool blocks.

## Change

- The curated set stays **preloaded** (common languages highlight with no flash).
- New `resolveLang()`: any other hint is checked against Shiki's `bundledLanguages` registry and its grammar is **loaded on demand** the first time it appears (deduplicated in-flight; failures fall back to plaintext). Shiki code-splits each grammar into its own chunk, so the initial bundle size is unchanged — a session with Kotlin fetches the Kotlin grammar once, on first sight.
- `normalizeLang` is now a pure alias map, extended with common fence tags and file extensions (`kt`/`kts` → kotlin, `h` → c, `cc`/`cxx`/`hpp` → cpp, `cs` → csharp, `rb` → ruby, `gradle` → groovy, `m` → objective-c, etc.).
- `CodeBlock` and `highlightLines` (diff view) both go through `resolveLang`, so tool blocks, markdown fences, and Edit diffs all benefit.

## Verification

- Runtime check (tsx): `kotlin`/`kt`/`swift`/`cpp`/`cs`/`rb` resolve and produce colored tokens; unknown hints fall back to `text`; kotlin sample renders with colored spans.
- `npm run typecheck`, `npm test` (127), and production `npm run build` green.