### PR TITLE
fix(server): deduplicate token usage and cost by billed API call

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -117,7 +117,9 @@ The CLI `update` command (`cli.ts`) detects the install method and defers to
 - **Cost is a local estimate** from token usage × rates; not real billing.
   Computed once at index time and stored. Rates auto-refresh daily from LiteLLM
   at runtime (`pricing.fetched.json`); `pricing.json` is the fallback/override
-  layer for families and the default rate.
+  layer for families and the default rate. Usage is deduplicated by billed API
+  call (`message.id`): multi-block splits and fork/resume copies repeat usage
+  across rows, and only the canonical row (elected at index time) is counted.
 - **Release is maintainer-only** and tag-triggered (npm Trusted Publishing /
   OIDC). See `CONTRIBUTING.md`.
 

--- a/docs/plans/0012-cost-dedup-billed-api-calls.md
+++ b/docs/plans/0012-cost-dedup-billed-api-calls.md
@@ -1,8 +1,8 @@
 # 0012 — Cost dedup: billed API calls
 
-- **Status:** in-progress
+- **Status:** done
 - **Date:** 2026-06-12
-- **PR:** <link, once opened>
+- **PR:** [#16](https://github.com/vladar107/claudescope/pull/16)
 
 ## Context
 
@@ -63,13 +63,15 @@ API call exactly once, while leaving raw event data and the thread view untouche
    from each assistant event row.
 3. **Codex + Junie connectors.** Emit `NULL` for both new columns (no change to
    their dedup logic).
-4. **`electCanonicalUsage`.** New function in `data/index.ts`: after each batch
-   of inserts, run a DuckDB UPDATE that sets `usage_canonical` via the election
-   window described above, scoped to the files that changed.
-5. **Filtered sums.** `rebuildSessions` and `/api/analytics` add
-   `WHERE usage_canonical` to all `SUM(input_tokens)` / `SUM(output_tokens)` /
-   `SUM(cache_*)` / `SUM(cost)` aggregates. Row counts (message count) also filter
-   on `usage_canonical`.
+4. **`electCanonicalUsage`.** New function in `data/index.ts`: after a reindex
+   pass that changed anything, run a global DuckDB UPDATE that re-elects
+   `usage_canonical` via the election window described above (a full recompute,
+   cheap at this scale — stays correct across added/edited/removed files).
+5. **Filtered sums.** `rebuildSessions` and `/api/analytics` apply
+   `FILTER (WHERE usage_canonical)` to all `SUM(input_tokens)` /
+   `SUM(output_tokens)` / `SUM(cache_*)` / `SUM(cost)` aggregates. The sessions
+   `message_count` stays unfiltered (it counts transcript rows); only the
+   analytics `messageCount` is deduped (it counts billed calls).
 6. **Integration test.** New `packages/server/test/dedup.integration.test.ts`
    covering: multi-block split, partial-output rows, marked fork pair, legacy
    unmarked fork.

--- a/docs/plans/0012-cost-dedup-billed-api-calls.md
+++ b/docs/plans/0012-cost-dedup-billed-api-calls.md
@@ -1,0 +1,107 @@
+# 0012 — Cost dedup: billed API calls
+
+- **Status:** in-progress
+- **Date:** 2026-06-12
+- **PR:** <link, once opened>
+
+## Context
+
+The indexer sums `message.usage` over every assistant event row, but one billed
+API call appears as multiple rows. Two mechanisms, verified empirically on real
+data (2026-06-12):
+
+1. **Multi-block splits** — Claude Code writes one JSONL line per content block
+   of a single API response, each line repeating the same `message.id` and the
+   full `usage`. In ~1,800 such groups the earlier lines carry partial
+   `output_tokens` (streaming progress); the max-output row is the true one.
+2. **Fork/resume copies** — branching copies the whole session history into the
+   new session file with `sessionId` rewritten (uuid/message.id/usage/timestamps
+   preserved). Each copied line is stamped with a top-level
+   `forkedFrom: {sessionId, messageUuid}` marker (legacy forks may lack it).
+
+Measured inflation on the author's corpus: 23,714 assistant rows vs 10,999
+billed calls; output tokens ×3.0, cache-read ×2.3.
+
+Codex is unaffected (usage accumulated from per-call `token_count` deltas, once
+per turn; no cross-file copies observed). Junie is unaffected (per-turn
+`LlmResponseMetadataEvent` sums; apparent duplicates are distinct tiny helper
+calls with identical usage).
+
+## Goal
+
+Eliminate double-counting so that all usage and cost aggregates count each billed
+API call exactly once, while leaving raw event data and the thread view untouched.
+
+## Decisions
+
+- **Dedup key: `message.id`** — unique per billed call on the verified corpus;
+  connector-agnostic column so other connectors can populate it later. `requestId`
+  is not stored (not needed).
+- **`usage_canonical` flag on `events`, not a separate table** — raw rows stay
+  untouched; the flag is re-elected globally on every reindex that changed files.
+  Simpler than a join table; analytics queries just add a `WHERE usage_canonical`.
+- **Election per `message_id` partition** — ORDER BY:
+  (1) `forked_from_session_id IS NOT NULL ASC` (original session beats fork copies,
+  exact attribution via the `forkedFrom` marker);
+  (2) `output_tokens DESC` (final streaming row beats partials);
+  (3) `file_path`, `uuid` (deterministic fallback for legacy forks — totals are
+  exact regardless of which copy wins). `NULL message_id` rows are always canonical.
+- **If the original file is deleted** the fork's copy is elected and cost
+  re-attaches there. No data is lost.
+- **Message/tool counts and FTS are unfiltered** — content blocks are not
+  duplicated, only usage is.
+- **Analytics `messageCount` becomes deduped billed-call count** — intentional
+  semantic change; more useful than raw row count.
+- **SCHEMA\_VERSION 5→6** — the index is a derived cache; it is discarded and
+  rebuilt on first run after upgrade.
+
+## Approach
+
+1. **Schema.** Add `message_id`, `forked_from_session_id`, `usage_canonical`
+   columns to `events`; bump `SCHEMA_VERSION` to 6.
+2. **Claude Code connector.** Extract `message.id` and `forkedFrom.sessionId`
+   from each assistant event row.
+3. **Codex + Junie connectors.** Emit `NULL` for both new columns (no change to
+   their dedup logic).
+4. **`electCanonicalUsage`.** New function in `data/index.ts`: after each batch
+   of inserts, run a DuckDB UPDATE that sets `usage_canonical` via the election
+   window described above, scoped to the files that changed.
+5. **Filtered sums.** `rebuildSessions` and `/api/analytics` add
+   `WHERE usage_canonical` to all `SUM(input_tokens)` / `SUM(output_tokens)` /
+   `SUM(cache_*)` / `SUM(cost)` aggregates. Row counts (message count) also filter
+   on `usage_canonical`.
+6. **Integration test.** New `packages/server/test/dedup.integration.test.ts`
+   covering: multi-block split, partial-output rows, marked fork pair, legacy
+   unmarked fork.
+
+## Files affected
+
+- `packages/server/src/db/schema.ts` — add `message_id`, `forked_from_session_id`,
+  `usage_canonical`; bump `SCHEMA_VERSION` to 6.
+- `packages/server/src/connectors/claude-code/claude-code.ts` — project
+  `message.id` and `forkedFrom.sessionId` per event row.
+- `packages/server/src/connectors/codex/codex.ts` — emit `NULL` for new columns.
+- `packages/server/src/connectors/junie/junie.ts` — emit `NULL` for new columns.
+- `packages/server/src/data/index.ts` — add `electCanonicalUsage`; filter all
+  usage/cost sums on `usage_canonical` in `rebuildSessions`.
+- `packages/server/src/routes/analytics.ts` — filter all usage/cost sums on
+  `usage_canonical`.
+- `packages/server/test/dedup.integration.test.ts` — new integration test.
+
+## Testing
+
+- Integration: `dedup.integration.test.ts` builds a real DuckDB index from
+  synthetic JSONL fixtures in a temp dir; asserts canonical row counts and token
+  totals for each dedup scenario. Never touches real `~/.claude*` dirs.
+- `npm test` and `npm run typecheck` green after the change.
+
+## Risks / open questions
+
+- Legacy forks without the `forkedFrom` marker fall back to
+  `file_path`/`uuid` ordering — totals remain exact, attribution may land on the
+  fork copy rather than the original. Acceptable given the rarity and the fallback
+  logic.
+- Codex fork support is out of scope; if Codex ever copies `token_count` lines,
+  its connector can populate `message_id` and gain dedup for free.
+- Per-bubble token chips in the thread view still show each raw row's usage
+  (unfiltered). Addressed separately if wanted.

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -36,3 +36,4 @@ decision, or a change worth explaining before doing. Skip it for one-line fixes.
 | 0009 | [Homebrew + Nix distribution](./0009-homebrew-nix-distribution.md) | done |
 | 0010 | [runtime pricing refresh](./0010-runtime-pricing-refresh.md) | done |
 | 0011 | [performance: search, scrolling, bench](./0011-performance-search-scroll-bench.md) | done |
+| 0012 | [cost dedup: billed API calls](./0012-cost-dedup-billed-api-calls.md) | in-progress |

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -36,4 +36,4 @@ decision, or a change worth explaining before doing. Skip it for one-line fixes.
 | 0009 | [Homebrew + Nix distribution](./0009-homebrew-nix-distribution.md) | done |
 | 0010 | [runtime pricing refresh](./0010-runtime-pricing-refresh.md) | done |
 | 0011 | [performance: search, scrolling, bench](./0011-performance-search-scroll-bench.md) | done |
-| 0012 | [cost dedup: billed API calls](./0012-cost-dedup-billed-api-calls.md) | in-progress |
+| 0012 | [cost dedup: billed API calls](./0012-cost-dedup-billed-api-calls.md) | done |

--- a/packages/server/src/connectors/claude-code/claude-code.ts
+++ b/packages/server/src/connectors/claude-code/claude-code.ts
@@ -101,7 +101,7 @@ function eventsProjectionSql(filePath: string): string {
   const readFn = `read_ndjson(${path}, ${READ_OPTS}, columns={
     type:'VARCHAR', uuid:'VARCHAR', parentUuid:'VARCHAR', sessionId:'VARCHAR',
     timestamp:'VARCHAR', cwd:'VARCHAR', gitBranch:'VARCHAR', isSidechain:'BOOLEAN',
-    message:'JSON'
+    message:'JSON', forkedFrom:'JSON'
   })`;
 
   return `
@@ -123,7 +123,9 @@ function eventsProjectionSql(filePath: string): string {
       json_extract_string(message, '$.usage.service_tier') AS service_tier,
       COALESCE(isSidechain, FALSE) AS is_sidechain,
       ${TOOL_USE_COUNT_EXPR} AS tool_use_count,
-      ${TEXT_CONTENT_EXPR} AS text_content
+      ${TEXT_CONTENT_EXPR} AS text_content,
+      json_extract_string(message, '$.id') AS message_id,
+      json_extract_string(forkedFrom, '$.sessionId') AS forked_from_session_id
     FROM ${readFn}
     WHERE type IN ('user', 'assistant')`;
 }

--- a/packages/server/src/connectors/codex/codex.ts
+++ b/packages/server/src/connectors/codex/codex.ts
@@ -69,7 +69,8 @@ function eventsProjectionSql(filePath: string): string {
     SELECT
       file_path, session_id, uuid, parent_uuid, role, type, ts, cwd, git_branch,
       model, input_tokens, output_tokens, cache_read_tokens, cache_write_tokens,
-      service_tier, is_sidechain, tool_use_count, text_content
+      service_tier, is_sidechain, tool_use_count, text_content,
+      CAST(NULL AS VARCHAR) AS message_id, CAST(NULL AS VARCHAR) AS forked_from_session_id
     FROM read_ndjson(${path}, format='newline_delimited', maximum_object_size=268435456, ignore_errors=true, columns={
       file_path:'VARCHAR', session_id:'VARCHAR', uuid:'VARCHAR', parent_uuid:'VARCHAR',
       role:'VARCHAR', type:'VARCHAR', ts:'TIMESTAMP', cwd:'VARCHAR', git_branch:'VARCHAR',

--- a/packages/server/src/connectors/junie/junie.ts
+++ b/packages/server/src/connectors/junie/junie.ts
@@ -77,7 +77,8 @@ function eventsProjectionSql(filePath: string): string {
     SELECT
       file_path, session_id, uuid, parent_uuid, role, type, ts, cwd, git_branch,
       model, input_tokens, output_tokens, cache_read_tokens, cache_write_tokens,
-      service_tier, is_sidechain, tool_use_count, text_content
+      service_tier, is_sidechain, tool_use_count, text_content,
+      CAST(NULL AS VARCHAR) AS message_id, CAST(NULL AS VARCHAR) AS forked_from_session_id
     FROM read_ndjson(${path}, format='newline_delimited', maximum_object_size=268435456, ignore_errors=true, columns={
       file_path:'VARCHAR', session_id:'VARCHAR', uuid:'VARCHAR', parent_uuid:'VARCHAR',
       role:'VARCHAR', type:'VARCHAR', ts:'TIMESTAMP', cwd:'VARCHAR', git_branch:'VARCHAR',

--- a/packages/server/src/data/index.ts
+++ b/packages/server/src/data/index.ts
@@ -143,7 +143,8 @@ async function loadFile(
       ev.model, ev.input_tokens, ev.output_tokens, ev.cache_read_tokens, ev.cache_write_tokens,
       ev.service_tier, ev.is_sidechain, ev.tool_use_count,
       ${costExpr} AS cost_usd,
-      ev.text_content
+      ev.text_content,
+      ev.message_id, ev.forked_from_session_id, TRUE AS usage_canonical
     FROM (
       ${connector.eventsProjectionSql(file.path)}
     ) AS ev
@@ -159,6 +160,52 @@ async function loadFile(
       `INSERT OR REPLACE INTO pr_links (session_id, pr_number, pr_repository, pr_url) ${aux.prLinks}`,
     );
   }
+}
+
+/**
+ * Mark exactly one `events` row per billed API call as the usage-canonical one,
+ * so token/cost SUMs don't multiply-count a single API response.
+ *
+ * Why this is needed: Claude Code writes one row per content block, all sharing
+ * the same `message.id` and repeating the FULL `usage` object; and forking a
+ * session copies the whole history into a new file (sessionId rewritten, usage
+ * preserved), with each copied row carrying a top-level `forkedFrom` marker.
+ * Both inflate the per-event usage SUMs. Codex/Junie carry NULL message_id and
+ * accumulate per-call deltas once in their normalizers, so they are unaffected.
+ *
+ * The election runs globally each reindex (a full recompute over `events`, cheap
+ * at this scale) so it stays correct across files added, edited, or removed:
+ *  - Rows with NULL message_id are ALWAYS canonical (synthetic rows have unique
+ *    ids when present, so partitioning by message_id never collapses real calls).
+ *  - Within a `message_id` partition, prefer the original over fork copies
+ *    (exact attribution), then the final streaming row over partial ones (only
+ *    `output_tokens` grows across a streamed group), then a deterministic
+ *    file_path/uuid tiebreak for legacy forks that predate the `forkedFrom`
+ *    marker. If the original file was deleted, a fork copy wins rank 1 and the
+ *    cost gracefully re-attaches to the surviving fork session.
+ */
+async function electCanonicalUsage(conn: DuckDBConnection): Promise<void> {
+  // Reset: NULL-id rows are always canonical; everything else starts non-canonical
+  // and only the elected rank-1 row per partition is flipped back below.
+  await conn.run(`UPDATE events SET usage_canonical = (message_id IS NULL)`);
+  await conn.run(`
+    UPDATE events SET usage_canonical = TRUE
+    FROM (
+      SELECT file_path, uuid, message_id,
+             row_number() OVER (
+               PARTITION BY message_id
+               ORDER BY (forked_from_session_id IS NOT NULL) ASC,
+                        output_tokens DESC,
+                        file_path, uuid
+             ) AS rn
+      FROM events
+      WHERE message_id IS NOT NULL
+    ) w
+    WHERE events.file_path = w.file_path
+      AND events.uuid = w.uuid
+      AND events.message_id = w.message_id
+      AND w.rn = 1
+  `);
 }
 
 /**
@@ -193,11 +240,14 @@ async function rebuildSessions(conn: DuckDBConnection): Promise<void> {
         max(ts) AS ended_at,
         count(*) AS message_count,
         sum(tool_use_count) AS tool_call_count,
-        sum(input_tokens) AS input_tokens,
-        sum(output_tokens) AS output_tokens,
-        sum(cache_read_tokens) AS cache_read_tokens,
-        sum(cache_write_tokens) AS cache_write_tokens,
-        sum(cost_usd) AS total_cost_usd,
+        -- Usage/cost SUMs filter on usage_canonical so a single billed API call
+        -- (written as many content-block rows, or copied by a fork) is counted
+        -- once; COALESCE guards a session whose every usage row is non-canonical.
+        COALESCE(sum(input_tokens) FILTER (WHERE usage_canonical), 0) AS input_tokens,
+        COALESCE(sum(output_tokens) FILTER (WHERE usage_canonical), 0) AS output_tokens,
+        COALESCE(sum(cache_read_tokens) FILTER (WHERE usage_canonical), 0) AS cache_read_tokens,
+        COALESCE(sum(cache_write_tokens) FILTER (WHERE usage_canonical), 0) AS cache_write_tokens,
+        COALESCE(sum(cost_usd) FILTER (WHERE usage_canonical), 0) AS total_cost_usd,
         bool_or(is_sidechain) AS has_sidechain,
         list_distinct(list(model) FILTER (WHERE model IS NOT NULL)) AS model_list
       FROM events GROUP BY session_id
@@ -364,8 +414,9 @@ async function doReindex(): Promise<ReindexResponse> {
     return { reindexed, durationMs: Date.now() - start };
   }
 
-  // Something changed: rebuild derived tables + FTS so additions, edits, and
-  // removals are all reflected.
+  // Something changed: re-elect the usage-canonical rows globally, then rebuild
+  // derived tables + FTS so additions, edits, and removals are all reflected.
+  await electCanonicalUsage(conn);
   await rebuildSessions(conn);
   await rebuildFtsIndex(conn);
 

--- a/packages/server/src/db/schema.ts
+++ b/packages/server/src/db/schema.ts
@@ -22,7 +22,8 @@
 // so existing indexes pick up the new output. On a version mismatch the index
 // (a derived cache) is discarded and rebuilt from source — see db/duckdb.ts.
 // v5: Codex title fallback (first user message) + `<image …>` placeholder strip.
-export const SCHEMA_VERSION = 5;
+// v6: usage dedup by billed API call (message_id / forked_from_session_id / usage_canonical).
+export const SCHEMA_VERSION = 6;
 
 /** All DDL statements, executed in order at startup. Idempotent. */
 export const SCHEMA_DDL: readonly string[] = [
@@ -59,7 +60,10 @@ export const SCHEMA_DDL: readonly string[] = [
      is_sidechain BOOLEAN DEFAULT FALSE,
      tool_use_count INTEGER DEFAULT 0,
      cost_usd     DOUBLE DEFAULT 0,
-     text_content VARCHAR
+     text_content VARCHAR,
+     message_id   VARCHAR,
+     forked_from_session_id VARCHAR,
+     usage_canonical BOOLEAN DEFAULT TRUE
    )`,
 
   `CREATE TABLE IF NOT EXISTS sessions (

--- a/packages/server/src/routes/analytics.ts
+++ b/packages/server/src/routes/analytics.ts
@@ -5,6 +5,10 @@
  * cacheHitRatio = cache_read / (cache_read + input). Computed both per-row and
  * for the totals. Optional inclusive date bounds `from` / `to` filter on the
  * event timestamp.
+ *
+ * Token/cost SUMs and messageCount filter on `usage_canonical` so one billed API
+ * call counts once (Claude Code writes a row per content block and copies usage
+ * across fork sessions); messageCount is therefore "billed API calls, deduped".
  */
 
 import type { FastifyInstance } from 'fastify';
@@ -71,12 +75,12 @@ export async function registerAnalyticsRoute(app: FastifyInstance): Promise<void
       conn,
       `SELECT
          ${keyExpr} AS group_key,
-         sum(e.input_tokens) AS input_tokens,
-         sum(e.output_tokens) AS output_tokens,
-         sum(e.cache_write_tokens) AS cache_write_tokens,
-         sum(e.cache_read_tokens) AS cache_read_tokens,
-         sum(e.cost_usd) AS cost_usd,
-         count(*) AS message_count
+         sum(e.input_tokens) FILTER (WHERE e.usage_canonical) AS input_tokens,
+         sum(e.output_tokens) FILTER (WHERE e.usage_canonical) AS output_tokens,
+         sum(e.cache_write_tokens) FILTER (WHERE e.usage_canonical) AS cache_write_tokens,
+         sum(e.cache_read_tokens) FILTER (WHERE e.usage_canonical) AS cache_read_tokens,
+         sum(e.cost_usd) FILTER (WHERE e.usage_canonical) AS cost_usd,
+         count(*) FILTER (WHERE e.usage_canonical) AS message_count
        ${fromSql}
        ${whereSql}
        GROUP BY group_key

--- a/packages/server/test/dedup.integration.test.ts
+++ b/packages/server/test/dedup.integration.test.ts
@@ -1,0 +1,362 @@
+/**
+ * Cost-deduplication integration tests.
+ *
+ * Models the two ways Claude Code inflates per-event usage SUMs on disk and
+ * verifies the `usage_canonical` election (see `electCanonicalUsage` in
+ * `src/data/index.ts`) counts each billed API call exactly once:
+ *
+ *  1. Multi-block split — one billed API response is written as N JSONL lines,
+ *     all sharing `message.id` and repeating the FULL `usage`; earlier lines
+ *     may carry a PARTIAL `output_tokens` (streaming progress). The max-output
+ *     row is the true one and must be the only one summed.
+ *  2. Fork copies — forking a session copies the original's lines into a new
+ *     file (sessionId rewritten, uuid/message.id/usage preserved). Marked forks
+ *     carry a top-level `forkedFrom`; legacy forks don't. The election prefers
+ *     the original over a marked-fork copy, and falls back to a deterministic
+ *     `(output_tokens DESC, file_path, uuid)` tiebreak when no marker
+ *     distinguishes the rows — so totals stay exact and attribution is stable.
+ *
+ * Built like `api.integration.test.ts`: a synthetic ~/.claude/projects tree is
+ * indexed into a throwaway DuckDB, then exercised through Fastify `.inject()`.
+ * The per-token-type breakdown isn't exposed by `/api/sessions` (only
+ * totalTokens/cost/messageCount), so the per-session input/output/cache numbers
+ * are read straight from the `sessions` table via the DB connection — the same
+ * derived table the routes read.
+ */
+
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import type { FastifyInstance } from 'fastify';
+import type { DuckDBConnection } from '@duckdb/node-api';
+
+// --- temp locations (decided before any server module is imported) ----------
+const work = mkdtempSync(join(tmpdir(), 'claudescope-dedup-'));
+const projectsDir = join(work, 'projects');
+const dbPath = join(work, 'index.duckdb');
+
+process.env.CLAUDE_PROJECTS_DIR = projectsDir;
+// Isolate from the real ~/.codex and ~/.junie so this Claude-only suite stays
+// deterministic.
+process.env.CODEX_SESSIONS_DIR = join(work, 'codex-empty');
+process.env.JUNIE_SESSIONS_DIR = join(work, 'junie-empty');
+process.env.DUCKDB_PATH = dbPath;
+process.env.CLAUDESCOPE_HOME = join(work, 'home');
+process.env.REINDEX_INTERVAL_MS = '0';
+
+const jsonl = (events: unknown[]): string => events.map((e) => JSON.stringify(e)).join('\n') + '\n';
+
+// `claude-opus-4-8` has no exact-id row in the default pricing.json, so cost
+// resolves via the "opus" family rate (USD per 1M tokens). Mirrored here so the
+// expected per-call/per-session cost can be hand-computed.
+const MODEL = 'claude-opus-4-8';
+const RATE = { input: 5, output: 25, cacheWrite: 6.25, cacheRead: 0.5 };
+const costOf = (u: { input: number; output: number; cacheRead: number; cacheWrite: number }): number =>
+  (u.input * RATE.input + u.output * RATE.output + u.cacheWrite * RATE.cacheWrite + u.cacheRead * RATE.cacheRead) /
+  1_000_000;
+
+const CWD = '/tmp/dedup';
+
+/** An assistant line in the canonical Claude transcript shape. */
+function asst(opts: {
+  uuid: string;
+  parentUuid: string | null;
+  sessionId: string;
+  timestamp: string;
+  messageId?: string; // omitted => NULL message_id (always canonical)
+  forkedFrom?: { sessionId: string; messageUuid: string };
+  usage: { input: number; output: number; cacheRead: number; cacheWrite: number };
+}): Record<string, unknown> {
+  const line: Record<string, unknown> = {
+    type: 'assistant',
+    uuid: opts.uuid,
+    parentUuid: opts.parentUuid,
+    sessionId: opts.sessionId,
+    timestamp: opts.timestamp,
+    cwd: CWD,
+    isSidechain: false,
+    requestId: `req_${opts.uuid}`,
+    message: {
+      ...(opts.messageId ? { id: opts.messageId } : {}),
+      role: 'assistant',
+      model: MODEL,
+      content: [{ type: 'text', text: `reply ${opts.uuid}` }],
+      usage: {
+        input_tokens: opts.usage.input,
+        output_tokens: opts.usage.output,
+        cache_read_input_tokens: opts.usage.cacheRead,
+        cache_creation_input_tokens: opts.usage.cacheWrite,
+      },
+    },
+  };
+  if (opts.forkedFrom) line.forkedFrom = opts.forkedFrom;
+  return line;
+}
+
+const user = (uuid: string, parentUuid: string | null, sessionId: string, ts: string, text: string) => ({
+  type: 'user',
+  uuid,
+  parentUuid,
+  sessionId,
+  timestamp: ts,
+  cwd: CWD,
+  isSidechain: false,
+  message: { role: 'user', content: text },
+});
+
+// The four unique billed calls + the NULL-id row, as ground truth for the
+// deduped grand totals. (See the per-session breakdown in the asserts.)
+const CALLS = {
+  // msg_split: written as 3 lines (partial 1, then final 50 x2); max-output wins.
+  split: { input: 10, output: 50, cacheRead: 100, cacheWrite: 5 },
+  o2: { input: 20, output: 30, cacheRead: 0, cacheWrite: 0 },
+  f1: { input: 40, output: 60, cacheRead: 200, cacheWrite: 0 },
+  l1: { input: 5, output: 7, cacheRead: 0, cacheWrite: 0 },
+  // A NULL-message-id assistant row: always canonical, never deduped away.
+  nul: { input: 1, output: 2, cacheRead: 0, cacheWrite: 0 },
+} as const;
+
+/**
+ * Write the fixture transcripts into one project dir. File names are chosen so
+ * the legacy-fork tiebreak (below) is deterministic: 'sessL' < 'sessO'.
+ */
+function writeFixtures(): void {
+  const proj = join(projectsDir, 'enc-dedup');
+  mkdirSync(proj, { recursive: true });
+
+  // --- Session O (original) -------------------------------------------------
+  // u1 → one API call `msg_split` written as THREE assistant lines (same
+  // message.id + full usage; the first carries a PARTIAL output_tokens) → a
+  // second normal call `msg_o2` → plus a NULL-message-id assistant row.
+  writeFileSync(
+    join(proj, 'sessO.jsonl'),
+    jsonl([
+      { type: 'ai-title', sessionId: 'sessO', aiTitle: 'Session O' },
+      user('o-u1', null, 'sessO', '2026-01-01T10:00:00.000Z', 'hello from O'),
+      // msg_split line 1: PARTIAL (streaming progress) — same input/cache, output=1.
+      asst({ uuid: 'o-a1', parentUuid: 'o-u1', sessionId: 'sessO', timestamp: '2026-01-01T10:00:01.000Z', messageId: 'msg_split', usage: { ...CALLS.split, output: 1 } }),
+      // msg_split lines 2 & 3: FINAL — full usage, output=50.
+      asst({ uuid: 'o-a2', parentUuid: 'o-u1', sessionId: 'sessO', timestamp: '2026-01-01T10:00:01.300Z', messageId: 'msg_split', usage: CALLS.split }),
+      asst({ uuid: 'o-a3', parentUuid: 'o-u1', sessionId: 'sessO', timestamp: '2026-01-01T10:00:01.600Z', messageId: 'msg_split', usage: CALLS.split }),
+      // msg_o2: a second, single-line call.
+      asst({ uuid: 'o-a4', parentUuid: 'o-a3', sessionId: 'sessO', timestamp: '2026-01-01T10:00:05.000Z', messageId: 'msg_o2', usage: CALLS.o2 }),
+      // NULL-message-id assistant row (no message.id) — always canonical.
+      asst({ uuid: 'o-a5', parentUuid: 'o-a4', sessionId: 'sessO', timestamp: '2026-01-01T10:00:08.000Z', usage: CALLS.nul }),
+    ]),
+  );
+
+  // --- Session F (marked fork of O) -----------------------------------------
+  // Full copy of O's lines (user + 4 assistant; uuid/message.id/usage preserved,
+  // sessionId rewritten), each copied line carrying forkedFrom → these lose the
+  // election to O's originals. Then a NEW call `msg_f1` (no forkedFrom).
+  const ffrom = { sessionId: 'sessO', messageUuid: 'o-a3' };
+  writeFileSync(
+    join(proj, 'sessF.jsonl'),
+    jsonl([
+      { type: 'ai-title', sessionId: 'sessF', aiTitle: 'Session F' },
+      { ...user('o-u1', null, 'sessF', '2026-01-01T10:00:00.000Z', 'hello from O'), forkedFrom: ffrom },
+      asst({ uuid: 'o-a1', parentUuid: 'o-u1', sessionId: 'sessF', timestamp: '2026-01-01T10:00:01.000Z', messageId: 'msg_split', forkedFrom: ffrom, usage: { ...CALLS.split, output: 1 } }),
+      asst({ uuid: 'o-a2', parentUuid: 'o-u1', sessionId: 'sessF', timestamp: '2026-01-01T10:00:01.300Z', messageId: 'msg_split', forkedFrom: ffrom, usage: CALLS.split }),
+      asst({ uuid: 'o-a3', parentUuid: 'o-u1', sessionId: 'sessF', timestamp: '2026-01-01T10:00:01.600Z', messageId: 'msg_split', forkedFrom: ffrom, usage: CALLS.split }),
+      asst({ uuid: 'o-a4', parentUuid: 'o-a3', sessionId: 'sessF', timestamp: '2026-01-01T10:00:05.000Z', messageId: 'msg_o2', forkedFrom: ffrom, usage: CALLS.o2 }),
+      // New turn unique to F.
+      user('f-u1', 'o-a4', 'sessF', '2026-01-01T11:00:00.000Z', 'new turn in F'),
+      asst({ uuid: 'f-a1', parentUuid: 'f-u1', sessionId: 'sessF', timestamp: '2026-01-01T11:00:05.000Z', messageId: 'msg_f1', usage: CALLS.f1 }),
+    ]),
+  );
+
+  // --- Session L (legacy fork of O — NO forkedFrom marker) ------------------
+  // Just a copy of O's `msg_o2` line (same uuid/message.id/usage, no marker) plus
+  // its own new call `msg_l1`.
+  writeFileSync(
+    join(proj, 'sessL.jsonl'),
+    jsonl([
+      { type: 'ai-title', sessionId: 'sessL', aiTitle: 'Session L' },
+      user('l-u1', null, 'sessL', '2026-01-01T12:00:00.000Z', 'hello from L'),
+      // Copy of msg_o2 — same uuid 'o-a4', no forkedFrom (legacy fork).
+      asst({ uuid: 'o-a4', parentUuid: 'l-u1', sessionId: 'sessL', timestamp: '2026-01-01T10:00:05.000Z', messageId: 'msg_o2', usage: CALLS.o2 }),
+      asst({ uuid: 'l-a1', parentUuid: 'o-a4', sessionId: 'sessL', timestamp: '2026-01-01T12:00:05.000Z', messageId: 'msg_l1', usage: CALLS.l1 }),
+    ]),
+  );
+}
+
+// Sums of the unique billed calls + the NULL-id row = the deduped grand total.
+const GRAND = {
+  input: CALLS.split.input + CALLS.o2.input + CALLS.f1.input + CALLS.l1.input + CALLS.nul.input,
+  output: CALLS.split.output + CALLS.o2.output + CALLS.f1.output + CALLS.l1.output + CALLS.nul.output,
+  cacheRead: CALLS.split.cacheRead + CALLS.o2.cacheRead + CALLS.f1.cacheRead + CALLS.l1.cacheRead + CALLS.nul.cacheRead,
+  cacheWrite: CALLS.split.cacheWrite + CALLS.o2.cacheWrite + CALLS.f1.cacheWrite + CALLS.l1.cacheWrite + CALLS.nul.cacheWrite,
+};
+const GRAND_TOTAL_TOKENS = GRAND.input + GRAND.output + GRAND.cacheRead + GRAND.cacheWrite;
+const GRAND_COST =
+  costOf(CALLS.split) + costOf(CALLS.o2) + costOf(CALLS.f1) + costOf(CALLS.l1) + costOf(CALLS.nul);
+
+let app: FastifyInstance;
+let conn: DuckDBConnection;
+let closeConnection: () => Promise<void>;
+
+beforeAll(async () => {
+  writeFixtures();
+
+  const Fastify = (await import('fastify')).default;
+  const { registerRoutes } = await import('../src/routes/index.js');
+  const { reindex } = await import('../src/data/index.js');
+  const { getConnection } = await import('../src/db/duckdb.js');
+  ({ closeConnection } = await import('../src/db/duckdb.js'));
+
+  app = Fastify();
+  await registerRoutes(app);
+  await reindex();
+  await app.ready();
+  conn = await getConnection();
+});
+
+afterAll(async () => {
+  await app?.close();
+  await closeConnection?.();
+  rmSync(work, { recursive: true, force: true });
+});
+
+const get = async (url: string) => app.inject({ method: 'GET', url });
+
+/** Per-session token columns straight from the derived `sessions` table. */
+async function sessionTokens(id: string): Promise<{
+  input: number;
+  output: number;
+  cacheRead: number;
+  cacheWrite: number;
+  total: number;
+  cost: number;
+}> {
+  const { queryRows } = await import('../src/db/duckdb.js');
+  const rows = await queryRows(
+    conn,
+    `SELECT input_tokens, output_tokens, cache_read_tokens, cache_write_tokens, total_tokens, total_cost_usd
+     FROM sessions WHERE id = '${id}'`,
+  );
+  const r = rows[0]!;
+  return {
+    input: Number(r.input_tokens),
+    output: Number(r.output_tokens),
+    cacheRead: Number(r.cache_read_tokens),
+    cacheWrite: Number(r.cache_write_tokens),
+    total: Number(r.total_tokens),
+    cost: Number(r.total_cost_usd),
+  };
+}
+
+describe('multi-block split + fork dedup — per-session token attribution', () => {
+  // Session O keeps the max-output msg_split row (output 50, not the partial 1)
+  // and the NULL-id row. It LOSES msg_o2 to session L (see the L tiebreak below).
+  // Expected O canonical: msg_split (10/50/100/5) + NULL row (1/2/0/0).
+  it('session O: split counted once at max output; NULL-id row always counted', async () => {
+    const t = await sessionTokens('sessO');
+    expect(t.input).toBe(CALLS.split.input + CALLS.nul.input); // 11
+    expect(t.output).toBe(CALLS.split.output + CALLS.nul.output); // 52
+    expect(t.cacheRead).toBe(CALLS.split.cacheRead + CALLS.nul.cacheRead); // 100
+    expect(t.cacheWrite).toBe(CALLS.split.cacheWrite + CALLS.nul.cacheWrite); // 5
+    expect(t.total).toBe(11 + 52 + 100 + 5); // 168
+    expect(t.cost).toBeCloseTo(costOf(CALLS.split) + costOf(CALLS.nul), 12);
+  });
+
+  // Session F's copied history all carries `forkedFrom`, so every copied row
+  // loses its message_id partition to O's (and L's) NULL-forkedFrom rows. Only
+  // F's NEW call msg_f1 survives. Expected F canonical: msg_f1 (40/60/200/0).
+  it('session F: marked-fork copies lose; only the new call counts', async () => {
+    const t = await sessionTokens('sessF');
+    expect(t.input).toBe(CALLS.f1.input); // 40
+    expect(t.output).toBe(CALLS.f1.output); // 60
+    expect(t.cacheRead).toBe(CALLS.f1.cacheRead); // 200
+    expect(t.cacheWrite).toBe(CALLS.f1.cacheWrite); // 0
+    expect(t.total).toBe(40 + 60 + 200 + 0); // 300
+    expect(t.cost).toBeCloseTo(costOf(CALLS.f1), 12);
+  });
+
+  // Legacy-fork tiebreak: the msg_o2 partition has O's row and L's copy, both
+  // with equal output_tokens, the same uuid, and forked_from_session_id NULL (L
+  // has no marker). The election orders by `file_path ASC` next, and
+  // 'sessL.jsonl' < 'sessO.jsonl' lexicographically — so L's COPY wins and
+  // msg_o2's usage attributes to L, NOT O. (The point of this case is that the
+  // totals stay exact and attribution is deterministic, regardless of which
+  // file happens to win.) Expected L canonical: msg_o2 (20/30/0/0) + msg_l1 (5/7/0/0).
+  it('session L: deterministic file_path tiebreak claims the shared msg_o2', async () => {
+    const t = await sessionTokens('sessL');
+    expect(t.input).toBe(CALLS.o2.input + CALLS.l1.input); // 25
+    expect(t.output).toBe(CALLS.o2.output + CALLS.l1.output); // 37
+    expect(t.cacheRead).toBe(CALLS.o2.cacheRead + CALLS.l1.cacheRead); // 0
+    expect(t.cacheWrite).toBe(CALLS.o2.cacheWrite + CALLS.l1.cacheWrite); // 0
+    expect(t.total).toBe(25 + 37 + 0 + 0); // 62
+    expect(t.cost).toBeCloseTo(costOf(CALLS.o2) + costOf(CALLS.l1), 12);
+  });
+
+  it('grand total across sessions is invariant: sum == deduped unique calls', async () => {
+    const [o, f, l] = await Promise.all([
+      sessionTokens('sessO'),
+      sessionTokens('sessF'),
+      sessionTokens('sessL'),
+    ]);
+    expect(o.input + f.input + l.input).toBe(GRAND.input); // 76
+    expect(o.output + f.output + l.output).toBe(GRAND.output); // 149
+    expect(o.cacheRead + f.cacheRead + l.cacheRead).toBe(GRAND.cacheRead); // 300
+    expect(o.cacheWrite + f.cacheWrite + l.cacheWrite).toBe(GRAND.cacheWrite); // 5
+    expect(o.total + f.total + l.total).toBe(GRAND_TOTAL_TOKENS); // 530
+    expect(o.cost + f.cost + l.cost).toBeCloseTo(GRAND_COST, 12);
+  });
+});
+
+describe('GET /api/sessions — deduped totals surfaced through the API', () => {
+  it('per-session totalTokens / totalCostUsd match the deduped values', async () => {
+    const sessions = (await get('/api/sessions')).json();
+    const byId = new Map(sessions.map((s: { id: string }) => [s.id, s]));
+
+    const o = byId.get('sessO') as { totalTokens: number; totalCostUsd: number };
+    const f = byId.get('sessF') as { totalTokens: number; totalCostUsd: number };
+    const l = byId.get('sessL') as { totalTokens: number; totalCostUsd: number };
+
+    expect(o.totalTokens).toBe(168);
+    expect(f.totalTokens).toBe(300);
+    expect(l.totalTokens).toBe(62);
+
+    // Costs are all > 0 and consistent with token attribution (F reflects only
+    // msg_f1; F's larger token+cache footprint makes it the costliest here).
+    expect(o.totalCostUsd).toBeGreaterThan(0);
+    expect(f.totalCostUsd).toBeGreaterThan(0);
+    expect(l.totalCostUsd).toBeGreaterThan(0);
+    expect(f.totalCostUsd).toBeCloseTo(costOf(CALLS.f1), 12);
+    expect(f.totalCostUsd).toBeGreaterThan(o.totalCostUsd);
+    expect(f.totalCostUsd).toBeGreaterThan(l.totalCostUsd);
+
+    // Grand total cost equals the sum of the unique-call costs.
+    expect(o.totalCostUsd + f.totalCostUsd + l.totalCostUsd).toBeCloseTo(GRAND_COST, 12);
+  });
+
+  // message_count is NOT deduped — it counts ALL events (every content-block row
+  // and the user turn), proving the dedup only affects the usage/cost SUMs.
+  it('message_count still counts every row (not deduped)', async () => {
+    const sessions = (await get('/api/sessions')).json();
+    const o = sessions.find((s: { id: string }) => s.id === 'sessO');
+    // sessO.jsonl carries: u1 + 3 msg_split rows + msg_o2 + NULL-id row = 6
+    // user/assistant events. (Far more than the 2 unique billed calls there.)
+    expect(o.messageCount).toBe(6);
+    expect(o.messageCount).toBeGreaterThanOrEqual(5);
+  });
+});
+
+describe('GET /api/analytics — deduped grand totals', () => {
+  it('totals equal the deduped grand totals', async () => {
+    const { totals } = (await get('/api/analytics')).json();
+    expect(totals.inputTokens).toBe(GRAND.input); // 76
+    expect(totals.outputTokens).toBe(GRAND.output); // 149
+    expect(totals.cacheReadTokens).toBe(GRAND.cacheRead); // 300
+    expect(totals.cacheCreationTokens).toBe(GRAND.cacheWrite); // 5
+    expect(totals.totalTokens).toBe(GRAND_TOTAL_TOKENS); // 530
+    expect(totals.costUsd).toBeCloseTo(GRAND_COST, 12);
+  });
+
+  it('messageCount equals the unique billed calls + NULL-id assistant rows', async () => {
+    const { totals } = (await get('/api/analytics')).json();
+    // 4 unique billed calls (msg_split, msg_o2, msg_f1, msg_l1) + 1 NULL-id row.
+    expect(totals.messageCount).toBe(5);
+  });
+});


### PR DESCRIPTION
## Problem

The indexer sums `message.usage` over every assistant event row, but one billed API call appears as many rows. Verified empirically on a real corpus (23,714 assistant rows vs 10,999 billed calls — output tokens inflated ~3×, cache-read ~2.3×):

1. **Multi-block splits** — Claude Code writes one JSONL line per content block of a single API response, each repeating the same `message.id` and the full `usage`; earlier lines may carry partial `output_tokens` (streaming progress).
2. **Fork/resume copies** — branching copies the whole history into the new session file (`sessionId` rewritten, uuid/`message.id`/usage preserved), each copied line stamped with a top-level `forkedFrom` marker (legacy forks lack it).

Codex and Junie are unaffected (verified): their normalizers accumulate per-call deltas exactly once.

## Fix

Elect exactly one `usage_canonical` row per `message.id` at index time — originals beat `forkedFrom`-marked copies (exact attribution), the final streaming row beats partials (`output_tokens DESC`), deterministic `file_path, uuid` tiebreak for legacy forks — and filter all token/cost sums (sessions rebuild, `/api/analytics`) on the flag. Counts and FTS stay unfiltered: content blocks are not duplicated, only usage is. NULL-`message.id` rows are always canonical, which keeps non-Claude connectors and synthetic rows counting as before. Schema v6 forces a one-time index rebuild (the index is a derived cache).

`/api/analytics` `messageCount` now counts deduped billed calls — intentional semantic change.

## Verification

- New integration suite (`dedup.integration.test.ts`, 8 tests): multi-block split with partial-output rows, marked fork pair, legacy unmarked fork tiebreak, grand-total invariance, NULL-id passthrough, counts-not-deduped.
- 135/135 tests, clean typecheck.
- End-to-end against a real 193-file corpus: flag-filtered sums match an independent window-function dedup exactly on all four token fields; a real fork pair now attributes history to the original session ($783.22) with the fork showing only its own turns ($2.44) instead of double-counting ~800M copied tokens.

Plan: [docs/plans/0012-cost-dedup-billed-api-calls.md](docs/plans/0012-cost-dedup-billed-api-calls.md)