### PR TITLE
feat(web): analytics breakdown by cost — Metric + Sort toggles

### DIFF
--- a/docs/plans/0018-analytics-breakdown-cost.md
+++ b/docs/plans/0018-analytics-breakdown-cost.md
@@ -1,0 +1,78 @@
+# 0018 — Analytics breakdown by cost (Metric + Sort toggles)
+
+- **Status:** done <!-- proposed | in-progress | done | superseded | abandoned -->
+- **Date:** 2026-06-15
+- **PR:** https://github.com/vladar107/claudescope/pull/21
+
+## Context
+
+The Analytics → *Breakdown* chart (per project / agent / model / day) only ever
+spoke in tokens: bars were stacked input/output/cache token segments, sorted by
+the visible token sum, with cost relegated to the tooltip. There was no way to
+see — or order — the breakdown by spend, even though cost is a first-class
+column in the analytics rows (`costUsd`). Users comparing projects by money had
+to read the tooltip row by row.
+
+## Goal
+
+Let the breakdown chart render and order by **cost** as well as tokens, without
+changing the default (tokens) behavior.
+
+## Decisions
+
+- **Two independent controls (Metric + Sort), not one.** Per product call, keep
+  them orthogonal so any of the four combinations is reachable: bars in tokens
+  but ordered by cost (to spot "lots of tokens, little spend"), or a pure cost
+  view. A single "sort by cost" toggle that re-ordered token bars was rejected
+  as visually incoherent on its own; a metric switch makes cost mode coherent.
+- **Cost mode = single bar, dollar axis.** In cost mode the stacked token
+  segments collapse to one `cost` bar (gold, matching the cost accent) and the
+  x-axis formats as `$`. The tooltip still shows the full token + cost breakdown
+  in every mode.
+- **Sibling `{cond && <Bar/>}` conditionals, not a `<>`-wrapped group.** Recharts
+  resolves chart children by component type; fragment flattening is
+  version-sensitive, and the rest of the codebase uses bare conditional siblings.
+  Matching that pattern avoids a silent "bars don't render" trap.
+- **Controls live in the chart-card header, not the page toolbar.** They only
+  affect the breakdown chart (the time series always shows both), so they belong
+  next to it. `ChartCard` grew an optional `actions` slot for this.
+- **Defaults unchanged** (`metric=tokens`, `sortBy=tokens`) so existing behavior
+  and the README screenshot are preserved.
+
+## Approach
+
+1. `BreakdownChart` — add `metric` / `sortBy` props; switch the sort comparator
+   (cost vs visible tokens) and the rendered bars (single cost bar vs stacked
+   token segments); make the x-axis formatter follow the metric.
+2. `AnalyticsPage` — add `metric` / `sortBy` state, a reusable `SegmentedControl`,
+   wire two controls into the breakdown card via a new `ChartCard` `actions` slot,
+   and make the card hint reflect the active sort.
+3. `analytics.css` — header layout for title/hint + right-aligned actions; a
+   compact `tv-segmented--sm` variant matching the existing segmented toggle.
+
+## Files affected
+
+- `packages/web/src/pages/analytics/BreakdownChart.tsx` — `metric`/`sortBy`
+  props, cost bar + dollar axis, sort comparator.
+- `packages/web/src/pages/analytics/AnalyticsPage.tsx` — state, `SegmentedControl`,
+  `ChartCard.actions`, dynamic hint.
+- `packages/web/src/pages/analytics/analytics.css` — header/actions layout,
+  `tv-segmented--sm`.
+
+## Testing
+
+- `npm run typecheck`, full `npm run build`, `npm test` (169 passing) — all green.
+- Manual (headless Chromium against synthetic demo data, isolated
+  `CLAUDESCOPE_HOME` — real `~/.claude` untouched): screenshotted all three
+  states. Confirmed tokens/sort-tokens unchanged; tokens/sort-cost reorders rows
+  while keeping token-sized bars; cost/sort-cost renders dollar-sized bars on a
+  `$` axis in descending order. Verified the active-state highlight and the
+  hint flip between "top 15 by tokens" / "top 15 by cost".
+
+## Risks / open questions
+
+- Pure UI change; no API, contract, or index changes, so nothing to add to the
+  integration suite.
+- With `metric=cost`, the global "Show cache" toggle no longer affects the
+  breakdown bars (cost is a single value); it still drives the time series and
+  summary card, so it's left enabled rather than contextually hidden.

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -42,3 +42,4 @@ decision, or a change worth explaining before doing. Skip it for one-line fixes.
 | 0015 | [Shared project header (nested layout route)](./0015-shared-project-header.md) | done   |
 | 0016 | [Dep upgrades: vite 8 / vitest 4 / shiki 4 (clear Dependabot)](./0016-dep-upgrades-vite8-shiki4.md) | done   |
 | 0017 | [Maintainer review fixes: resiliency tests, daemon hardening, render & contract guards](./0017-maintainer-review-fixes.md) | done |
