### PR TITLE
feat: memory viewer — instruction files + per-agent memory

### DIFF
--- a/docs/plans/0014-memory-viewer.md
+++ b/docs/plans/0014-memory-viewer.md
@@ -1,0 +1,216 @@
+# 0014 — Memory viewer (instruction files + per-agent memory)
+
+- **Status:** proposed <!-- proposed | in-progress | done | superseded | abandoned -->
+- **Date:** 2026-06-15 (revised 2026-06-15 after source- and disk-grounded research; see "Research basis")
+- **PR:** <link, once opened>
+
+## Context
+
+Coding agents persist long-lived "memory" on disk, separate from the transcripts
+Claudescope indexes, and it's invisible unless you go spelunking in dotfiles or
+the repo. The first cut of this plan assumed only Claude had per-project memory;
+**source- and disk-grounded research (24 adversarial verdicts) showed all three
+supported agents have a real memory subsystem.** There are two provenances:
+
+- **User-authored instruction files** — what *you* tell the agent, globally:
+  `~/.claude/CLAUDE.md`, `~/.codex/AGENTS.md`, `~/.junie/AGENTS.md`.
+- **Agent-authored memory** — what the agent *distilled on its own*:
+  - **Claude Code** — `~/.claude/projects/<slug>/memory/`: a `MEMORY.md` index + one
+    `.md` file per fact with frontmatter (`name`, `description`, `type`,
+    `originSessionId`). Written by **model-initiated `Write`/`Edit`** mid-session
+    (the harness injects `node_type`/`originSessionId`); GA, default-on. 6 of 14
+    local projects have one (23 fact files).
+  - **Junie** — **repo-local** `<project>/.junie/memory/`: `tasks.md`, `errors.md`,
+    `feedback.md`, `language.json`, `memory.version`. Written by automatic LLM
+    "reflection" (user-feedback / error→rule / trajectory), flushed on close.
+    Gated/experimental — present as empty scaffolds on this machine (verified:
+    `~/src/transript-viewer/.junie/memory/`, gitignored).
+  - **Codex** — a **global** store: `~/.codex/memories/` (git-baselined markdown:
+    `MEMORY.md` handbook, `memory_summary.md`) + `memories_1.sqlite`
+    (`stage1_outputs`). Written by an automatic background two-phase job at session
+    start (distills *other* recent rollouts idle ≥6h). Experimental, off by
+    default, geo-gated → empty for essentially everyone (0 rows here).
+
+The unlock specific to *this* product remains Claude's `originSessionId`: every
+fact deep-links to the transcript that produced it — a cross-link only a viewer
+that already indexes those sessions can offer.
+
+**Scope decision (after research):** v1 covers all three agents' **global
+instruction files** plus **Claude's and Codex's agent-authored memory** (Codex
+best-effort / graceful-empty). **Junie's per-project `.junie/memory/` is OUT of
+scope** — it lives *inside each repo*, so surfacing it would force Claudescope to
+read arbitrary user project directories, breaking the invariant that it reads only
+from the agent home dirs (`~/.claude`, `~/.codex`, `~/.junie`). Junie still
+contributes its global `~/.junie/AGENTS.md`. User-authored *repo-level* `CLAUDE.md`
+/ root `AGENTS.md` likewise stay deferred (same reason — they're in the repo).
+
+## Research basis
+
+Findings the build depends on, each verified against source code *and* disk:
+
+- **Claude memory is NOT the Anthropic server-side memory tool** (refuted). It's
+  model-initiated `Write`/`Edit` to the `memory/` path; the connector must read the
+  directory directly (writes aren't reconstructable from transcript tool replay).
+- **Claude has two coexisting frontmatter layouts:** nested
+  (`metadata:{node_type, type, originSessionId}`, since ~2026-05-13) and flat/legacy
+  (top-level `name/description/type/originSessionId`, oldest two lack
+  `originSessionId`). Parse both.
+- **Claude `type` enum = exactly `user | feedback | project | reference`** (from the
+  binary). `originSessionId` is a clean FK to `<slug>/<originSessionId>.jsonl`.
+- **Claude slug is keyed by the git repo root** (`git rev-parse --git-common-dir`),
+  not raw cwd — worktrees/subdirs of one repo share one memory dir. Claudescope
+  buckets transcripts by raw cwd, so memory keying can diverge from project keying.
+- **Codex memory is real but experimental/off-by-default/geo-gated** and a **global**
+  store (no cwd column; cwd needs `stage1_outputs.thread_id → state_5.sqlite
+  threads.cwd`). DB files are **version-suffixed** (`memories_1`, `state_5`).
+- **Junie memory is repo-local** (`<cwd>/.junie/memory/`), plain MD/JSON, distinct
+  from `~/.junie/AGENTS.md`.
+- **No agent has a built-in `/remember` that writes its memory store.** The local
+  `~/.junie/commands/remember.md` and `~/.claude/.../remember` skill are the user's
+  own Claude skill (imported into Junie via `/import`); both target a `CLAUDE.md`.
+  Do not surface `/remember` artifacts as agent memory.
+
+## Goal
+
+A read-only **Memory** area that surfaces, for every connector: its global
+user-authored instruction file(s) **and** its (home-dir-resident) agent-authored
+memory — Claude's typed facts (with `[[wiki-link]]` resolution and an "origin →"
+deep-link to the session that produced each) and Codex's global handbook
+(best-effort). Reachable as a **top-level page** (global-first, cross-project) and
+a **per-project Memory tab**. Every store is usually empty/absent — "no memory" is
+a normal, first-class state, never an error.
+
+## Decisions
+
+- **Read only from agent home dirs; never read user project directories** — the
+  whole tool's read surface stays `~/.claude` / `~/.codex` / `~/.junie` (+ their env
+  overrides). This is the load-bearing constraint: it's *why* Junie's repo-local
+  `.junie/memory/` is excluded, and *why* Claude attribution must not shell out to
+  `git` inside a project (see below).
+- **Read live, not indexed** — files are tiny and change between sessions; reading
+  on request keeps them never-stale and out of the rebuildable DuckDB cache.
+- **Memory is a connector capability** — `globalMemory()` and `projectMemory(cwd)`
+  on the `AgentConnector` port (TS methods like `loadSession`, not SQL projections).
+  Each returns a list of `MemorySource` (a flexible shape covering typed facts,
+  category documents, and handbook blobs), tagged `provenance:
+  'user-authored' | 'agent-authored'`. Keeps "add an agent = add a connector" intact.
+- **`MemorySource` over a rigid `MemoryFact`** — the three stores differ structurally
+  (Claude = per-fact-with-frontmatter; Junie = fixed category files; Codex =
+  markdown handbook). One union shape with `kind: 'fact' | 'document'` fits all and
+  keeps the API/UI uniform.
+- **Graceful-empty everywhere** — absent dir / 0 rows / empty scaffold all render as
+  "no memory for this agent," never an error. (Critical: this is the common case.)
+- **Claude project attribution stays home-dir-only** — for `projectMemory(cwd)`,
+  dash-encode the cwd to the candidate slug and read `~/.claude/projects/<slug>/memory/`
+  (pure string transform; no `git` call into the project dir). For the top-level page,
+  attach each fact to the project of its `originSessionId` (Claudescope already maps
+  sessions→projects), which also absorbs the git-root/worktree divergence. Tolerate
+  dangling refs. Worktree-keyed dirs that the dash-encode misses are an accepted v1
+  gap (open question), **not** a reason to run git in user repos.
+- **Codex: markdown-first, SQLite-second** — read `~/.codex/memories/MEMORY.md` +
+  `memory_summary.md` (stable, human-readable) as a global agent-memory doc; the
+  `memories_*.sqlite` + `state_*.sqlite` cwd-join is a secondary/per-project path
+  (deferred attribution — open question). **Glob `*_<N>.sqlite` and pick the highest**;
+  never hardcode the suffix. Open SQLite read-only (copy-to-tmp to dodge WAL).
+- **Hand-parse frontmatter, no new dependency** — server runtime deps stay
+  `@duckdb/node-api` + `fastify`. A ~20-line parser handles both Claude layouts;
+  Junie/Codex are plain markdown/JSON.
+- **Global memory rendered verbatim** — do not resolve Claude `@path` imports in v1.
+- **Separate provenance in the UI** — user-authored instruction files visually
+  distinct from agent-distilled memory; imported `commands/skills` are labelled user
+  artifacts, surfaced by file path, never as agent memory.
+
+## Per-agent storage reference
+
+| Agent | Global (user-authored) | Agent-authored memory | Format | cwd key |
+| --- | --- | --- | --- | --- |
+| Claude | `~/.claude/CLAUDE.md` | `~/.claude/projects/<git-root-slug>/memory/*.md` | MD + frontmatter (2 layouts) | git repo root; per-fact via `originSessionId` |
+| Junie | `~/.junie/AGENTS.md` | — *(out of scope: repo-local `.junie/memory/` would require reading all project dirs)* | MD | — |
+| Codex | `~/.codex/AGENTS.md` | `~/.codex/memories/MEMORY.md`, `memory_summary.md`; `memories_*.sqlite` `stage1_outputs` | MD; SQLite | **global** (cwd via `state_*.sqlite threads.cwd` join) |
+
+## Approach
+
+1. **Shared types** (`packages/shared/src/api.ts`): `MemorySource`
+   (`provenance`, `kind`, `title`, `category?`, `markdown`, `sourcePath`,
+   `updatedAt`, `originSessionId?`, `relatedNames?`, `empty?`), `GlobalMemory`
+   (per connector: label + `MemorySource[]`), `ProjectMemory` (per connector:
+   `MemorySource[]` + optional `indexMarkdown`), and the two response bodies.
+2. **Connector port** (`connectors/types.ts`): optional
+   `globalMemory(): MemorySource[]` and `projectMemory(cwd): MemorySource[]`.
+3. **Claude connector**: `globalMemory` → `~/.claude/CLAUDE.md` (user-authored).
+   `projectMemory(cwd)` → dash-encode cwd → slug → read `memory/*.md` (skip the
+   redundant `MEMORY.md` index), hand-parse **both** frontmatter layouts, extract
+   `[[name]]` → `relatedNames`, carry `originSessionId`, `updatedAt` from mtime,
+   `provenance: 'agent-authored'`. `[]` if absent.
+4. **Junie connector**: `globalMemory` → `~/.junie/AGENTS.md` (user-authored) only.
+   **No `projectMemory`** — its store is repo-local and out of scope per the
+   home-dir-only invariant.
+5. **Codex connector**: `globalMemory` → `~/.codex/AGENTS.md` (user-authored) **plus**
+   best-effort `~/.codex/memories/MEMORY.md` + `memory_summary.md` (agent-authored,
+   global). `projectMemory` → `[]` in v1 (per-project Codex attribution deferred).
+   All paths optional/graceful-empty; glob versioned DBs only if/when SQLite path lands.
+6. **Server route** (`routes/memory.ts`, registered in `routes/index.ts`):
+   - `GET /api/memory` → `{ global: GlobalMemory[], projects: ProjectMemorySummary[] }`
+     (every connector's global sources + projects that have any agent memory, with
+     per-agent counts).
+   - `GET /api/projects/:projectId/memory` → `{ byAgent: { connectorId, label,
+     sources }[] }` — resolve the project's cwd, ask each connector.
+7. **Web — top-level page** (`pages/memory/MemoryPage.tsx`): instruction-file cards
+   (one per agent) clearly separated from agent-memory; then projects-with-memory,
+   expanding fetches the per-project endpoint. Add `Memory` to `NAV_ITEMS` + `/memory`.
+8. **Web — project tab**: Sessions | Memory tabs on `/projects/:projectId`; reuse the
+   memory components.
+9. **Web — rendering**: a `MemorySource` renderer — provenance/category chip,
+   markdown body, `[[name]]` → in-page anchors (unmatched → plain text), and
+   "origin →" to `/sessions/<originSessionId>` when present and indexed.
+10. **API client** (`web/src/api/client.ts`): `memory()` + `projectMemory(id)`.
+
+## Files affected
+
+- `packages/shared/src/api.ts` — memory types + response bodies.
+- `packages/server/src/connectors/types.ts` — optional memory methods.
+- `packages/server/src/connectors/claude-code/` — facts + git-root slug + dual
+  frontmatter parse (likely a `memory.ts` helper).
+- `packages/server/src/connectors/junie/` — `globalMemory` (`~/.junie/AGENTS.md`) only.
+- `packages/server/src/connectors/codex/` — AGENTS.md + best-effort `memories/` MD.
+- `packages/server/src/routes/memory.ts` (new) + `routes/index.ts`.
+- `packages/web/src/App.tsx` — nav item, `/memory` route, project tabs.
+- `packages/web/src/pages/memory/MemoryPage.tsx` (new) + `MemorySource` component.
+- `packages/web/src/pages/browse/SessionList.tsx` — project view tabs.
+- `packages/web/src/api/client.ts` — client methods.
+
+## Testing
+
+- `npm run typecheck` + `npm test`.
+- Temp-dir fixtures (never touch real `~/.claude`/`~/.codex`/`~/.junie`):
+  - Claude: a `memory/` with **both** frontmatter layouts, a `[[link]]`, a fact
+    with and without `originSessionId` (incl. a dangling one) → assert parsed sources;
+    missing dir → `[]`.
+  - Junie: global `~/.junie/AGENTS.md` present/absent → assert the doc / graceful-empty.
+  - Codex: a `~/.codex/memories/MEMORY.md` present and absent → assert graceful-empty.
+  - A worktree fixture (cwd under a linked worktree) → assert Claude memory still
+    attributes to the right project via `originSessionId`.
+- Manual: open Memory — three instruction cards render; the 6 Claude projects show
+  facts; wiki-links jump; "origin →" lands on the right session (degrades when the
+  session isn't indexed); Junie/Codex show "no memory" cleanly when empty.
+
+## Risks / open questions
+
+- **Claude slug ≠ Claudescope project key** (git-root vs raw cwd) — handle worktrees
+  via `originSessionId` attribution; cross-check the slug-derivation fallback.
+- **Codex markdown block format is source-described, unobserved live** — the
+  `cwd=/rollout_path=/thread_id=` block convention in `MEMORY.md` has never been seen
+  populated; validate against a real opted-in user before relying on it for
+  per-project Codex attribution.
+- **Versioned SQLite filenames** (`memories_N`, `state_N`) will bump — always glob.
+- **Junie memory schema is v1.0 scaffold; binary expects v3.0** — the *populated*
+  body shape of `tasks/errors/feedback.md` and the v3 `language.json` are unknown;
+  parse defensively, render raw markdown.
+- **Claude lifecycle unknowns** — does an in-place rewrite keep the first
+  `originSessionId` or adopt the editor's? Are deleted facts tombstoned? Is
+  `MEMORY.md` auto-reconciled? Affects "when"/orphan detection.
+- **Claude `scope: private|team` and unobserved `user`/`reference` types** — defined
+  in the binary but not seen on disk; parser should tolerate a `scope` key and all
+  four types.
+- **Markdown safety** — reuse the hardened `Markdown` component; `[[name]]` rewrites
+  to internal anchors only, never arbitrary URLs.

--- a/docs/plans/0014-memory-viewer.md
+++ b/docs/plans/0014-memory-viewer.md
@@ -1,8 +1,8 @@
 # 0014 — Memory viewer (instruction files + per-agent memory)
 
-- **Status:** proposed <!-- proposed | in-progress | done | superseded | abandoned -->
+- **Status:** done <!-- proposed | in-progress | done | superseded | abandoned -->
 - **Date:** 2026-06-15 (revised 2026-06-15 after source- and disk-grounded research; see "Research basis")
-- **PR:** <link, once opened>
+- **PR:** https://github.com/vladar107/claudescope/pull/17
 
 ## Context
 

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -38,4 +38,4 @@ decision, or a change worth explaining before doing. Skip it for one-line fixes.
 | 0011 | [performance: search, scrolling, bench](./0011-performance-search-scroll-bench.md) | done |
 | 0012 | [cost dedup: billed API calls](./0012-cost-dedup-billed-api-calls.md) | done |
 | 0013 | [Codex review fixes: project ids, aux rows, images](./0013-codex-review-fixes.md) | done |
-| 0014 | [Memory viewer (instruction files + per-agent memory)](./0014-memory-viewer.md) | proposed |
+| 0014 | [Memory viewer (instruction files + per-agent memory)](./0014-memory-viewer.md) | done   |

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -38,3 +38,4 @@ decision, or a change worth explaining before doing. Skip it for one-line fixes.
 | 0011 | [performance: search, scrolling, bench](./0011-performance-search-scroll-bench.md) | done |
 | 0012 | [cost dedup: billed API calls](./0012-cost-dedup-billed-api-calls.md) | done |
 | 0013 | [Codex review fixes: project ids, aux rows, images](./0013-codex-review-fixes.md) | done |
+| 0014 | [Memory viewer (instruction files + per-agent memory)](./0014-memory-viewer.md) | proposed |

--- a/packages/server/src/config.ts
+++ b/packages/server/src/config.ts
@@ -55,6 +55,17 @@ export const JUNIE_SESSIONS_DIR = expandHome(
   process.env.JUNIE_SESSIONS_DIR ?? join(homedir(), '.junie', 'sessions'),
 );
 
+/**
+ * READ-ONLY agent home directories — the parents of the session/project dirs
+ * above, where each agent keeps its memory (`CLAUDE.md`, `AGENTS.md`, the Codex
+ * `memories/` tree). Derived from the dirs above so the env overrides carry
+ * through. The app MUST NEVER write here. Memory is read **only** from these
+ * home dirs — never from the user's project directories.
+ */
+export const CLAUDE_HOME = dirname(CLAUDE_PROJECTS_DIR);
+export const CODEX_HOME = dirname(CODEX_SESSIONS_DIR);
+export const JUNIE_HOME = dirname(JUNIE_SESSIONS_DIR);
+
 /** Whether to auto-open the default browser on startup (set by the launcher). */
 export const OPEN_BROWSER = process.env.OPEN_BROWSER === '1';
 

--- a/packages/server/src/connectors/claude-code/claude-code.ts
+++ b/packages/server/src/connectors/claude-code/claude-code.ts
@@ -17,6 +17,7 @@ import { CLAUDE_PROJECTS_DIR } from '../../config.js';
 import { sqlString } from '../../db/duckdb.js';
 import type { SessionData, SubagentSource } from '../../data/session-loader.js';
 import type { AgentConnector, AuxProjections, DiscoveredFile } from '../types.js';
+import { globalMemory, projectMemory } from './memory.js';
 
 /**
  * Shared `read_ndjson` options for the line-delimited Claude transcripts.
@@ -286,4 +287,6 @@ export const claudeCodeConnector: AgentConnector = {
   eventsProjectionSql,
   auxProjections,
   loadSession,
+  globalMemory,
+  projectMemory,
 };

--- a/packages/server/src/connectors/claude-code/memory.ts
+++ b/packages/server/src/connectors/claude-code/memory.ts
@@ -1,0 +1,201 @@
+/**
+ * Claude Code memory — read live (never indexed) from `~/.claude`.
+ *
+ * Two stores:
+ *   - global: `~/.claude/CLAUDE.md`, the user-authored global instruction file,
+ *     surfaced as a single `document` source.
+ *   - per-project: `~/.claude/projects/<slug>/memory/*.md`, the agent-distilled
+ *     typed facts. Each fact is a markdown file with a leading `---` YAML
+ *     frontmatter block; the `MEMORY.md` index file is redundant and skipped.
+ *
+ * Claude keys a memory dir by the **git repo root**, so one dir may hold facts
+ * learned across several worktrees/cwds. We therefore do NOT attribute facts to
+ * a cwd here — {@link projectMemory} returns every dir tagged with its slug, and
+ * the route attributes each fact to a project via its `originSessionId`.
+ *
+ * STRICTLY READ-ONLY with respect to ~/.claude, and only ever reads from the
+ * agent home dir — never from the user's project directories.
+ */
+
+import { readdirSync, readFileSync, statSync } from 'node:fs';
+import { join } from 'node:path';
+import type { MemorySource } from '@claudescope/shared';
+import type { AgentMemoryDir } from '../types.js';
+import { CLAUDE_HOME, CLAUDE_PROJECTS_DIR } from '../../config.js';
+import { contractHome } from '../../util/paths.js';
+
+/**
+ * Dash-encode a `cwd` to the directory slug Claude Code uses under
+ * `~/.claude/projects/`. Every non-alphanumeric character maps to a single `-`,
+ * per-character (NOT run-collapsed): `/Users/x/src/y` → `-Users-x-src-y`. This
+ * intentionally differs from the Claudescope project-id slug, which collapses
+ * runs and trims edges (see `data/project-id.ts`). Exported so the memory route
+ * can map a project cwd to its memory dir slug for attribution fallback.
+ */
+export function memorySlugForCwd(cwd: string): string {
+  return cwd.replace(/[^a-zA-Z0-9]/g, '-');
+}
+
+/** Parsed frontmatter fields we care about, normalized across both layouts. */
+interface Frontmatter {
+  name?: string;
+  description?: string;
+  type?: string;
+  originSessionId?: string;
+}
+
+/**
+ * Hand-parse the leading `---` YAML frontmatter of a fact file, returning the
+ * normalized fields plus the markdown body that follows. Tolerates BOTH
+ * layouts: (A) nested — top-level `name`/`description` plus a `metadata:` block
+ * with indented `node_type`/`type`/`originSessionId`; (B) flat/legacy —
+ * `name`/`description`/`type`/`originSessionId` all top-level (oldest files lack
+ * `originSessionId`). A stray `scope` key is tolerated and ignored.
+ */
+function parseFrontmatter(raw: string): { fm: Frontmatter; body: string } {
+  const lines = raw.split('\n');
+  if (lines[0]?.trim() !== '---') return { fm: {}, body: raw };
+
+  let end = -1;
+  for (let i = 1; i < lines.length; i++) {
+    if (lines[i]?.trim() === '---') {
+      end = i;
+      break;
+    }
+  }
+  if (end === -1) return { fm: {}, body: raw };
+
+  const fm: Frontmatter = {};
+  // Depth-agnostic key match: the nested `metadata:` block holds
+  // `type`/`originSessionId`, so matching keys regardless of indent captures both
+  // the nested and flat layouts.
+  const assign = (key: string, value: string): void => {
+    const v = value.trim().replace(/^["']|["']$/g, '');
+    if (!v) return;
+    switch (key) {
+      case 'name':
+        fm.name = v;
+        break;
+      case 'description':
+        fm.description = v;
+        break;
+      case 'type':
+        fm.type = v;
+        break;
+      case 'originSessionId':
+        fm.originSessionId = v;
+        break;
+      default:
+        break;
+    }
+  };
+
+  for (let i = 1; i < end; i++) {
+    const m = (lines[i] ?? '').match(/^\s*([A-Za-z_][\w]*)\s*:\s*(.*)$/);
+    if (m) assign(m[1] as string, m[2] as string);
+  }
+
+  const body = lines.slice(end + 1).join('\n').replace(/^\n+/, '');
+  return { fm, body };
+}
+
+/** Unique `[[name]]` wiki-link targets referenced in a fact body, in order. */
+function relatedNames(body: string): string[] {
+  const out: string[] = [];
+  const seen = new Set<string>();
+  const re = /\[\[([^\]]+)\]\]/g;
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(body)) !== null) {
+    const name = (m[1] as string).trim();
+    if (name && !seen.has(name)) {
+      seen.add(name);
+      out.push(name);
+    }
+  }
+  return out;
+}
+
+/**
+ * The user-authored global instruction file (`~/.claude/CLAUDE.md`), as a single
+ * `document` source. `[]` when absent, empty, or unreadable.
+ */
+export function globalMemory(): MemorySource[] {
+  const path = join(CLAUDE_HOME, 'CLAUDE.md');
+  try {
+    const markdown = readFileSync(path, 'utf8');
+    if (!markdown.trim()) return [];
+    return [
+      {
+        provenance: 'user-authored',
+        kind: 'document',
+        title: 'CLAUDE.md (global)',
+        markdown,
+        sourcePath: contractHome(path),
+        updatedAt: new Date(statSync(path).mtimeMs).toISOString(),
+      },
+    ];
+  } catch {
+    return [];
+  }
+}
+
+/** Parse one fact file into a MemorySource, or `null` if it's not a fact file. */
+function readFact(dir: string, fileName: string): MemorySource | null {
+  if (!fileName.endsWith('.md') || fileName === 'MEMORY.md') return null;
+  const path = join(dir, fileName);
+  try {
+    const raw = readFileSync(path, 'utf8');
+    const updatedAt = new Date(statSync(path).mtimeMs).toISOString();
+    const { fm, body } = parseFrontmatter(raw);
+    return {
+      provenance: 'agent-authored',
+      kind: 'fact',
+      title: fm.name ?? fileName.replace(/\.md$/, ''),
+      ...(fm.description ? { description: fm.description } : {}),
+      ...(fm.type ? { category: fm.type } : {}),
+      markdown: body,
+      sourcePath: contractHome(path),
+      updatedAt,
+      ...(fm.originSessionId ? { originSessionId: fm.originSessionId } : {}),
+      relatedNames: relatedNames(body),
+    };
+  } catch {
+    return null; // vanished/unreadable between readdir and read
+  }
+}
+
+/**
+ * Every `~/.claude/projects/<slug>/memory/` directory that holds at least one
+ * fact, tagged with its `slug`. The route attributes each fact to a project via
+ * `originSessionId` (slug as the fallback). `[]` when none exist.
+ */
+export function projectMemory(): AgentMemoryDir[] {
+  let projectDirs: import('node:fs').Dirent[];
+  try {
+    projectDirs = readdirSync(CLAUDE_PROJECTS_DIR, { withFileTypes: true });
+  } catch {
+    return [];
+  }
+
+  const dirs: AgentMemoryDir[] = [];
+  for (const projectDir of projectDirs) {
+    if (!projectDir.isDirectory()) continue;
+    const memDir = join(CLAUDE_PROJECTS_DIR, projectDir.name, 'memory');
+
+    let entries: import('node:fs').Dirent[];
+    try {
+      entries = readdirSync(memDir, { withFileTypes: true });
+    } catch {
+      continue; // no memory/ dir for this project
+    }
+
+    const facts: MemorySource[] = [];
+    for (const entry of entries) {
+      if (!entry.isFile()) continue;
+      const fact = readFact(memDir, entry.name);
+      if (fact) facts.push(fact);
+    }
+    if (facts.length > 0) dirs.push({ slug: projectDir.name, facts });
+  }
+  return dirs;
+}

