### PR TITLE
docs(security): document the LiteLLM pricing fetch as an outbound request

### DIFF
--- a/README.md
+++ b/README.md
@@ -346,8 +346,10 @@ bundles, and publishes. Auth uses npm **Trusted Publishing** (OIDC) — no
 ## Security & privacy
 
 Claudescope runs entirely on your machine. It treats `~/.claude`, `~/.codex`, and
-`~/.junie` as **read-only**, **binds to `127.0.0.1` only**, sends **no telemetry**, and its sole outbound
-request is a cached npm-registry version check for the update notice. See
+`~/.junie` as **read-only**, **binds to `127.0.0.1` only**, and sends **no telemetry**. Its only
+outbound requests are a cached npm-registry version check for the update notice
+and a daily fetch of public model pricing rates from LiteLLM (disable with
+`PRICING_REFRESH_INTERVAL_MS=0`). See
 [`SECURITY.md`](./SECURITY.md) for the full breakdown of filesystem, network,
 shell, and self-update behavior — and how to report a vulnerability.
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -36,9 +36,17 @@ None of these are misused; they're listed here so you can verify that.
 
 - **Binds to `127.0.0.1` only** (`packages/server/src/index.ts`) — the server is
   never exposed to your LAN or the internet.
-- The **only outbound request** in shipped code is a version check against
-  `https://registry.npmjs.org` (cached for 24h) to tell you when an update is
-  available (`packages/server/src/cli.ts`).
+- Shipped code makes exactly **two kinds of outbound request**, both to
+  hardcoded trusted endpoints:
+  - a version check against `https://registry.npmjs.org` (cached for 24h) to
+    tell you when an update is available (`packages/server/src/cli.ts`);
+  - a daily fetch of model pricing rates from LiteLLM's public table at
+    `https://raw.githubusercontent.com/BerriAI/litellm/…/model_prices_and_context_window.json`
+    (`packages/server/src/data/pricing-refresh.ts`), validated and written
+    atomically to `~/.claudescope/pricing.fetched.json`. Set
+    `PRICING_REFRESH_INTERVAL_MS=0` to disable it entirely.
+
+  Both are GET requests that **send no data** beyond the request itself.
 - **No telemetry, analytics, or data exfiltration.** Your transcript content
   never leaves your machine.
 - The only other URLs in the repository (`example.com`, `platform.claude.com`)


### PR DESCRIPTION
Prompted by re-reviewing the [Socket alerts on 0.4.2](https://socket.dev/npm/package/@vladar107/claudescope/alerts/0.4.2).

Audit result: shipped code still matches SECURITY.md on shell access (hardcoded argument arrays, no `shell: true` outside the documented Windows case) and filesystem behavior — **except** the network section: since the runtime pricing refresh (#9), the npm-registry version check is no longer the *only* outbound request. There's now a daily GET to LiteLLM's public pricing table (`raw.githubusercontent.com/BerriAI/litellm/…`), validated and atomically written to `~/.claudescope/pricing.fetched.json`, disableable via `PRICING_REFRESH_INTERVAL_MS=0`.

This updates SECURITY.md and the README security section so the next release's scanner alerts can be checked against accurate docs.

Context on the alerts themselves: Socket re-scans every published version, so the capability alerts (fs read of transcripts, spawn for daemon/browser/update, URL strings) reappear on each release by design — they describe what the app inherently does and can't be 'fixed' away, only documented and kept truthful.