+| 0018 | [Analytics breakdown by cost (Metric + Sort toggles)](./0018-analytics-breakdown-cost.md) | done |

--- a/packages/web/src/pages/analytics/AnalyticsPage.tsx
+++ b/packages/web/src/pages/analytics/AnalyticsPage.tsx
@@ -19,6 +19,7 @@ import type { AnalyticsGroupBy, AnalyticsResponse, AnalyticsTotals } from '@clau
 import { api } from '../../api/client.js';
 import { CostBadge, ErrorBox, Spinner } from '../../components/index.js';
 import { BreakdownChart } from './BreakdownChart.js';
+import type { BreakdownMetric, BreakdownSort } from './BreakdownChart.js';
 import { TimeSeriesChart } from './TimeSeriesChart.js';
 import { formatCount, formatCost, formatPct } from './format.js';
 import './analytics.css';
@@ -28,6 +29,15 @@ const GROUP_OPTIONS: { value: AnalyticsGroupBy; label: string }[] = [
   { value: 'agent', label: 'By agent' },
   { value: 'model', label: 'By model' },
   { value: 'day', label: 'By day' },
+];
+
+const METRIC_OPTIONS: { value: BreakdownMetric; label: string }[] = [
+  { value: 'tokens', label: 'Tokens' },
+  { value: 'cost', label: 'Cost' },
+];
+const SORT_OPTIONS: { value: BreakdownSort; label: string }[] = [
+  { value: 'tokens', label: 'Tokens' },
+  { value: 'cost', label: 'Cost' },
 ];
 
 /** Fetch state for one analytics query. */