--- a/packages/server/src/connectors/codex/codex.ts
+++ b/packages/server/src/connectors/codex/codex.ts
@@ -17,6 +17,7 @@ import { CLAUDESCOPE_HOME, CODEX_SESSIONS_DIR } from '../../config.js';
 import { sqlString } from '../../db/duckdb.js';
 import type { SessionData } from '../../data/session-loader.js';
 import type { AgentConnector, AuxProjections, DiscoveredFile } from '../types.js';
+import { codexGlobalMemory } from './memory.js';
 import { parseRollout, toCanonicalRows } from './normalize.js';
 
 const CACHE_DIR = join(CLAUDESCOPE_HOME, 'cache', 'codex');
@@ -98,4 +99,5 @@ export const codexConnector: AgentConnector = {
   eventsProjectionSql,
   auxProjections,
   loadSession,
+  globalMemory: codexGlobalMemory,
 };

--- a/packages/server/src/connectors/codex/memory.ts
+++ b/packages/server/src/connectors/codex/memory.ts
@@ -1,0 +1,78 @@
+/**
+ * Codex memory — read live from `~/.codex`, never indexed.
+ *
+ * Two provenances surface here, in display order:
+ *   1. `~/.codex/AGENTS.md` — the user-authored global instruction file.
+ *   2. `~/.codex/memories/{MEMORY.md,memory_summary.md}` — Codex's own
+ *      agent-distilled global handbook/summary. This store is experimental,
+ *      off-by-default, and geo-gated, so it is absent for essentially everyone;
+ *      it is read best-effort and simply omitted when missing or empty.
+ *
+ * STRICTLY READ-ONLY with respect to ~/.codex — files are only ever read.
+ * Every store is usually absent: missing files yield `[]`, never an error.
+ */
+
+import { readFileSync, statSync } from 'node:fs';
+import { join } from 'node:path';
+import type { MemorySource } from '@claudescope/shared';
+import { CODEX_HOME } from '../../config.js';
+import { contractHome } from '../../util/paths.js';
+
+/**
+ * Read a memory file into a `MemorySource`, or `undefined` if it's absent or
+ * empty (or unreadable). Best-effort: every read is wrapped so an absent store
+ * — the common case — degrades to omission, never an error.
+ */
+function readSource(
+  path: string,
+  base: Pick<MemorySource, 'provenance' | 'kind' | 'title'>,
+): MemorySource | undefined {
+  try {
+    const markdown = readFileSync(path, 'utf8');
+    if (!markdown.trim()) return undefined;
+    return {
+      ...base,
+      markdown,
+      sourcePath: contractHome(path),
+      updatedAt: new Date(statSync(path).mtimeMs).toISOString(),
+    };
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Codex's global, cross-project memory: the user-authored `AGENTS.md` plus the
+ * best-effort agent-authored `memories/` handbook and summary. Per-project
+ * Codex attribution (the `memories_*.sqlite`/`state_*.sqlite` cwd join) is
+ * deferred and intentionally not read here.
+ */
+export function codexGlobalMemory(): MemorySource[] {
+  const out: MemorySource[] = [];
+
+  // Instruction file first: the user-authored global AGENTS.md.
+  const agents = readSource(join(CODEX_HOME, 'AGENTS.md'), {
+    provenance: 'user-authored',
+    kind: 'document',
+    title: 'AGENTS.md (global)',
+  });
+  if (agents) out.push(agents);
+
+  // Best-effort agent-authored handbook + summary; absent for almost everyone.
+  const memoriesDir = join(CODEX_HOME, 'memories');
+  const handbook = readSource(join(memoriesDir, 'MEMORY.md'), {
+    provenance: 'agent-authored',
+    kind: 'document',
+    title: 'Codex memory handbook',
+  });
+  if (handbook) out.push(handbook);
+
+  const summary = readSource(join(memoriesDir, 'memory_summary.md'), {
+    provenance: 'agent-authored',
+    kind: 'document',
+    title: 'Codex memory summary',
+  });
+  if (summary) out.push(summary);
+
+  return out;
+}

--- a/packages/server/src/connectors/junie/junie.ts
+++ b/packages/server/src/connectors/junie/junie.ts
@@ -14,7 +14,9 @@
 import { createHash } from 'node:crypto';
 import { existsSync, mkdirSync, readFileSync, statSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
-import { CLAUDESCOPE_HOME, JUNIE_SESSIONS_DIR } from '../../config.js';
+import type { MemorySource } from '@claudescope/shared';
+import { CLAUDESCOPE_HOME, JUNIE_HOME, JUNIE_SESSIONS_DIR } from '../../config.js';
+import { contractHome } from '../../util/paths.js';
 import { sqlString } from '../../db/duckdb.js';
 import type { SessionData } from '../../data/session-loader.js';
 import type { AgentConnector, AuxProjections, DiscoveredFile } from '../types.js';
@@ -107,6 +109,33 @@ async function loadSession(_sessionId: string, paths: string[]): Promise<Session
   return { mainEvents, subagents: [] };
 }
 
+/**
+ * Junie's global, user-authored instruction file: `~/.junie/AGENTS.md`. Junie's
+ * per-project memory (`<repo>/.junie/memory/`) is repo-local and intentionally
+ * OUT OF SCOPE — surfacing it would require reading arbitrary user project
+ * directories, violating the home-dir-only invariant (see plan 0014); hence no
+ * `projectMemory`. Returns `[]` when the file is absent.
+ */
+function globalMemory(): MemorySource[] {
+  const agentsPath = join(JUNIE_HOME, 'AGENTS.md');
+  try {
+    const markdown = readFileSync(agentsPath, 'utf8');
+    if (!markdown.trim()) return []; // empty file → no memory
+    return [
+      {
+        provenance: 'user-authored',
+        kind: 'document',
+        title: 'AGENTS.md (global)',
+        markdown,
+        sourcePath: contractHome(agentsPath),
+        updatedAt: new Date(statSync(agentsPath).mtimeMs).toISOString(),
+      },
+    ];
+  } catch {
+    return []; // no global instruction file — a normal, first-class empty state
+  }
+}
+
 export const junieConnector: AgentConnector = {
   id: 'junie',
   label: 'Junie',
@@ -116,4 +145,5 @@ export const junieConnector: AgentConnector = {
   eventsProjectionSql,
   auxProjections,
   loadSession,
+  globalMemory,
 };

--- a/packages/server/src/connectors/types.ts
+++ b/packages/server/src/connectors/types.ts
@@ -12,6 +12,7 @@
  * hot path into the TS layer.
  */
 
+import type { MemorySource } from '@claudescope/shared';
 import type { SessionData } from '../data/session-loader.js';
 
 /** A discovered source file with the stats used for incremental change detection. */
@@ -96,4 +97,42 @@ export interface AgentConnector {
    * assembler. `paths` are all files recorded for the session.
    */
   loadSession(sessionId: string, paths: string[]): Promise<SessionData>;
+
+  /**
+   * Optional: the agent's global, cross-project memory — user-authored
+   * instruction file(s) and/or agent-distilled global memory. Read live (NOT
+   * indexed). Returns `[]` when the agent has none.
+   *
+   * INVARIANT: read only from the agent's own home dir (e.g. `~/.claude`,
+   * `~/.codex`, `~/.junie`) — never from the user's project directories.
+   */
+  globalMemory?(): MemorySource[];
+
+  /**
+   * Optional: every agent-authored per-project memory directory this connector
+   * owns, each tagged with the encoded-cwd `slug` that names it. Read live (NOT
+   * indexed); returns `[]` when there are none.
+   *
+   * The connector does NOT attribute facts to Claudescope projects — it just
+   * enumerates its memory dirs. The route attributes each fact to a project via
+   * its `originSessionId` (falling back to the dir `slug` for facts whose origin
+   * session is unknown), because a single memory dir is keyed by the git repo
+   * root and so may hold facts learned across several worktrees/cwds.
+   *
+   * INVARIANT: read only from the agent's own home dir — never from the user's
+   * project directories. (This is why Junie's repo-local `.junie/memory/` is out
+   * of scope: surfacing it would require reading arbitrary project dirs.)
+   */
+  projectMemory?(): AgentMemoryDir[];
+}
+
+/**
+ * One agent-authored per-project memory directory: the facts it holds and the
+ * encoded-cwd `slug` that names it (e.g. Claude's `~/.claude/projects/<slug>/`).
+ * The slug is used by the route as the attribution fallback for facts whose
+ * `originSessionId` can't be resolved to an indexed session.
+ */
+export interface AgentMemoryDir {
+  slug: string;
+  facts: MemorySource[];
 }

--- a/packages/server/src/data/memory.ts
+++ b/packages/server/src/data/memory.ts
@@ -1,0 +1,101 @@
+/**
+ * Live memory collection + attribution, shared by the memory and search routes.
+ *
+ * Memory is read live from the agent home dirs (never indexed). A connector's
+ * per-project memory dir is keyed by the git repo root, so one dir may hold facts
+ * learned across several worktrees/cwds. We attach each fact to the project of
+ * its `originSessionId` (resolved against the index), falling back to the project
+ * that owns the dir (its encoded-cwd slug). This makes a worktree project surface
+ * the facts that were actually learned in it.
+ */
+
+import type { MemorySource } from '@claudescope/shared';
+import { getConnection, queryRows } from '../db/duckdb.js';
+import { connectors } from '../connectors/registry.js';
+import type { AgentConnector } from '../connectors/types.js';
+import { displayNameFromCwd, projectIdFromCwd } from './project-id.js';
+import { memorySlugForCwd } from '../connectors/claude-code/memory.js';
+
+/** One memory source, attributed to a connector and (for project facts) a project. */
+export interface AttributedMemory {
+  connectorId: string;
+  label: string;
+  scope: 'global' | 'project';
+  /** Project facts only. */
+  projectId?: string;
+  projectDisplayName?: string;
+  source: MemorySource;
+}
+
+function safeGlobal(c: AgentConnector): MemorySource[] {
+  try {
+    return c.globalMemory?.() ?? [];
+  } catch {
+    return [];
+  }
+}
+
+function safeProject(c: AgentConnector) {
+  try {
+    return c.projectMemory?.() ?? [];
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Every memory source across all connectors: global instruction files/handbooks
+ * plus per-project facts attributed to a Claudescope project. Facts whose origin
+ * session isn't indexed and whose dir slug matches no project are dropped.
+ */
+export async function collectMemory(): Promise<AttributedMemory[]> {
+  const out: AttributedMemory[] = [];
+
+  for (const c of connectors) {
+    for (const source of safeGlobal(c)) {
+      out.push({ connectorId: c.id, label: c.label, scope: 'global', source });
+    }
+  }
+
+  const conn = await getConnection();
+  // The derived `sessions` table exposes the session id as `id`.
+  const rows = await queryRows(
+    conn,
+    'SELECT id, project_cwd FROM sessions WHERE project_cwd IS NOT NULL',
+  );
+
+  const sessionToProject = new Map<string, string>();
+  const slugToProject = new Map<string, string>();
+  const displayNames = new Map<string, string>();
+  for (const r of rows) {
+    const cwd = String(r.project_cwd);
+    const projectId = projectIdFromCwd(cwd);
+    if (r.id != null) sessionToProject.set(String(r.id), projectId);
+    const slug = memorySlugForCwd(cwd);
+    if (!slugToProject.has(slug)) slugToProject.set(slug, projectId);
+    if (!displayNames.has(projectId)) displayNames.set(projectId, displayNameFromCwd(cwd));
+  }
+
+  for (const c of connectors) {
+    for (const dir of safeProject(c)) {
+      const fallback = slugToProject.get(dir.slug);
+      for (const source of dir.facts) {
+        const byOrigin = source.originSessionId
+          ? sessionToProject.get(source.originSessionId)
+          : undefined;
+        const projectId = byOrigin ?? fallback;
+        if (!projectId) continue;
+        out.push({
+          connectorId: c.id,
+          label: c.label,
+          scope: 'project',
+          projectId,
+          projectDisplayName: displayNames.get(projectId),
+          source,
+        });
+      }
+    }
+  }
+
+  return out;
+}

--- a/packages/server/src/routes/index.ts
+++ b/packages/server/src/routes/index.ts
@@ -1,7 +1,7 @@
 /**
  * API route registration. Wires the health check plus every feature route per
- * the API contract: projects, sessions (list + detail), search, analytics, and
- * reindex.
+ * the API contract: projects, sessions (list + detail), search, analytics,
+ * sources, memory, and reindex.
  */
 
 import type { FastifyInstance } from 'fastify';
@@ -13,6 +13,7 @@ import { registerSessionsRoutes } from './sessions.js';
 import { registerSearchRoute } from './search.js';
 import { registerAnalyticsRoute } from './analytics.js';
 import { registerSourcesRoute } from './sources.js';
+import { registerMemoryRoute } from './memory.js';
 
 export async function registerRoutes(app: FastifyInstance): Promise<void> {
   app.get('/api/health', async (): Promise<HealthResponse & { ready: boolean }> => {
@@ -24,6 +25,7 @@ export async function registerRoutes(app: FastifyInstance): Promise<void> {
   await registerSearchRoute(app);
   await registerAnalyticsRoute(app);
   await registerSourcesRoute(app);
+  await registerMemoryRoute(app);
 
   app.post('/api/reindex', async (): Promise<ReindexResponse> => {
     return reindex();

--- a/packages/server/src/routes/memory.ts
+++ b/packages/server/src/routes/memory.ts
@@ -1,0 +1,89 @@
+/**
+ * Memory routes — surface each connector's live (NOT indexed) memory.
+ *
+ *   - GET /api/memory                       → global memory per connector plus a
+ *                                             per-project summary of which agents
+ *                                             have any project memory.
+ *   - GET /api/projects/:projectId/memory   → per-agent memory for one project.
+ *
+ * Attribution (origin-session → project, dir slug fallback) lives in
+ * `data/memory.ts` and is shared with search. Every store is usually
+ * absent/empty, so "no memory" is a normal state.
+ */
+
+import type { FastifyInstance } from 'fastify';
+import type { GlobalMemory, MemoryResponse, MemorySource, ProjectMemoryResponse } from '@claudescope/shared';
+import { collectMemory, type AttributedMemory } from '../data/memory.js';
+
+/** Group attributed memory by `projectId` then `connectorId`. */
+function projectBuckets(items: AttributedMemory[]) {
+  const buckets = new Map<string, Map<string, { label: string; sources: MemorySource[] }>>();
+  const displayNames = new Map<string, string>();
+  for (const it of items) {
+    if (it.scope !== 'project' || !it.projectId) continue;
+    if (it.projectDisplayName) displayNames.set(it.projectId, it.projectDisplayName);
+    let byConnector = buckets.get(it.projectId);
+    if (!byConnector) {
+      byConnector = new Map();
+      buckets.set(it.projectId, byConnector);
+    }
+    let bucket = byConnector.get(it.connectorId);
+    if (!bucket) {
+      bucket = { label: it.label, sources: [] };
+      byConnector.set(it.connectorId, bucket);
+    }
+    bucket.sources.push(it.source);
+  }
+  return { buckets, displayNames };
+}
+
+export async function registerMemoryRoute(app: FastifyInstance): Promise<void> {
+  app.get('/api/memory', async (): Promise<MemoryResponse> => {
+    const items = await collectMemory();
+
+    // Global memory grouped per connector (first occurrence sets the label).
+    const globalByConnector = new Map<string, GlobalMemory>();
+    for (const it of items) {
+      if (it.scope !== 'global') continue;
+      let g = globalByConnector.get(it.connectorId);
+      if (!g) {
+        g = { connectorId: it.connectorId, label: it.label, sources: [] };
+        globalByConnector.set(it.connectorId, g);
+      }
+      g.sources.push(it.source);
+    }
+
+    const { buckets, displayNames } = projectBuckets(items);
+    const projects = [...buckets.entries()]
+      .map(([projectId, byConnector]) => {
+        const counts = [...byConnector.entries()].map(([connectorId, b]) => ({
+          connectorId,
+          count: b.sources.length,
+        }));
+        const total = counts.reduce((n, c) => n + c.count, 0);
+        return { projectId, displayName: displayNames.get(projectId) ?? projectId, counts, total };
+      })
+      .sort((a, b) => b.total - a.total || a.displayName.localeCompare(b.displayName))
+      .map(({ projectId, displayName, counts }) => ({ projectId, displayName, counts }));
+
+    return { global: [...globalByConnector.values()], projects };
+  });
+
+  app.get<{ Params: { projectId: string } }>(
+    '/api/projects/:projectId/memory',
+    async (req): Promise<ProjectMemoryResponse> => {
+      const { projectId } = req.params;
+      const { buckets, displayNames } = projectBuckets(await collectMemory());
+      const byConnector = buckets.get(projectId);
+      const byAgent = byConnector
+        ? [...byConnector.entries()].map(([connectorId, b]) => ({
+            connectorId,
+            label: b.label,
+            sources: b.sources,
+          }))
+        : [];
+      const displayName = displayNames.get(projectId);
+      return { projectId, ...(displayName ? { displayName } : {}), byAgent };
+    },
+  );
+}

--- a/packages/server/src/routes/search.ts
+++ b/packages/server/src/routes/search.ts
@@ -1,26 +1,37 @@
 /**
- * GET /api/search — BM25 full-text search over event text.
+ * GET /api/search — full-text search over transcripts and/or agent memory.
  *
- * Uses the `fts` index built on `events.text_content` (keyed by `uuid`). Results
- * are ranked by `match_bm25` score and carry a snippet with the matched terms
- * highlighted via `<mark>`. Optional filters: `project` (slug) and `type`
- * (user|assistant|all).
+ * Transcripts use the BM25 `fts` index on `events.text_content` (keyed by
+ * `uuid`); memory is searched live (it isn't indexed). The `scope` param picks
+ * which: `sessions` (default), `all` (both), or `memory` (memory only). Both
+ * kinds carry a snippet with matched terms highlighted via `<mark>`. Optional
+ * filters: `project` (slug) and `type` (user|assistant|all; sessions only).
  */
 
 import type { FastifyInstance } from 'fastify';
-import type { SearchResult, SearchType } from '@claudescope/shared';
+import type {
+  MemorySearchHit,
+  SearchResponse,
+  SearchResult,
+  SearchScope,
+  SearchType,
+} from '@claudescope/shared';
 import { getConnection, queryRows, sqlString } from '../db/duckdb.js';
 import { projectIdFromCwd } from '../data/project-id.js';
+import { collectMemory } from '../data/memory.js';
 
 /** Max characters of context around the first match in a snippet. */
 const SNIPPET_RADIUS = 120;
+/** Cap on live memory hits returned. */
+const MEMORY_LIMIT = 50;
 
 /** Escape HTML special chars so snippets are safe to render. */
 function escapeHtml(s: string): string {
-  return s
-    .replace(/&/g, '&amp;')
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;');
+  return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+}
+
+function escapeRegExp(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }
 
 /**
@@ -43,79 +54,135 @@ function makeSnippet(text: string, terms: string[]): string {
   let escaped = escapeHtml(window);
   for (const t of terms) {
     if (!t) continue;
-    const re = new RegExp(`(${escapeRegExp(escapeHtml(t))})`, 'gi');
-    escaped = escaped.replace(re, '<mark>$1</mark>');
+    escaped = escaped.replace(new RegExp(`(${escapeRegExp(escapeHtml(t))})`, 'gi'), '<mark>$1</mark>');
   }
   return escaped;
 }
 
-function escapeRegExp(s: string): string {
-  return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+/** Sessions (BM25) search. Empty unless scope includes sessions. */
+async function searchSessions(
+  q: string,
+  terms: string[],
+  type: SearchType,
+  project: string | undefined,
+): Promise<SearchResult[]> {
+  const conn = await getConnection();
+  // `events.uuid` is duplicated by fork/resume copies (the same lines re-listed
+  // under a new session id), so `match_bm25(uuid, …)` — whose internal lookup is
+  // a scalar subquery keyed by uuid — can hit multiple rows. Newer DuckDB errors
+  // on that; this restores the prior "pick a representative row" behavior (the
+  // duplicates are identical copies, so any is fine). Pre-existing issue on main.
+  await conn.run('SET scalar_subquery_error_on_multiple_rows = false');
+
+  const filters: string[] = ['score IS NOT NULL'];
+  if (type === 'user' || type === 'assistant') filters.push(`role = ${sqlString(type)}`);
+  if (project) {
+    const cwds = await queryRows(
+      conn,
+      'SELECT DISTINCT project_cwd FROM sessions WHERE project_cwd IS NOT NULL',
+    );
+    const match = cwds.map((c) => String(c.project_cwd)).find((c) => projectIdFromCwd(c) === project);
+    filters.push(`project_cwd = ${match ? sqlString(match) : "'\\0'"}`);
+  }
+
+  const rows = await queryRows(
+    conn,
+    `SELECT * FROM (
+       SELECT
+         e.uuid AS message_uuid,
+         e.session_id AS session_id,
+         e.role AS role,
+         e.text_content AS text_content,
+         s.project_cwd AS project_cwd,
+         s.title AS title,
+         fts_main_events.match_bm25(e.uuid, ${sqlString(q)}) AS score
+       FROM events e
+       JOIN sessions s ON s.id = e.session_id
+       WHERE e.text_content IS NOT NULL
+     )
+     WHERE ${filters.join(' AND ')}
+     ORDER BY score DESC
+     LIMIT 50`,
+  );
+
+  return rows.map((r): SearchResult => {
+    const cwd = r.project_cwd != null ? String(r.project_cwd) : '';
+    const text = r.text_content != null ? String(r.text_content) : '';
+    return {
+      sessionId: String(r.session_id),
+      projectId: cwd ? projectIdFromCwd(cwd) : '',
+      title: r.title != null ? String(r.title) : '',
+      snippet: makeSnippet(text, terms),
+      score: Number(r.score ?? 0),
+      messageUuid: String(r.message_uuid),
+      role: r.role != null ? String(r.role) : '',
+    };
+  });
+}
+
+/** Live memory search. Empty unless scope includes memory. */
+async function searchMemory(
+  terms: string[],
+  project: string | undefined,
+): Promise<MemorySearchHit[]> {
+  const lowered = terms.map((t) => t.toLowerCase());
+  const items = await collectMemory();
+  const scored: { hits: number; hit: MemorySearchHit }[] = [];
+
+  for (const it of items) {
+    // A project filter restricts to that project's facts (drops global memory).
+    if (project && (it.scope !== 'project' || it.projectId !== project)) continue;
+
+    const s = it.source;
+    const haystack = `${s.title}\n${s.description ?? ''}\n${s.category ?? ''}\n${s.markdown}`.toLowerCase();
+    const hits = lowered.filter((t) => t && haystack.includes(t)).length;
+    if (hits === 0) continue;
+
+    // Snippet from the body where possible, else the title.
+    const bodyHasTerm = lowered.some((t) => t && s.markdown.toLowerCase().includes(t));
+    const snippet = makeSnippet(bodyHasTerm ? s.markdown : s.title, terms);
+
+    scored.push({
+      hits,
+      hit: {
+        connectorId: it.connectorId,
+        label: it.label,
+        scope: it.scope,
+        ...(it.projectId ? { projectId: it.projectId } : {}),
+        ...(it.projectDisplayName ? { projectDisplayName: it.projectDisplayName } : {}),
+        title: s.title,
+        ...(s.category ? { category: s.category } : {}),
+        snippet,
+        sourcePath: s.sourcePath,
+        ...(s.originSessionId ? { originSessionId: s.originSessionId } : {}),
+      },
+    });
+  }
+
+  return scored
+    .sort((a, b) => b.hits - a.hits)
+    .slice(0, MEMORY_LIMIT)
+    .map((x) => x.hit);
 }
 
 export async function registerSearchRoute(app: FastifyInstance): Promise<void> {
   app.get<{
-    Querystring: { q?: string; project?: string; type?: string };
-  }>('/api/search', async (req): Promise<SearchResult[]> => {
-    const conn = await getConnection();
+    Querystring: { q?: string; project?: string; type?: string; scope?: string };
+  }>('/api/search', async (req): Promise<SearchResponse> => {
     const q = (req.query.q ?? '').trim();
-    if (!q) return [];
-
-    const type = (req.query.type as SearchType) ?? 'all';
-    const project = req.query.project;
-
-    // Filters reference the OUTER (projected) column names, not the inner
-    // table aliases, since the bm25 score is computed in an inner subquery.
-    const filters: string[] = ['score IS NOT NULL'];
-    if (type === 'user' || type === 'assistant') {
-      filters.push(`role = ${sqlString(type)}`);
-    }
-    if (project) {
-      const cwds = await queryRows(
-        conn,
-        'SELECT DISTINCT project_cwd FROM sessions WHERE project_cwd IS NOT NULL',
-      );
-      const match = cwds
-        .map((c) => String(c.project_cwd))
-        .find((c) => projectIdFromCwd(c) === project);
-      filters.push(`project_cwd = ${match ? sqlString(match) : "'\\0'"}`);
-    }
-
-    // match_bm25 takes the document key (uuid) and the raw query string.
-    const rows = await queryRows(
-      conn,
-      `SELECT * FROM (
-         SELECT
-           e.uuid AS message_uuid,
-           e.session_id AS session_id,
-           e.role AS role,
-           e.text_content AS text_content,
-           s.project_cwd AS project_cwd,
-           s.title AS title,
-           fts_main_events.match_bm25(e.uuid, ${sqlString(q)}) AS score
-         FROM events e
-         JOIN sessions s ON s.id = e.session_id
-         WHERE e.text_content IS NOT NULL
-       )
-       WHERE ${filters.join(' AND ')}
-       ORDER BY score DESC
-       LIMIT 50`,
-    );
+    if (!q) return { sessions: [], memory: [] };
 
     const terms = q.split(/\s+/).filter(Boolean);
+    const type = (req.query.type as SearchType) ?? 'all';
+    const project = req.query.project;
+    const scope = (req.query.scope as SearchScope) ?? 'sessions';
 
-    return rows.map((r): SearchResult => {
-      const cwd = r.project_cwd != null ? String(r.project_cwd) : '';
-      const text = r.text_content != null ? String(r.text_content) : '';
-      return {
-        sessionId: String(r.session_id),
-        projectId: cwd ? projectIdFromCwd(cwd) : '',
-        title: r.title != null ? String(r.title) : '',
-        snippet: makeSnippet(text, terms),
-        score: Number(r.score ?? 0),
-        messageUuid: String(r.message_uuid),
-        role: r.role != null ? String(r.role) : '',
-      };
-    });
+    // Each kind is guarded so a failure in one (e.g. an FTS edge case) still
+    // returns the other rather than 500-ing the whole request.
+    const sessions =
+      scope === 'memory' ? [] : await searchSessions(q, terms, type, project).catch(() => []);
+    const memory = scope === 'sessions' ? [] : await searchMemory(terms, project).catch(() => []);
+
+    return { sessions, memory };
   });
 }

--- a/packages/server/src/routes/sources.ts
+++ b/packages/server/src/routes/sources.ts
@@ -7,21 +7,15 @@
  */
 
 import { existsSync } from 'node:fs';
-import { homedir } from 'node:os';
 import type { FastifyInstance } from 'fastify';
 import type { SourcesResponse } from '@claudescope/shared';
 import { connectors } from '../connectors/registry.js';
-
-/** Contract a leading home-dir path to `~` for display. */
-function tildify(p: string): string {
-  const home = homedir();
-  return p === home ? '~' : p.startsWith(home + '/') ? `~${p.slice(home.length)}` : p;
-}
+import { contractHome } from '../util/paths.js';
 
 export async function registerSourcesRoute(app: FastifyInstance): Promise<void> {
   app.get('/api/sources', async (): Promise<SourcesResponse> => {
     return connectors
       .filter((c) => existsSync(c.sourceDir))
-      .map((c) => ({ id: c.id, label: c.label, path: tildify(c.sourceDir) }));
+      .map((c) => ({ id: c.id, label: c.label, path: contractHome(c.sourceDir) }));
   });
 }

--- a/packages/server/src/util/paths.ts
+++ b/packages/server/src/util/paths.ts
@@ -1,0 +1,10 @@
+/** Shared path display helpers. */
+
+import { homedir } from 'node:os';
+
+/** Contract a leading home-dir prefix to `~` for display (e.g. `~/.claude/...`). */
+export function contractHome(p: string): string {
+  const home = homedir();
+  if (p === home) return '~';
+  return p.startsWith(`${home}/`) ? `~${p.slice(home.length)}` : p;
+}

--- a/packages/server/test/api.integration.test.ts
+++ b/packages/server/test/api.integration.test.ts
@@ -196,7 +196,7 @@ describe('GET /api/sessions/:id', () => {
 
 describe('GET /api/search', () => {
   it('finds a session by full-text content', async () => {
-    const results = (await get('/api/search?q=needle')).json();
+    const { sessions: results } = (await get('/api/search?q=needle')).json();
     expect(results.length).toBeGreaterThan(0);
     expect(results.some((r: { sessionId: string }) => r.sessionId === 'sessA')).toBe(true);
   });

--- a/packages/server/test/codex.integration.test.ts
+++ b/packages/server/test/codex.integration.test.ts
@@ -121,7 +121,7 @@ describe('Codex session indexing', () => {
   });
 
   it('finds the Codex session via full-text search', async () => {
-    const results = (await get('/api/search?q=needle')).json();
+    const { sessions: results } = (await get('/api/search?q=needle')).json();
     expect(results.some((r: { sessionId: string }) => r.sessionId === 'codex-sess-1')).toBe(true);
   });
 });

--- a/packages/server/test/junie.integration.test.ts
+++ b/packages/server/test/junie.integration.test.ts
@@ -204,7 +204,7 @@ describe('Junie session indexing', () => {
   });
 
   it('finds the Junie session via full-text search on tool labels', async () => {
-    const results = (await get('/api/search?q=needle')).json();
+    const { sessions: results } = (await get('/api/search?q=needle')).json();
     expect(results.some((r: { sessionId: string }) => r.sessionId === SESSION_ID)).toBe(true);
   });
 });

--- a/packages/shared/src/api.ts
+++ b/packages/shared/src/api.ts
@@ -115,10 +115,19 @@ export interface SessionsQuery {
 
 export type SearchType = 'user' | 'assistant' | 'all';
 
+/**
+ * Where full-text search looks:
+ * - `sessions` — transcripts only (default; the original behavior).
+ * - `all` — transcripts **and** agent memory.
+ * - `memory` — agent memory only.
+ */
+export type SearchScope = 'sessions' | 'all' | 'memory';
+
 export interface SearchQuery {
   q: string;
   project?: string;
   type?: SearchType;
+  scope?: SearchScope;
 }
 
 export type AnalyticsGroupBy = 'project' | 'model' | 'day' | 'agent';
@@ -150,8 +159,31 @@ export interface SessionDetailResponse {
   subagents: SubagentRun[];
 }
 
+/** A full-text search hit in agent memory (instruction file or distilled fact). */
+export interface MemorySearchHit {
+  connectorId: string;
+  /** Human-friendly agent label. */
+  label: string;
+  /** `global` instruction file/handbook, or a per-project `project` fact. */
+  scope: 'global' | 'project';
+  /** Present for project facts; absent for global memory. */
+  projectId?: string;
+  projectDisplayName?: string;
+  title: string;
+  category?: string;
+  /** Snippet with matched terms in `<mark>` (the server HTML-escapes the rest). */
+  snippet: string;
+  /** Source path, home contracted to `~`. */
+  sourcePath: string;
+  /** Claude facts: the session that produced the fact (deep-link). */
+  originSessionId?: string;
+}
+
 /** GET /api/search */
-export type SearchResponse = SearchResult[];
+export interface SearchResponse {
+  sessions: SearchResult[];
+  memory: MemorySearchHit[];
+}
 
 /** One read-only source directory backing an agent connector. */
 export interface SourceInfo {
@@ -183,3 +215,89 @@ export interface HealthResponse {
   status: 'ok';
   version: string;
 }
+
+// ---------------------------------------------------------------------------
+// Memory
+// ---------------------------------------------------------------------------
+
+/**
+ * Where a piece of memory came from:
+ * - `user-authored` — instruction files the user wrote (CLAUDE.md, AGENTS.md).
+ * - `agent-authored` — memory the agent distilled on its own (Claude facts,
+ *   Codex's memories handbook).
+ */
+export type MemoryProvenance = 'user-authored' | 'agent-authored';
+
+/**
+ * Structural shape of a memory item:
+ * - `fact` — a single typed fact with frontmatter (Claude `memory/*.md`).
+ * - `document` — a named markdown/JSON file rendered whole (Codex `MEMORY.md`).
+ */
+export type MemoryKind = 'fact' | 'document';
+
+/**
+ * One unit of memory from an agent. Read live from disk (never indexed). For
+ * Claude facts, `category` is one of `user` | `feedback` | `project` |
+ * `reference`; other agents may use free-form categories.
+ */
+export interface MemorySource {
+  provenance: MemoryProvenance;
+  kind: MemoryKind;
+  /** Fact name or document label, e.g. `cost-double-counting` or `Codex handbook`. */
+  title: string;
+  /** One-line description (Claude facts), when present. */
+  description?: string;
+  /** Fact type (Claude) or category; see {@link MemorySource}. */
+  category?: string;
+  /** Markdown body, rendered read-only. */
+  markdown: string;
+  /** Source path with the home dir contracted to `~`, for provenance display. */
+  sourcePath: string;
+  /** ISO timestamp of last modification (file mtime). */
+  updatedAt: string;
+  /** Claude: the session that produced this fact — a deep-link target. */
+  originSessionId?: string;
+  /** Claude: `[[wiki-link]]` fact names referenced in the body. */
+  relatedNames?: string[];
+  /** True when the store exists but is an empty scaffold (no content yet). */
+  empty?: boolean;
+}
+
+/** Global, cross-project memory contributed by one connector. */
+export interface GlobalMemory {
+  connectorId: string;
+  /** Human-friendly agent label, e.g. `Claude Code`. */
+  label: string;
+  sources: MemorySource[];
+}
+
+/** Memory for one project from one connector. */
+export interface ProjectAgentMemory {
+  connectorId: string;
+  label: string;
+  sources: MemorySource[];
+}
+
+/** Per-project memory grouped by agent. */
+export interface ProjectMemory {
+  projectId: string;
+  /** Human-friendly project name, when the project is known to the index. */
+  displayName?: string;
+  byAgent: ProjectAgentMemory[];
+}
+
+/** Which projects have any agent memory, with per-connector counts. */
+export interface ProjectMemorySummary {
+  projectId: string;
+  displayName: string;
+  counts: { connectorId: string; count: number }[];
+}
+
+/** GET /api/memory */
+export interface MemoryResponse {
+  global: GlobalMemory[];
+  projects: ProjectMemorySummary[];
+}
+
+/** GET /api/projects/:projectId/memory */
+export type ProjectMemoryResponse = ProjectMemory;

--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -8,6 +8,10 @@ import { SessionListPage } from './pages/browse/SessionList.js';
 import { SessionPage } from './pages/session/SessionPage.js';
 import { SearchPage } from './pages/search/SearchPage.js';
 import { AnalyticsPage } from './pages/analytics/AnalyticsPage.js';
+import { MemoryPage } from './pages/memory/MemoryPage.js';
+import { AgentMemoryPage } from './pages/memory/AgentMemoryPage.js';
+import { AgentProjectMemoryPage } from './pages/memory/AgentProjectMemoryPage.js';
+import { ProjectMemoryPage } from './pages/memory/ProjectMemoryPage.js';
 
 interface NavItem {
   to: string;
@@ -19,6 +23,7 @@ interface NavItem {
 
 const NAV_ITEMS: NavItem[] = [
   { to: '/', label: 'Browse', icon: '📁', end: true },
+  { to: '/memory', label: 'Memory', icon: '🧠' },
   { to: '/search', label: 'Search', icon: '🔍' },
   { to: '/analytics', label: 'Analytics', icon: '📊' },
 ];
@@ -103,9 +108,13 @@ export function App() {
         <Routes>
           <Route path="/" element={<BrowsePage />} />
           <Route path="/projects/:projectId" element={<SessionListPage />} />
+          <Route path="/projects/:projectId/memory" element={<ProjectMemoryPage />} />
           <Route path="/sessions/:id" element={<SessionPage />} />
           <Route path="/search" element={<SearchPage />} />
           <Route path="/analytics" element={<AnalyticsPage />} />
+          <Route path="/memory" element={<MemoryPage />} />
+          <Route path="/memory/:connectorId" element={<AgentMemoryPage />} />
+          <Route path="/memory/:connectorId/:projectId" element={<AgentProjectMemoryPage />} />
         </Routes>
       </main>
     </div>

--- a/packages/web/src/api/client.ts
+++ b/packages/web/src/api/client.ts
@@ -8,9 +8,12 @@ import type {
   AnalyticsGroupBy,
   AnalyticsResponse,
   HealthResponse,
+  MemoryResponse,
+  ProjectMemoryResponse,
   ProjectsResponse,
   ReindexResponse,
   SearchResponse,
+  SearchScope,
   SearchType,
   SessionDetailResponse,
   SessionSort,
@@ -81,6 +84,7 @@ export interface SearchParams {
   q: string;
   project?: string;
   type?: SearchType;
+  scope?: SearchScope;
 }
 
 export interface AnalyticsParams {
@@ -121,7 +125,7 @@ export const api = {
   /** GET /api/search?q=&project=&type= */
   search(params: SearchParams, signal?: AbortSignal): Promise<SearchResponse> {
     return request<SearchResponse>(
-      `/search${qs({ q: params.q, project: params.project, type: params.type })}`,
+      `/search${qs({ q: params.q, project: params.project, type: params.type, scope: params.scope })}`,
       { signal },
     );
   },
@@ -137,6 +141,19 @@ export const api = {
   /** GET /api/sources */
   sources(signal?: AbortSignal): Promise<SourcesResponse> {
     return request<SourcesResponse>('/sources', { signal });
+  },
+
+  /** GET /api/memory */
+  memory(signal?: AbortSignal): Promise<MemoryResponse> {
+    return request<MemoryResponse>('/memory', { signal });
+  },
+
+  /** GET /api/projects/:id/memory */
+  projectMemory(projectId: string, signal?: AbortSignal): Promise<ProjectMemoryResponse> {
+    return request<ProjectMemoryResponse>(
+      `/projects/${encodeURIComponent(projectId)}/memory`,
+      { signal },
+    );
   },
 
   /** POST /api/reindex */

--- a/packages/web/src/pages/browse/SessionList.tsx
+++ b/packages/web/src/pages/browse/SessionList.tsx
@@ -4,6 +4,7 @@ import type { ProjectMeta, SessionMeta, SessionSort } from '@claudescope/shared'
 import { api, ApiError } from '../../api/client.js';
 import { AgentBadge, agentLabel, CostBadge, ErrorBox, Spinner, TokenChips } from '../../components';
 import { formatBytes, formatDateTime, shortModel, timeAgo } from './format.js';
+import '../memory/memory.css';
 
 const SORT_OPTIONS: { value: SessionSort; label: string }[] = [
   { value: 'recent', label: 'Most recent' },
@@ -129,6 +130,21 @@ export function SessionListPage() {
           </select>
         </div>
       </header>
+
+      {/* Sessions | Memory tab bar — switches to this project's memory view. */}
+      <div className="tv-memory-tabs" role="tablist" aria-label="Project view">
+        <span className="tv-memory-tabs__tab is-active" role="tab" aria-selected="true">
+          Sessions
+        </span>
+        <Link
+          to={`/projects/${encodeURIComponent(projectId)}/memory`}
+          className="tv-memory-tabs__tab"
+          role="tab"
+          aria-selected="false"
+        >
+          Memory
+        </Link>
+      </div>
 
       {/* Agent filter — only meaningful when the project spans 2+ agents. */}
       {agents.length > 1 ? (

--- a/packages/web/src/pages/memory/AgentMemoryPage.tsx
+++ b/packages/web/src/pages/memory/AgentMemoryPage.tsx
@@ -1,0 +1,135 @@
+/**
+ * One agent's memory (`/memory/:connectorId`) — its global user-authored
+ * instruction files and agent-distilled memory, plus the projects where this
+ * agent has any memory, each drilling into `/memory/:connectorId/:projectId`.
+ *
+ * Memory is read LIVE from the agent home dirs on the server (never indexed), so
+ * this page just fetches and renders. "No memory" is a normal, first-class state
+ * here, never an error.
+ */
+
+import { useEffect, useMemo, useState } from 'react';
+import { Link, useParams } from 'react-router-dom';
+import type { MemoryResponse, MemorySource } from '@claudescope/shared';
+import { api } from '../../api/client.js';
+import { AgentBadge, agentLabel, ErrorBox, Spinner } from '../../components';
+import { MemorySourceCard } from './MemorySourceCard.js';
+import { collectNames, isBenignError } from './shared.js';
+import './memory.css';
+
+/** A project where this connector has memory, with its fact count. */
+interface ProjectEntry {
+  projectId: string;
+  displayName: string;
+  count: number;
+}
+
+export function AgentMemoryPage() {
+  const { connectorId = '' } = useParams<{ connectorId: string }>();
+
+  const [data, setData] = useState<MemoryResponse | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<unknown>(null);
+  const [reloadKey, setReloadKey] = useState(0);
+
+  useEffect(() => {
+    const controller = new AbortController();
+    setLoading(true);
+    setError(null);
+    api
+      .memory(controller.signal)
+      .then((res) => {
+        setData(res);
+        setLoading(false);
+      })
+      .catch((err: unknown) => {
+        if (isBenignError(err)) return;
+        setError(err);
+        setLoading(false);
+      });
+    return () => controller.abort();
+  }, [reloadKey]);
+
+  const label = agentLabel(connectorId);
+
+  // This connector's global sources.
+  const globalSources: MemorySource[] = useMemo(
+    () => data?.global.find((g) => g.connectorId === connectorId)?.sources ?? [],
+    [data, connectorId],
+  );
+  const knownNames = useMemo(() => collectNames(globalSources), [globalSources]);
+
+  // Projects where this connector contributes any memory.
+  const projects: ProjectEntry[] = useMemo(() => {
+    if (!data) return [];
+    return data.projects
+      .map((p) => {
+        const count = p.counts.find((c) => c.connectorId === connectorId)?.count ?? 0;
+        return { projectId: p.projectId, displayName: p.displayName, count };
+      })
+      .filter((p) => p.count > 0);
+  }, [data, connectorId]);
+
+  const hasGlobal = globalSources.length > 0;
+  const hasProjects = projects.length > 0;
+
+  return (
+    <section className="tv-memory">
+      <div className="tv-browse__crumbs">
+        <Link to="/memory" className="tv-linkbtn">
+          ← Memory
+        </Link>
+      </div>
+
+      <header className="tv-memory-connector__head">
+        <AgentBadge connectorId={connectorId} />
+        <h1 className="tv-page-title" style={{ marginBottom: 0 }}>
+          {label}
+        </h1>
+      </header>
+
+      {loading ? (
+        <Spinner size="lg" label="Loading memory…" />
+      ) : error ? (
+        <ErrorBox error={error} title="Failed to load memory" onRetry={() => setReloadKey((k) => k + 1)} />
+      ) : !hasGlobal && !hasProjects ? (
+        <p className="tv-muted">No memory found for this agent yet.</p>
+      ) : (
+        <>
+          {hasGlobal ? (
+            <section className="tv-memory__section">
+              <h2 className="tv-memory__section-title">Global memory</h2>
+              <div className="tv-memory-group__items">
+                {globalSources.map((s) => (
+                  <MemorySourceCard key={s.sourcePath} source={s} knownNames={knownNames} />
+                ))}
+              </div>
+            </section>
+          ) : null}
+
+          {hasProjects ? (
+            <section className="tv-memory__section">
+              <h2 className="tv-memory__section-title">Project memory</h2>
+              <ul className="tv-list">
+                {projects.map((p) => (
+                  <li key={p.projectId} className="tv-card tv-memory__project">
+                    <Link
+                      to={`/memory/${encodeURIComponent(connectorId)}/${encodeURIComponent(p.projectId)}`}
+                      className="tv-memory__project-main"
+                    >
+                      <span className="tv-memory__project-name">{p.displayName}</span>
+                      <span className="tv-chip tv-memory__project-count">
+                        <span className="tv-chip__label">facts</span>
+                        <span className="tv-memory__project-count-n">{p.count}</span>
+                      </span>
+                    </Link>
+                  </li>
+                ))}
+              </ul>
+            </section>
+          ) : null}
+        </>
+      )}
+    </section>
+  );
+}

--- a/packages/web/src/pages/memory/AgentProjectMemoryPage.tsx
+++ b/packages/web/src/pages/memory/AgentProjectMemoryPage.tsx
@@ -1,0 +1,94 @@
+/**
+ * One agent's memory for one project (`/memory/:connectorId/:projectId`) — the
+ * facts a single agent has distilled for a single project. Reached by drilling
+ * from the per-agent page (`/memory/:connectorId`).
+ *
+ * Memory is read LIVE from the agent home dirs on the server (never indexed), so
+ * this page just fetches and renders. "No memory" is a normal, first-class state
+ * here, never an error.
+ */
+
+import { useEffect, useMemo, useState } from 'react';
+import { Link, useParams } from 'react-router-dom';
+import type { ProjectMemoryResponse } from '@claudescope/shared';
+import { api } from '../../api/client.js';
+import { AgentBadge, agentLabel, ErrorBox, Spinner } from '../../components';
+import { MemorySourceCard } from './MemorySourceCard.js';
+import { collectNames, isBenignError } from './shared.js';
+import './memory.css';
+
+export function AgentProjectMemoryPage() {
+  const { connectorId = '', projectId = '' } = useParams<{
+    connectorId: string;
+    projectId: string;
+  }>();
+
+  const [data, setData] = useState<ProjectMemoryResponse | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<unknown>(null);
+  const [reloadKey, setReloadKey] = useState(0);
+
+  useEffect(() => {
+    const controller = new AbortController();
+    setLoading(true);
+    setError(null);
+    api
+      .projectMemory(projectId, controller.signal)
+      .then((res) => {
+        setData(res);
+        setLoading(false);
+      })
+      .catch((err: unknown) => {
+        if (isBenignError(err)) return;
+        setError(err);
+        setLoading(false);
+      });
+    return () => controller.abort();
+  }, [projectId, reloadKey]);
+
+  const label = agentLabel(connectorId);
+
+  const agent = useMemo(
+    () => data?.byAgent.find((a) => a.connectorId === connectorId) ?? null,
+    [data, connectorId],
+  );
+  const sources = agent?.sources ?? [];
+  const knownNames = useMemo(() => collectNames(sources), [sources]);
+
+  return (
+    <section className="tv-memory">
+      <div className="tv-browse__crumbs">
+        <Link to="/memory" className="tv-linkbtn">
+          ← Memory
+        </Link>
+        <span className="tv-muted"> / </span>
+        <Link to={`/memory/${encodeURIComponent(connectorId)}`} className="tv-linkbtn">
+          {label}
+        </Link>
+        <span className="tv-muted"> / </span>
+        <span className="tv-mono">{data?.displayName ?? projectId}</span>
+      </div>
+
+      <header className="tv-memory-connector__head">
+        <AgentBadge connectorId={connectorId} />
+        <h1 className="tv-page-title" style={{ marginBottom: 0 }}>
+          {label} memory
+        </h1>
+      </header>
+
+      {loading ? (
+        <Spinner size="lg" label="Loading memory…" />
+      ) : error ? (
+        <ErrorBox error={error} title="Failed to load memory" onRetry={() => setReloadKey((k) => k + 1)} />
+      ) : sources.length === 0 ? (
+        <p className="tv-muted">No memory found for this agent in this project yet.</p>
+      ) : (
+        <div className="tv-memory-group__items">
+          {sources.map((s) => (
+            <MemorySourceCard key={s.sourcePath} source={s} knownNames={knownNames} />
+          ))}
+        </div>
+      )}
+    </section>
+  );
+}

--- a/packages/web/src/pages/memory/MemoryPage.tsx
+++ b/packages/web/src/pages/memory/MemoryPage.tsx
@@ -1,0 +1,140 @@
+/**
+ * Memory landing (`/memory`) — a folder grid, one card per agent (connector)
+ * that has any memory, mirroring the BrowsePage project-card look. Each card
+ * drills into that agent's memory at `/memory/:connectorId`.
+ *
+ * Memory is read LIVE from the agent home dirs on the server (never indexed), so
+ * this page just fetches and renders. Every store is usually absent/empty —
+ * "no memory" is a normal, first-class state here, never an error.
+ */
+
+import { useEffect, useMemo, useState } from 'react';
+import { Link } from 'react-router-dom';
+import type { MemoryResponse } from '@claudescope/shared';
+import { api } from '../../api/client.js';
+import { AgentBadge, agentLabel, ErrorBox, Spinner } from '../../components';
+import { isBenignError } from './shared.js';
+import './memory.css';
+
+/** Per-agent rollup driving one folder card on the landing page. */
+interface AgentSummary {
+  connectorId: string;
+  label: string;
+  /** Number of global user-authored instruction files. */
+  globalFiles: number;
+  /** Number of projects where this agent has any memory. */
+  projectsWithFacts: number;
+  /** Total facts this agent contributes across all projects. */
+  totalFacts: number;
+}
+
+/**
+ * Roll the global + project response into one summary per connector that has
+ * any memory. A connector qualifies if it appears in `global` with sources, or
+ * in any project's per-agent counts.
+ */
+function summarize(data: MemoryResponse): AgentSummary[] {
+  const byId = new Map<string, AgentSummary>();
+
+  const ensure = (connectorId: string, label: string): AgentSummary => {
+    let s = byId.get(connectorId);
+    if (!s) {
+      s = { connectorId, label, globalFiles: 0, projectsWithFacts: 0, totalFacts: 0 };
+      byId.set(connectorId, s);
+    }
+    return s;
+  };
+
+  for (const g of data.global) {
+    if (g.sources.length === 0) continue;
+    ensure(g.connectorId, g.label).globalFiles += g.sources.length;
+  }
+
+  for (const p of data.projects) {
+    for (const c of p.counts) {
+      if (c.count === 0) continue;
+      const s = ensure(c.connectorId, agentLabel(c.connectorId));
+      s.projectsWithFacts += 1;
+      s.totalFacts += c.count;
+    }
+  }
+
+  return [...byId.values()];
+}
+
+export function MemoryPage() {
+  const [data, setData] = useState<MemoryResponse | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<unknown>(null);
+  const [reloadKey, setReloadKey] = useState(0);
+
+  useEffect(() => {
+    const controller = new AbortController();
+    setLoading(true);
+    setError(null);
+    api
+      .memory(controller.signal)
+      .then((res) => {
+        setData(res);
+        setLoading(false);
+      })
+      .catch((err: unknown) => {
+        if (isBenignError(err)) return;
+        setError(err);
+        setLoading(false);
+      });
+    return () => controller.abort();
+  }, [reloadKey]);
+
+  const agents = useMemo(() => (data ? summarize(data) : []), [data]);
+
+  return (
+    <div className="tv-memory">
+      <h1 className="tv-page-title">Memory</h1>
+      <p className="tv-memory__lede tv-muted">
+        Long-lived instruction files and agent-distilled memory, read live from
+        each agent&rsquo;s home directory. Pick an agent to browse its global
+        memory and per-project facts.
+      </p>
+
+      {loading ? (
+        <Spinner size="lg" label="Loading memory…" />
+      ) : error ? (
+        <ErrorBox error={error} title="Failed to load memory" onRetry={() => setReloadKey((k) => k + 1)} />
+      ) : agents.length === 0 ? (
+        <p className="tv-muted">No memory found yet.</p>
+      ) : (
+        <div className="tv-project-grid">
+          {agents.map((a) => (
+            <AgentMemoryCard key={a.connectorId} summary={a} />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function AgentMemoryCard({ summary }: { summary: AgentSummary }) {
+  return (
+    <Link to={`/memory/${encodeURIComponent(summary.connectorId)}`} className="tv-card tv-project-card">
+      <div className="tv-memory-card__head">
+        <AgentBadge connectorId={summary.connectorId} />
+        <span className="tv-project-card__name">{summary.label}</span>
+      </div>
+      <div className="tv-project-card__stats">
+        <span className="tv-chip">
+          <span className="tv-chip__label">instruction files</span>
+          <span className="tv-chip__value">{summary.globalFiles}</span>
+        </span>
+        <span className="tv-chip">
+          <span className="tv-chip__label">projects</span>
+          <span className="tv-chip__value">{summary.projectsWithFacts}</span>
+        </span>
+        <span className="tv-chip">
+          <span className="tv-chip__label">facts</span>
+          <span className="tv-chip__value">{summary.totalFacts}</span>
+        </span>
+      </div>
+    </Link>
+  );
+}

--- a/packages/web/src/pages/memory/MemorySourceCard.tsx
+++ b/packages/web/src/pages/memory/MemorySourceCard.tsx
@@ -1,0 +1,108 @@
+/**
+ * Renders one {@link MemorySource} — an agent instruction file or a distilled
+ * memory fact/document — as a card.
+ *
+ * The header carries a provenance/category chip, the title, an optional
+ * description, and (for Claude facts) an "origin →" deep-link to the session
+ * that produced the fact. The body is rendered through the shared, hardened
+ * {@link Markdown} component, with `[[name]]` wiki-links rewritten to in-page
+ * anchors that scroll to the matching fact in the same view. Unmatched links
+ * degrade to plain text — we never synthesise an arbitrary URL.
+ */
+
+import { Fragment, useMemo, type ReactNode } from 'react';
+import { Link } from 'react-router-dom';
+import type { MemorySource } from '@claudescope/shared';
+import { Markdown } from '../../components';
+import { anchorId, splitWikiLinks } from './wiki.js';
+
+/** Human label + class modifier for a source's provenance. */
+function provenanceMeta(source: MemorySource): { label: string; modifier: string } {
+  return source.provenance === 'user-authored'
+    ? { label: 'Instruction file', modifier: 'tv-memory-chip--user' }
+    : { label: 'Agent memory', modifier: 'tv-memory-chip--agent' };
+}
+
+export interface MemorySourceCardProps {
+  source: MemorySource;
+  /**
+   * Fact names present in the current view, used to resolve `[[name]]` links to
+   * in-page anchors. Names not in this set render as plain text.
+   */
+  knownNames: ReadonlySet<string>;
+}
+
+export function MemorySourceCard({ source, knownNames }: MemorySourceCardProps) {
+  const { label: provenanceLabel, modifier } = provenanceMeta(source);
+
+  // Resolve `[[name]]` references in the body to in-page anchors. Plain markdown
+  // (no wiki-links) is passed straight through to the renderer unchanged.
+  const body = useMemo(
+    () => renderBody(source.markdown, knownNames),
+    [source.markdown, knownNames],
+  );
+
+  return (
+    <article id={anchorId(source.title)} className="tv-card tv-memory-source">
+      <header className="tv-memory-source__head">
+        <span className={`tv-chip tv-memory-chip ${modifier}`}>{provenanceLabel}</span>
+        {source.category ? (
+          <span className="tv-chip tv-memory-chip tv-memory-chip--category">{source.category}</span>
+        ) : null}
+        <span className="tv-memory-source__title">{source.title}</span>
+        {source.originSessionId ? (
+          <Link
+            to={`/sessions/${encodeURIComponent(source.originSessionId)}`}
+            className="tv-memory-source__origin"
+            title="Open the session that produced this fact"
+          >
+            origin →
+          </Link>
+        ) : null}
+      </header>
+
+      {source.description ? (
+        <p className="tv-memory-source__desc tv-muted">{source.description}</p>
+      ) : null}
+
+      {source.empty ? (
+        <p className="tv-muted">Empty scaffold — no memory recorded yet.</p>
+      ) : (
+        <div className="tv-memory-source__body">{body}</div>
+      )}
+
+      <footer className="tv-memory-source__foot tv-muted tv-mono">{source.sourcePath}</footer>
+    </article>
+  );
+}
+
+/**
+ * Split the markdown on `[[name]]` references. Segments that match a known fact
+ * become in-page anchor links; everything else (including unmatched links) is
+ * rendered as ordinary markdown.
+ */
+function renderBody(markdown: string, knownNames: ReadonlySet<string>): ReactNode {
+  const segments = splitWikiLinks(markdown);
+  // No links → render the whole body in one pass (the common case).
+  if (segments.length === 1 && segments[0]?.kind === 'text') {
+    return <Markdown>{markdown}</Markdown>;
+  }
+
+  return segments.map((seg, i) => {
+    if (seg.kind === 'link' && knownNames.has(seg.name)) {
+      return (
+        <a key={i} href={`#${anchorId(seg.name)}`} className="tv-memory-source__wiki">
+          {seg.name}
+        </a>
+      );
+    }
+    // Unmatched link → its original `[[name]]` text; render as markdown so any
+    // surrounding formatting still applies.
+    const text = seg.kind === 'link' ? `[[${seg.name}]]` : seg.text;
+    return (
+      <Fragment key={i}>
+        <Markdown className="tv-memory-source__inline">{text}</Markdown>
+      </Fragment>
+    );
+  });
+}

--- a/packages/web/src/pages/memory/ProjectMemoryPage.tsx
+++ b/packages/web/src/pages/memory/ProjectMemoryPage.tsx
@@ -1,0 +1,96 @@
+/**
+ * Per-project memory (`/projects/:projectId/memory`) — every agent's memory for
+ * one project, reached from that project's Sessions | Memory tab bar.
+ *
+ * Renders the same tab bar {@link SessionListPage} uses (Memory active, Sessions
+ * linking back to `/projects/:projectId`), so back-navigation returns to the
+ * project's sessions rather than to the global Memory landing.
+ *
+ * Memory is read LIVE from the agent home dirs on the server (never indexed), so
+ * this page just fetches and renders. "No memory" is a normal, first-class state
+ * here, never an error.
+ */
+
+import { useEffect, useState } from 'react';
+import { Link, useParams } from 'react-router-dom';
+import type { ProjectMemoryResponse } from '@claudescope/shared';
+import { api } from '../../api/client.js';
+import { ErrorBox, Spinner } from '../../components';
+import { ConnectorMemoryCard, isBenignError } from './shared.js';
+import './memory.css';
+
+export function ProjectMemoryPage() {
+  const { projectId = '' } = useParams<{ projectId: string }>();
+
+  const [data, setData] = useState<ProjectMemoryResponse | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<unknown>(null);
+  const [reloadKey, setReloadKey] = useState(0);
+
+  useEffect(() => {
+    const controller = new AbortController();
+    setLoading(true);
+    setError(null);
+    api
+      .projectMemory(projectId, controller.signal)
+      .then((res) => {
+        setData(res);
+        setLoading(false);
+      })
+      .catch((err: unknown) => {
+        if (isBenignError(err)) return;
+        setError(err);
+        setLoading(false);
+      });
+    return () => controller.abort();
+  }, [projectId, reloadKey]);
+
+  const byAgent = (data?.byAgent ?? []).filter((a) => a.sources.length > 0);
+
+  return (
+    <section className="tv-memory">
+      <div className="tv-browse__crumbs">
+        <Link to="/" className="tv-linkbtn">
+          ← Projects
+        </Link>
+      </div>
+
+      <h1 className="tv-page-title">Project memory</h1>
+
+      {/* Sessions | Memory tab bar — Memory active; Sessions returns to this
+          project's session list (not the global Memory landing). */}
+      <div className="tv-memory-tabs" role="tablist" aria-label="Project view">
+        <Link
+          to={`/projects/${encodeURIComponent(projectId)}`}
+          className="tv-memory-tabs__tab"
+          role="tab"
+          aria-selected="false"
+        >
+          Sessions
+        </Link>
+        <span className="tv-memory-tabs__tab is-active" role="tab" aria-selected="true">
+          Memory
+        </span>
+      </div>
+
+      {loading ? (
+        <Spinner size="lg" label="Loading memory…" />
+      ) : error ? (
+        <ErrorBox error={error} title="Failed to load memory" onRetry={() => setReloadKey((k) => k + 1)} />
+      ) : byAgent.length === 0 ? (
+        <p className="tv-muted">No memory found for this project yet.</p>
+      ) : (
+        <div className="tv-memory__connectors">
+          {byAgent.map((a) => (
+            <ConnectorMemoryCard
+              key={a.connectorId}
+              connectorId={a.connectorId}
+              label={a.label}
+              sources={a.sources}
+            />
+          ))}
+        </div>
+      )}
+    </section>
+  );
+}

--- a/packages/web/src/pages/memory/memory.css
+++ b/packages/web/src/pages/memory/memory.css
@@ -1,0 +1,170 @@
+/* ===========================================================================
+   Memory area styles. Scoped under .tv-memory; relies on the global theme
+   variables/utilities from styles/global.css.
+   =========================================================================== */
+
+.tv-memory__lede {
+  margin: calc(-1 * var(--tv-space-2)) 0 var(--tv-space-5);
+  font-size: var(--tv-fs-md);
+  max-width: 64ch;
+}
+
+.tv-memory__section {
+  margin-bottom: var(--tv-space-6);
+}
+.tv-memory__section-title {
+  font-size: var(--tv-fs-lg);
+  font-weight: 600;
+  margin: 0 0 var(--tv-space-3);
+}
+
+.tv-memory__connectors {
+  display: flex;
+  flex-direction: column;
+  gap: var(--tv-space-5);
+}
+
+/* Agent folder card (landing page) */
+.tv-memory-card__head {
+  display: flex;
+  align-items: center;
+  gap: var(--tv-space-2);
+}
+
+/* Project memory list (top-level / per-agent pages) */
+.tv-memory__project-main {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--tv-space-3);
+  color: var(--tv-fg);
+  text-decoration: none;
+}
+.tv-memory__project-main:hover .tv-memory__project-name {
+  color: var(--tv-accent);
+}
+.tv-memory__project-name {
+  font-weight: 600;
+}
+.tv-memory__project-count {
+  gap: 6px;
+}
+.tv-memory__project-count-n {
+  color: var(--tv-fg);
+  font-variant-numeric: tabular-nums;
+}
+
+/* One connector's memory */
+.tv-memory-connector__head {
+  display: flex;
+  align-items: center;
+  gap: var(--tv-space-2);
+  margin-bottom: var(--tv-space-3);
+}
+.tv-memory-connector__label {
+  font-size: var(--tv-fs-lg);
+  font-weight: 600;
+}
+
+/* Provenance groups within a connector */
+.tv-memory-group {
+  margin-bottom: var(--tv-space-4);
+}
+.tv-memory-group__title {
+  font-size: var(--tv-fs-sm);
+  color: var(--tv-fg-faint);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  margin: 0 0 var(--tv-space-2);
+}
+.tv-memory-group__subtitle {
+  font-size: var(--tv-fs-md);
+  font-weight: 600;
+  color: var(--tv-fg-muted);
+  margin: var(--tv-space-3) 0 var(--tv-space-2);
+}
+.tv-memory-group__items {
+  display: flex;
+  flex-direction: column;
+  gap: var(--tv-space-3);
+}
+
+/* A single memory source card */
+.tv-memory-source__head {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: var(--tv-space-2);
+  margin-bottom: var(--tv-space-2);
+}
+.tv-memory-source__title {
+  font-weight: 600;
+  font-family: var(--tv-font-mono);
+}
+.tv-memory-source__origin {
+  margin-left: auto;
+  color: var(--tv-accent);
+  font-size: var(--tv-fs-sm);
+  white-space: nowrap;
+}
+.tv-memory-source__desc {
+  margin: 0 0 var(--tv-space-2);
+  font-size: var(--tv-fs-md);
+}
+.tv-memory-source__foot {
+  margin-top: var(--tv-space-3);
+  font-size: var(--tv-fs-sm);
+  word-break: break-all;
+}
+.tv-memory-source__wiki {
+  color: var(--tv-accent);
+}
+/* Inline markdown fragments around wiki-links shouldn't add block spacing. */
+.tv-memory-source__inline {
+  display: inline;
+}
+.tv-memory-source__inline > * {
+  display: inline;
+}
+
+/* Provenance / category chips */
+.tv-memory-chip--user {
+  border-color: var(--tv-accent);
+  color: var(--tv-accent);
+}
+.tv-memory-chip--agent {
+  border-color: #bc8cff55;
+}
+.tv-memory-chip--category {
+  color: var(--tv-fg);
+}
+
+/* Sessions | Memory tab bar on the project view */
+.tv-memory-tabs {
+  display: inline-flex;
+  border: 1px solid var(--tv-border);
+  border-radius: var(--tv-radius);
+  overflow: hidden;
+  background: var(--tv-bg-elevated);
+  margin-bottom: var(--tv-space-4);
+}
+.tv-memory-tabs__tab {
+  background: transparent;
+  border: 0;
+  color: var(--tv-fg-muted);
+  padding: var(--tv-space-2) var(--tv-space-4);
+  cursor: pointer;
+  font-size: var(--tv-fs-md);
+  text-decoration: none;
+}
+.tv-memory-tabs__tab + .tv-memory-tabs__tab {
+  border-left: 1px solid var(--tv-border);
+}
+.tv-memory-tabs__tab:hover {
+  background: var(--tv-bg-hover);
+  color: var(--tv-fg);
+}
+.tv-memory-tabs__tab.is-active {
+  background: var(--tv-accent-muted);
+  color: var(--tv-fg);
+}

--- a/packages/web/src/pages/memory/shared.tsx
+++ b/packages/web/src/pages/memory/shared.tsx
@@ -1,0 +1,123 @@
+/**
+ * Shared helpers and presentation pieces for the Memory area pages
+ * (`/memory`, `/memory/:connectorId`, `/memory/:connectorId/:projectId`,
+ * `/projects/:projectId/memory`).
+ *
+ * Memory is read LIVE from the agent home dirs on the server (never indexed), so
+ * the pages just fetch and render. Every store is usually absent/empty — "no
+ * memory" is a normal, first-class state here, never an error.
+ */
+
+import { useMemo } from 'react';
+import type { MemorySource } from '@claudescope/shared';
+import { ApiError } from '../../api/client.js';
+import { AgentBadge } from '../../components';
+import { MemorySourceCard } from './MemorySourceCard.js';
+
+/** Ignore aborted/offline fetch errors that are not user-actionable. */
+export function isBenignError(err: unknown): boolean {
+  if (err instanceof DOMException && err.name === 'AbortError') return true;
+  if (err instanceof ApiError && err.status === 0) return true;
+  return false;
+}
+
+/** Names of facts in a set of sources, for in-view `[[wiki-link]]` resolution. */
+export function collectNames(sources: MemorySource[]): Set<string> {
+  return new Set(sources.map((s) => s.title));
+}
+
+interface CategoryGroup {
+  category?: string;
+  sources: MemorySource[];
+}
+
+/**
+ * Group sources by `category`, preserving first-seen order. Sources without a
+ * category collapse into one trailing group (rendered without a subtitle). When
+ * nothing is categorised, returns a single uncategorised group.
+ */
+export function groupByCategory(sources: MemorySource[]): CategoryGroup[] {
+  const order: string[] = [];
+  const byCategory = new Map<string, MemorySource[]>();
+  const uncategorised: MemorySource[] = [];
+
+  for (const s of sources) {
+    if (!s.category) {
+      uncategorised.push(s);
+      continue;
+    }
+    if (!byCategory.has(s.category)) {
+      byCategory.set(s.category, []);
+      order.push(s.category);
+    }
+    byCategory.get(s.category)!.push(s);
+  }
+
+  const groups: CategoryGroup[] = order.map((category) => ({
+    category,
+    sources: byCategory.get(category)!,
+  }));
+  if (uncategorised.length > 0) groups.push({ sources: uncategorised });
+  return groups;
+}
+
+/**
+ * One agent's memory card: a header with the agent badge, then its sources
+ * visually separated into user-authored instruction files and agent-distilled
+ * memory. Agent-authored Claude facts are grouped by category when present.
+ */
+export function ConnectorMemoryCard({
+  connectorId,
+  label,
+  sources,
+}: {
+  connectorId: string;
+  label: string;
+  sources: MemorySource[];
+}) {
+  // Resolve `[[wiki-links]]` against every fact this connector contributes.
+  const knownNames = useMemo(() => collectNames(sources), [sources]);
+
+  const userAuthored = sources.filter((s) => s.provenance === 'user-authored');
+  const agentAuthored = sources.filter((s) => s.provenance === 'agent-authored');
+
+  // Group agent-authored sources by category (Claude facts); uncategorised
+  // sources fall under a single trailing bucket.
+  const agentGroups = useMemo(() => groupByCategory(agentAuthored), [agentAuthored]);
+
+  return (
+    <section className="tv-memory-connector">
+      <header className="tv-memory-connector__head">
+        <AgentBadge connectorId={connectorId} />
+        <span className="tv-memory-connector__label">{label}</span>
+      </header>
+
+      {userAuthored.length > 0 ? (
+        <div className="tv-memory-group">
+          <h3 className="tv-memory-group__title">Instruction files</h3>
+          <div className="tv-memory-group__items">
+            {userAuthored.map((s) => (
+              <MemorySourceCard key={s.sourcePath} source={s} knownNames={knownNames} />
+            ))}
+          </div>
+        </div>
+      ) : null}
+
+      {agentAuthored.length > 0 ? (
+        <div className="tv-memory-group">
+          <h3 className="tv-memory-group__title">Agent memory</h3>
+          {agentGroups.map((group) => (
+            <div key={group.category ?? '__none'} className="tv-memory-group__items">
+              {group.category ? (
+                <h4 className="tv-memory-group__subtitle">{group.category}</h4>
+              ) : null}
+              {group.sources.map((s) => (
+                <MemorySourceCard key={s.sourcePath} source={s} knownNames={knownNames} />
+              ))}
+            </div>
+          ))}
+        </div>
+      ) : null}
+    </section>
+  );
+}

--- a/packages/web/src/pages/memory/wiki.ts
+++ b/packages/web/src/pages/memory/wiki.ts
@@ -1,0 +1,40 @@
+/**
+ * Helpers for Claude memory `[[wiki-link]]` resolution. Links resolve to in-page
+ * anchors only — we never build arbitrary URLs from fact names.
+ */
+
+/** A run of plain markdown, or a `[[name]]` wiki-link reference. */
+export type WikiSegment = { kind: 'text'; text: string } | { kind: 'link'; name: string };
+
+/** Matches `[[name]]`; the captured name is trimmed by the caller. */
+const WIKI_LINK = /\[\[([^\]]+)\]\]/g;
+
+/**
+ * Split markdown into alternating text / wiki-link segments. Always returns at
+ * least one segment; a body with no links yields a single text segment.
+ */
+export function splitWikiLinks(markdown: string): WikiSegment[] {
+  const segments: WikiSegment[] = [];
+  let lastIndex = 0;
+  for (const match of markdown.matchAll(WIKI_LINK)) {
+    const start = match.index ?? 0;
+    if (start > lastIndex) {
+      segments.push({ kind: 'text', text: markdown.slice(lastIndex, start) });
+    }
+    segments.push({ kind: 'link', name: (match[1] ?? '').trim() });
+    lastIndex = start + match[0].length;
+  }
+  if (lastIndex < markdown.length) {
+    segments.push({ kind: 'text', text: markdown.slice(lastIndex) });
+  }
+  return segments.length > 0 ? segments : [{ kind: 'text', text: markdown }];
+}
+
+/** Stable in-page anchor id for a fact title (slugified, namespaced). */
+export function anchorId(title: string): string {
+  const slug = title
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+  return `memory-${slug}`;
+}

--- a/packages/web/src/pages/search/SearchPage.tsx
+++ b/packages/web/src/pages/search/SearchPage.tsx
@@ -2,24 +2,30 @@
  * Full-text search view (/search).
  *
  * Drives the FTS-backed `/api/search` endpoint with a debounced query box plus
- * project and role/type filters. Results are BM25-ranked and carry server-built
- * HTML snippets with `<mark>` highlights (rendered via dangerouslySetInnerHTML —
- * the server HTML-escapes everything but the marks). Each hit deep-links to the
- * session thread at the matching message anchor: `/sessions/:id#<messageUuid>`.
+ * project, role/type, and scope filters. Results are BM25-ranked and carry
+ * server-built HTML snippets with `<mark>` highlights (rendered via
+ * dangerouslySetInnerHTML — the server HTML-escapes everything but the marks).
+ * Session hits deep-link to the thread at the matching message anchor
+ * (`/sessions/:id#<messageUuid>`); memory hits link to the relevant memory view.
  *
- * Query state lives in the URL (?q=&project=&type=) so searches are shareable
- * and survive reloads.
+ * The scope control selects where search looks: transcripts only (`sessions`,
+ * the default), transcripts plus agent memory (`all`), or memory only (`memory`).
+ *
+ * Query state lives in the URL (?q=&project=&type=&scope=) so searches are
+ * shareable and survive reloads.
  */
 
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { Link, useSearchParams } from 'react-router-dom';
 import type {
+  MemorySearchHit,
   ProjectMeta,
   SearchResult,
+  SearchScope,
   SearchType,
 } from '@claudescope/shared';
 import { api, ApiError } from '../../api/client.js';
-import { ErrorBox, Spinner } from '../../components';
+import { AgentBadge, ErrorBox, Spinner } from '../../components';
 import './search.css';
 
 /** Debounce delay (ms) before firing a search after the query box settles. */
@@ -31,9 +37,20 @@ const TYPE_OPTIONS: ReadonlyArray<{ value: SearchType; label: string }> = [
   { value: 'assistant', label: 'Assistant' },
 ];
 
+const SCOPE_OPTIONS: ReadonlyArray<{ value: SearchScope; label: string }> = [
+  { value: 'sessions', label: 'Without memory' },
+  { value: 'all', label: 'Including memory' },
+  { value: 'memory', label: 'Memory only' },
+];
+
 /** Narrow an arbitrary string to a valid SearchType, defaulting to 'all'. */
 function asSearchType(value: string | null): SearchType {
   return value === 'user' || value === 'assistant' ? value : 'all';
+}
+
+/** Narrow an arbitrary string to a valid SearchScope, defaulting to 'sessions'. */
+function asSearchScope(value: string | null): SearchScope {
+  return value === 'all' || value === 'memory' ? value : 'sessions';
 }
 
 /** CSS modifier class for a result's role pill. */
@@ -43,6 +60,14 @@ function roleClass(role: string): string {
   return 'tv-search__role';
 }
 
+/** Memory view route for a hit: project facts deep-link, globals to the agent. */
+function memoryLink(hit: MemorySearchHit): string {
+  if (hit.scope === 'project' && hit.projectId) {
+    return `/memory/${encodeURIComponent(hit.connectorId)}/${encodeURIComponent(hit.projectId)}`;
+  }
+  return `/memory/${encodeURIComponent(hit.connectorId)}`;
+}
+
 export function SearchPage() {
   const [searchParams, setSearchParams] = useSearchParams();
 
@@ -50,14 +75,19 @@ export function SearchPage() {
   const query = searchParams.get('q') ?? '';
   const project = searchParams.get('project') ?? '';
   const type = asSearchType(searchParams.get('type'));
+  const scope = asSearchScope(searchParams.get('scope'));
 
-  const [results, setResults] = useState<SearchResult[]>([]);
+  const [sessions, setSessions] = useState<SearchResult[]>([]);
+  const [memory, setMemory] = useState<MemorySearchHit[]>([]);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<unknown>(null);
   /** True once at least one search has resolved for the current query. */
   const [searched, setSearched] = useState(false);
 
   const [projects, setProjects] = useState<ProjectMeta[]>([]);
+
+  // The role filter only applies to session transcripts; hide it for memory-only.
+  const showRoleFilter = scope !== 'memory';
 
   /** Update one or more URL params, dropping empties to keep the URL clean. */
   function patchParams(patch: Record<string, string>) {
@@ -95,7 +125,8 @@ export function SearchPage() {
     if (debounceRef.current) clearTimeout(debounceRef.current);
 
     if (trimmed === '') {
-      setResults([]);
+      setSessions([]);
+      setMemory([]);
       setLoading(false);
       setError(null);
       setSearched(false);
@@ -108,9 +139,13 @@ export function SearchPage() {
 
     debounceRef.current = setTimeout(() => {
       api
-        .search({ q: trimmed, project: project || undefined, type }, controller.signal)
-        .then((hits) => {
-          setResults(hits);
+        .search(
+          { q: trimmed, project: project || undefined, type, scope },
+          controller.signal,
+        )
+        .then((res) => {
+          setSessions(res.sessions);
+          setMemory(res.memory);
           setSearched(true);
           setLoading(false);
         })
@@ -126,7 +161,7 @@ export function SearchPage() {
       controller.abort();
       if (debounceRef.current) clearTimeout(debounceRef.current);
     };
-  }, [query, project, type]);
+  }, [query, project, type, scope]);
 
   const hasQuery = query.trim() !== '';
 
@@ -134,6 +169,12 @@ export function SearchPage() {
     () => [...projects].sort((a, b) => a.displayName.localeCompare(b.displayName)),
     [projects],
   );
+
+  // The active scope decides which sections are visible and what the count means.
+  const showSessions = scope !== 'memory';
+  const showMemory = scope !== 'sessions';
+  const totalCount =
+    (showSessions ? sessions.length : 0) + (showMemory ? memory.length : 0);
 
   return (
     <div className="tv-search">
@@ -175,22 +216,42 @@ export function SearchPage() {
         </div>
 
         <div className="tv-search__field">
-          <label className="tv-search__label" htmlFor="tv-search-type">
-            Role
+          <label className="tv-search__label" htmlFor="tv-search-scope">
+            Scope
           </label>
           <select
-            id="tv-search-type"
+            id="tv-search-scope"
             className="tv-search__select"
-            value={type}
-            onChange={(e) => patchParams({ type: e.target.value })}
+            value={scope}
+            onChange={(e) => patchParams({ scope: e.target.value })}
           >
-            {TYPE_OPTIONS.map((opt) => (
+            {SCOPE_OPTIONS.map((opt) => (
               <option key={opt.value} value={opt.value}>
                 {opt.label}
               </option>
             ))}
           </select>
         </div>
+
+        {showRoleFilter ? (
+          <div className="tv-search__field">
+            <label className="tv-search__label" htmlFor="tv-search-type">
+              Role
+            </label>
+            <select
+              id="tv-search-type"
+              className="tv-search__select"
+              value={type}
+              onChange={(e) => patchParams({ type: e.target.value })}
+            >
+              {TYPE_OPTIONS.map((opt) => (
+                <option key={opt.value} value={opt.value}>
+                  {opt.label}
+                </option>
+              ))}
+            </select>
+          </div>
+        ) : null}
       </div>
 
       {error ? (
@@ -199,7 +260,7 @@ export function SearchPage() {
         <Spinner label="Searching…" />
       ) : !hasQuery ? (
         <p className="tv-search__empty">Type a query above to search across all transcripts.</p>
-      ) : searched && results.length === 0 ? (
+      ) : searched && totalCount === 0 ? (
         <p className="tv-search__empty">
           No matches for <strong>{query}</strong>
           {project ? ' in this project' : ''}.
@@ -207,37 +268,74 @@ export function SearchPage() {
       ) : (
         <>
           <div className="tv-search__meta">
-            {results.length} result{results.length === 1 ? '' : 's'}
-            {results.length >= 50 ? ' (showing top 50)' : ''}
+            {totalCount} result{totalCount === 1 ? '' : 's'}
           </div>
-          <div className="tv-search__results">
-            {results.map((r) => (
-              <Link
-                key={`${r.sessionId}:${r.messageUuid}`}
-                to={`/sessions/${encodeURIComponent(r.sessionId)}#${encodeURIComponent(r.messageUuid)}`}
-                className="tv-card tv-search__result"
-              >
-                <div className="tv-search__result-head">
-                  <span
-                    className={
-                      r.title
-                        ? 'tv-search__result-title'
-                        : 'tv-search__result-title tv-search__result-title--untitled'
-                    }
+
+          {showSessions && sessions.length > 0 ? (
+            <section className="tv-search__section">
+              <h2 className="tv-search__section-title">Sessions ({sessions.length})</h2>
+              <div className="tv-search__results">
+                {sessions.map((r) => (
+                  <Link
+                    key={`${r.sessionId}:${r.messageUuid}`}
+                    to={`/sessions/${encodeURIComponent(r.sessionId)}#${encodeURIComponent(r.messageUuid)}`}
+                    className="tv-card tv-search__result"
                   >
-                    {r.title || 'Untitled session'}
-                  </span>
-                  {r.role ? <span className={roleClass(r.role)}>{r.role}</span> : null}
-                  <span className="tv-search__score">score {r.score.toFixed(2)}</span>
-                </div>
-                <div
-                  className="tv-search__snippet"
-                  // Server snippet is HTML-escaped except <mark> wraps (safe).
-                  dangerouslySetInnerHTML={{ __html: r.snippet }}
-                />
-              </Link>
-            ))}
-          </div>
+                    <div className="tv-search__result-head">
+                      <span
+                        className={
+                          r.title
+                            ? 'tv-search__result-title'
+                            : 'tv-search__result-title tv-search__result-title--untitled'
+                        }
+                      >
+                        {r.title || 'Untitled session'}
+                      </span>
+                      {r.role ? <span className={roleClass(r.role)}>{r.role}</span> : null}
+                      <span className="tv-search__score">score {r.score.toFixed(2)}</span>
+                    </div>
+                    <div
+                      className="tv-search__snippet"
+                      // Server snippet is HTML-escaped except <mark> wraps (safe).
+                      dangerouslySetInnerHTML={{ __html: r.snippet }}
+                    />
+                  </Link>
+                ))}
+              </div>
+            </section>
+          ) : null}
+
+          {showMemory && memory.length > 0 ? (
+            <section className="tv-search__section">
+              <h2 className="tv-search__section-title">Memory ({memory.length})</h2>
+              <div className="tv-search__results">
+                {memory.map((hit, i) => (
+                  <Link
+                    key={`${hit.connectorId}:${hit.sourcePath}:${i}`}
+                    to={memoryLink(hit)}
+                    className="tv-card tv-search__result"
+                  >
+                    <div className="tv-search__result-head">
+                      <AgentBadge connectorId={hit.connectorId} />
+                      <span className="tv-chip tv-search__mem-scope">
+                        {hit.scope === 'project' ? 'Project' : 'Global'}
+                        {hit.category ? ` · ${hit.category}` : ''}
+                      </span>
+                      <span className="tv-search__result-title">{hit.title}</span>
+                      {hit.projectDisplayName ? (
+                        <span className="tv-search__mem-project">{hit.projectDisplayName}</span>
+                      ) : null}
+                    </div>
+                    <div
+                      className="tv-search__snippet"
+                      // Server snippet is HTML-escaped except <mark> wraps (safe).
+                      dangerouslySetInnerHTML={{ __html: hit.snippet }}
+                    />
+                  </Link>
+                ))}
+              </div>
+            </section>
+          ) : null}
         </>
       )}
     </div>

--- a/packages/web/src/pages/search/search.css
+++ b/packages/web/src/pages/search/search.css
@@ -48,6 +48,15 @@
   margin-bottom: var(--tv-space-3);
 }
 
+.tv-search__section {
+  margin-bottom: var(--tv-space-5);
+}
+.tv-search__section-title {
+  font-size: var(--tv-fs-lg);
+  font-weight: 600;
+  margin: 0 0 var(--tv-space-3);
+}
+
 .tv-search__results {
   display: flex;
   flex-direction: column;
@@ -105,6 +114,15 @@
   font-size: var(--tv-fs-sm);
   color: var(--tv-fg-faint);
   font-variant-numeric: tabular-nums;
+}
+
+.tv-search__mem-scope {
+  text-transform: capitalize;
+}
+.tv-search__mem-project {
+  margin-left: auto;
+  font-size: var(--tv-fs-sm);
+  color: var(--tv-fg-faint);
 }
 
 .tv-search__snippet {


### PR DESCRIPTION
## What

Adds a read-only **Memory** area that surfaces each coding agent's long-lived
memory alongside the transcripts Claudescope already indexes — read **live**
(never indexed) and **only from the agent home dirs** (`~/.claude`, `~/.codex`,
`~/.junie`), never from the user's project directories.

Two provenances:

- **User-authored instruction files** — `~/.claude/CLAUDE.md`,
  `~/.codex/AGENTS.md`, `~/.junie/AGENTS.md`.
- **Agent-authored memory** — Claude's `~/.claude/projects/<slug>/memory/`
  typed facts (both nested and flat/legacy frontmatter layouts) and Codex's
  best-effort `~/.codex/memories/` handbook. Every store is usually empty/absent,
  so "no memory" is a normal, first-class state.

## How facts attribute to projects

A Claude memory dir is keyed by the **git repo root**, so one dir can hold facts
learned across several worktrees. Each fact is attributed to the project of its
`originSessionId` (resolved against the index), falling back to the dir's slug.
Result: a worktree project (e.g. `…-alt`) surfaces the facts that were actually
learned in it, instead of everything rolling up under the main repo.

## UI

- **Memory** is the 2nd left-nav item; the section is organized
  **agent → projects → facts** (agent folder cards → an agent's global memory +
  its projects → that agent's facts for a project).
- A per-project **Memory tab** (alongside Sessions) whose back-navigation returns
  to the project's sessions.
- **Search** gains a scope control — *Without memory* (default) / *Including
  memory* / *Memory only* — with a dedicated **Memory** results section; memory
  hits link into the memory view.

## Architecture

Memory is a connector capability (`globalMemory()` / `projectMemory()` on the
`AgentConnector` port), so adding an agent keeps bringing its memory along. The
index/FTS/cost paths are untouched; attribution is shared by the memory and
search routes (`data/memory.ts`).

## Notable

Restores BM25 search on corpora with **duplicate `events.uuid`** (fork/resume
copies), which newer DuckDB rejects inside `match_bm25` — a **pre-existing**
failure unrelated to this feature (`main` has the identical query). Applied the
documented `scalar_subquery_error_on_multiple_rows=false` shim; the clean
long-term fix is de-duplicating uuids in the FTS index build (follow-up).

## Testing

`npm run typecheck` and `npm test` (137 tests) pass. Verified end-to-end against
real local data: all three global instruction files load; worktree projects show
their own facts; the three search scopes return the expected session/memory
splits. Existing search integration tests updated for the new
`SearchResponse` shape (`{ sessions, memory }`).

Plan: `docs/plans/0014-memory-viewer.md`.
