### PR TITLE
refactor(web): shared project header via nested layout route

### DIFF
--- a/docs/plans/0015-shared-project-header.md
+++ b/docs/plans/0015-shared-project-header.md
@@ -1,8 +1,8 @@
 # 0015 — Shared project header (nested layout route)
 
-- **Status:** proposed <!-- proposed | in-progress | done | superseded | abandoned -->
+- **Status:** done <!-- proposed | in-progress | done | superseded | abandoned -->
 - **Date:** 2026-06-15
-- **PR:** <link, once opened>
+- **PR:** https://github.com/vladar107/claudescope/pull/18
 
 ## Context
 

--- a/docs/plans/0015-shared-project-header.md
+++ b/docs/plans/0015-shared-project-header.md
@@ -1,0 +1,73 @@
+# 0015 — Shared project header (nested layout route)
+
+- **Status:** proposed <!-- proposed | in-progress | done | superseded | abandoned -->
+- **Date:** 2026-06-15
+- **PR:** <link, once opened>
+
+## Context
+
+After 0014 added a per-project Memory tab, navigating **Sessions ↔ Memory**
+within a project swapped the *entire* header: the Sessions view showed the
+project name + cwd + sort/filter controls, while the Memory view showed a
+"Project memory" title and a different crumb. The two sub-views rendered as
+separate pages, so switching tabs read as a full page reload rather than
+swapping a panel — visual noise the user flagged.
+
+## Goal
+
+A **stable shared header** across a project's sub-views: the breadcrumb, project
+name, cwd, and the Sessions | Memory tab bar stay put; only the body below the
+tabs changes when switching tabs.
+
+## Decisions
+
+- **Nested layout route, not a shared component** — `/projects/:projectId` is a
+  layout route (`ProjectLayout`) that renders the header once + `<Outlet>`, with
+  child routes `index` (sessions) and `memory`. The header *instance persists*
+  across tab switches (no remount), and the project-meta fetch happens once in
+  the layout instead of in each tab — so the transition is seamless and avoids a
+  redundant `listProjects` call. Rejected: a `<ProjectHeader>` component rendered
+  by each page (headers would look identical but each page still remounts and
+  refetches — cosmetic only).
+- **Tabs via `NavLink`** — active state derives from the route (`end` on the
+  Sessions/index link), replacing the manual `is-active` toggle.
+- **Sub-view-specific controls move into the body** — the sort/filter controls
+  (Sessions-only) render below the tab bar in the Sessions tab, so they
+  appear/disappear without shifting the shared header.
+- **Tab bodies read shared meta via Outlet context** — `useProjectContext()`
+  exposes `{ projectId, project }`; the Memory body keeps using `useParams` for
+  the id (it doesn't need project meta).
+
+## Approach
+
+1. `pages/browse/ProjectLayout.tsx` (new): fetch project meta once; render
+   crumb + name + cwd + Sessions|Memory `NavLink` tabs + `<Outlet context={{ projectId, project }}>`.
+   Export `useProjectContext()`.
+2. `pages/browse/SessionList.tsx`: drop the crumb/header/tab bar; read
+   `{ projectId, project }` from context; render the controls + agent filter +
+   list as the tab body.
+3. `pages/memory/ProjectMemoryPage.tsx`: drop the crumb/title/tab bar; render the
+   per-agent memory as the tab body.
+4. `App.tsx`: nest the project routes under `ProjectLayout` (`index` → sessions,
+   `memory` → memory).
+
+## Files affected
+
+- `packages/web/src/pages/browse/ProjectLayout.tsx` (new) — shared chrome.
+- `packages/web/src/pages/browse/SessionList.tsx` — Sessions tab body.
+- `packages/web/src/pages/memory/ProjectMemoryPage.tsx` — Memory tab body.
+- `packages/web/src/App.tsx` — nested routes.
+
+## Testing
+
+- `npm run typecheck` + `npm test` (no server/contract changes).
+- Manual: open a project, toggle Sessions ↔ Memory — the header/tabs stay put,
+  only the body swaps; deep-links and back/forward still work.
+
+## Risks / open questions
+
+- The agent-first Memory pages (`/memory/:connectorId[/:projectId]`) are a
+  separate hierarchy and intentionally keep their own breadcrumbs.
+- Per-project **Codex** memory attribution (so Codex memory appears under a
+  project like Claude) remains a separate follow-up — Codex memory is a single
+  global handbook, not per-project files.

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -39,4 +39,4 @@ decision, or a change worth explaining before doing. Skip it for one-line fixes.
 | 0012 | [cost dedup: billed API calls](./0012-cost-dedup-billed-api-calls.md) | done |
 | 0013 | [Codex review fixes: project ids, aux rows, images](./0013-codex-review-fixes.md) | done |
 | 0014 | [Memory viewer (instruction files + per-agent memory)](./0014-memory-viewer.md) | done   |
-| 0015 | [Shared project header (nested layout route)](./0015-shared-project-header.md) | proposed |
+| 0015 | [Shared project header (nested layout route)](./0015-shared-project-header.md) | done   |

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -39,3 +39,4 @@ decision, or a change worth explaining before doing. Skip it for one-line fixes.
 | 0012 | [cost dedup: billed API calls](./0012-cost-dedup-billed-api-calls.md) | done |
 | 0013 | [Codex review fixes: project ids, aux rows, images](./0013-codex-review-fixes.md) | done |
 | 0014 | [Memory viewer (instruction files + per-agent memory)](./0014-memory-viewer.md) | done   |
+| 0015 | [Shared project header (nested layout route)](./0015-shared-project-header.md) | proposed |

--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -4,6 +4,7 @@ import type { SourceInfo } from '@claudescope/shared';
 import { api } from './api/client.js';
 import { useTheme, type ThemeChoice } from './theme/ThemeProvider.js';
 import { BrowsePage } from './pages/browse/BrowsePage.js';
+import { ProjectLayout } from './pages/browse/ProjectLayout.js';
 import { SessionListPage } from './pages/browse/SessionList.js';
 import { SessionPage } from './pages/session/SessionPage.js';
 import { SearchPage } from './pages/search/SearchPage.js';
@@ -107,8 +108,10 @@ export function App() {
       <main className="tv-main">
         <Routes>
           <Route path="/" element={<BrowsePage />} />
-          <Route path="/projects/:projectId" element={<SessionListPage />} />
-          <Route path="/projects/:projectId/memory" element={<ProjectMemoryPage />} />
+          <Route path="/projects/:projectId" element={<ProjectLayout />}>
+            <Route index element={<SessionListPage />} />
+            <Route path="memory" element={<ProjectMemoryPage />} />
+          </Route>
           <Route path="/sessions/:id" element={<SessionPage />} />
           <Route path="/search" element={<SearchPage />} />
           <Route path="/analytics" element={<AnalyticsPage />} />

--- a/packages/web/src/pages/browse/ProjectLayout.tsx
+++ b/packages/web/src/pages/browse/ProjectLayout.tsx
@@ -1,0 +1,96 @@
+/**
+ * Shared chrome for a single project (`/projects/:projectId` and its `/memory`
+ * child). Owns the breadcrumb, project name + cwd, and the Sessions | Memory tab
+ * bar; the active tab's body renders through `<Outlet>`.
+ *
+ * Because the header and the project-meta fetch live here (not in each tab),
+ * switching Sessions ↔ Memory swaps only the body — the header stays put and the
+ * project list isn't refetched, so the transition reads as a panel switch rather
+ * than a full page load.
+ */
+
+import { useEffect, useState } from 'react';
+import { Link, NavLink, Outlet, useOutletContext, useParams } from 'react-router-dom';
+import type { ProjectMeta } from '@claudescope/shared';
+import { api, ApiError } from '../../api/client.js';
+import '../memory/memory.css';
+
+export interface ProjectOutletContext {
+  projectId: string;
+  /** Project meta (name, cwd, per-agent breakdown); null while loading or unknown. */
+  project: ProjectMeta | null;
+}
+
+/** Tab children read the shared project meta via this hook. */
+export function useProjectContext(): ProjectOutletContext {
+  return useOutletContext<ProjectOutletContext>();
+}
+
+/** Ignore aborted/offline fetch errors that are not user-actionable. */
+function isBenignError(err: unknown): boolean {
+  if (err instanceof DOMException && err.name === 'AbortError') return true;
+  if (err instanceof ApiError && err.status === 0) return true;
+  return false;
+}
+
+const tabClass = ({ isActive }: { isActive: boolean }): string =>
+  isActive ? 'tv-memory-tabs__tab is-active' : 'tv-memory-tabs__tab';
+
+export function ProjectLayout() {
+  const { projectId = '' } = useParams<{ projectId: string }>();
+  const [project, setProject] = useState<ProjectMeta | null>(null);
+
+  // Project meta is fetched once for the whole project view; tab switches reuse it.
+  useEffect(() => {
+    const controller = new AbortController();
+    api
+      .listProjects(controller.signal)
+      .then((projects) => setProject(projects.find((p) => p.id === projectId) ?? null))
+      .catch((err: unknown) => {
+        if (!isBenignError(err)) console.warn('Failed to load project meta', err);
+      });
+    return () => controller.abort();
+  }, [projectId]);
+
+  const displayName = project?.displayName ?? projectId;
+
+  return (
+    <section>
+      <div className="tv-browse__crumbs">
+        <Link to="/" className="tv-linkbtn">
+          ← Projects
+        </Link>
+        <span className="tv-muted"> / </span>
+        <span className="tv-mono">{displayName}</span>
+      </div>
+
+      <header className="tv-browse__header">
+        <div>
+          <h1 className="tv-page-title" style={{ marginBottom: 4 }}>
+            {displayName}
+          </h1>
+          {project ? (
+            <div className="tv-muted tv-mono" style={{ fontSize: 'var(--tv-fs-sm)' }}>
+              {project.cwd}
+            </div>
+          ) : null}
+        </div>
+      </header>
+
+      <div className="tv-memory-tabs" role="tablist" aria-label="Project view">
+        <NavLink to={`/projects/${encodeURIComponent(projectId)}`} end className={tabClass} role="tab">
+          Sessions
+        </NavLink>
+        <NavLink
+          to={`/projects/${encodeURIComponent(projectId)}/memory`}
+          className={tabClass}
+          role="tab"
+        >
+          Memory
+        </NavLink>
+      </div>
+
+      <Outlet context={{ projectId, project }} />
+    </section>
+  );
+}

--- a/packages/web/src/pages/browse/SessionList.tsx
+++ b/packages/web/src/pages/browse/SessionList.tsx
@@ -1,10 +1,10 @@
 import { useEffect, useMemo, useState } from 'react';
-import { Link, useParams } from 'react-router-dom';
-import type { ProjectMeta, SessionMeta, SessionSort } from '@claudescope/shared';
+import { Link } from 'react-router-dom';
+import type { SessionMeta, SessionSort } from '@claudescope/shared';
 import { api, ApiError } from '../../api/client.js';
 import { AgentBadge, agentLabel, CostBadge, ErrorBox, Spinner, TokenChips } from '../../components';
 import { formatBytes, formatDateTime, shortModel, timeAgo } from './format.js';
-import '../memory/memory.css';
+import { useProjectContext } from './ProjectLayout.js';
 
 const SORT_OPTIONS: { value: SessionSort; label: string }[] = [
   { value: 'recent', label: 'Most recent' },
@@ -22,15 +22,15 @@ function isBenignError(err: unknown): boolean {
 }
 
 /**
- * Sessions for a single project, addressed by `/projects/:projectId`. Sort and
- * agent filter are server-driven (re-fetch on change); the text filter is
- * applied client-side against title / branch / id. Breadcrumbs link back to the
- * project grid, so deep-links and the browser back button both work.
+ * The Sessions tab of a project (`/projects/:projectId`). The breadcrumb, name,
+ * cwd, and the Sessions | Memory tab bar live in {@link ProjectLayout}; this
+ * renders the tab body — sort/filter controls, the agent filter, and the list.
+ * Sort and agent filter are server-driven (re-fetch on change); the text filter
+ * is applied client-side against title / branch / id.
  */
 export function SessionListPage() {
-  const { projectId = '' } = useParams<{ projectId: string }>();
+  const { projectId, project } = useProjectContext();
 
-  const [project, setProject] = useState<ProjectMeta | null>(null);
   const [sessions, setSessions] = useState<SessionMeta[]>([]);
   const [sort, setSort] = useState<SessionSort>('recent');
   const [filter, setFilter] = useState('');
@@ -38,22 +38,6 @@ export function SessionListPage() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<unknown>(null);
   const [reloadKey, setReloadKey] = useState(0);
-
-  // Project meta (name, cwd, per-agent breakdown). Refetched only when the
-  // project changes; the breakdown drives the agent filter chips.
-  useEffect(() => {
-    const controller = new AbortController();
-    api
-      .listProjects(controller.signal)
-      .then((projects) => {
-        setProject(projects.find((p) => p.id === projectId) ?? null);
-      })
-      .catch((err: unknown) => {
-        if (isBenignError(err)) return;
-        setError(err);
-      });
-    return () => controller.abort();
-  }, [projectId]);
 
   useEffect(() => {
     const controller = new AbortController();
@@ -84,66 +68,30 @@ export function SessionListPage() {
     });
   }, [sessions, filter]);
 
-  const displayName = project?.displayName ?? sessions[0]?.projectDisplayName ?? projectId;
   const agents = project?.agents ?? [];
 
   return (
-    <section>
-      <div className="tv-browse__crumbs">
-        <Link to="/" className="tv-linkbtn">
-          ← Projects
-        </Link>
-        <span className="tv-muted"> / </span>
-        <span className="tv-mono">{displayName}</span>
-      </div>
-
-      <header className="tv-browse__header">
-        <div>
-          <h1 className="tv-page-title" style={{ marginBottom: 4 }}>
-            {displayName}
-          </h1>
-          {project ? (
-            <div className="tv-muted tv-mono" style={{ fontSize: 'var(--tv-fs-sm)' }}>
-              {project.cwd}
-            </div>
-          ) : null}
-        </div>
-        <div className="tv-browse__controls">
-          <input
-            className="tv-input"
-            type="search"
-            placeholder="Filter sessions…"
-            value={filter}
-            onChange={(e) => setFilter(e.target.value)}
-          />
-          <select
-            className="tv-select"
-            value={sort}
-            onChange={(e) => setSort(e.target.value as SessionSort)}
-            aria-label="Sort sessions"
-          >
-            {SORT_OPTIONS.map((o) => (
-              <option key={o.value} value={o.value}>
-                {o.label}
-              </option>
-            ))}
-          </select>
-        </div>
-      </header>
-
-      {/* Sessions | Memory tab bar — switches to this project's memory view. */}
-      <div className="tv-memory-tabs" role="tablist" aria-label="Project view">
-        <span className="tv-memory-tabs__tab is-active" role="tab" aria-selected="true">
-          Sessions
-        </span>
-        <Link
-          to={`/projects/${encodeURIComponent(projectId)}/memory`}
-          className="tv-memory-tabs__tab"
-          role="tab"
-          aria-selected="false"
+    <>
+      <div className="tv-browse__controls" style={{ marginBottom: 'var(--tv-space-3)' }}>
+        <input
+          className="tv-input"
+          type="search"
+          placeholder="Filter sessions…"
+          value={filter}
+          onChange={(e) => setFilter(e.target.value)}
+        />
+        <select
+          className="tv-select"
+          value={sort}
+          onChange={(e) => setSort(e.target.value as SessionSort)}
+          aria-label="Sort sessions"
         >
-          Memory
-        </Link>
+          {SORT_OPTIONS.map((o) => (
+            <option key={o.value} value={o.value}>
+              {o.label}
+            </option>
+          ))}
+        </select>
       </div>
 
       {/* Agent filter — only meaningful when the project spans 2+ agents. */}
@@ -193,7 +141,7 @@ export function SessionListPage() {
           </ul>
         </>
       )}
-    </section>
+    </>
   );
 }
 

--- a/packages/web/src/pages/memory/ProjectMemoryPage.tsx
+++ b/packages/web/src/pages/memory/ProjectMemoryPage.tsx
@@ -1,10 +1,7 @@
 /**
- * Per-project memory (`/projects/:projectId/memory`) — every agent's memory for
- * one project, reached from that project's Sessions | Memory tab bar.
- *
- * Renders the same tab bar {@link SessionListPage} uses (Memory active, Sessions
- * linking back to `/projects/:projectId`), so back-navigation returns to the
- * project's sessions rather than to the global Memory landing.
+ * The Memory tab of a project (`/projects/:projectId/memory`) — every agent's
+ * memory for one project. The breadcrumb, name, and the Sessions | Memory tab
+ * bar live in {@link ProjectLayout}; this renders just the tab body.
  *
  * Memory is read LIVE from the agent home dirs on the server (never indexed), so
  * this page just fetches and renders. "No memory" is a normal, first-class state
@@ -12,7 +9,7 @@
  */
 
 import { useEffect, useState } from 'react';
-import { Link, useParams } from 'react-router-dom';
+import { useParams } from 'react-router-dom';
 import type { ProjectMemoryResponse } from '@claudescope/shared';
 import { api } from '../../api/client.js';
 import { ErrorBox, Spinner } from '../../components';
@@ -47,50 +44,24 @@ export function ProjectMemoryPage() {
 
   const byAgent = (data?.byAgent ?? []).filter((a) => a.sources.length > 0);
 
+  if (loading) return <Spinner size="lg" label="Loading memory…" />;
+  if (error) {
+    return <ErrorBox error={error} title="Failed to load memory" onRetry={() => setReloadKey((k) => k + 1)} />;
+  }
+  if (byAgent.length === 0) {
+    return <p className="tv-muted">No memory found for this project yet.</p>;
+  }
+
   return (
-    <section className="tv-memory">
-      <div className="tv-browse__crumbs">
-        <Link to="/" className="tv-linkbtn">
-          ← Projects
-        </Link>
-      </div>
-
-      <h1 className="tv-page-title">Project memory</h1>
-
-      {/* Sessions | Memory tab bar — Memory active; Sessions returns to this
-          project's session list (not the global Memory landing). */}
-      <div className="tv-memory-tabs" role="tablist" aria-label="Project view">
-        <Link
-          to={`/projects/${encodeURIComponent(projectId)}`}
-          className="tv-memory-tabs__tab"
-          role="tab"
-          aria-selected="false"
-        >
-          Sessions
-        </Link>
-        <span className="tv-memory-tabs__tab is-active" role="tab" aria-selected="true">
-          Memory
-        </span>
-      </div>
-
-      {loading ? (
-        <Spinner size="lg" label="Loading memory…" />
-      ) : error ? (
-        <ErrorBox error={error} title="Failed to load memory" onRetry={() => setReloadKey((k) => k + 1)} />
-      ) : byAgent.length === 0 ? (
-        <p className="tv-muted">No memory found for this project yet.</p>
-      ) : (
-        <div className="tv-memory__connectors">
-          {byAgent.map((a) => (
-            <ConnectorMemoryCard
-              key={a.connectorId}
-              connectorId={a.connectorId}
-              label={a.label}
-              sources={a.sources}
-            />
-          ))}
-        </div>
-      )}
-    </section>
+    <div className="tv-memory__connectors">
+      {byAgent.map((a) => (
+        <ConnectorMemoryCard
+          key={a.connectorId}
+          connectorId={a.connectorId}
+          label={a.label}
+          sources={a.sources}
+        />
+      ))}
+    </div>
   );
 }

--- a/packages/web/src/pages/session/SessionPage.tsx
+++ b/packages/web/src/pages/session/SessionPage.tsx
@@ -346,19 +346,21 @@ function SessionView({
       <header className="tv-session__header">
         <div className="tv-session__crumbs">
           <nav className="tv-session__trail" aria-label="Breadcrumb">
+            <Link to="/" className="tv-linkbtn">
+              ← Projects
+            </Link>
             {meta.projectId ? (
-              <Link
-                to={`/projects/${meta.projectId}`}
-                className="tv-linkbtn"
-                title={`All ${meta.projectDisplayName || 'project'} sessions`}
-              >
-                ← {meta.projectDisplayName || 'Sessions'}
-              </Link>
-            ) : (
-              <Link to="/" className="tv-linkbtn">
-                ← Browse
-              </Link>
-            )}
+              <>
+                <span className="tv-muted"> / </span>
+                <Link
+                  to={`/projects/${meta.projectId}`}
+                  className="tv-linkbtn tv-mono"
+                  title={`All ${meta.projectDisplayName || 'project'} sessions`}
+                >
+                  {meta.projectDisplayName || 'project'}
+                </Link>
+              </>
+            ) : null}
           </nav>
           <SubagentJumpMenu subagents={subagents} />
           <ExportMenu data={data} />

--- a/packages/web/src/pages/session/session.css
+++ b/packages/web/src/pages/session/session.css
@@ -1,7 +1,9 @@
 /* Session reader — threaded conversation view. Relies on global tokens. */
 
 .tv-session {
-  max-width: 920px;
+  /* Capped for transcript readability, but roomy enough for code blocks, diffs,
+     and tool output — 920px was tight once a session has wide content. */
+  max-width: 1100px;
   margin: 0 auto;
 }
 


### PR DESCRIPTION
## What

Follow-up to #17. Navigating **Sessions ↔ Memory** within a project swapped the
entire header (different title, breadcrumb, and controls), so switching tabs read
as a full page reload. This makes `/projects/:projectId` a **layout route** whose
shared header — breadcrumb, project name, cwd, and the Sessions | Memory tab bar —
stays put; only the body below the tabs changes.

## How

- New `ProjectLayout` renders the shared chrome once + `<Outlet>`, with child
  routes: `index` → Sessions, `memory` → Memory. The header **instance persists**
  across tab switches (no remount), and project meta is fetched **once** in the
  layout instead of in each tab (drops a redundant `listProjects` call).
- `SessionList` and `ProjectMemoryPage` become tab **bodies** — they read
  `{ projectId, project }` via Outlet context and no longer render their own
  breadcrumb/title/tabs. Sessions' sort/filter controls move into the tab body so
  they appear/disappear without shifting the header.
- Tabs use `NavLink` for active state.

## Testing

`npm run typecheck` and `npm test` (137) pass — no server/contract changes (web
only). Manual: toggling Sessions ↔ Memory keeps the header/tabs fixed and swaps
only the body; deep-links and back/forward still work.

Plan: `docs/plans/0015-shared-project-header.md`. Not included (separate
follow-up): per-project Codex memory attribution.