@@ -45,6 +55,10 @@ export function AnalyticsPage() {
   const [to, setTo] = useState('');
   // Cache tokens dwarf input/output and clutter the charts — hidden by default.
   const [showCache, setShowCache] = useState(false);
+  // Breakdown chart controls (default to tokens, preserving prior behavior):
+  // `metric` picks what the bars render, `sortBy` picks the row order.
+  const [metric, setMetric] = useState<BreakdownMetric>('tokens');
+  const [sortBy, setSortBy] = useState<BreakdownSort>('tokens');
 
   // The breakdown query follows the active group-by toggle.
   const [breakdown, setBreakdown] = useState<QueryState>(INITIAL);
@@ -182,12 +196,34 @@ export function AnalyticsPage() {
 
             <ChartCard
               title={`Breakdown ${groupByNoun(groupBy)}`}
-              hint="top 15 by total tokens"
+              hint={`top 15 by ${sortBy === 'cost' ? 'cost' : 'tokens'}`}
               loading={breakdown.loading}
               empty={!breakdown.data || breakdown.data.rows.length === 0}
+              actions={
+                <>
+                  <SegmentedControl
+                    label="Metric"
+                    options={METRIC_OPTIONS}
+                    value={metric}
+                    onChange={setMetric}
+                  />
+                  <SegmentedControl
+                    label="Sort by"
+                    options={SORT_OPTIONS}
+                    value={sortBy}
+                    onChange={setSortBy}
+                  />
+                </>
+              }
             >
               {breakdown.data && (
-                <BreakdownChart rows={breakdown.data.rows} groupBy={groupBy} showCache={showCache} />
+                <BreakdownChart
+                  rows={breakdown.data.rows}
+                  groupBy={groupBy}
+                  showCache={showCache}
+                  metric={metric}
+                  sortBy={sortBy}
+                />
               )}
             </ChartCard>
           </div>
@@ -253,6 +289,41 @@ function SummaryCards({
   );
 }
 
+// ---------------------------------------------------------------------------
+// Segmented control (reused by the breakdown chart's Metric / Sort toggles)
+// ---------------------------------------------------------------------------
+
+function SegmentedControl<T extends string>({
+  label,
+  options,
+  value,
+  onChange,
+}: {
+  label: string;
+  options: { value: T; label: string }[];
+  value: T;
+  onChange: (v: T) => void;
+}) {
+  return (
+    <div className="tv-chart-card__control">
+      <span className="tv-chart-card__control-label">{label}</span>
+      <div className="tv-segmented tv-segmented--sm" role="group" aria-label={label}>
+        {options.map((opt) => (
+          <button
+            key={opt.value}
+            type="button"
+            className={value === opt.value ? 'tv-segmented__btn is-active' : 'tv-segmented__btn'}
+            aria-pressed={value === opt.value}
+            onClick={() => onChange(opt.value)}
+          >
+            {opt.label}
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+}
+
 function StatCard({ label, value, sub }: { label: string; value: string; sub?: ReactNode }) {
   return (
     <div className="tv-card tv-stat-card">
@@ -272,19 +343,24 @@ function ChartCard({
   hint,
   loading,
   empty,
+  actions,
   children,
 }: {
   title: string;
   hint?: string;
   loading: boolean;
   empty: boolean;
+  actions?: ReactNode;
   children: ReactNode;
 }) {
   return (
     <section className="tv-card tv-chart-card">
       <div className="tv-chart-card__head">
-        <h2 className="tv-chart-card__title">{title}</h2>
-        {hint && <span className="tv-chart-card__hint">{hint}</span>}
+        <div className="tv-chart-card__heading">
+          <h2 className="tv-chart-card__title">{title}</h2>
+          {hint && <span className="tv-chart-card__hint">{hint}</span>}
+        </div>
+        {actions && <div className="tv-chart-card__actions">{actions}</div>}
       </div>
       {loading ? (
         <div className="tv-chart-empty">

--- a/packages/web/src/pages/analytics/BreakdownChart.tsx
+++ b/packages/web/src/pages/analytics/BreakdownChart.tsx
@@ -1,8 +1,13 @@
 /**
- * Horizontal breakdown bars for the active group-by (project | model | day):
- * stacked token segments per group plus the cost shown in the tooltip. Rows are
- * sorted by the visible token sum (desc) — total with cache shown, otherwise
- * input + output — and capped to the top 15 to stay readable.
+ * Horizontal breakdown bars for the active group-by (project | model | day).
+ *
+ * Two independent controls, supplied by the page:
+ *   - `metric` — what the bars render: stacked token segments (input/output/
+ *     cache) or a single cost bar. The x-axis units follow suit.
+ *   - `sortBy` — how rows are ordered (desc): by cost, or by the visible token
+ *     sum (total with cache shown, otherwise input + output).
+ * Either way the full token + cost breakdown stays in the tooltip, and the list
+ * is capped to the top 15 to stay readable.
  */
 
 import { useMemo } from 'react';
@@ -30,6 +35,11 @@ import { shortKey } from './format.js';
 
 const MAX_BARS = 15;
 
+/** What the bars render. */
+export type BreakdownMetric = 'tokens' | 'cost';
+/** How rows are ordered (descending). */
+export type BreakdownSort = 'tokens' | 'cost';
+
 interface Bucket {
   key: string;
   label: string;
@@ -44,15 +54,21 @@ export function BreakdownChart({
   rows,
   groupBy,
   showCache,
+  metric,
+  sortBy,
 }: {
   rows: AnalyticsRow[];
   groupBy: AnalyticsGroupBy;
   showCache: boolean;
+  metric: BreakdownMetric;
+  sortBy: BreakdownSort;
 }) {
-  // Sort by what the bars actually render: with cache hidden, ordering by the
-  // full total would shuffle the visible (input + output) bar lengths.
+  // Order by the chosen sort key. For tokens, sort by what the bars actually
+  // render: with cache hidden, ordering by the full total would shuffle the
+  // visible (input + output) bar lengths.
   const data = useMemo<Bucket[]>(() => {
-    const visible = (b: Bucket) => (showCache ? b.total : b.input + b.output);
+    const sortVal = (b: Bucket) =>
+      sortBy === 'cost' ? b.cost : showCache ? b.total : b.input + b.output;
     return rows
       .map((r) => ({
         key: r.key,
@@ -63,9 +79,9 @@ export function BreakdownChart({
         cost: r.costUsd,
         total: r.totalTokens,
       }))
-      .sort((a, b) => visible(b) - visible(a))
+      .sort((a, b) => sortVal(b) - sortVal(a))
       .slice(0, MAX_BARS);
-  }, [rows, groupBy, showCache]);
+  }, [rows, groupBy, showCache, sortBy]);
 
   // Scale height with the number of bars so labels never overlap.
   const height = Math.max(220, data.length * 34 + 60);
@@ -83,7 +99,7 @@ export function BreakdownChart({
           tick={tick}
           tickLine={false}
           axisLine={{ stroke: colors.grid }}
-          tickFormatter={(v: number) => formatCount(v)}
+          tickFormatter={(v: number) => (metric === 'cost' ? formatCost(v) : formatCount(v))}
         />
         <YAxis
           type="category"
@@ -96,9 +112,16 @@ export function BreakdownChart({
         />
         <Tooltip cursor={{ fill: colors.cursor }} content={<BreakdownTooltip colors={colors} />} />
         <Legend wrapperStyle={{ fontSize: 12 }} />
-        <Bar dataKey="input" name="Input" stackId="tok" fill={colors.input} isAnimationActive={false} />
-        <Bar dataKey="output" name="Output" stackId="tok" fill={colors.output} radius={showCache ? undefined : [0, 2, 2, 0]} isAnimationActive={false} />
-        {showCache && (
+        {metric === 'cost' && (
+          <Bar dataKey="cost" name="Cost" fill={colors.cost} radius={[0, 2, 2, 0]} isAnimationActive={false} />
+        )}
+        {metric === 'tokens' && (
+          <Bar dataKey="input" name="Input" stackId="tok" fill={colors.input} isAnimationActive={false} />
+        )}
+        {metric === 'tokens' && (
+          <Bar dataKey="output" name="Output" stackId="tok" fill={colors.output} radius={showCache ? undefined : [0, 2, 2, 0]} isAnimationActive={false} />
+        )}
+        {metric === 'tokens' && showCache && (
           <Bar dataKey="cache" name="Cache" stackId="tok" fill={colors.cacheWrite} radius={[0, 2, 2, 0]} isAnimationActive={false} />
         )}
       </BarChart>

--- a/packages/web/src/pages/analytics/analytics.css
+++ b/packages/web/src/pages/analytics/analytics.css
@@ -124,10 +124,16 @@
 }
 .tv-chart-card__head {
   display: flex;
-  align-items: baseline;
+  align-items: center;
   justify-content: space-between;
   gap: var(--tv-space-3);
   margin-bottom: var(--tv-space-4);
+  flex-wrap: wrap;
+}
+.tv-chart-card__heading {
+  display: flex;
+  align-items: baseline;
+  gap: var(--tv-space-3);
 }
 .tv-chart-card__title {
   font-size: var(--tv-fs-lg);
@@ -137,6 +143,31 @@
 .tv-chart-card__hint {
   font-size: var(--tv-fs-sm);
   color: var(--tv-fg-faint);
+}
+
+/* Per-chart action controls (e.g. the breakdown Metric / Sort toggles). */
+.tv-chart-card__actions {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: var(--tv-space-4);
+}
+.tv-chart-card__control {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--tv-space-2);
+}
+.tv-chart-card__control-label {
+  font-size: var(--tv-fs-sm);
+  color: var(--tv-fg-faint);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+/* Compact variant of the segmented toggle for chart-card headers. */
+.tv-segmented--sm .tv-segmented__btn {
+  padding: var(--tv-space-1) var(--tv-space-3);
+  font-size: var(--tv-fs-sm);
 }
 
 .tv-chart-empty {


### PR DESCRIPTION
## What

The Analytics → **Breakdown** chart (per project / agent / model / day) only ever spoke in tokens: bars were stacked input/output/cache token segments sorted by token volume, with cost relegated to the tooltip. This adds two independent controls to the breakdown card header so you can view and order the breakdown by **spend**:

- **Metric (Tokens | Cost)** — cost mode renders a single cost bar with a dollar-formatted x-axis; tokens mode keeps the existing stacked segments.
- **Sort by (Tokens | Cost)** — orders rows independently of the metric, so a project with lots of tokens but little spend (cache-heavy / cheaper model) is easy to spot.

Defaults stay `tokens` / `tokens`, so prior behavior and the README screenshot are unchanged. The tooltip still shows the full token + cost breakdown in every mode.

## Why two controls

Per product call they're orthogonal — all four combinations are reachable. A lone "sort by cost" that re-ordered token bars is visually incoherent (shorter bar above longer); the metric switch makes the cost view coherent.

## Implementation notes

- Cost bar uses sibling `{metric === 'cost' && <Bar/>}` conditionals (not a `<>`-wrapped group) — Recharts resolves children by component type and fragment flattening is version-sensitive; this matches the existing pattern.
- Controls live in the chart-card header (new `ChartCard` `actions` slot) since they only affect the breakdown chart, not the time series.
- Pure UI change — no API, contract, or index changes.

## Testing

- `npm run typecheck`, full `npm run build`, `npm test` (169 passing) — all green.
- Manual: drove the built app in headless Chromium against synthetic demo data (isolated `CLAUDESCOPE_HOME`, real `~/.claude` untouched) and verified all three control states render correctly.

Plan: [`docs/plans/0018-analytics-breakdown-cost.md`](./docs/plans/0018-analytics-breakdown-cost.md)