### PR TITLE
Maintainer review fixes: resiliency tests, daemon hardening, render & contract guards

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -90,6 +90,11 @@ The CLI `update` command (`cli.ts`) detects the install method and defers to
 - **Tests:** run `npm test` and `npm run typecheck` after changes. Add tests only
   when the logic warrants it (the integration suite builds a real DuckDB index
   from synthetic fixtures in a temp dir — never touches real `~/.claude`).
+  **Keep tests focused on the weird stuff** — the hard, bug-prone domain edges,
+  not happy-path glue: malformed/truncated JSONL, subagent correlation, cost
+  dedup-by-`message.id`, stale-cache / index-corruption recovery, pricing refresh
+  and fallback, connector normalization quirks. Don't pad coverage with trivial
+  cases that can't realistically fail.
 - **Commits:** [Conventional Commits](https://www.conventionalcommits.org)
   (`feat:`, `fix:`, `chore:`, `docs:`, `refactor:`, `test:`). **Do not add AI
   co-author / "Generated with" trailers** — keep history clean and human-authored.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,7 +36,10 @@ the app is **read-only** over `~/.claude`; its own state lives in `~/.claudescop
 - **Match the existing code** — TypeScript, ESM, surrounding naming and comment
   density. Don't refactor or "improve" code unrelated to your change.
 - **Run `npm test` and `npm run typecheck`** before opening a PR. Add tests when
-  the logic warrants it; don't add tests for trivial changes.
+  the logic warrants it; don't add tests for trivial changes. **Keep tests
+  focused on the weird stuff** — malformed/truncated JSONL, subagent correlation,
+  cost dedup-by-`message.id`, stale-cache / index-corruption recovery, pricing
+  refresh and fallback, connector quirks — not happy-path glue that can't fail.
 - **Validate at boundaries** (user input, external data); trust internal code.
 
 ## Commits & history

--- a/README.md
+++ b/README.md
@@ -244,6 +244,11 @@ Shipped fallback rates (USD per 1M tokens):
 - Edit `~/.claudescope/pricing.json` to override families, the default rate, or
   pin specific model prices. Re-index (`POST /api/reindex` or `claudescope
   restart`) to recompute stored costs at the new rates.
+- `pricing.json` carries a `schemaVersion`. When an upgrade ships a newer default
+  (new families/models or a changed default rate), the app **reconciles your copy
+  on startup**: it backs the old file up to `pricing.json.bak`, adds the new
+  shipped keys, and **keeps every value you customized**. Your edits are never
+  discarded; a copy you've left current is not rewritten.
 - The `opus`/`sonnet`/`haiku`/`gemini`/`gpt` family rules use **current**
   pricing; the deprecated Opus 4 / 4.1 ($15/$75) and specific GPT-5 versions are
   pinned via exact `models` entries. Add an exact entry to override any model.

--- a/docs/plans/0017-maintainer-review-fixes.md
+++ b/docs/plans/0017-maintainer-review-fixes.md
@@ -1,0 +1,209 @@
+# 0017 — Maintainer review fixes: resiliency tests, daemon hardening, render & contract guards
+
+- **Status:** proposed <!-- proposed | in-progress | done | superseded | abandoned -->
+- **Date:** 2026-06-15
+- **PR:** <link, once opened>
+
+## Context
+
+A maintainer-style code review raised five themes: harden daemon/process
+lifecycle, make parser/indexer invariants explicit, reduce scattered runtime
+special-cases, add boundary validation, and keep tests focused on the hard cases.
+
+We assessed each theme against the actual code with a fan-out of mappers, then
+adversarially re-verified every candidate finding against the source (a finding
+only survived if a second agent could confirm it by re-reading the cited code).
+Result: **37 candidate issues → 19 real (almost all low severity) → 16 false
+positives → 3 the area-split missed.** There is **no high-severity bug**. The
+reviewer's thesis is right (quality is good; risk concentrates in the
+parser/indexer and daemon), but most of the review's *specific* asks resolve to
+low-value polish. The genuinely worthwhile work is a small set:
+
+- Two **untested resiliency paths** the code already implements (index-corruption
+  self-heal; daemon stale/wedged recovery).
+- One **real lifecycle bug** (a wedged-but-alive daemon is orphaned, not replaced).
+- Two **structural seams the review didn't name**: no React error boundary, and an
+  unenforced DuckDB-column → shared-type mapping.
+- The **pricing.json config has no migration** (unlike the self-healing index) —
+  same silent-drift class of risk, flagged by the user as important.
+
+Scope agreed with the maintainer: **Tier 1 + Tier 2 + the pricing migration**;
+Tier 3 cleanups only where they fall inside files already being touched.
+
+This is a localhost, single-user, read-only app — severity and "done" are judged
+against that threat model (no auth/rate-limiting concerns).
+
+## Goal
+
+Lock the two self-healing recovery paths with tests, fix the one real daemon gap,
+stop a single render throw or a column rename from silently degrading the app, and
+give the user-editable `pricing.json` the same non-destructive, versioned
+self-reconciliation the index already enjoys — all as minimal, in-style changes.
+
+## Decisions
+
+- **Test the recovery paths without source changes** — assert
+  `discardCorruptDb`/stale-schema rebuild via the existing `console.warn` signal +
+  post-rebuild data equality, rather than adding test seams to `db/duckdb.ts`.
+  Honors "no drive-by refactors / add tests only where logic warrants."
+- **Fix the wedged-daemon case by replacing, not orphaning** — on
+  *alive-but-unhealthy*, `SIGTERM` + wait-for-exit then respawn; if it won't die in
+  budget, **stop with an actionable error** (no auto `SIGKILL` — avoid nuking a
+  possibly-recycled PID). Rejected: blindly spawning (today's behavior → EADDRINUSE
+  + 20s timeout + orphan).
+- **Hand-written class `ErrorBoundary`, no new dependency** — React 19 error
+  boundaries must be class components; `react-error-boundary` is not a dep and
+  CLAUDE.md gates new deps. Reuse `ErrorBox` for the fallback so there's zero new
+  CSS. Two tiers: root (keeps the sidebar alive) + per-block (one bad transcript
+  block degrades locally).
+- **Guard the column→DTO seam with a typed row-reader that throws on drift** —
+  a missing column becomes a loud 500, not a silent `0`/`''`. Reinforce with a
+  fixture "DTO completeness" assertion. Rejected: a shared column-name const list
+  (weaker, still driftable).
+- **Pricing migration = monotonic integer `schemaVersion` + non-destructive merge
+  + single `.bak`** — *not* the index's content-hash signature (which would
+  mis-fire on every legitimate user rate edit) and *not* re-seed (which would wipe
+  user edits). Merge new shipped keys, keep user overrides, back up once, log.
+- **Explicitly out of scope / do-not-do** (verifier flagged these):
+  - ⚠️ **Do NOT** change usage dedup to `PARTITION BY session_id, message_id` — it
+    would reintroduce the ~2.4–3× cost over-count that `PARTITION BY message_id`
+    (by design) prevents for fork/resume copies. See plan 0012.
+  - **Do NOT** add "security" validation to analytics `from`/`to`/`groupBy` — SQL is
+    parameterized via `sqlString()`; the "silent NULL" claim is false (`::TIMESTAMP`
+    throws). At most a cosmetic 500→400 from the app's own frontend.
+  - **Do NOT** add the "already covered" tests (orphan workflow subagent, Codex
+    function_call w/o output, Junie unreadable image, pricing partial-write) or
+    remove the intentional redundant `mkdirSync`.
+
+## Approach
+
+Five independent work items; each is its own commit and can land in any order.
+
+### 1. Index-corruption recovery test (new `test/index-recovery.integration.test.ts`)
+1. Mirror the `api.integration.test.ts` harness: `mkdtempSync` work dir; set
+   `CLAUDE_PROJECTS_DIR`/`CODEX_*`/`JUNIE_*`/`DUCKDB_PATH`/`CLAUDESCOPE_HOME`/
+   `REINDEX_INTERVAL_MS=0` **before** importing server modules; write one tiny
+   synthetic Claude session.
+2. **2a — byte corruption:** `reindex()`, capture baseline `SELECT id FROM
+   sessions` + `count(*) FROM events`; `closeConnection()`; overwrite the
+   `.duckdb` with ≥4KB `randomBytes` and remove the `.wal`; `vi.resetModules()`;
+   re-`getConnection()` → assert `console.warn` matched `/discarding and
+   rebuilding/`, it resolves, and post-`reindex()` data equals baseline.
+3. **2b — stale schema:** tamper `meta.schema_signature` to a sentinel +
+   `CHECKPOINT` + close; reconnect → assert the same warn fired, rebuild matches
+   baseline, and `meta.schema_signature` is re-stamped to a 40-hex sha1 (≠ sentinel).
+4. Per-scenario fresh `DUCKDB_PATH` + `vi.resetModules()` (module-level
+   `DUCKDB_PATH`/`SCHEMA_SIGNATURE`/singleton are frozen at import; `closeConnection`
+   only nulls the JS ref, so isolate paths to avoid a lingering-handle lock).
+
+### 2. Daemon hung-state fix + first CLI test (`src/cli.ts`, new `test/cli.test.ts`)
+1. In `start()`, split the post-check into three cases: healthy → return
+   (unchanged); `!isAlive` → clear stale `daemon.json` (unchanged); **`isAlive &&
+   !healthy` (wedged)** → log, `SIGTERM`, `await waitForExit(pid, ~5s)`, clear
+   `daemon.json`, fall through to spawn; if it won't exit → actionable error,
+   `exitCode = 1`, **return without spawning**.
+2. Add `waitForExit(pid, timeoutMs)` (100ms poll, same idiom as `waitForHealth`).
+3. Make `stop()` `async` and `await waitForExit` after `SIGTERM` before removing
+   `daemon.json`; update **all three** call sites (`stop`, `restart`, `update`) to
+   `await stop()` — closes the restart/update rebind race.
+4. Extract a pure `classifyExisting(record, aliveFn, healthyFn): 'healthy' |
+   'stale' | 'wedged' | 'none'` so the exact bug is unit-testable without spawning.
+5. Testability seam: `export` the lifecycle helpers; guard the bottom `main()` call
+   with `realpathSync(argv[1]) === realpathSync(fileURLToPath(import.meta.url))` so
+   importing the module under Vitest doesn't execute a command.
+6. New `test/cli.test.ts`: `classifyExisting` truth table, `isAlive`/`readDaemon`
+   (valid/missing/corrupt), `isHealthy`, `waitForHealth` retry+timeout (fake
+   timers), `waitForExit` — all mocking `process.kill`/`fetch`, no real server.
+7. **Tier-3 fold-ins (in-file, recommended):** extract the byte-identical
+   `openBrowser()` (dup in `cli.ts` + `index.ts`) into a shared util; size-cap/roll
+   the append-only `daemon.log` before reopening for append.
+
+### 3. React error boundary (`packages/web`)
+1. New `components/ErrorBoundary.tsx`: class component
+   (`getDerivedStateFromError` + `componentDidCatch` → `console.error`),
+   `resetKeys` to auto-recover, default fallback delegates to `<ErrorBox>`.
+2. Export it from `components/index.ts`.
+3. Root: wrap `<Routes>` in `App.tsx` with `resetKeys={[pathname]}`
+   (`useLocation`), **sidebar stays outside** so nav survives a crash.
+4. Per-block: wrap `ThreadBlockView` inside `RevealableBlock` in `ThreadView.tsx`
+   with a compact fallback + `resetKeys={[block]}` — keep the boundary **inside**
+   the existing `.tv-block`/`data-block-id` wrapper so the in-session finder DOM
+   queries still work.
+5. No automated test (see Testing) — manual verification.
+
+### 4. DB-column → shared-type guard (`packages/server/src/routes/*`, new `db/row.ts`)
+1. New `db/row.ts`: `readRow(row, ctx)` → `req`/`str`/`num`/`bool`/`opt` getters;
+   `req()` throws `"<ctx>: column '<k>' missing (alias drift?)"` if the key is
+   absent (distinguishing absent from present-null).
+2. Rewrite the mappers in `routes/sessions.ts`, `routes/projects.ts`,
+   `routes/analytics.ts`, and `routes/search.ts` to read via `readRow`, preserving
+   current null-defaults (e.g. `connector_id || 'claude-code'`).
+3. Add a "DTO completeness (alias-drift guard)" describe to
+   `api.integration.test.ts` asserting each route's DTO fields are populated to
+   their expected non-defaults against the existing fixtures; add a small
+   `test/row.test.ts` for the helper's absent/present-null/coercion branches.
+
+### 5. Pricing.json versioned migration (`packages/shared`, `packages/server`)
+1. Add optional `schemaVersion?: number` to `PricingConfig` (`shared/src/pricing.ts`);
+   add `"schemaVersion": 1` to the shipped `packages/server/pricing.json` (flows to
+   `dist/pricing.default.json` via `bundle.mjs` unchanged).
+2. New `reconcileUserPricing()` in `data/pricing.ts`, called from `ensureStateDir`
+   (`config.ts`) right after `mkdirSync` (already sequenced before any pricing read):
+   - absent user file → copy default (current behavior; now carries version);
+   - `userV >= shippedV` → **no-op** (don't rewrite — preserves mtime / loader cache);
+   - `userV < shippedV` → back up to `pricing.json.bak`, deep-merge
+     (`models`/`families` merged, user values win, `default` prefers user,
+     `schemaVersion` stamped forward), atomic temp-then-rename write, `console.warn`
+     a one-line "migrated, edits preserved, backup written" message;
+   - corrupt user file → leave untouched + warn (never delete user data).
+3. Tests in `pricing.test.ts` (param the default path so tests control it); update
+   the README pricing section to document versioning + `.bak`.
+
+## Files affected
+
+- `packages/server/test/index-recovery.integration.test.ts` *(new)* — corruption + stale-schema recovery.
+- `packages/server/src/cli.ts` — wedged-daemon handling, `waitForExit`, async `stop()`, exported helpers + entrypoint guard, (fold-in) shared `openBrowser` + log cap.
+- `packages/server/test/cli.test.ts` *(new)* — lifecycle helper + `classifyExisting` tests.
+- `packages/server/src/util/open-browser.ts` *(new, fold-in)* + `packages/server/src/index.ts` — use the shared opener.
+- `packages/web/src/components/ErrorBoundary.tsx` *(new)*, `components/index.ts`, `App.tsx`, `pages/session/ThreadView.tsx` — render boundaries.
+- `packages/server/src/db/row.ts` *(new)*, `routes/{sessions,projects,analytics,search}.ts` — typed row reader; `test/row.test.ts` *(new)* + `test/api.integration.test.ts` — guard coverage.
+- `packages/shared/src/pricing.ts`, `packages/server/pricing.json`, `packages/server/src/config.ts`, `packages/server/src/data/pricing.ts`, `packages/server/test/pricing.test.ts`, `README.md` — pricing migration.
+
+## Testing
+
+- `npm test` (Vitest) and `npm run typecheck` (tsc -b) after each item.
+- New/extended suites: `index-recovery.integration`, `cli`, `row`, `pricing`
+  (reconcile), and DTO-completeness assertions in `api.integration`.
+- **React boundary has no automated test** — the web test env is `node`-only with
+  no jsdom/testing-library, and adding them is a dep decision (see open questions).
+  Verified manually via `npm run dev`: force a `ThreadBlockView` branch to throw,
+  confirm only that block shows the inline `ErrorBox` while the rest of the thread
+  and the sidebar stay usable; navigate away to confirm the boundary resets.
+- Manual negative check (PR notes, not committed): temporarily renaming a SELECT
+  alias should make the new DTO-completeness assertions fail and `readRow` throw.
+
+## Risks / open questions
+
+- **Index test flakiness** — reopening a path with a lingering DuckDB handle can
+  raise a *lock* error instead of the wanted *corruption* error; mitigated by a
+  fresh `DUCKDB_PATH` per scenario. The test couples to the `console.warn` wording
+  (treat that log line as load-bearing; note it in a comment).
+- **`main()` entrypoint guard** is the riskiest daemon change — a wrong comparison
+  would make the shipped CLI silently no-op. Mitigated with `realpathSync` on both
+  sides (handles the brew/symlink case) + unchanged production launch path.
+- **Daemon behavior change** — `stop()` becomes `async`; all three call sites must
+  `await`. Wedged-case bails with an actionable error rather than `SIGKILL` (open
+  question: is auto-`kill -9` escalation ever wanted? default: no).
+- **Guard throws on drift** — routes that previously returned silent defaults now
+  500 on a renamed/dropped column. Intended (loud failure); all SELECTs are
+  in-repo and uniform, so `req()`-vs-`opt()` is unambiguous today.
+- **Pricing merge correctness** — must deep-merge `models`/`families` or newly
+  shipped keys silently won't appear (a variant of the original bug); the
+  equal-version path must truly not rewrite (else every boot busts the loader cache).
+  Corrupt user file is left untouched (no data loss).
+- **Open — React boundary tests:** ship without (matches current node-only,
+  no-new-deps setup) *or* add `jsdom` + `@testing-library/react` devDeps for a real
+  render test? Default recommendation: ship without; revisit if desired.
+- **Open — Tier-3 fold-ins:** include the in-file `openBrowser` extraction + log
+  cap (both live in `cli.ts`, which we're already editing), or keep the diff
+  strictly to the fix? Default: include (the user opted into in-file Tier-3).

--- a/docs/plans/0017-maintainer-review-fixes.md
+++ b/docs/plans/0017-maintainer-review-fixes.md
@@ -1,8 +1,8 @@
 # 0017 — Maintainer review fixes: resiliency tests, daemon hardening, render & contract guards
 
-- **Status:** proposed <!-- proposed | in-progress | done | superseded | abandoned -->
+- **Status:** done <!-- proposed | in-progress | done | superseded | abandoned -->
 - **Date:** 2026-06-15
-- **PR:** <link, once opened>
+- **PR:** [#20](https://github.com/vladar107/claudescope/pull/20)
 
 ## Context
 

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -41,3 +41,4 @@ decision, or a change worth explaining before doing. Skip it for one-line fixes.
 | 0014 | [Memory viewer (instruction files + per-agent memory)](./0014-memory-viewer.md) | done   |
 | 0015 | [Shared project header (nested layout route)](./0015-shared-project-header.md) | done   |
 | 0016 | [Dep upgrades: vite 8 / vitest 4 / shiki 4 (clear Dependabot)](./0016-dep-upgrades-vite8-shiki4.md) | done   |
+| 0017 | [Maintainer review fixes: resiliency tests, daemon hardening, render & contract guards](./0017-maintainer-review-fixes.md) | proposed |

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -41,4 +41,4 @@ decision, or a change worth explaining before doing. Skip it for one-line fixes.
 | 0014 | [Memory viewer (instruction files + per-agent memory)](./0014-memory-viewer.md) | done   |
 | 0015 | [Shared project header (nested layout route)](./0015-shared-project-header.md) | done   |
 | 0016 | [Dep upgrades: vite 8 / vitest 4 / shiki 4 (clear Dependabot)](./0016-dep-upgrades-vite8-shiki4.md) | done   |
-| 0017 | [Maintainer review fixes: resiliency tests, daemon hardening, render & contract guards](./0017-maintainer-review-fixes.md) | proposed |
+| 0017 | [Maintainer review fixes: resiliency tests, daemon hardening, render & contract guards](./0017-maintainer-review-fixes.md) | done |

--- a/packages/server/pricing.json
+++ b/packages/server/pricing.json
@@ -1,4 +1,5 @@
 {
+  "schemaVersion": 1,
   "models": {
     "claude-opus-4-1": { "input": 15, "output": 75, "cacheWrite": 18.75, "cacheRead": 1.5 },
     "claude-opus-4": { "input": 15, "output": 75, "cacheWrite": 18.75, "cacheRead": 1.5 },

--- a/packages/server/src/cli.ts
+++ b/packages/server/src/cli.ts
@@ -20,7 +20,9 @@ import {
   openSync,
   readFileSync,
   realpathSync,
+  renameSync,
   rmSync,
+  statSync,
   writeFileSync,
 } from 'node:fs';
 import { dirname, join } from 'node:path';
@@ -29,6 +31,7 @@ import { parseArgs } from 'node:util';
 import { fileURLToPath } from 'node:url';
 import { APP_VERSION, CLAUDE_PROJECTS_DIR, CLAUDESCOPE_HOME, PORT as DEFAULT_PORT } from './config.js';
 import { refreshPricing } from './data/pricing-refresh.js';
+import { openBrowser } from './util/open-browser.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 /** The server bundle, a sibling of this CLI in the published package. */
@@ -38,8 +41,13 @@ const LOG_FILE = join(CLAUDESCOPE_HOME, 'daemon.log');
 const UPDATE_CHECK_FILE = join(CLAUDESCOPE_HOME, 'update-check.json');
 const PKG = '@vladar107/claudescope';
 const UPDATE_CHECK_TTL_MS = 24 * 60 * 60 * 1000;
+/** Roll the append-only daemon log once it grows past this, so a long-lived or
+ *  crash-looping daemon doesn't grow the log without bound. */
+const LOG_MAX_BYTES = 5 * 1024 * 1024;
+/** How long to wait for a signalled process to actually exit before giving up. */
+const EXIT_WAIT_MS = 5000;
 
-interface DaemonRecord {
+export interface DaemonRecord {
   pid: number;
   port: number;
   url: string;
@@ -48,7 +56,7 @@ interface DaemonRecord {
 }
 
 /** Read the daemon record, or null if absent/corrupt. */
-function readDaemon(): DaemonRecord | null {
+export function readDaemon(): DaemonRecord | null {
   if (!existsSync(DAEMON_FILE)) return null;
   try {
     return JSON.parse(readFileSync(DAEMON_FILE, 'utf8')) as DaemonRecord;
@@ -58,7 +66,7 @@ function readDaemon(): DaemonRecord | null {
 }
 
 /** Is a process with this PID currently alive? */
-function isAlive(pid: number): boolean {
+export function isAlive(pid: number): boolean {
   try {
     process.kill(pid, 0);
     return true;
@@ -68,7 +76,7 @@ function isAlive(pid: number): boolean {
 }
 
 /** Probe the server's health endpoint (short timeout, never throws). */
-async function isHealthy(port: number): Promise<boolean> {
+export async function isHealthy(port: number): Promise<boolean> {
   try {
     const res = await fetch(`http://127.0.0.1:${port}/api/health`, {
       signal: AbortSignal.timeout(1500),
@@ -80,7 +88,7 @@ async function isHealthy(port: number): Promise<boolean> {
 }
 
 /** Poll health until ready or the deadline, printing progress dots. */
-async function waitForHealth(port: number, timeoutMs: number): Promise<boolean> {
+export async function waitForHealth(port: number, timeoutMs: number): Promise<boolean> {
   const deadline = Date.now() + timeoutMs;
   while (Date.now() < deadline) {
     if (await isHealthy(port)) return true;
@@ -90,18 +98,39 @@ async function waitForHealth(port: number, timeoutMs: number): Promise<boolean> 
   return false;
 }
 
-/** Open a URL in the default browser (best-effort, cross-platform). */
-function openBrowser(url: string): void {
-  const cmd =
-    process.platform === 'darwin' ? 'open' : process.platform === 'win32' ? 'start' : 'xdg-open';
+/** Poll until the process is gone or the deadline; returns whether it exited. */
+export async function waitForExit(pid: number, timeoutMs: number): Promise<boolean> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (!isAlive(pid)) return true;
+    await new Promise((r) => setTimeout(r, 100));
+  }
+  return !isAlive(pid);
+}
+
+/** What the recorded daemon (if any) currently is, so callers can decide whether
+ *  to reuse it, clear a stale record, or replace a wedged (alive-but-unhealthy)
+ *  process. Injectable probes keep this pure and unit-testable. */
+export type ExistingState = 'healthy' | 'stale' | 'wedged' | 'none';
+export async function classifyExisting(
+  record: DaemonRecord | null,
+  aliveFn: (pid: number) => boolean,
+  healthyFn: (port: number) => Promise<boolean>,
+): Promise<ExistingState> {
+  if (!record) return 'none';
+  if (!aliveFn(record.pid)) return 'stale';
+  return (await healthyFn(record.port)) ? 'healthy' : 'wedged';
+}
+
+/** Roll the daemon log to `.1` once it exceeds {@link LOG_MAX_BYTES}. Best-effort. */
+function rotateLogIfLarge(): void {
   try {
-    spawn(cmd, [url], {
-      stdio: 'ignore',
-      detached: true,
-      shell: process.platform === 'win32',
-    }).unref();
+    if (existsSync(LOG_FILE) && statSync(LOG_FILE).size > LOG_MAX_BYTES) {
+      rmSync(`${LOG_FILE}.1`, { force: true });
+      renameSync(LOG_FILE, `${LOG_FILE}.1`);
+    }
   } catch {
-    /* non-fatal: the URL is printed regardless */
+    /* non-fatal: logging is best-effort */
   }
 }
 
@@ -110,15 +139,37 @@ async function start(port: number, open: boolean): Promise<void> {
   mkdirSync(CLAUDESCOPE_HOME, { recursive: true });
 
   const existing = readDaemon();
-  if (existing && isAlive(existing.pid) && (await isHealthy(existing.port))) {
+  const state = await classifyExisting(existing, isAlive, isHealthy);
+  if (state === 'healthy' && existing) {
     console.log(`✓ claudescope is already running → ${existing.url}`);
     if (open) openBrowser(existing.url);
     return;
   }
   // Clear a stale record left by a crashed/killed process.
-  if (existing && !isAlive(existing.pid)) rmSync(DAEMON_FILE, { force: true });
+  if (state === 'stale') rmSync(DAEMON_FILE, { force: true });
+  // Alive but unhealthy: a wedged server still holding the port. Replace it —
+  // SIGTERM and wait for it to exit, rather than spawning a second server that
+  // would fail to bind (EADDRINUSE) and leave the old one orphaned.
+  if (state === 'wedged' && existing) {
+    console.log(`claudescope (pid ${existing.pid}) is unresponsive; restarting it…`);
+    try {
+      process.kill(existing.pid, 'SIGTERM');
+    } catch {
+      /* already gone */
+    }
+    if (!(await waitForExit(existing.pid, EXIT_WAIT_MS))) {
+      console.error(
+        `✗ Could not stop the unresponsive process (pid ${existing.pid}). ` +
+          `Kill it manually and retry: kill -9 ${existing.pid}`,
+      );
+      process.exitCode = 1;
+      return;
+    }
+    rmSync(DAEMON_FILE, { force: true });
+  }
 
   const url = `http://localhost:${port}`;
+  rotateLogIfLarge();
   const logFd = openSync(LOG_FILE, 'a');
   // Detached + stdio→log + unref: the server keeps running after this CLI exits.
   // OPEN_BROWSER=0 so the daemon never opens a browser; the CLI owns that.
@@ -151,8 +202,9 @@ async function start(port: number, open: boolean): Promise<void> {
   await maybeNotifyUpdate(false);
 }
 
-/** Stop the background server. */
-function stop(): void {
+/** Stop the background server. Waits for the process to actually exit before
+ *  clearing the record so a following `restart`/`update` can rebind the port. */
+async function stop(): Promise<void> {
   const d = readDaemon();
   if (!d || !isAlive(d.pid)) {
     console.log('claudescope is not running.');
@@ -164,6 +216,7 @@ function stop(): void {
   } catch {
     /* already gone */
   }
+  await waitForExit(d.pid, EXIT_WAIT_MS);
   rmSync(DAEMON_FILE, { force: true });
   console.log(`✓ Stopped claudescope (pid ${d.pid}).`);
 }
@@ -284,7 +337,7 @@ async function update(skipConfirm: boolean): Promise<void> {
   }
   // Stop the old daemon, then start via PATH so the freshly-installed binary
   // (new code) supervises the new server, not this now-stale process.
-  stop();
+  await stop();
   console.log('✓ Updated. Restarting…');
   spawnSync('claudescope', ['start'], {
     stdio: 'inherit',
@@ -412,10 +465,10 @@ async function main(): Promise<void> {
       await start(port, open);
       break;
     case 'stop':
-      stop();
+      await stop();
       break;
     case 'restart':
-      stop();
+      await stop();
       await start(port, open);
       break;
     case 'status':
@@ -452,7 +505,22 @@ async function main(): Promise<void> {
   }
 }
 
-main().catch((err) => {
-  console.error(err);
-  process.exit(1);
-});
+/** True only when this module is the process entrypoint (the real CLI launch),
+ *  so importing it (e.g. from tests) does not execute a command. realpathSync on
+ *  both sides handles the Homebrew bin symlink the same way detectInstallMethod does. */
+function isEntrypoint(): boolean {
+  const argv1 = process.argv[1];
+  if (!argv1) return false;
+  try {
+    return realpathSync(argv1) === realpathSync(fileURLToPath(import.meta.url));
+  } catch {
+    return false;
+  }
+}
+
+if (isEntrypoint()) {
+  main().catch((err) => {
+    console.error(err);
+    process.exit(1);
+  });
+}

--- a/packages/server/src/config.ts
+++ b/packages/server/src/config.ts
@@ -1,9 +1,10 @@
 /** Centralized server configuration constants. */
 
-import { copyFileSync, existsSync, mkdirSync } from 'node:fs';
+import { copyFileSync, existsSync, mkdirSync, readFileSync, renameSync, writeFileSync } from 'node:fs';
 import { homedir } from 'node:os';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import type { PricingConfig } from '@claudescope/shared';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
@@ -156,12 +157,79 @@ export const APP_VERSION =
   typeof __CLAUDESCOPE_VERSION__ !== 'undefined' ? __CLAUDESCOPE_VERSION__ : '0.0.0-dev';
 
 /**
- * Create the state directory and seed the user-editable pricing file from the
- * shipped default if it doesn't exist yet. Idempotent; call once at boot.
+ * Schema version of the shipped pricing default. Bump when the shipped
+ * `pricing.json` shape — or its families/default rates — change, so an existing
+ * user copy reconciles with the new default on the next boot instead of silently
+ * shadowing it. A monotonic integer (not a content hash): the user copy is meant
+ * to be edited, so only a real shipped change should trigger a reconcile.
+ */
+export const PRICING_SCHEMA_VERSION = 1;
+
+/**
+ * Reconcile the user-editable pricing file with the shipped default.
+ *
+ * Non-destructive and self-healing: on first run it seeds the user copy; when the
+ * shipped schema version is newer than the user's, it backs up the old file to
+ * `<path>.bak`, then merges so NEW shipped keys (models/families) appear while
+ * every value the user customized wins. A corrupt user file is left untouched
+ * (never discard user data). Paths are injectable for tests.
+ */
+export function reconcilePricingConfig(
+  userPath: string = PRICING_PATH,
+  defaultPath: string = DEFAULT_PRICING_PATH,
+): void {
+  // First run: no user copy yet → seed from the default (which carries the version).
+  if (!existsSync(userPath)) {
+    if (existsSync(defaultPath)) copyFileSync(defaultPath, userPath);
+    return;
+  }
+  if (!existsSync(defaultPath)) return; // nothing to reconcile against (dev without a build)
+
+  let user: PricingConfig;
+  let shipped: PricingConfig;
+  try {
+    user = JSON.parse(readFileSync(userPath, 'utf8')) as PricingConfig;
+    shipped = JSON.parse(readFileSync(defaultPath, 'utf8')) as PricingConfig;
+  } catch {
+    // Corrupt user (or default) file: leave the user's file alone — never discard
+    // their edits. loadPricing surfaces a clear error if the base is unreadable.
+    console.warn(`[pricing] could not read ${userPath} for reconciliation; leaving it untouched`);
+    return;
+  }
+
+  const userV = typeof user.schemaVersion === 'number' ? user.schemaVersion : 0;
+  const shippedV =
+    typeof shipped.schemaVersion === 'number' ? shipped.schemaVersion : PRICING_SCHEMA_VERSION;
+  // Up to date (or a user copy claiming to be newer): do nothing. Crucially, do
+  // NOT rewrite — that would bump the mtime and needlessly bust loadPricing's cache.
+  if (userV >= shippedV) return;
+
+  // Back up the current file (single rollback copy), then merge: new shipped keys
+  // are added, but every value the user set wins (user edits are preserved).
+  copyFileSync(userPath, `${userPath}.bak`);
+  const merged: PricingConfig = {
+    schemaVersion: shippedV,
+    models: { ...shipped.models, ...user.models },
+    families: { ...(shipped.families ?? {}), ...(user.families ?? {}) },
+    default: user.default ?? shipped.default,
+  };
+  // Atomic write: stage to a temp file then rename, so a reader never sees a torn
+  // file (same idiom as the pricing-refresh snapshot writer).
+  const tmp = `${userPath}.${process.pid}.tmp`;
+  writeFileSync(tmp, `${JSON.stringify(merged, null, 2)}\n`);
+  renameSync(tmp, userPath);
+  console.warn(
+    `[pricing] migrated ${userPath} schema v${userV} → v${shippedV}; ` +
+      `your edits were preserved and the previous file backed up to ${userPath}.bak`,
+  );
+}
+
+/**
+ * Create the state directory and reconcile the user-editable pricing file with
+ * the shipped default (seed on first run; non-destructively migrate a stale
+ * copy). Idempotent; call once at boot.
  */
 export function ensureStateDir(): void {
   mkdirSync(CLAUDESCOPE_HOME, { recursive: true });
-  if (!existsSync(PRICING_PATH) && existsSync(DEFAULT_PRICING_PATH)) {
-    copyFileSync(DEFAULT_PRICING_PATH, PRICING_PATH);
-  }
+  reconcilePricingConfig();
 }

--- a/packages/server/src/db/duckdb.ts
+++ b/packages/server/src/db/duckdb.ts
@@ -23,6 +23,7 @@ const SCHEMA_SIGNATURE = createHash('sha1')
   .digest('hex');
 
 let connection: DuckDBConnection | null = null;
+let instance: DuckDBInstance | null = null;
 let connecting: Promise<DuckDBConnection> | null = null;
 
 /** Does a table exist in the open database? */
@@ -54,16 +55,17 @@ async function isStaleSchema(conn: DuckDBConnection): Promise<boolean> {
 }
 
 /** Open the DB file, load extensions, and apply the idempotent schema. */
-async function openAndPrepare(): Promise<DuckDBConnection> {
+async function openAndPrepare(): Promise<{ conn: DuckDBConnection; inst: DuckDBInstance }> {
   mkdirSync(dirname(DUCKDB_PATH), { recursive: true });
-  const instance = await DuckDBInstance.create(DUCKDB_PATH);
-  const conn = await instance.connect();
+  const inst = await DuckDBInstance.create(DUCKDB_PATH);
+  const conn = await inst.connect();
   await conn.run('INSTALL json; LOAD json;');
   await conn.run('INSTALL fts; LOAD fts;');
 
   // A schema-version mismatch means the persisted shape is outdated. The index
   // is a derived cache, so signal a discard+rebuild rather than migrate in place.
   if (await isStaleSchema(conn)) {
+    inst.closeSync();
     throw new Error(`index schema is stale (expected v${SCHEMA_VERSION}); rebuilding`);
   }
 
@@ -74,7 +76,7 @@ async function openAndPrepare(): Promise<DuckDBConnection> {
   await conn.run(
     `INSERT OR REPLACE INTO meta (key, value) VALUES ('schema_signature', '${SCHEMA_SIGNATURE}')`,
   );
-  return conn;
+  return { conn, inst };
 }
 
 /** Delete the persistent DB file and its WAL/temp siblings. */
@@ -100,19 +102,20 @@ export async function getConnection(): Promise<DuckDBConnection> {
   if (connecting) return connecting;
 
   connecting = (async () => {
-    let conn: DuckDBConnection;
+    let opened: { conn: DuckDBConnection; inst: DuckDBInstance };
     try {
-      conn = await openAndPrepare();
+      opened = await openAndPrepare();
     } catch (err) {
       console.warn(
         `[duckdb] failed to open index at ${DUCKDB_PATH}; discarding and rebuilding. Cause:`,
         err instanceof Error ? err.message : err,
       );
       discardCorruptDb();
-      conn = await openAndPrepare();
+      opened = await openAndPrepare();
     }
-    connection = conn;
-    return conn;
+    connection = opened.conn;
+    instance = opened.inst;
+    return opened.conn;
   })();
 
   try {
@@ -122,8 +125,21 @@ export async function getConnection(): Promise<DuckDBConnection> {
   }
 }
 
+/** Close the open connection and release the underlying DB instance (and its
+ *  file lock). Best-effort: a double-close or already-closed handle is ignored. */
 export async function closeConnection(): Promise<void> {
+  try {
+    connection?.disconnectSync();
+  } catch {
+    /* already closed */
+  }
+  try {
+    instance?.closeSync();
+  } catch {
+    /* already closed */
+  }
   connection = null;
+  instance = null;
 }
 
 /**

--- a/packages/server/src/db/row.ts
+++ b/packages/server/src/db/row.ts
@@ -1,0 +1,49 @@
+/**
+ * Typed reader for DuckDB result rows.
+ *
+ * The route mappers translate snake_case columns into the camelCase shapes in
+ * `@claudescope/shared`. That hop is hand-maintained and otherwise unchecked: if
+ * a SELECT alias or schema column is renamed/dropped, `Number(r.col ?? 0)` would
+ * silently yield a default (0 / '') and ship wrong data with no error. `readRow`
+ * makes the contract loud — reading a column that isn't in the row throws, so
+ * drift surfaces as a failure instead of a silent zero. A column that is present
+ * but NULL still falls back to the supplied default (a legitimate value).
+ */
+
+export interface RowReader {
+  /** Raw value after asserting the column is present (may be null). */
+  req(col: string): unknown;
+  /** Raw value if the column is present, else `undefined` (no drift check). */
+  opt(col: string): unknown;
+  /** String value; present-but-null → `fallback`. Throws if the column is absent. */
+  str(col: string, fallback?: string): string;
+  /** Finite number; present-but-null/NaN → `fallback`. Throws if the column is absent. */
+  num(col: string, fallback?: number): number;
+  /** Boolean value. Throws if the column is absent. */
+  bool(col: string): boolean;
+}
+
+export function readRow(row: Record<string, unknown>, ctx: string): RowReader {
+  const has = (col: string): boolean => Object.prototype.hasOwnProperty.call(row, col);
+  const req = (col: string): unknown => {
+    if (!has(col)) {
+      throw new Error(`${ctx}: expected column '${col}' is missing from the row (SELECT alias drift?)`);
+    }
+    return row[col];
+  };
+  return {
+    req,
+    opt: (col) => (has(col) ? row[col] : undefined),
+    str: (col, fallback = '') => {
+      const v = req(col);
+      return v != null ? String(v) : fallback;
+    },
+    num: (col, fallback = 0) => {
+      const v = req(col);
+      if (v == null) return fallback;
+      const n = Number(v);
+      return Number.isFinite(n) ? n : fallback;
+    },
+    bool: (col) => Boolean(req(col)),
+  };
+}

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -4,7 +4,6 @@
  */
 
 import { existsSync, readFileSync } from 'node:fs';
-import { spawn } from 'node:child_process';
 import Fastify from 'fastify';
 import fastifyStatic from '@fastify/static';
 import type { FetchedPricing } from '@claudescope/shared';
@@ -22,6 +21,7 @@ import {
 import { registerRoutes } from './routes/index.js';
 import { reindex } from './data/index.js';
 import { refreshPricing } from './data/pricing-refresh.js';
+import { openBrowser } from './util/open-browser.js';
 
 /** How old a fetched-pricing snapshot may be before a boot refresh fires. */
 const PRICING_STALE_MS = 24 * 60 * 60 * 1000;
@@ -38,17 +38,6 @@ function pricingSnapshotIsStale(): boolean {
     return Date.now() - fetchedAt > PRICING_STALE_MS;
   } catch {
     return true; // missing or corrupt → refresh
-  }
-}
-
-/** Open a URL in the user's default browser (best-effort, cross-platform). */
-function openBrowser(url: string): void {
-  const cmd =
-    process.platform === 'darwin' ? 'open' : process.platform === 'win32' ? 'start' : 'xdg-open';
-  try {
-    spawn(cmd, [url], { stdio: 'ignore', detached: true, shell: process.platform === 'win32' }).unref();
-  } catch {
-    /* non-fatal: the URL is printed in the banner regardless */
   }
 }
 

--- a/packages/server/src/routes/analytics.ts
+++ b/packages/server/src/routes/analytics.ts
@@ -19,6 +19,7 @@ import type {
   AnalyticsTotals,
 } from '@claudescope/shared';
 import { getConnection, queryRows, sqlString } from '../db/duckdb.js';
+import { readRow } from '../db/row.js';
 import { projectIdFromCwd } from '../data/project-id.js';
 
 /**
@@ -88,11 +89,12 @@ export async function registerAnalyticsRoute(app: FastifyInstance): Promise<void
     );
 
     const resultRows: AnalyticsRow[] = rows.map((r) => {
-      const input = Number(r.input_tokens ?? 0);
-      const output = Number(r.output_tokens ?? 0);
-      const cacheWrite = Number(r.cache_write_tokens ?? 0);
-      const cacheRead = Number(r.cache_read_tokens ?? 0);
-      let key = String(r.group_key ?? '');
+      const rd = readRow(r, 'analytics');
+      const input = rd.num('input_tokens');
+      const output = rd.num('output_tokens');
+      const cacheWrite = rd.num('cache_write_tokens');
+      const cacheRead = rd.num('cache_read_tokens');
+      let key = rd.str('group_key');
       // For project grouping, expose the slug id (matches /api/projects ids).
       if (groupBy === 'project' && key && key !== 'unknown') {
         key = projectIdFromCwd(key);
@@ -104,9 +106,9 @@ export async function registerAnalyticsRoute(app: FastifyInstance): Promise<void
         cacheCreationTokens: cacheWrite,
         cacheReadTokens: cacheRead,
         totalTokens: input + output + cacheWrite + cacheRead,
-        costUsd: Number(r.cost_usd ?? 0),
+        costUsd: rd.num('cost_usd'),
         cacheHitRatio: cacheHitRatio(cacheRead, cacheWrite, input),
-        messageCount: Number(r.message_count ?? 0),
+        messageCount: rd.num('message_count'),
       };
     });
 

--- a/packages/server/src/routes/projects.ts
+++ b/packages/server/src/routes/projects.ts
@@ -9,6 +9,7 @@
 import type { FastifyInstance } from 'fastify';
 import type { AgentBreakdown, ProjectMeta } from '@claudescope/shared';
 import { getConnection, queryRows } from '../db/duckdb.js';
+import { readRow } from '../db/row.js';
 import { displayNameFromCwd, projectIdFromCwd } from '../data/project-id.js';
 
 export async function registerProjectsRoute(app: FastifyInstance): Promise<void> {
@@ -46,28 +47,30 @@ export async function registerProjectsRoute(app: FastifyInstance): Promise<void>
 
     const agentsByCwd = new Map<string, AgentBreakdown[]>();
     for (const r of agentRows) {
-      const cwd = String(r.cwd);
+      const rd = readRow(r, 'projects.agents');
+      const cwd = rd.str('cwd');
       const list = agentsByCwd.get(cwd) ?? [];
       list.push({
-        connectorId: String(r.connector_id),
-        sessionCount: Number(r.session_count ?? 0),
-        totalTokens: Number(r.total_tokens ?? 0),
-        totalCostUsd: Number(r.total_cost_usd ?? 0),
+        connectorId: rd.str('connector_id'),
+        sessionCount: rd.num('session_count'),
+        totalTokens: rd.num('total_tokens'),
+        totalCostUsd: rd.num('total_cost_usd'),
       });
       agentsByCwd.set(cwd, list);
     }
 
     return rows.map((r): ProjectMeta => {
-      const cwd = String(r.cwd);
+      const rd = readRow(r, 'projects');
+      const cwd = rd.str('cwd');
       const agents = agentsByCwd.get(cwd) ?? [];
       return {
         id: projectIdFromCwd(cwd),
         cwd,
         displayName: displayNameFromCwd(cwd),
-        sessionCount: Number(r.session_count ?? 0),
-        totalTokens: Number(r.total_tokens ?? 0),
-        totalCostUsd: Number(r.total_cost_usd ?? 0),
-        lastActive: toIso(r.last_active),
+        sessionCount: rd.num('session_count'),
+        totalTokens: rd.num('total_tokens'),
+        totalCostUsd: rd.num('total_cost_usd'),
+        lastActive: toIso(rd.req('last_active')),
         connectorIds: agents.map((a) => a.connectorId),
         agents,
       };

--- a/packages/server/src/routes/search.ts
+++ b/packages/server/src/routes/search.ts
@@ -17,6 +17,7 @@ import type {
   SearchType,
 } from '@claudescope/shared';
 import { getConnection, queryRows, sqlString } from '../db/duckdb.js';
+import { readRow } from '../db/row.js';
 import { projectIdFromCwd } from '../data/project-id.js';
 import { collectMemory } from '../data/memory.js';
 
@@ -106,16 +107,17 @@ async function searchSessions(
   );
 
   return rows.map((r): SearchResult => {
-    const cwd = r.project_cwd != null ? String(r.project_cwd) : '';
-    const text = r.text_content != null ? String(r.text_content) : '';
+    const rd = readRow(r, 'search');
+    const cwd = rd.str('project_cwd');
+    const text = rd.str('text_content');
     return {
-      sessionId: String(r.session_id),
+      sessionId: rd.str('session_id'),
       projectId: cwd ? projectIdFromCwd(cwd) : '',
-      title: r.title != null ? String(r.title) : '',
+      title: rd.str('title'),
       snippet: makeSnippet(text, terms),
-      score: Number(r.score ?? 0),
-      messageUuid: String(r.message_uuid),
-      role: r.role != null ? String(r.role) : '',
+      score: rd.num('score'),
+      messageUuid: rd.str('message_uuid'),
+      role: rd.str('role'),
     };
   });
 }

--- a/packages/server/src/routes/sessions.ts
+++ b/packages/server/src/routes/sessions.ts
@@ -13,6 +13,7 @@ import type {
   SessionSort,
 } from '@claudescope/shared';
 import { getConnection, queryRows, sqlString } from '../db/duckdb.js';
+import { readRow } from '../db/row.js';
 import { displayNameFromCwd, projectIdFromCwd } from '../data/project-id.js';
 import { toIso } from './projects.js';
 import { assembleThread, buildSubagentRuns } from '../data/parser.js';
@@ -27,30 +28,29 @@ const SORT_SQL: Record<SessionSort, string> = {
 };
 
 function rowToSessionMeta(r: Record<string, unknown>): SessionMeta {
-  const cwd = r.project_cwd != null ? String(r.project_cwd) : '';
-  const modelsStr = r.models != null ? String(r.models) : '';
+  const rd = readRow(r, 'sessions');
+  const cwd = rd.str('project_cwd');
+  const modelsStr = rd.str('models');
   const meta: SessionMeta = {
-    id: String(r.id),
+    id: rd.str('id'),
     projectId: cwd ? projectIdFromCwd(cwd) : '',
     projectDisplayName: cwd ? displayNameFromCwd(cwd) : '',
-    title: r.title != null ? String(r.title) : '',
-    startedAt: toIso(r.started_at),
-    endedAt: toIso(r.ended_at),
-    messageCount: Number(r.message_count ?? 0),
-    toolCallCount: Number(r.tool_call_count ?? 0),
-    totalTokens: Number(r.total_tokens ?? 0),
-    totalCostUsd: Number(r.total_cost_usd ?? 0),
+    title: rd.str('title'),
+    startedAt: toIso(rd.req('started_at')),
+    endedAt: toIso(rd.req('ended_at')),
+    messageCount: rd.num('message_count'),
+    toolCallCount: rd.num('tool_call_count'),
+    totalTokens: rd.num('total_tokens'),
+    totalCostUsd: rd.num('total_cost_usd'),
     models: modelsStr ? modelsStr.split(',').filter(Boolean) : [],
-    sizeBytes: Number(r.size_bytes ?? 0),
-    hasSidechain: Boolean(r.has_sidechain),
-    connectorId: r.connector_id != null ? String(r.connector_id) : 'claude-code',
+    sizeBytes: rd.num('size_bytes'),
+    hasSidechain: rd.bool('has_sidechain'),
+    connectorId: rd.str('connector_id') || 'claude-code',
   };
-  if (r.git_branch != null && String(r.git_branch).length > 0) {
-    meta.gitBranch = String(r.git_branch);
-  }
-  if (r.pr_url != null && String(r.pr_url).length > 0) {
-    meta.prUrl = String(r.pr_url);
-  }
+  const gitBranch = rd.str('git_branch');
+  if (gitBranch) meta.gitBranch = gitBranch;
+  const prUrl = rd.str('pr_url');
+  if (prUrl) meta.prUrl = prUrl;
   return meta;
 }
 

--- a/packages/server/src/util/open-browser.ts
+++ b/packages/server/src/util/open-browser.ts
@@ -1,0 +1,19 @@
+/** Open a URL in the user's default browser (best-effort, cross-platform). */
+
+import { spawn } from 'node:child_process';
+
+/** Launch the platform browser opener detached; non-fatal on failure (callers
+ *  print the URL regardless). Shared by the CLI and the server entrypoint. */
+export function openBrowser(url: string): void {
+  const cmd =
+    process.platform === 'darwin' ? 'open' : process.platform === 'win32' ? 'start' : 'xdg-open';
+  try {
+    spawn(cmd, [url], {
+      stdio: 'ignore',
+      detached: true,
+      shell: process.platform === 'win32',
+    }).unref();
+  } catch {
+    /* non-fatal: the URL is printed regardless */
+  }
+}

--- a/packages/server/test/api.integration.test.ts
+++ b/packages/server/test/api.integration.test.ts
@@ -222,6 +222,77 @@ describe('GET /api/analytics', () => {
   });
 });
 
+describe('DTO completeness (alias-drift guard)', () => {
+  // If a SELECT alias or schema column drifts, the typed row reader throws (→ a
+  // failed request) or a field lands on its default. These assert each route's
+  // DTO is fully populated for a known fixture, so a renamed/dropped column fails
+  // loudly here instead of silently shipping 0 / '' values.
+  it('/api/sessions populates every SessionMeta field for sessA', async () => {
+    const sessions = (await get('/api/sessions')).json();
+    const a = sessions.find((s: { id: string }) => s.id === 'sessA');
+    expect(a).toMatchObject({
+      id: 'sessA',
+      projectId: projAId,
+      title: 'Session A',
+      connectorId: 'claude-code',
+      hasSidechain: true,
+      prUrl: 'https://example/pr/7',
+      gitBranch: 'main',
+    });
+    expect(a.projectDisplayName.length).toBeGreaterThan(0);
+    expect(a.startedAt.length).toBeGreaterThan(0);
+    expect(a.endedAt.length).toBeGreaterThan(0);
+    expect(a.messageCount).toBeGreaterThan(0);
+    expect(a.toolCallCount).toBeGreaterThan(0);
+    expect(a.totalTokens).toBeGreaterThan(0);
+    expect(a.totalCostUsd).toBeGreaterThanOrEqual(0);
+    expect(a.sizeBytes).toBeGreaterThan(0);
+    expect(a.models.length).toBeGreaterThan(0);
+  });
+
+  it('/api/projects populates every ProjectMeta field', async () => {
+    const projects = (await get('/api/projects')).json();
+    const a = projects.find((p: { id: string }) => p.id === projAId);
+    expect(a.cwd.length).toBeGreaterThan(0);
+    expect(a.displayName.length).toBeGreaterThan(0);
+    expect(a.sessionCount).toBeGreaterThan(0);
+    expect(a.totalTokens).toBeGreaterThan(0);
+    expect(a.totalCostUsd).toBeGreaterThanOrEqual(0);
+    expect(a.lastActive.length).toBeGreaterThan(0);
+    expect(a.connectorIds.length).toBeGreaterThan(0);
+    expect(a.agents.length).toBeGreaterThan(0);
+    expect(a.agents[0].connectorId.length).toBeGreaterThan(0);
+    expect(a.agents[0].sessionCount).toBeGreaterThan(0);
+  });
+
+  it('/api/analytics populates every AnalyticsRow field', async () => {
+    const { rows } = (await get('/api/analytics?groupBy=model')).json();
+    expect(rows.length).toBeGreaterThan(0);
+    for (const r of rows) {
+      expect(r.key.length).toBeGreaterThan(0);
+      expect(r.totalTokens).toBe(
+        r.inputTokens + r.outputTokens + r.cacheCreationTokens + r.cacheReadTokens,
+      );
+      expect(r.messageCount).toBeGreaterThan(0);
+      expect(Number.isFinite(r.costUsd)).toBe(true);
+      expect(Number.isFinite(r.cacheHitRatio)).toBe(true);
+    }
+    expect(rows.some((r: { inputTokens: number }) => r.inputTokens > 0)).toBe(true);
+    expect(rows.some((r: { outputTokens: number }) => r.outputTokens > 0)).toBe(true);
+  });
+
+  it('/api/search populates every SearchResult field', async () => {
+    const { sessions: results } = (await get('/api/search?q=needle')).json();
+    const hit = results.find((r: { sessionId: string }) => r.sessionId === 'sessA');
+    expect(hit.messageUuid.length).toBeGreaterThan(0);
+    expect(hit.projectId).toBe(projAId);
+    expect(hit.title).toBe('Session A');
+    expect(hit.role.length).toBeGreaterThan(0);
+    expect(hit.snippet.length).toBeGreaterThan(0);
+    expect(Number.isFinite(hit.score)).toBe(true);
+  });
+});
+
 describe('POST /api/reindex', () => {
   it('is incremental and reports zero changes on a clean re-run', async () => {
     const res = await app.inject({ method: 'POST', url: '/api/reindex' });

--- a/packages/server/test/cli.test.ts
+++ b/packages/server/test/cli.test.ts
@@ -1,0 +1,148 @@
+/**
+ * Unit tests for the daemon-lifecycle primitives in cli.ts — the project's first
+ * CLI test. Covers the helpers that decide whether to reuse, clear, or replace a
+ * recorded daemon, including the alive-but-unhealthy ("wedged") case that used to
+ * fall through and spawn a conflicting server.
+ *
+ * CLAUDESCOPE_HOME is set before importing cli.js (config.ts reads env at import
+ * time, and DAEMON_FILE/LOG_FILE derive from it). No real server is ever spawned;
+ * process.kill and fetch are mocked.
+ */
+
+import { afterAll, afterEach, describe, expect, it, vi } from 'vitest';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+// --- temp state dir (decided before importing the module under test) ---------
+const work = mkdtempSync(join(tmpdir(), 'claudescope-cli-'));
+const home = join(work, 'home');
+mkdirSync(home, { recursive: true });
+process.env.CLAUDESCOPE_HOME = home;
+const DAEMON_FILE = join(home, 'daemon.json');
+
+const cli = await import('../src/cli.js');
+
+const record = (over: Partial<import('../src/cli.js').DaemonRecord> = {}) => ({
+  pid: 4242,
+  port: 4317,
+  url: 'http://localhost:4317',
+  version: '1.2.3',
+  startedAt: '2026-06-15T00:00:00.000Z',
+  ...over,
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+  rmSync(DAEMON_FILE, { force: true });
+});
+
+afterAll(() => rmSync(work, { recursive: true, force: true }));
+
+describe('classifyExisting', () => {
+  const alive = () => true;
+  const dead = () => false;
+  const healthy = async () => true;
+  const unhealthy = async () => false;
+
+  it("returns 'none' when there is no record", async () => {
+    expect(await cli.classifyExisting(null, alive, healthy)).toBe('none');
+  });
+
+  it("returns 'stale' when the recorded process is gone", async () => {
+    expect(await cli.classifyExisting(record(), dead, healthy)).toBe('stale');
+  });
+
+  it("returns 'healthy' when the process is alive and the endpoint responds", async () => {
+    expect(await cli.classifyExisting(record(), alive, healthy)).toBe('healthy');
+  });
+
+  it("returns 'wedged' when the process is alive but the endpoint is unresponsive", async () => {
+    // The regression guard: this case must be distinguishable from 'stale' so
+    // start() replaces the wedged process instead of spawning a conflicting one.
+    expect(await cli.classifyExisting(record(), alive, unhealthy)).toBe('wedged');
+  });
+});
+
+describe('isAlive', () => {
+  it('probes with signal 0 and is true when kill does not throw', () => {
+    const kill = vi.spyOn(process, 'kill').mockReturnValue(true);
+    expect(cli.isAlive(4242)).toBe(true);
+    expect(kill).toHaveBeenCalledWith(4242, 0);
+  });
+
+  it('is false when kill throws (no such process)', () => {
+    vi.spyOn(process, 'kill').mockImplementation(() => {
+      throw new Error('ESRCH');
+    });
+    expect(cli.isAlive(4242)).toBe(false);
+  });
+});
+
+describe('readDaemon', () => {
+  it('parses a valid record', () => {
+    writeFileSync(DAEMON_FILE, JSON.stringify(record()));
+    expect(cli.readDaemon()).toMatchObject({ pid: 4242, port: 4317 });
+  });
+
+  it('returns null when the file is absent', () => {
+    expect(cli.readDaemon()).toBeNull();
+  });
+
+  it('returns null on corrupt JSON', () => {
+    writeFileSync(DAEMON_FILE, '{ not valid json');
+    expect(cli.readDaemon()).toBeNull();
+  });
+});
+
+describe('isHealthy', () => {
+  it('is true on an ok response', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => ({ ok: true })));
+    expect(await cli.isHealthy(4317)).toBe(true);
+  });
+
+  it('is false on a non-ok response', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => ({ ok: false })));
+    expect(await cli.isHealthy(4317)).toBe(false);
+  });
+
+  it('is false when fetch rejects (server down)', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => {
+      throw new Error('ECONNREFUSED');
+    }));
+    expect(await cli.isHealthy(4317)).toBe(false);
+  });
+});
+
+describe('waitForHealth', () => {
+  it('retries until healthy', async () => {
+    let calls = 0;
+    vi.stubGlobal('fetch', vi.fn(async () => ({ ok: ++calls >= 2 })));
+    vi.spyOn(process.stdout, 'write').mockReturnValue(true);
+    expect(await cli.waitForHealth(4317, 5000)).toBe(true);
+    expect(calls).toBeGreaterThanOrEqual(2);
+  });
+
+  it('gives up at the deadline', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => ({ ok: false })));
+    vi.spyOn(process.stdout, 'write').mockReturnValue(true);
+    expect(await cli.waitForHealth(4317, 300)).toBe(false);
+  });
+});
+
+describe('waitForExit', () => {
+  it('resolves true once the process is gone', async () => {
+    let calls = 0;
+    vi.spyOn(process, 'kill').mockImplementation(() => {
+      if (++calls >= 2) throw new Error('ESRCH');
+      return true;
+    });
+    expect(await cli.waitForExit(4242, 5000)).toBe(true);
+  });
+
+  it('resolves false if the process never exits within the budget', async () => {
+    vi.spyOn(process, 'kill').mockReturnValue(true);
+    expect(await cli.waitForExit(4242, 300)).toBe(false);
+  });
+});

--- a/packages/server/test/index-recovery.integration.test.ts
+++ b/packages/server/test/index-recovery.integration.test.ts
@@ -1,0 +1,140 @@
+/**
+ * Index self-heal recovery tests — the documented "if the index is corrupt,
+ * discard and rebuild" contract (db/duckdb.ts), which was previously untested.
+ *
+ * Two paths through getConnection()'s recovery:
+ *  - (2a) a byte-corrupted .duckdb file fails to open → discarded → rebuilt.
+ *  - (2b) a valid DB whose persisted schema signature no longer matches →
+ *         isStaleSchema throws → discarded → rebuilt.
+ *
+ * Each scenario uses its own DUCKDB_PATH and re-imports the db/index modules
+ * after vi.resetModules(), because DUCKDB_PATH / SCHEMA_SIGNATURE / the
+ * connection singleton are all frozen at module import. closeConnection() fully
+ * releases the instance (and its file lock) between phases so a reopen exercises
+ * the real recovery path rather than a lock conflict. No real ~/.claude is touched.
+ */
+
+import { afterAll, describe, expect, it, vi } from 'vitest';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { randomBytes } from 'node:crypto';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+// --- temp locations (decided before any server module is imported) ----------
+const work = mkdtempSync(join(tmpdir(), 'claudescope-recovery-'));
+const projectsDir = join(work, 'projects');
+
+process.env.CLAUDE_PROJECTS_DIR = projectsDir;
+process.env.CODEX_SESSIONS_DIR = join(work, 'codex-empty');
+process.env.JUNIE_SESSIONS_DIR = join(work, 'junie-empty');
+process.env.CLAUDESCOPE_HOME = join(work, 'home');
+process.env.REINDEX_INTERVAL_MS = '0';
+process.env.PRICING_REFRESH_INTERVAL_MS = '0';
+
+const jsonl = (events: unknown[]): string => events.map((e) => JSON.stringify(e)).join('\n') + '\n';
+
+/** One tiny Claude session, enough to assert "rebuilt to the same sessions". */
+function writeFixture(): void {
+  const proj = join(projectsDir, 'enc-projR');
+  mkdirSync(proj, { recursive: true });
+  const base = { sessionId: 'sessR', cwd: '/tmp/projR', gitBranch: 'main', version: '2.1.0' };
+  writeFileSync(
+    join(proj, 'sessR.jsonl'),
+    jsonl([
+      { type: 'ai-title', sessionId: 'sessR', aiTitle: 'Session R' },
+      { ...base, type: 'user', uuid: 'r-u1', parentUuid: null, timestamp: '2026-01-01T10:00:00.000Z', isSidechain: false, message: { role: 'user', content: 'hello recovery' } },
+      { ...base, type: 'assistant', uuid: 'r-a1', parentUuid: 'r-u1', timestamp: '2026-01-01T10:00:05.000Z', isSidechain: false, message: { role: 'assistant', model: 'claude-opus-4-8', content: [{ type: 'text', text: 'recovered' }], usage: { input_tokens: 100, output_tokens: 50 } } },
+    ]),
+  );
+}
+
+writeFixture();
+
+/** Re-import the db + index modules against a fresh DUCKDB_PATH. */
+async function loadDbModules(dbPath: string) {
+  process.env.DUCKDB_PATH = dbPath;
+  vi.resetModules();
+  const { getConnection, closeConnection, queryRows } = await import('../src/db/duckdb.js');
+  const { reindex } = await import('../src/data/index.js');
+  return { getConnection, closeConnection, queryRows, reindex };
+}
+
+type DbModules = Awaited<ReturnType<typeof loadDbModules>>;
+
+/** The derived output we compare before/after a rebuild. */
+async function snapshot(db: DbModules): Promise<{ ids: unknown[]; events: number }> {
+  const conn = await db.getConnection();
+  const ids = (await db.queryRows(conn, 'SELECT id FROM sessions ORDER BY id')).map((r) => r.id);
+  const rows = await db.queryRows(conn, 'SELECT count(*) AS n FROM events');
+  return { ids, events: Number(rows[0]?.n ?? 0) };
+}
+
+/** The catch in getConnection logs this when it discards a bad DB. */
+const RECOVERY_LOG = 'discarding and rebuilding';
+
+afterAll(() => rmSync(work, { recursive: true, force: true }));
+
+describe('byte-corrupted index file', () => {
+  it('is discarded and rebuilt to the same sessions on the next open', async () => {
+    const dbPath = join(work, 'corrupt.duckdb');
+
+    // Build a valid index, capture the baseline, fully close to release the lock.
+    let db = await loadDbModules(dbPath);
+    await db.reindex();
+    const before = await snapshot(db);
+    expect(before.ids).toEqual(['sessR']);
+    expect(before.events).toBeGreaterThan(0);
+    await db.closeConnection();
+
+    // Corrupt the file: clobber the header with garbage and drop the WAL.
+    writeFileSync(dbPath, randomBytes(8192));
+    rmSync(`${dbPath}.wal`, { force: true });
+
+    // Reconnect in a fresh module: open fails → discard → clean rebuild.
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    db = await loadDbModules(dbPath);
+    await expect(db.getConnection()).resolves.toBeTruthy();
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining(RECOVERY_LOG), expect.anything());
+    warn.mockRestore();
+
+    await db.reindex();
+    expect(await snapshot(db)).toEqual(before);
+    await db.closeConnection();
+  });
+});
+
+describe('stale schema signature', () => {
+  it('forces a discard + rebuild to the same sessions', async () => {
+    const dbPath = join(work, 'stale.duckdb');
+
+    let db = await loadDbModules(dbPath);
+    await db.reindex();
+    const before = await snapshot(db);
+    expect(before.ids).toEqual(['sessR']);
+
+    // Tamper the persisted signature, flush it to disk, then fully close.
+    const conn = await db.getConnection();
+    await conn.run(
+      "INSERT OR REPLACE INTO meta (key, value) VALUES ('schema_signature', 'STALE-DOES-NOT-MATCH')",
+    );
+    await conn.run('CHECKPOINT');
+    await db.closeConnection();
+
+    // Reconnect: isStaleSchema sees the mismatch → discard → clean rebuild.
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    db = await loadDbModules(dbPath);
+    await expect(db.getConnection()).resolves.toBeTruthy();
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining(RECOVERY_LOG), expect.anything());
+    warn.mockRestore();
+
+    await db.reindex();
+    expect(await snapshot(db)).toEqual(before);
+
+    // The signature was re-stamped to a real sha1, not the tampered sentinel.
+    const conn2 = await db.getConnection();
+    const rows = await db.queryRows(conn2, "SELECT value FROM meta WHERE key = 'schema_signature'");
+    expect(rows[0]?.value).not.toBe('STALE-DOES-NOT-MATCH');
+    expect(String(rows[0]?.value)).toMatch(/^[0-9a-f]{40}$/);
+    await db.closeConnection();
+  });
+});

--- a/packages/server/test/pricing.test.ts
+++ b/packages/server/test/pricing.test.ts
@@ -12,12 +12,14 @@
  * No network, no real ~/.claude* dirs.
  */
 
-import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   existsSync,
   mkdirSync,
   mkdtempSync,
+  readFileSync,
   rmSync,
+  statSync,
   utimesSync,
   writeFileSync,
 } from 'node:fs';
@@ -69,6 +71,7 @@ const bumpMtime = (path: string): void => {
 };
 
 const { loadPricing } = await import('../src/data/pricing.js');
+const { reconcilePricingConfig, PRICING_SCHEMA_VERSION } = await import('../src/config.js');
 
 describe('loadPricing — layered merge', () => {
   beforeAll(() => {
@@ -131,6 +134,89 @@ describe('loadPricing — layered merge', () => {
     bumpMtime(fetchedPath);
     const reloaded = loadPricing();
     expect(reloaded.models['claude-opus-4-8']).toEqual({ input: 7, output: 8, cacheWrite: 9, cacheRead: 10 });
+  });
+});
+
+describe('reconcilePricingConfig — versioned migration', () => {
+  let dir: string;
+  let userPath: string;
+  let defaultPath: string;
+
+  const SHIPPED = {
+    schemaVersion: PRICING_SCHEMA_VERSION,
+    models: {
+      'shared-model': { input: 2, output: 2, cacheWrite: 2, cacheRead: 2 },
+      'shipped-only': { input: 9, output: 9, cacheWrite: 9, cacheRead: 9 },
+    },
+    families: {
+      opus: { input: 5, output: 25, cacheWrite: 6.25, cacheRead: 0.5 },
+      newfam: { input: 7, output: 7, cacheWrite: 7, cacheRead: 7 },
+    },
+    default: { input: 3, output: 15, cacheWrite: 3.75, cacheRead: 0.3 },
+  };
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'claudescope-pricing-migrate-'));
+    userPath = join(dir, 'pricing.json');
+    defaultPath = join(dir, 'pricing.default.json');
+    writeJson(defaultPath, SHIPPED);
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('seeds the user copy on first run', () => {
+    reconcilePricingConfig(userPath, defaultPath);
+    expect(existsSync(userPath)).toBe(true);
+    expect(JSON.parse(readFileSync(userPath, 'utf8')).schemaVersion).toBe(PRICING_SCHEMA_VERSION);
+  });
+
+  it('migrates a legacy copy: preserves user edits, adds new shipped keys, backs up', () => {
+    const legacyUser = {
+      // no schemaVersion → treated as v0
+      models: {
+        'shared-model': { input: 99, output: 99, cacheWrite: 99, cacheRead: 99 },
+        'user-only': { input: 1, output: 1, cacheWrite: 1, cacheRead: 1 },
+      },
+      families: { opus: { input: 100, output: 100, cacheWrite: 100, cacheRead: 100 } },
+      default: { input: 42, output: 42, cacheWrite: 42, cacheRead: 42 },
+    };
+    writeJson(userPath, legacyUser);
+
+    reconcilePricingConfig(userPath, defaultPath);
+
+    // The previous file is backed up verbatim.
+    expect(JSON.parse(readFileSync(`${userPath}.bak`, 'utf8'))).toEqual(legacyUser);
+
+    const merged = JSON.parse(readFileSync(userPath, 'utf8'));
+    expect(merged.schemaVersion).toBe(PRICING_SCHEMA_VERSION);
+    // User edits win on shared keys…
+    expect(merged.models['shared-model']).toEqual(legacyUser.models['shared-model']);
+    expect(merged.families.opus).toEqual(legacyUser.families.opus);
+    expect(merged.default).toEqual(legacyUser.default);
+    // …user-only keys survive…
+    expect(merged.models['user-only']).toEqual(legacyUser.models['user-only']);
+    // …and new shipped keys are added.
+    expect(merged.models['shipped-only']).toEqual(SHIPPED.models['shipped-only']);
+    expect(merged.families.newfam).toEqual(SHIPPED.families.newfam);
+  });
+
+  it('is a no-op when the user copy is already current (no rewrite, no backup)', () => {
+    writeJson(userPath, SHIPPED);
+    const before = statSync(userPath).mtimeMs;
+    reconcilePricingConfig(userPath, defaultPath);
+    expect(statSync(userPath).mtimeMs).toBe(before);
+    expect(existsSync(`${userPath}.bak`)).toBe(false);
+  });
+
+  it('leaves a corrupt user file untouched (no throw, no data loss)', () => {
+    writeFileSync(userPath, '{ not valid json');
+    expect(() => reconcilePricingConfig(userPath, defaultPath)).not.toThrow();
+    expect(readFileSync(userPath, 'utf8')).toBe('{ not valid json');
+    expect(existsSync(`${userPath}.bak`)).toBe(false);
   });
 });
 

--- a/packages/server/test/row.test.ts
+++ b/packages/server/test/row.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest';
+import { readRow } from '../src/db/row.js';
+
+describe('readRow', () => {
+  it('throws when a referenced column is absent (alias drift)', () => {
+    const rd = readRow({ a: 1 }, 'ctx');
+    expect(() => rd.num('missing')).toThrow(/expected column 'missing'/);
+    expect(() => rd.str('missing')).toThrow(/ctx/);
+    expect(() => rd.req('missing')).toThrow();
+  });
+
+  it('distinguishes a present-null column from an absent one', () => {
+    const rd = readRow({ present: null }, 'ctx');
+    expect(rd.req('present')).toBeNull(); // present → returns null, no throw
+    expect(() => rd.req('absent')).toThrow();
+  });
+
+  it('returns the fallback for a present-but-null value', () => {
+    const rd = readRow({ title: null, n: null }, 'ctx');
+    expect(rd.str('title')).toBe('');
+    expect(rd.str('title', 'x')).toBe('x');
+    expect(rd.num('n')).toBe(0);
+    expect(rd.num('n', 7)).toBe(7);
+  });
+
+  it('coerces present values', () => {
+    const rd = readRow({ s: 42, n: '3.5', b: true, z: 0 }, 'ctx');
+    expect(rd.str('s')).toBe('42');
+    expect(rd.num('n')).toBe(3.5);
+    expect(rd.bool('b')).toBe(true);
+    expect(rd.bool('z')).toBe(false); // present but falsy
+  });
+
+  it('num falls back on a non-finite value', () => {
+    const rd = readRow({ bad: 'not-a-number' }, 'ctx');
+    expect(rd.num('bad')).toBe(0);
+    expect(rd.num('bad', -1)).toBe(-1);
+  });
+
+  it('opt returns undefined for an absent column without throwing', () => {
+    const rd = readRow({ a: 1 }, 'ctx');
+    expect(rd.opt('missing')).toBeUndefined();
+    expect(rd.opt('a')).toBe(1);
+  });
+});

--- a/packages/shared/src/pricing.ts
+++ b/packages/shared/src/pricing.ts
@@ -23,6 +23,13 @@ export interface FetchedPricing {
 }
 
 export interface PricingConfig {
+  /**
+   * Schema version of the shipped default. Present in the shipped `pricing.json`
+   * and stamped into the seeded/migrated user copy; absent means a legacy (v0)
+   * copy. Used to reconcile an out-of-date user copy with a newer default on
+   * startup. Bumped when the shipped families/default/shape change.
+   */
+  schemaVersion?: number;
   /** Per-model rate table, keyed by exact model id (highest precedence). */
   models: Record<string, ModelRates>;
   /**

--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react';
-import { NavLink, Route, Routes } from 'react-router-dom';
+import { NavLink, Route, Routes, useLocation } from 'react-router-dom';
 import type { SourceInfo } from '@claudescope/shared';
+import { ErrorBoundary } from './components';
 import { api } from './api/client.js';
 import { useTheme, type ThemeChoice } from './theme/ThemeProvider.js';
 import { BrowsePage } from './pages/browse/BrowsePage.js';
@@ -102,23 +103,28 @@ function Sidebar() {
 
 /** Application shell: left navigation plus the routed page outlet. */
 export function App() {
+  // A render throw on a page degrades to an in-place error (sidebar stays usable);
+  // pathname in resetKeys clears the boundary when the user navigates elsewhere.
+  const { pathname } = useLocation();
   return (
     <div className="tv-app">
       <Sidebar />
       <main className="tv-main">
-        <Routes>
-          <Route path="/" element={<BrowsePage />} />
-          <Route path="/projects/:projectId" element={<ProjectLayout />}>
-            <Route index element={<SessionListPage />} />
-            <Route path="memory" element={<ProjectMemoryPage />} />
-          </Route>
-          <Route path="/sessions/:id" element={<SessionPage />} />
-          <Route path="/search" element={<SearchPage />} />
-          <Route path="/analytics" element={<AnalyticsPage />} />
-          <Route path="/memory" element={<MemoryPage />} />
-          <Route path="/memory/:connectorId" element={<AgentMemoryPage />} />
-          <Route path="/memory/:connectorId/:projectId" element={<AgentProjectMemoryPage />} />
-        </Routes>
+        <ErrorBoundary resetKeys={[pathname]} title="This page failed to render">
+          <Routes>
+            <Route path="/" element={<BrowsePage />} />
+            <Route path="/projects/:projectId" element={<ProjectLayout />}>
+              <Route index element={<SessionListPage />} />
+              <Route path="memory" element={<ProjectMemoryPage />} />
+            </Route>
+            <Route path="/sessions/:id" element={<SessionPage />} />
+            <Route path="/search" element={<SearchPage />} />
+            <Route path="/analytics" element={<AnalyticsPage />} />
+            <Route path="/memory" element={<MemoryPage />} />
+            <Route path="/memory/:connectorId" element={<AgentMemoryPage />} />
+            <Route path="/memory/:connectorId/:projectId" element={<AgentProjectMemoryPage />} />
+          </Routes>
+        </ErrorBoundary>
       </main>
     </div>
   );

--- a/packages/web/src/components/ErrorBoundary.tsx
+++ b/packages/web/src/components/ErrorBoundary.tsx
@@ -1,0 +1,74 @@
+import { Component, type ErrorInfo, type ReactNode } from 'react';
+import { ErrorBox } from './ErrorBox.js';
+
+export interface ErrorBoundaryProps {
+  children: ReactNode;
+  /** Heading for the default ErrorBox fallback. */
+  title?: string;
+  /** Custom fallback; receives the caught error and a reset callback. */
+  fallback?: (error: unknown, reset: () => void) => ReactNode;
+  /**
+   * When any value here changes (shallow compare), the boundary clears its error
+   * and re-renders its children — e.g. pass `[pathname]` so navigating away from
+   * a crashed page recovers it, or `[block]` so a fresh payload retries.
+   */
+  resetKeys?: unknown[];
+}
+
+interface ErrorBoundaryState {
+  error: unknown;
+}
+
+/**
+ * Catches render-time exceptions in its subtree so one throw degrades locally
+ * instead of white-screening the whole SPA. Complements {@link ErrorBox} (the
+ * default fallback): ErrorBox surfaces *async* fetch failures that pages store in
+ * state, while an error boundary catches errors thrown during render/lifecycle —
+ * the two are complementary, not overlapping. React 19 error boundaries must be
+ * class components (getDerivedStateFromError / componentDidCatch are class-only).
+ */
+export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundaryState> {
+  state: ErrorBoundaryState = { error: null };
+
+  static getDerivedStateFromError(error: unknown): ErrorBoundaryState {
+    return { error };
+  }
+
+  componentDidCatch(error: unknown, info: ErrorInfo): void {
+    // Single-user, 127.0.0.1 app — logging transcript-derived errors locally is fine.
+    console.error('Render error caught by ErrorBoundary', error, info);
+  }
+
+  componentDidUpdate(prev: ErrorBoundaryProps): void {
+    if (this.state.error != null && !sameKeys(prev.resetKeys, this.props.resetKeys)) {
+      this.reset();
+    }
+  }
+
+  reset = (): void => {
+    this.setState({ error: null });
+  };
+
+  render(): ReactNode {
+    const { error } = this.state;
+    if (error != null) {
+      const { fallback, title } = this.props;
+      if (fallback) return fallback(error, this.reset);
+      return (
+        <ErrorBox
+          error={error}
+          title={title ?? 'Something went wrong rendering this view'}
+          onRetry={this.reset}
+        />
+      );
+    }
+    return this.props.children;
+  }
+}
+
+/** Shallow array compare for resetKeys. */
+function sameKeys(a?: unknown[], b?: unknown[]): boolean {
+  if (a === b) return true;
+  if (!a || !b || a.length !== b.length) return false;
+  return a.every((v, i) => Object.is(v, b[i]));
+}

--- a/packages/web/src/components/index.ts
+++ b/packages/web/src/components/index.ts
@@ -11,5 +11,6 @@ export { TokenChips, type TokenChipsProps, formatCount } from './TokenChips.js';
 export { CostBadge, type CostBadgeProps, formatCost } from './CostBadge.js';
 export { Spinner, type SpinnerProps } from './Spinner.js';
 export { ErrorBox, type ErrorBoxProps } from './ErrorBox.js';
+export { ErrorBoundary, type ErrorBoundaryProps } from './ErrorBoundary.js';
 export { AgentBadge, agentLabel, type AgentBadgeProps } from './AgentBadge.js';
 export { extractImage } from './image.js';

--- a/packages/web/src/pages/session/ThreadView.tsx
+++ b/packages/web/src/pages/session/ThreadView.tsx
@@ -1,6 +1,6 @@
 import { Fragment, memo, useContext, useEffect, useRef, useState } from 'react';
 import type { SubagentRun, ThreadBlock, ThreadItem } from '@claudescope/shared';
-import { ClampedText, Collapsible, TokenChips } from '../../components';
+import { ClampedText, Collapsible, ErrorBoundary, ErrorBox, TokenChips } from '../../components';
 import { formatDateTime, shortModel } from '../browse/format.js';
 import { ThreadBlockView, hasRenderableContent } from './blocks.js';
 import { classifySystemText } from './text.js';
@@ -113,7 +113,16 @@ function RevealableBlock({ blockId, block }: { blockId: string; block: ThreadBlo
   const { blockIds } = useContext(SessionSearchContext);
   return (
     <div className="tv-block" data-block-id={blockId}>
-      <ThreadBlockView block={block} forceOpen={blockIds.has(blockId)} />
+      {/* A throw while rendering one block (markdown/Shiki/diff over arbitrary
+          transcript content) degrades to an in-place notice; the rest of the
+          thread keeps rendering. Boundary stays inside .tv-block so the finder's
+          DOM queries still resolve. */}
+      <ErrorBoundary
+        resetKeys={[block]}
+        fallback={(error) => <ErrorBox error={error} title="This block failed to render" />}
+      >
+        <ThreadBlockView block={block} forceOpen={blockIds.has(blockId)} />
+      </ErrorBoundary>
     </div>
   );
 }


### PR DESCRIPTION
Implements [`docs/plans/0017-maintainer-review-fixes.md`](docs/plans/0017-maintainer-review-fixes.md). A maintainer-style review was assessed against the code (map → adversarially verify → completeness critic); most of its specific asks turned out to be low-value, so this PR lands only the few items that hold up, plus two structural seams the review missed.

### What changed
- **`fix(db)` — index-recovery, now tested.** `closeConnection` actually releases the DuckDB instance (it was leaking the native handle + file lock); a failed-attempt instance is closed before the stale-schema throw so discard+rebuild reopens cleanly. New integration test covers the two documented self-heal paths (byte-corrupt `.duckdb`, stale schema signature) that had no coverage.
- **`fix(cli)` — daemon hardening.** `start()` now replaces an *alive-but-unhealthy (wedged)* daemon instead of spawning a conflicting server that EADDRINUSE-times-out and orphans the old one; `stop()` waits for exit before clearing the record (closes the restart/update rebind race). First CLI test added. Folded in: shared `openBrowser` util, `daemon.log` size cap, and an entrypoint guard so the module is importable from tests.
- **`fix(routes)` — column→DTO drift guard.** A typed `readRow` throws when an expected column is absent (present-but-null still defaults), so a renamed/dropped SELECT alias fails loudly instead of silently shipping `0`/`''`. Applied to sessions/projects/analytics/search + a DTO-completeness test.
- **`feat(pricing)` — versioned, non-destructive migration.** `pricing.json` gains a `schemaVersion`; on startup an out-of-date user copy is backed up to `.bak`, gains new shipped keys, and keeps every user edit. A current copy is never rewritten; a corrupt one is left untouched.
- **`feat(web)` — React error boundaries.** A render throw no longer white-screens the SPA: a root boundary keeps the sidebar usable (and resets on navigation), and a per-block boundary degrades one bad thread block in place. Hand-written class, no new dependency.
- **`docs`** — "keep tests focused on the weird stuff" guidance in `CLAUDE.md` + `CONTRIBUTING.md`.

### Explicitly out of scope
The review's harmful suggestion (`PARTITION BY session_id, message_id` for usage dedup — would reintroduce the ~2.4–3× cost over-count) and its boundary-validation "security" items (already parameterized; localhost single-user) were deliberately **not** applied.

### Verification
- `npm run typecheck`, `npm test` (169 tests, incl. new recovery/CLI/row/pricing-migration/DTO-completeness), `npm run build`, and `npm run bundle` all pass.
- Real end-to-end against the **bundled CLI** on an isolated `CLAUDESCOPE_HOME`: `start` → `status` → idempotent `start` → `restart` (rebinds same port, old pid confirmed dead) → `stop` → stop-when-not-running → `logs`, plus the pricing migration firing live (user edit preserved, `.bak` written).
- Adversarial review of the diff: 8 candidate findings, **0 confirmed real**.