### PR TITLE
feat: add pi connector + official OpenAI pricing

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,9 +3,10 @@
 A local, **read-only**, **multi-agent** viewer to browse, read, search, and
 analyze AI coding-agent transcripts in one place — [Claude Code](https://claude.com/claude-code) (`~/.claude/projects/**/*.jsonl`),
 [OpenAI Codex](https://openai.com/codex)
-(`~/.codex/sessions/**/rollout-*.jsonl`), and
+(`~/.codex/sessions/**/rollout-*.jsonl`),
 [JetBrains Junie](https://www.jetbrains.com/junie/)
-(`~/.junie/sessions/session-*/events.jsonl`). Sessions are merged by working
+(`~/.junie/sessions/session-*/events.jsonl`), and [pi](https://pi.dev)
+(`~/.pi/agent/sessions/**/*.jsonl`). Sessions are merged by working
 directory into one project per `cwd`, each session tagged with its agent.
 Distributed as a single npm CLI (`@vladar107/claudescope`). This file is the
 source of truth for both humans and agents working in this repo; `AGENTS.md`
@@ -112,8 +113,17 @@ The CLI `update` command (`cli.ts`) detects the install method and defers to
 
 - **Thinking blocks render empty** — Claude Code stores only a signature (and
   Codex only encrypted reasoning), not the plaintext. Expected, not a bug.
+  **pi is the exception**: it stores plaintext thinking (plus an opaque
+  `thinkingSignature`), so pi reasoning renders in full.
 - **Codex sessions have no stored title** — the session title falls back to the
-  first user message (see `first_user` in `data/index.ts`).
+  first user message (see `first_user` in `data/index.ts`). Same for **pi**.
+- **pi connector** (`connectors/pi/`) — JSONL like Claude/Codex but `cwd` is on
+  the `session` line and tool results are separate `toolResult` records, so a
+  `prepare()` pass normalizes to canonical NDJSON (Codex pattern). `model` comes
+  per-turn from the assistant message (the `model_change` records are ignored for
+  attribution); the `uuid`/`parentUuid` chain is synthesized over message rows
+  because pi's native chain threads through `model_change`/`thinking_level_change`
+  records. pi has no home-dir memory, so the connector implements no memory.
 - **Junie transcripts read differently** — Junie stores an event-sourced UI
   stream (`events.jsonl`), not a chat log: no assistant prose and no thinking, so
   a session renders as tool/terminal/file blocks plus a final result. Expected,
@@ -129,3 +139,4 @@ The CLI `update` command (`cli.ts`) detects the install method and defers to
   OIDC). See `CONTRIBUTING.md`.
 
 See `CONTRIBUTING.md` for the full workflow and `README.md` for user-facing docs.
+

--- a/README.md
+++ b/README.md
@@ -20,14 +20,15 @@ machine and only ever reads your transcripts.
 | [Claude Code](https://claude.com/claude-code)     | `~/.claude/projects/**/*.jsonl`               |
 | [OpenAI Codex](https://openai.com/codex)          | `~/.codex/sessions/**/rollout-*.jsonl`        |
 | [JetBrains Junie](https://www.jetbrains.com/junie/) | `~/.junie/sessions/session-*/events.jsonl`  |
+| [pi](https://pi.dev)                              | `~/.pi/agent/sessions/**/*.jsonl`             |
 
 Each source is optional — a directory that doesn't exist is simply skipped, so
-Claudescope works whether you use one agent or all three. Adding another is just
+Claudescope works whether you use one agent or all four. Adding another is just
 [adding another connector](#how-it-works).
 
 ## What it can do
 
-- **Multi-agent** — Claude Code, Codex, and Junie sessions side by side, each labeled with an **agent badge**. A project that several agents touched shows one card with all its agent tags; drill in and **filter the session list by agent**.
+- **Multi-agent** — Claude Code, Codex, Junie, and pi sessions side by side, each labeled with an **agent badge**. A project that several agents touched shows one card with all its agent tags; drill in and **filter the session list by agent**.
 - **Browse** every session grouped by project — titles, dates, message/tool counts, token totals, cost, git branch, PR links.
 - **Read** a session as a clean threaded conversation: markdown, syntax-highlighted code, collapsible thinking, paired tool calls + results, **syntax-highlighted red/green diffs** for edits, attachments, and sidechain/subagent turns. A built-in **find-in-session** bar (⌘/Ctrl+F) searches the whole transcript — including collapsed thinking, tool, and subagent content — auto-expanding and highlighting matches, with a user/assistant filter.
 - **Review changes** via a **Files changed** tab that aggregates every edit/write in the session by file, with per-file diffs and +/− counts (diffs load lazily per file).
@@ -172,11 +173,12 @@ All optional — set via environment variables.
 | `CLAUDE_PROJECTS_DIR` | `~/.claude/projects`   | Where to read Claude Code transcripts from. A leading `~` is expanded. |
 | `CODEX_SESSIONS_DIR`  | `~/.codex/sessions`    | Where to read OpenAI Codex transcripts from. A leading `~` is expanded.|
 | `JUNIE_SESSIONS_DIR`  | `~/.junie/sessions`    | Where to read JetBrains Junie transcripts from. A leading `~` is expanded.|
+| `PI_SESSIONS_DIR`     | `~/.pi/agent/sessions` | Where to read pi transcripts from. A leading `~` is expanded.          |
 | `CLAUDESCOPE_HOME`    | `~/.claudescope`       | Where the app keeps its own state (index, pricing copy, logs, PID).    |
 | `REINDEX_INTERVAL_MS` | `15000`                | How often to auto-pick-up new/updated sessions. Set `0` to disable.    |
 
 Each agent source is optional — if a directory doesn't exist it's simply skipped,
-so the app works whether you use one agent or all three.
+so the app works whether you use one agent or all four.
 
 Examples:
 
@@ -185,6 +187,7 @@ claudescope --port 8080                                  # custom port
 CLAUDE_PROJECTS_DIR=/path/to/exported/projects claudescope  # view someone else's transcripts
 CODEX_SESSIONS_DIR=/path/to/codex/sessions claudescope   # point at Codex sessions elsewhere
 JUNIE_SESSIONS_DIR=/path/to/junie/sessions claudescope   # point at Junie sessions elsewhere
+PI_SESSIONS_DIR=/path/to/pi/sessions claudescope         # point at pi sessions elsewhere
 claudescope --no-open                                    # don't pop a browser tab
 ```
 
@@ -279,12 +282,16 @@ served from cache (legitimately high for Claude Code, which re-reads cached cont
   (and Codex only encrypted reasoning), not the plaintext — the app notes this
   explicitly. (Not a bug.)
 - **Codex sessions have no stored title**, so the title falls back to the first
-  user message.
+  user message. The same is true for **pi** sessions.
 - **Junie sessions render differently.** Junie records an event-sourced UI stream
   rather than a chat log, so a session reads as tool / terminal / file blocks plus
   a final result — there's no assistant prose or thinking to show. Pasted
   screenshots are surfaced inline. Older Junie sessions don't record a working
   directory and group under an **"(unknown — Junie)"** project.
+- **pi reasoning renders in full.** Unlike Claude Code / Codex, pi stores the
+  plaintext of its thinking blocks, so they show real reasoning rather than an
+  empty placeholder. pi keeps no memory in its home dir, so it contributes nothing
+  to the memory viewer.
 
 ---
 
@@ -363,7 +370,7 @@ shell, and self-update behavior — and how to report a vulnerability.
 ## Troubleshooting
 
 - **App is empty / "sessions directory not found"** — none of `CLAUDE_PROJECTS_DIR`,
-  `CODEX_SESSIONS_DIR`, or `JUNIE_SESSIONS_DIR` points at real transcripts. Check
+  `CODEX_SESSIONS_DIR`, `JUNIE_SESSIONS_DIR`, or `PI_SESSIONS_DIR` points at real transcripts. Check
   the banner and set them correctly. Any source can be absent; only the present
   ones are indexed.
 - **`Error: listen EADDRINUSE :4317`** — the port is taken; run `claudescope --port <n>`.

--- a/docs/plans/0019-pi-connector.md
+++ b/docs/plans/0019-pi-connector.md
@@ -1,0 +1,179 @@
+# 0019 — pi connector
+
+- **Status:** done <!-- proposed | in-progress | done | superseded | abandoned -->
+- **Date:** 2026-06-15
+- **PR:** https://github.com/vladar107/claudescope/pull/22
+
+## Context
+
+[pi](https://pi.dev) (v0.79.4, `@earendil-works/pi-coding-agent` — Mario
+Zechner's minimal terminal coding harness, backed here by the `openai-codex`
+provider) writes transcripts to `~/.pi/agent/sessions/<encoded-cwd>/<ts>_<uuid>.jsonl`
+— one JSONL per session, grouped per working directory, exactly like Claude Code
+and Codex.
+Adding it is a new `AgentConnector`; the index/FTS/cost/derived paths stay shared
+(see `0004-connector-seam.md`, `0005-codex-connector.md`).
+
+The format is **threaded JSONL very close to Claude Code**, but two session-level
+facts are spread across record types, so it needs a Codex-style `prepare()`
+normalizer rather than a per-row DuckDB projection.
+
+Record shape (verified against the two real sessions on disk):
+
+- `{type:"session", version, id, timestamp, cwd}` — **cwd lives here only**.
+- `{type:"model_change", provider, modelId}` — model selection records.
+- `{type:"thinking_level_change", thinkingLevel}` — reasoning-effort records.
+- `{type:"message", id, parentId, timestamp, message:{role, content[], model,
+  provider, usage}}` — the conversation. `message.usage` is camelCase
+  `{input, output, cacheRead, cacheWrite, totalTokens, cost}` on assistant turns.
+- content blocks: `text`, `thinking` (**plaintext** in `.thinking`, plus an
+  encrypted `thinkingSignature`), `toolCall {id, name, arguments}`, and a
+  separate `toolResult {toolCallId, toolName, content[]}` record.
+
+## Goal
+
+pi sessions are indexed, browsable, searchable, costed, and render with text,
+**plaintext thinking**, tool calls, and tool results — merged into the per-`cwd`
+project view and tagged with a `pi` agent badge.
+
+## Decisions
+
+- **`prepare()`-based normalizer (Codex pattern), not a per-row projection** —
+  `cwd` is only on the `session` line and must be broadcast to every event; a TS
+  pre-pass is the established way (`codex/normalize.ts`). Output a canonical
+  NDJSON to `~/.claudescope/cache/pi/<sha1(path)>.ndjson`; the projection reads it
+  1:1 with the same column map Codex/Junie use.
+- **Model/provider taken per-turn from `message.model`/`message.provider`; ignore
+  `model_change` for attribution** — verified every assistant turn self-reports
+  its model, so we sidestep mid-session-switch and branching concerns. Only `cwd`
+  is carried forward (from the `session` line).
+- **Synthesize a fresh sequential `uuid`/`parentUuid` chain over message rows
+  only** (`<sessionId>-<seq++>`, `prevUuid → next`) — pi's native `parentId`
+  graph threads *through* `model_change`/`thinking_level_change` records (the
+  first user turn's `parentId` points at a `thinking_level_change` id), so copying
+  it verbatim would dangle. Matches `codex/normalize.ts`.
+- **Thinking is PLAINTEXT — map `block.thinking → ThinkingBlock.thinking`, do NOT
+  blank it**, and carry `thinkingSignature → ThinkingBlock.signature`. This is the
+  one place pi diverges from the "thinking renders empty" gotcha (Claude/Codex
+  store only a signature). A connector that blanked it would silently drop
+  readable reasoning pi actually preserves.
+- **Tool results ride a synthetic `user` event** (there is no `toolResult`
+  RawEvent type), paired to their `tool_use` by the **verbatim composite id**
+  (`call_…|fc_…`) — preserve the full id on both sides or pairing breaks.
+- **Map pi's tool vocabulary to Claude's canonical names** (`edit`→`MultiEdit`,
+  `write`→`Write`, `read`→`Read`, `bash`→`Bash`), translating input keys
+  (`path`→`file_path`, `edits[].oldText/newText`→`old_string/new_string`). The web
+  renderer (`ToolBlock`) and the **Files-changed tab** (`changeset.ts`) key off the
+  Claude tool names + `file_path`; without this, pi edits never reach the
+  Files-changed tab and tools render as raw JSON. Mirrors how the Junie connector
+  emits canonical `Edit` blocks. Unknown tools pass through with their native name.
+- **Preserve images / embed screenshots.** pi stores a pasted screenshot as
+  `{type:'image', data, mimeType}` inside the `read` tool *result* (the user
+  message only holds the temp-file path). Map it to the canonical
+  `ImageBlock` (`source:{type:'base64', media_type, data}`) so `extractImage`
+  renders it — the normalizer must keep image blocks, not just text. One small,
+  Claude-safe web tweak: the `Read` renderer now uses `ResultSection` whenever the
+  result has non-text blocks, so an image read shows the picture even when pi also
+  includes a descriptive text block (previously the text suppressed the image).
+- **`message_id = NULL`** (pi has no per-block id and no fork/resume) → every row
+  is usage-canonical, no dedup logic. `forked_from_session_id = NULL`,
+  `service_tier = NULL` (absent in pi), `git_branch = NULL` (not stored).
+- **Token map (camelCase):** `input→input_tokens`, `output→output_tokens`,
+  `cacheRead→cache_read_tokens`, `cacheWrite→cache_write_tokens`; user/toolResult
+  rows get zero usage. pi's own `cost` is ignored — Claudescope recomputes from
+  tokens × pricing, as for every connector.
+- **No memory (decided: skip for both pi and opencode).** `~/.pi` holds only
+  `settings.json`/`auth.json`; pi's instruction files are the project-local
+  `CLAUDE.md`/`AGENTS.md`, out of scope under the read-only-home invariant. Per
+  the maintainer decision, the connector implements **neither** `globalMemory()`
+  **nor** `projectMemory()` (both omitted) — pi simply doesn't appear in the
+  memory viewer.
+- **Pricing landed with this work (already applied).** pi uses `gpt-5.4-mini`,
+  which was missing from `pricing.json` and mis-resolved to the `gpt` family
+  (2.5/15) — a ~3.3× overcharge. `pricing.json` was repopulated from OpenAI's
+  official tables (June 2026): the full GPT‑5.x / GPT‑4.x / o‑series / Codex /
+  ChatGPT lineup as exact‑id entries (short‑context rates), so exact‑id joins win
+  over the order‑fragile family matching. This also **corrected two pre‑existing
+  errors**: `gpt-5` was `0.625/5` (official `1.25/10`) and `gpt-5.4` cached was
+  `0.5` (official `0.25`). `gpt-5.4-mini-fast` (opencode's id) is priced as
+  `gpt-5.4-mini` — there is no official `-fast` SKU; it's opencode's service‑tier
+  label. `PRICING_SCHEMA_VERSION` bumped `1 → 2` so existing user copies merge the
+  new keys (user edits still win — so a user whose copy predates this keeps their
+  old `gpt-5`/`gpt-5.4` values; fresh installs and the LiteLLM refresh get the
+  corrected ones).
+
+## Approach
+
+1. `packages/server/src/config.ts` — add `PI_SESSIONS_DIR`
+   (`~/.pi/agent/sessions`, env-overridable, `~`-expanded) and derived `PI_HOME`
+   (= `dirname(dirname(PI_SESSIONS_DIR))` → `~/.pi`), mirroring the existing
+   Claude/Codex/Junie constants.
+2. `packages/server/src/connectors/pi/normalize.ts` — parse one session JSONL into
+   Claude-shaped `RawEvent[]` (cwd from the session line; synthesized uuid chain;
+   plaintext thinking; tool_use on assistant turns; tool_result on a following
+   user turn paired by composite id) and `toCanonicalRows()` → the canonical NDJSON
+   rows. Tolerate blank/corrupt lines and unknown record types.
+3. `packages/server/src/connectors/pi/pi.ts` — the `AgentConnector`: `discover()`
+   (walk the sessions tree, real path as the key), `prepare()` (write the cache
+   NDJSON), `eventsProjectionSql()` (read the cache, identical shape to Codex),
+   `auxProjections()` → `{}` (no titles/PR links; first-user-message title
+   fallback applies), `loadSession()` (re-run the normalizer → `{mainEvents,
+   subagents: []}`). No `globalMemory`/`projectMemory` (memory skipped).
+4. `packages/server/src/connectors/registry.ts` — register `piConnector`.
+5. **Pricing** — ✅ done. `packages/server/pricing.json` repopulated from
+   OpenAI's official tables (full GPT‑5.x/4.x/o‑series/Codex lineup as exact‑ids,
+   short‑context rates), incl. `gpt-5.4-mini` + `gpt-5.4-mini-fast`; corrected
+   `gpt-5`/`gpt-5.4`; `PRICING_SCHEMA_VERSION` bumped to 2 in `config.ts`.
+6. **Web** — `packages/web/src/components/AgentBadge.tsx` add `'pi' → 'pi'`;
+   `packages/web/src/pages/browse/browse.css` add `.tv-agent--pi` colors
+   (dark + light).
+7. **Docs** — `README.md` supported-agents + env-var tables; `CLAUDE.md` gotchas
+   ("pi thinking renders plaintext, unlike Claude/Codex").
+
+## Files affected
+
+- `packages/server/src/config.ts` — `PI_SESSIONS_DIR` + `PI_HOME`.
+- `packages/server/src/connectors/pi/{normalize,pi}.ts` — new connector (+ memory
+  is intentionally empty, so no `memory.ts`).
+- `packages/server/src/connectors/registry.ts` — register.
+- `packages/server/pricing.json` + `config.ts` `PRICING_SCHEMA_VERSION` — gpt-5.4
+  family rates.
+- `packages/server/src/data/index.ts` — build the pricing join table lazily (only
+  on the first file load) so a no-op reindex does no pricing work. Avoids a perf
+  regression from the now-larger pricing table on the 15s auto-poll.
+- `packages/web/src/components/AgentBadge.tsx`, `pages/browse/browse.css` — label
+  + badge color.
+- `packages/web/src/components/ToolBlock.tsx` — `Read` renderer shows image
+  results even when descriptive text is present (Claude-safe; fixes pi screenshots).
+- `packages/server/test/pi.integration.test.ts` — new suite (fixtures in a temp
+  dir; never touches real `~/.pi`). Add `PI_SESSIONS_DIR` isolation to the other
+  integration/pricing/dedup/recovery suites.
+- `README.md`, `CLAUDE.md`, `docs/plans/README.md` (index row).
+
+## Testing
+
+`npm run typecheck` + `npm test`. New integration fixtures target the weird stuff
+(per `CLAUDE.md` test guidance), not happy-path glue:
+
+- **cwd broadcast** — every event gets the session-line `cwd` (project grouping).
+- **plaintext thinking survives** — a `thinking` block's text reaches
+  `text_content`/the rendered thread (regression guard for the blank-thinking trap).
+- **tool_use ↔ tool_result pairing** by composite `call_…|fc_…` id, including a
+  fan-out turn with multiple tool calls.
+- **dangling-parent avoidance** — first user turn whose native `parentId` points at
+  a `thinking_level_change` record still threads (synthesized chain).
+- **cost** — a `gpt-5.4-mini` assistant turn costs `tokens × 0.75/4.50/0.075`, not
+  the `gpt`-family 2.5/15.
+- **malformed/truncated trailing line** is skipped, not fatal.
+
+## Risks / open questions
+
+- **`gpt-5.4-mini-fast` premium tier** — we price it as standard `gpt-5.4-mini`.
+  OpenAI's priority/"fast" processing can cost ~2× standard; opencode's `-fast`
+  suffix (see `0020`) may or may not map to priority billing. Pricing is a local
+  estimate; confirm with the user / adjust the exact-id rate if they're on priority.
+- **Older pi schema versions** — discovered files are `version: 3`; guard the
+  `prepare()` pass for hypothetical v1/v2 (not observed) instead of assuming the v3
+  shape.
+- **`thinkingSignature` is JSON-wrapped** (an OpenAI Responses reasoning blob),
+  unlike Claude's opaque signature — store as-is; it is render-irrelevant.

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -43,3 +43,4 @@ decision, or a change worth explaining before doing. Skip it for one-line fixes.
 | 0016 | [Dep upgrades: vite 8 / vitest 4 / shiki 4 (clear Dependabot)](./0016-dep-upgrades-vite8-shiki4.md) | done   |
 | 0017 | [Maintainer review fixes: resiliency tests, daemon hardening, render & contract guards](./0017-maintainer-review-fixes.md) | done |
 | 0018 | [Analytics breakdown by cost (Metric + Sort toggles)](./0018-analytics-breakdown-cost.md) | done |
+| 0019 | [pi connector](./0019-pi-connector.md) | done |

--- a/packages/server/perf/run.ts
+++ b/packages/server/perf/run.ts
@@ -32,8 +32,9 @@ const outPath = resolve(String(values.out));
 const work = mkdtempSync(join(tmpdir(), 'claudescope-perf-'));
 const projectsDir = join(work, 'projects');
 process.env.CLAUDE_PROJECTS_DIR = projectsDir;
-// Isolate from any real ~/.codex so the bench corpus is exactly what we generate.
+// Isolate from any real ~/.codex / ~/.pi so the bench corpus is exactly what we generate.
 process.env.CODEX_SESSIONS_DIR = join(work, 'codex-empty');
+process.env.PI_SESSIONS_DIR = join(work, 'pi-empty');
 process.env.DUCKDB_PATH = join(work, 'index.duckdb');
 process.env.CLAUDESCOPE_HOME = join(work, 'home');
 process.env.REINDEX_INTERVAL_MS = '0';

--- a/packages/server/pricing.json
+++ b/packages/server/pricing.json
@@ -1,20 +1,64 @@
 {
-  "schemaVersion": 1,
+  "schemaVersion": 2,
   "models": {
     "claude-opus-4-1": { "input": 15, "output": 75, "cacheWrite": 18.75, "cacheRead": 1.5 },
     "claude-opus-4": { "input": 15, "output": 75, "cacheWrite": 18.75, "cacheRead": 1.5 },
     "<synthetic>": { "input": 0, "output": 0, "cacheWrite": 0, "cacheRead": 0 },
-    "gpt-5": { "input": 0.625, "output": 5, "cacheWrite": 0, "cacheRead": 0.125 },
-    "gpt-5.4": { "input": 2.5, "output": 15, "cacheWrite": 0, "cacheRead": 0.5 },
+
     "gpt-5.5": { "input": 5, "output": 30, "cacheWrite": 0, "cacheRead": 0.5 },
-    "gpt-5.5-pro": { "input": 30, "output": 180, "cacheWrite": 0, "cacheRead": 30 }
+    "gpt-5.5-pro": { "input": 30, "output": 180, "cacheWrite": 0, "cacheRead": 30 },
+    "gpt-5.5-cyber": { "input": 20, "output": 120, "cacheWrite": 0, "cacheRead": 2 },
+
+    "gpt-5.4": { "input": 2.5, "output": 15, "cacheWrite": 0, "cacheRead": 0.25 },
+    "gpt-5.4-mini": { "input": 0.75, "output": 4.5, "cacheWrite": 0, "cacheRead": 0.075 },
+    "gpt-5.4-mini-fast": { "input": 0.75, "output": 4.5, "cacheWrite": 0, "cacheRead": 0.075 },
+    "gpt-5.4-nano": { "input": 0.2, "output": 1.25, "cacheWrite": 0, "cacheRead": 0.02 },
+    "gpt-5.4-pro": { "input": 30, "output": 180, "cacheWrite": 0, "cacheRead": 30 },
+
+    "gpt-5.3-codex": { "input": 1.75, "output": 14, "cacheWrite": 0, "cacheRead": 0.175 },
+    "gpt-5.3-chat-latest": { "input": 1.75, "output": 14, "cacheWrite": 0, "cacheRead": 0.175 },
+
+    "gpt-5.2": { "input": 1.75, "output": 14, "cacheWrite": 0, "cacheRead": 0.175 },
+    "gpt-5.2-pro": { "input": 21, "output": 168, "cacheWrite": 0, "cacheRead": 21 },
+    "gpt-5.2-codex": { "input": 1.75, "output": 14, "cacheWrite": 0, "cacheRead": 0.175 },
+    "gpt-5.2-chat-latest": { "input": 1.75, "output": 14, "cacheWrite": 0, "cacheRead": 0.175 },
+
+    "gpt-5.1": { "input": 1.25, "output": 10, "cacheWrite": 0, "cacheRead": 0.125 },
+    "gpt-5.1-codex-max": { "input": 1.25, "output": 10, "cacheWrite": 0, "cacheRead": 0.125 },
+    "gpt-5.1-codex": { "input": 1.25, "output": 10, "cacheWrite": 0, "cacheRead": 0.125 },
+    "gpt-5.1-codex-mini": { "input": 0.25, "output": 2, "cacheWrite": 0, "cacheRead": 0.025 },
+    "gpt-5.1-chat-latest": { "input": 1.25, "output": 10, "cacheWrite": 0, "cacheRead": 0.125 },
+
+    "gpt-5": { "input": 1.25, "output": 10, "cacheWrite": 0, "cacheRead": 0.125 },
+    "gpt-5-mini": { "input": 0.25, "output": 2, "cacheWrite": 0, "cacheRead": 0.025 },
+    "gpt-5-nano": { "input": 0.05, "output": 0.4, "cacheWrite": 0, "cacheRead": 0.005 },
+    "gpt-5-pro": { "input": 15, "output": 120, "cacheWrite": 0, "cacheRead": 15 },
+    "gpt-5-codex": { "input": 1.25, "output": 10, "cacheWrite": 0, "cacheRead": 0.125 },
+    "gpt-5-chat-latest": { "input": 1.25, "output": 10, "cacheWrite": 0, "cacheRead": 0.125 },
+    "gpt-5-search-api": { "input": 1.25, "output": 10, "cacheWrite": 0, "cacheRead": 0.125 },
+
+    "gpt-4.1": { "input": 2, "output": 8, "cacheWrite": 0, "cacheRead": 0.5 },
+    "gpt-4.1-mini": { "input": 0.4, "output": 1.6, "cacheWrite": 0, "cacheRead": 0.1 },
+    "gpt-4.1-nano": { "input": 0.1, "output": 0.4, "cacheWrite": 0, "cacheRead": 0.025 },
+
+    "gpt-4o": { "input": 2.5, "output": 10, "cacheWrite": 0, "cacheRead": 1.25 },
+    "gpt-4o-mini": { "input": 0.15, "output": 0.6, "cacheWrite": 0, "cacheRead": 0.075 },
+    "chatgpt-4o-latest": { "input": 5, "output": 15, "cacheWrite": 0, "cacheRead": 5 },
+
+    "codex-mini-latest": { "input": 1.5, "output": 6, "cacheWrite": 0, "cacheRead": 0.375 },
+
+    "o4-mini": { "input": 1.1, "output": 4.4, "cacheWrite": 0, "cacheRead": 0.275 },
+    "o3": { "input": 2, "output": 8, "cacheWrite": 0, "cacheRead": 0.5 },
+    "o3-mini": { "input": 1.1, "output": 4.4, "cacheWrite": 0, "cacheRead": 0.55 },
+    "o3-pro": { "input": 20, "output": 80, "cacheWrite": 0, "cacheRead": 20 },
+    "o1": { "input": 15, "output": 60, "cacheWrite": 0, "cacheRead": 7.5 }
   },
   "families": {
     "opus": { "input": 5, "output": 25, "cacheWrite": 6.25, "cacheRead": 0.5 },
     "sonnet": { "input": 3, "output": 15, "cacheWrite": 3.75, "cacheRead": 0.3 },
     "haiku": { "input": 1, "output": 5, "cacheWrite": 1.25, "cacheRead": 0.1 },
     "gemini": { "input": 1.25, "output": 10, "cacheWrite": 0, "cacheRead": 0.31 },
-    "gpt": { "input": 2.5, "output": 15, "cacheWrite": 0, "cacheRead": 0.5 }
+    "gpt": { "input": 2.5, "output": 15, "cacheWrite": 0, "cacheRead": 0.25 }
   },
   "default": { "input": 3, "output": 15, "cacheWrite": 3.75, "cacheRead": 0.3 }
 }

--- a/packages/server/src/config.ts
+++ b/packages/server/src/config.ts
@@ -57,6 +57,16 @@ export const JUNIE_SESSIONS_DIR = expandHome(
 );
 
 /**
+ * READ-ONLY source of pi (`@earendil-works/pi-coding-agent`) sessions. The app
+ * MUST NEVER write here. Defaults to `~/.pi/agent/sessions` (one
+ * `<ts>_<uuid>.jsonl` per session, under a per-`cwd` directory). Override with
+ * PI_SESSIONS_DIR. A leading `~` is expanded.
+ */
+export const PI_SESSIONS_DIR = expandHome(
+  process.env.PI_SESSIONS_DIR ?? join(homedir(), '.pi', 'agent', 'sessions'),
+);
+
+/**
  * READ-ONLY agent home directories — the parents of the session/project dirs
  * above, where each agent keeps its memory (`CLAUDE.md`, `AGENTS.md`, the Codex
  * `memories/` tree). Derived from the dirs above so the env overrides carry
@@ -163,7 +173,7 @@ export const APP_VERSION =
  * shadowing it. A monotonic integer (not a content hash): the user copy is meant
  * to be edited, so only a real shipped change should trigger a reconcile.
  */
-export const PRICING_SCHEMA_VERSION = 1;
+export const PRICING_SCHEMA_VERSION = 2;
 
 /**
  * Reconcile the user-editable pricing file with the shipped default.

--- a/packages/server/src/connectors/pi/normalize.ts
+++ b/packages/server/src/connectors/pi/normalize.ts
@@ -1,0 +1,344 @@
+/**
+ * pi session → canonical thread normalizer.
+ *
+ * A pi session (`<ts>_<uuid>.jsonl`) is a flat, threaded record stream: a
+ * `session` line (carrying `cwd` + the session id), `message` records
+ * (`role: user | assistant | toolResult`), and `model_change` /
+ * `thinking_level_change` records. The conversation lives entirely in the
+ * `message` records; the model and usage ride the assistant message itself, and
+ * `cwd` ride the single `session` line.
+ *
+ * This parses one session into Claude-shaped `RawEvent[]` — assistant/user turns
+ * whose `message.content` carries text / thinking / tool_use / tool_result blocks
+ * — so the existing thread assembler and the canonical index row builder both
+ * reuse it (mirrors `codex/normalize.ts`).
+ *
+ * Grouping: each assistant/user `message` record becomes one turn; consecutive
+ * `toolResult` records coalesce into a single user turn carrying all their
+ * `tool_result` blocks (the Claude convention the thread assembler expects).
+ * The `uuid`/`parentUuid` chain is synthesized in file order — pi's native
+ * `parentId` graph threads *through* `model_change`/`thinking_level_change`
+ * records, so copying it verbatim would dangle.
+ *
+ * STRICTLY READ-ONLY with respect to ~/.pi — files are only ever read.
+ */
+
+import { readFileSync } from 'node:fs';
+import type { AssistantEvent, ContentBlock, MessageUsage, UserEvent } from '@claudescope/shared';
+
+export interface PiSession {
+  sessionId: string;
+  cwd: string;
+  events: (UserEvent | AssistantEvent)[];
+}
+
+const str = (v: unknown): string => (typeof v === 'string' ? v : '');
+const num = (v: unknown): number => (typeof v === 'number' && Number.isFinite(v) ? v : 0);
+
+/** pi assistant `usage` (`{input, output, cacheRead, cacheWrite, …}`) → canonical usage. */
+function toUsage(raw: unknown): MessageUsage {
+  const u = (raw ?? {}) as Record<string, unknown>;
+  return {
+    input_tokens: num(u.input),
+    output_tokens: num(u.output),
+    cache_read_input_tokens: num(u.cacheRead),
+    cache_creation_input_tokens: num(u.cacheWrite),
+  };
+}
+
+/**
+ * Map a pi `toolCall` to a canonical `tool_use` block. pi's tool vocabulary maps
+ * 1:1 onto Claude's, so we translate names + input keys to the shapes the web
+ * renderer and the Files-changed changeset extractor recognize — both key off the
+ * Claude tool names (`Edit`/`MultiEdit`/`Write`/`Read`/`Bash`) and `file_path`,
+ * NOT pi's lowercase `edit`/`read`/`bash` with `path`/`oldText`/`newText`. Without
+ * this, pi's file edits never reach the Files-changed tab and tools render as raw
+ * JSON. Mirrors how the Junie connector emits canonical `Edit` blocks. Unknown
+ * tools pass through with their native name (generic rendering).
+ */
+function toolUseBlock(b: Record<string, unknown>): ContentBlock {
+  const id = str(b.id);
+  const args = (b.arguments ?? {}) as Record<string, unknown>;
+  switch (str(b.name)) {
+    case 'edit': {
+      // pi edits are `{path, edits:[{oldText,newText}]}` → Claude MultiEdit.
+      const edits = (Array.isArray(args.edits) ? args.edits : []).map((e) => {
+        const er = (e ?? {}) as Record<string, unknown>;
+        return { old_string: str(er.oldText), new_string: str(er.newText) };
+      });
+      return { type: 'tool_use', id, name: 'MultiEdit', input: { file_path: str(args.path), edits } };
+    }
+    case 'write':
+      return {
+        type: 'tool_use',
+        id,
+        name: 'Write',
+        input: { file_path: str(args.path), content: str(args.content) || str(args.text) },
+      };
+    case 'read':
+      return {
+        type: 'tool_use',
+        id,
+        name: 'Read',
+        input: { file_path: str(args.path), offset: args.offset, limit: args.limit },
+      };
+    case 'bash':
+      return {
+        type: 'tool_use',
+        id,
+        name: 'Bash',
+        input: { command: str(args.command), timeout: args.timeout, description: str(args.description) },
+      };
+    default:
+      return { type: 'tool_use', id, name: str(b.name), input: args };
+  }
+}
+
+/** Map a pi assistant message's content blocks to canonical content blocks. */
+function assistantBlocks(content: unknown): ContentBlock[] {
+  if (!Array.isArray(content)) return [];
+  const out: ContentBlock[] = [];
+  for (const c of content) {
+    if (!c || typeof c !== 'object') continue;
+    const b = c as Record<string, unknown>;
+    switch (str(b.type)) {
+      case 'text': {
+        const text = str(b.text);
+        if (text) out.push({ type: 'text', text });
+        break;
+      }
+      case 'thinking':
+        // pi stores PLAINTEXT reasoning (not just a signature, unlike Claude /
+        // Codex) — keep it. `thinkingSignature` is an opaque encrypted blob.
+        out.push({
+          type: 'thinking',
+          thinking: str(b.thinking),
+          ...(str(b.thinkingSignature) ? { signature: str(b.thinkingSignature) } : {}),
+        });
+        break;
+      case 'image': {
+        const img = imageBlock(b);
+        if (img) out.push(img);
+        break;
+      }
+      case 'toolCall':
+        out.push(toolUseBlock(b));
+        break;
+      default:
+        break; // unknown block type — tolerate and skip
+    }
+  }
+  return out;
+}
+
+/** Map a pi `{type:'image', data, mimeType}` block to a canonical ImageBlock. */
+function imageBlock(b: Record<string, unknown>): ContentBlock | null {
+  const data = str(b.data);
+  if (!data) return null; // only inline base64 is embeddable
+  return {
+    type: 'image',
+    source: { type: 'base64', media_type: str(b.mimeType) || 'image/png', data },
+  };
+}
+
+/**
+ * Map a pi user / toolResult message's content to canonical blocks. Keeps text
+ * AND images: pi returns a pasted screenshot as `{type:'image', data, mimeType}`
+ * inside a `read` tool result (the user message only holds the temp-file path),
+ * so dropping non-text blocks here would lose the embedded screenshot.
+ */
+function contentBlocks(content: unknown): ContentBlock[] {
+  if (typeof content === 'string') {
+    return content ? [{ type: 'text', text: content }] : [];
+  }
+  if (!Array.isArray(content)) return [];
+  const out: ContentBlock[] = [];
+  for (const c of content) {
+    if (!c || typeof c !== 'object') continue;
+    const b = c as Record<string, unknown>;
+    if (str(b.type) === 'text') {
+      if (str(b.text)) out.push({ type: 'text', text: str(b.text) });
+    } else if (str(b.type) === 'image') {
+      const img = imageBlock(b);
+      if (img) out.push(img);
+    }
+  }
+  return out;
+}
+
+interface PiLine {
+  type?: string;
+  timestamp?: string;
+  message?: {
+    role?: string;
+    content?: unknown;
+    model?: string;
+    usage?: unknown;
+    toolCallId?: string;
+  };
+  id?: string;
+  cwd?: string;
+}
+
+/** Parse a pi session JSONL into a Claude-shaped session, or null if unreadable. */
+export function parsePiSession(path: string): PiSession | null {
+  let raw: string;
+  try {
+    raw = readFileSync(path, 'utf8');
+  } catch {
+    return null;
+  }
+  const lines: PiLine[] = [];
+  for (const line of raw.split('\n')) {
+    const t = line.trim();
+    if (!t) continue;
+    try {
+      lines.push(JSON.parse(t) as PiLine);
+    } catch {
+      /* tolerate a corrupt/partial trailing line */
+    }
+  }
+
+  // The session record carries the immutable session id + cwd for every event.
+  const session = lines.find((l) => l.type === 'session');
+  const sessionId = str(session?.id) || path;
+  const cwd = str(session?.cwd);
+
+  const events: (UserEvent | AssistantEvent)[] = [];
+  let seq = 0;
+  let prevUuid: string | null = null;
+  const nextUuid = (): string => `${sessionId}-${seq++}`;
+
+  // Consecutive `toolResult` records coalesce into one user turn.
+  let toolResults: ContentBlock[] = [];
+  let toolResultTs = '';
+  const flushToolResults = (): void => {
+    if (toolResults.length === 0) return;
+    const uuid = nextUuid();
+    events.push({
+      uuid,
+      parentUuid: prevUuid,
+      sessionId,
+      timestamp: toolResultTs,
+      cwd,
+      isSidechain: false,
+      type: 'user',
+      message: { role: 'user', content: toolResults },
+    } as UserEvent);
+    prevUuid = uuid;
+    toolResults = [];
+    toolResultTs = '';
+  };
+
+  for (const line of lines) {
+    if (line.type !== 'message' || !line.message) continue;
+    const msg = line.message;
+    const role = str(msg.role);
+    const ts = str(line.timestamp);
+
+    if (role === 'toolResult') {
+      toolResults.push({
+        type: 'tool_result',
+        tool_use_id: str(msg.toolCallId),
+        content: contentBlocks(msg.content),
+      });
+      if (!toolResultTs) toolResultTs = ts;
+      continue;
+    }
+
+    // A real user/assistant turn closes any pending tool-result group first.
+    flushToolResults();
+
+    if (role === 'assistant') {
+      const uuid = nextUuid();
+      events.push({
+        uuid,
+        parentUuid: prevUuid,
+        sessionId,
+        timestamp: ts,
+        cwd,
+        isSidechain: false,
+        type: 'assistant',
+        message: {
+          role: 'assistant',
+          model: str(msg.model),
+          content: assistantBlocks(msg.content),
+          usage: toUsage(msg.usage),
+        },
+      } as AssistantEvent);
+      prevUuid = uuid;
+    } else if (role === 'user') {
+      const uuid = nextUuid();
+      events.push({
+        uuid,
+        parentUuid: prevUuid,
+        sessionId,
+        timestamp: ts,
+        cwd,
+        isSidechain: false,
+        type: 'user',
+        message: { role: 'user', content: contentBlocks(msg.content) },
+      } as UserEvent);
+      prevUuid = uuid;
+    }
+    // other roles (none observed) are tolerated and skipped
+  }
+  flushToolResults();
+
+  return { sessionId, cwd, events };
+}
+
+/** A canonical index row (matches the events NDJSON the projection reads). */
+export interface CanonicalRow {
+  file_path: string;
+  session_id: string;
+  uuid: string;
+  parent_uuid: string | null;
+  role: string;
+  type: string;
+  ts: string;
+  cwd: string;
+  git_branch: string | null;
+  model: string | null;
+  input_tokens: number;
+  output_tokens: number;
+  cache_read_tokens: number;
+  cache_write_tokens: number;
+  service_tier: string | null;
+  is_sidechain: boolean;
+  tool_use_count: number;
+  text_content: string;
+}
+
+/** Flatten a parsed session into canonical index rows for one file. */
+export function toCanonicalRows(session: PiSession, filePath: string): CanonicalRow[] {
+  return session.events.map((e) => {
+    const msg = e.message;
+    const content = Array.isArray(msg.content) ? msg.content : [];
+    const usage = (msg as { usage?: MessageUsage }).usage;
+    const text = content
+      .map((b) => (b.type === 'text' ? b.text : b.type === 'thinking' ? b.thinking : ''))
+      .filter(Boolean)
+      .join(' ');
+    return {
+      file_path: filePath,
+      session_id: session.sessionId,
+      uuid: e.uuid,
+      parent_uuid: e.parentUuid,
+      role: msg.role,
+      type: e.type,
+      ts: e.timestamp,
+      cwd: session.cwd,
+      git_branch: null,
+      model: (msg as { model?: string }).model ?? null,
+      input_tokens: num(usage?.input_tokens),
+      output_tokens: num(usage?.output_tokens),
+      cache_read_tokens: num(usage?.cache_read_input_tokens),
+      cache_write_tokens: num(usage?.cache_creation_input_tokens),
+      service_tier: null,
+      is_sidechain: false,
+      tool_use_count: content.filter((b) => b.type === 'tool_use').length,
+      text_content: text,
+    };
+  });
+}

--- a/packages/server/src/connectors/pi/pi.ts
+++ b/packages/server/src/connectors/pi/pi.ts
@@ -1,0 +1,105 @@
+/**
+ * pi (`@earendil-works/pi-coding-agent`) connector.
+ *
+ * Source layout: `~/.pi/agent/sessions/<encoded-cwd>/<ts>_<uuid>.jsonl`. pi
+ * spreads session-level facts (cwd on the `session` line, tool results in their
+ * own `toolResult` records), so it can't be projected per-row by DuckDB. Instead
+ * `prepare()` normalizes a session to a canonical NDJSON (in TS, via
+ * {@link parsePiSession}/{@link toCanonicalRows}) and `eventsProjectionSql` reads
+ * that 1:1 — the indexer/FTS/cost stay native and Claude's path is untouched.
+ *
+ * pi keeps no instruction/memory files in its home dir (only `settings.json` /
+ * `auth.json`), so this connector contributes no memory.
+ *
+ * STRICTLY READ-ONLY with respect to ~/.pi — files are only ever read.
+ */
+
+import { createHash } from 'node:crypto';
+import { mkdirSync, readdirSync, statSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { CLAUDESCOPE_HOME, PI_SESSIONS_DIR } from '../../config.js';
+import { sqlString } from '../../db/duckdb.js';
+import type { SessionData } from '../../data/session-loader.js';
+import type { AgentConnector, AuxProjections, DiscoveredFile } from '../types.js';
+import { parsePiSession, toCanonicalRows } from './normalize.js';
+
+const CACHE_DIR = join(CLAUDESCOPE_HOME, 'cache', 'pi');
+
+/** Deterministic temp NDJSON path for a given session file. */
+function cachePath(filePath: string): string {
+  const hash = createHash('sha1').update(filePath).digest('hex').slice(0, 16);
+  return join(CACHE_DIR, `${hash}.ndjson`);
+}
+
+/** Recursively collect every `*.jsonl` under the pi sessions dir. */
+function discover(): DiscoveredFile[] {
+  const out: DiscoveredFile[] = [];
+  const walk = (dir: string): void => {
+    let entries: import('node:fs').Dirent[];
+    try {
+      entries = readdirSync(dir, { withFileTypes: true });
+    } catch {
+      return;
+    }
+    for (const entry of entries) {
+      const full = join(dir, entry.name);
+      if (entry.isDirectory()) {
+        walk(full);
+      } else if (entry.isFile() && entry.name.endsWith('.jsonl')) {
+        try {
+          const st = statSync(full);
+          out.push({ path: full, mtimeMs: Math.floor(st.mtimeMs), size: st.size });
+        } catch {
+          /* file vanished between readdir and stat; ignore */
+        }
+      }
+    }
+  };
+  walk(PI_SESSIONS_DIR);
+  return out;
+}
+
+/** Normalize a session to canonical NDJSON the projection will read. */
+async function prepare(filePath: string): Promise<void> {
+  const session = parsePiSession(filePath);
+  mkdirSync(CACHE_DIR, { recursive: true });
+  const rows = session ? toCanonicalRows(session, filePath) : [];
+  writeFileSync(cachePath(filePath), rows.map((r) => JSON.stringify(r)).join('\n') + '\n');
+}
+
+function eventsProjectionSql(filePath: string): string {
+  const path = sqlString(cachePath(filePath));
+  return `
+    SELECT
+      file_path, session_id, uuid, parent_uuid, role, type, ts, cwd, git_branch,
+      model, input_tokens, output_tokens, cache_read_tokens, cache_write_tokens,
+      service_tier, is_sidechain, tool_use_count, text_content,
+      CAST(NULL AS VARCHAR) AS message_id, CAST(NULL AS VARCHAR) AS forked_from_session_id
+    FROM read_ndjson(${path}, format='newline_delimited', maximum_object_size=268435456, ignore_errors=true, columns={
+      file_path:'VARCHAR', session_id:'VARCHAR', uuid:'VARCHAR', parent_uuid:'VARCHAR',
+      role:'VARCHAR', type:'VARCHAR', ts:'TIMESTAMP', cwd:'VARCHAR', git_branch:'VARCHAR',
+      model:'VARCHAR', input_tokens:'BIGINT', output_tokens:'BIGINT', cache_read_tokens:'BIGINT',
+      cache_write_tokens:'BIGINT', service_tier:'VARCHAR', is_sidechain:'BOOLEAN',
+      tool_use_count:'INTEGER', text_content:'VARCHAR'
+    })`;
+}
+
+function auxProjections(_filePath: string): AuxProjections {
+  return {}; // pi has no ai-title / pr-link records (first-user-message title fallback applies)
+}
+
+async function loadSession(_sessionId: string, paths: string[]): Promise<SessionData> {
+  const mainEvents = paths.flatMap((p) => parsePiSession(p)?.events ?? []);
+  return { mainEvents, subagents: [] };
+}
+
+export const piConnector: AgentConnector = {
+  id: 'pi',
+  label: 'pi',
+  sourceDir: PI_SESSIONS_DIR,
+  discover,
+  prepare,
+  eventsProjectionSql,
+  auxProjections,
+  loadSession,
+};

--- a/packages/server/src/connectors/registry.ts
+++ b/packages/server/src/connectors/registry.ts
@@ -7,8 +7,14 @@ import type { AgentConnector } from './types.js';
 import { claudeCodeConnector } from './claude-code/claude-code.js';
 import { codexConnector } from './codex/codex.js';
 import { junieConnector } from './junie/junie.js';
+import { piConnector } from './pi/pi.js';
 
-export const connectors: AgentConnector[] = [claudeCodeConnector, codexConnector, junieConnector];
+export const connectors: AgentConnector[] = [
+  claudeCodeConnector,
+  codexConnector,
+  junieConnector,
+  piConnector,
+];
 
 /** The connector with the given id, falling back to Claude Code if unknown. */
 export function connectorById(id: string | null | undefined): AgentConnector {

--- a/packages/server/src/data/index.ts
+++ b/packages/server/src/data/index.ts
@@ -343,10 +343,17 @@ async function doReindex(): Promise<ReindexResponse> {
   const start = Date.now();
   const conn = await getConnection();
   const pricing = loadPricing();
-  // Refresh the pricing join table (cheap; recreated once per run) before any
-  // file loads so the cost expression's exact-id join sees current rates.
-  await syncPricingTable(conn, pricing);
   const costExpr = buildCostExpr(pricing);
+  // The pricing join table is only read by loadFile (its exact-id LEFT JOIN), so
+  // build it lazily on the first file load. A no-op reindex — the common 15s
+  // auto-poll case — then never pays the DROP/CREATE/INSERT, which matters now
+  // that the shipped pricing carries the full OpenAI model lineup.
+  let pricingSynced = false;
+  const ensurePricingTable = async (): Promise<void> => {
+    if (pricingSynced) return;
+    await syncPricingTable(conn, pricing);
+    pricingSynced = true;
+  };
 
   // Discover across every registered connector, tagging each file with its owner.
   const discovered: { file: DiscoveredFile; connector: AgentConnector }[] = [];
@@ -389,6 +396,7 @@ async function doReindex(): Promise<ReindexResponse> {
     // wedge every other session. Skip it (its `files` row keeps the old mtime,
     // so a later edit retries it) and carry on.
     try {
+      await ensurePricingTable();
       await loadFile(conn, connector, file, costExpr);
 
       // Determine the session id from loaded events (filename usually matches,

--- a/packages/server/test/api.integration.test.ts
+++ b/packages/server/test/api.integration.test.ts
@@ -24,6 +24,7 @@ process.env.CLAUDE_PROJECTS_DIR = projectsDir;
 // deterministic.
 process.env.CODEX_SESSIONS_DIR = join(work, 'codex-empty');
 process.env.JUNIE_SESSIONS_DIR = join(work, 'junie-empty');
+process.env.PI_SESSIONS_DIR = join(work, 'pi-empty');
 process.env.DUCKDB_PATH = dbPath;
 process.env.CLAUDESCOPE_HOME = join(work, 'home');
 process.env.REINDEX_INTERVAL_MS = '0';

--- a/packages/server/test/codex.integration.test.ts
+++ b/packages/server/test/codex.integration.test.ts
@@ -20,8 +20,9 @@ const claudeDir = join(work, 'claude-empty');
 
 process.env.CLAUDE_PROJECTS_DIR = claudeDir;
 process.env.CODEX_SESSIONS_DIR = codexDir;
-// Isolate from the real ~/.junie so this Codex-only suite stays deterministic.
+// Isolate from the real ~/.junie and ~/.pi so this Codex-only suite stays deterministic.
 process.env.JUNIE_SESSIONS_DIR = join(work, 'junie-empty');
+process.env.PI_SESSIONS_DIR = join(work, 'pi-empty');
 process.env.DUCKDB_PATH = join(work, 'index.duckdb');
 process.env.CLAUDESCOPE_HOME = join(work, 'home');
 process.env.REINDEX_INTERVAL_MS = '0';
@@ -111,8 +112,8 @@ describe('Codex session indexing', () => {
     const s = (await get('/api/sessions')).json()[0];
     // input 1000 - cached 200 = 800 input; 200 cache_read; 300 output → 1300 total.
     expect(s.totalTokens).toBe(1300);
-    // gpt-5.4: (800*2.5 + 300*15 + 200*0.5) / 1e6 = 0.0066
-    expect(s.totalCostUsd).toBeCloseTo(0.0066, 5);
+    // gpt-5.4 @ official cached 0.25: (800*2.5 + 300*15 + 200*0.25) / 1e6 = 0.00655
+    expect(s.totalCostUsd).toBeCloseTo(0.00655, 5);
   });
 
   it('groups analytics by the OpenAI model', async () => {

--- a/packages/server/test/dedup.integration.test.ts
+++ b/packages/server/test/dedup.integration.test.ts
@@ -41,6 +41,7 @@ process.env.CLAUDE_PROJECTS_DIR = projectsDir;
 // deterministic.
 process.env.CODEX_SESSIONS_DIR = join(work, 'codex-empty');
 process.env.JUNIE_SESSIONS_DIR = join(work, 'junie-empty');
+process.env.PI_SESSIONS_DIR = join(work, 'pi-empty');
 process.env.DUCKDB_PATH = dbPath;
 process.env.CLAUDESCOPE_HOME = join(work, 'home');
 process.env.REINDEX_INTERVAL_MS = '0';

--- a/packages/server/test/index-recovery.integration.test.ts
+++ b/packages/server/test/index-recovery.integration.test.ts
@@ -27,6 +27,7 @@ const projectsDir = join(work, 'projects');
 process.env.CLAUDE_PROJECTS_DIR = projectsDir;
 process.env.CODEX_SESSIONS_DIR = join(work, 'codex-empty');
 process.env.JUNIE_SESSIONS_DIR = join(work, 'junie-empty');
+process.env.PI_SESSIONS_DIR = join(work, 'pi-empty');
 process.env.CLAUDESCOPE_HOME = join(work, 'home');
 process.env.REINDEX_INTERVAL_MS = '0';
 process.env.PRICING_REFRESH_INTERVAL_MS = '0';

--- a/packages/server/test/junie.integration.test.ts
+++ b/packages/server/test/junie.integration.test.ts
@@ -24,6 +24,7 @@ const claudeDir = join(work, 'claude-empty');
 process.env.CLAUDE_PROJECTS_DIR = claudeDir;
 process.env.CODEX_SESSIONS_DIR = codexDir;
 process.env.JUNIE_SESSIONS_DIR = junieDir;
+process.env.PI_SESSIONS_DIR = join(work, 'pi-empty');
 process.env.DUCKDB_PATH = join(work, 'index.duckdb');
 process.env.CLAUDESCOPE_HOME = join(work, 'home');
 process.env.REINDEX_INTERVAL_MS = '0';

--- a/packages/server/test/pi.integration.test.ts
+++ b/packages/server/test/pi.integration.test.ts
@@ -1,0 +1,197 @@
+/**
+ * pi connector integration test.
+ *
+ * Builds the index from a synthetic pi session JSONL (in an isolated temp
+ * PI_SESSIONS_DIR, with the other agents empty) and exercises the routes,
+ * verifying the pi-specific normalization: cwd/session id from the `session`
+ * line, model from the assistant message, plaintext thinking (NOT blanked),
+ * composite-id tool_use ↔ tool_result pairing, the synthesized thread chain that
+ * sidesteps pi's `model_change`/`thinking_level_change` records, and correct
+ * `gpt-5.4-mini` cost (not the `gpt`-family overcharge).
+ */
+
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import type { FastifyInstance } from 'fastify';
+
+const work = mkdtempSync(join(tmpdir(), 'claudescope-pi-'));
+const piDir = join(work, 'pi');
+const claudeDir = join(work, 'claude-empty');
+
+process.env.CLAUDE_PROJECTS_DIR = claudeDir;
+process.env.CODEX_SESSIONS_DIR = join(work, 'codex-empty');
+process.env.JUNIE_SESSIONS_DIR = join(work, 'junie-empty');
+process.env.PI_SESSIONS_DIR = piDir;
+process.env.DUCKDB_PATH = join(work, 'index.duckdb');
+process.env.CLAUDESCOPE_HOME = join(work, 'home');
+process.env.REINDEX_INTERVAL_MS = '0';
+
+const jsonl = (events: unknown[]): string => events.map((e) => JSON.stringify(e)).join('\n') + '\n';
+const ts = (s: number) => `2026-06-15T10:00:${String(s).padStart(2, '0')}.000Z`;
+
+// Composite tool ids as pi writes them (`call_…|fc_…`) — must survive verbatim
+// on both the tool_use and its tool_result, or the pairing breaks.
+const CALL_A = 'call_AAA|fc_aaa';
+const CALL_B = 'call_BBB|fc_bbb';
+const CALL_C = 'call_CCC|fc_ccc';
+// 1x1 transparent PNG (base64) — stands in for a pasted screenshot pi read back.
+const PNG_B64 =
+  'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYPhfDwAChwGA60e6kgAAAABJRU5ErkJggg==';
+
+/** Write one synthetic pi session under piDir/<encoded-cwd>/. */
+function writeSession(): string {
+  const dir = join(piDir, '--tmp-piproj--');
+  mkdirSync(dir, { recursive: true });
+  const file = join(dir, '2026-06-15T10-00-00-000Z_019eca90-8e90-7467-bfdf-365232b0c66b.jsonl');
+  writeFileSync(
+    file,
+    jsonl([
+      { type: 'session', version: 3, id: 'pi-sess-1', timestamp: ts(0), cwd: '/tmp/piproj' },
+      // model_change / thinking_level_change carry the native parent chain that the
+      // first user turn points at — the connector must NOT thread through them.
+      { type: 'model_change', id: 'mc1', parentId: null, timestamp: ts(0), provider: 'openai-codex', modelId: 'gpt-5.4-mini' },
+      { type: 'thinking_level_change', id: 'tl1', parentId: 'mc1', timestamp: ts(0), thinkingLevel: 'high' },
+      { type: 'message', id: 'u1', parentId: 'tl1', timestamp: ts(1), message: { role: 'user', content: [{ type: 'text', text: 'find the needle in this pi haystack' }] } },
+      { type: 'message', id: 'a1', parentId: 'u1', timestamp: ts(2), message: {
+        role: 'assistant', model: 'gpt-5.4-mini', provider: 'openai-codex',
+        content: [
+          { type: 'thinking', thinking: 'let me search the haystack', thinkingSignature: '{"id":"rs_enc"}' },
+          { type: 'toolCall', id: CALL_A, name: 'bash', arguments: { command: 'grep needle', timeout: 10 } },
+          // pi's native edit shape: `{path, edits:[{oldText,newText}]}`.
+          { type: 'toolCall', id: CALL_B, name: 'edit', arguments: { path: '/tmp/piproj/hay.txt', edits: [{ oldText: 'hay', newText: 'needle' }] } },
+          // pi reads a pasted screenshot from a temp file; the image rides the RESULT.
+          { type: 'toolCall', id: CALL_C, name: 'read', arguments: { path: '/tmp/pi-clipboard-x.png' } },
+        ],
+        usage: { input: 1000, output: 300, cacheRead: 200, cacheWrite: 0, totalTokens: 1500 },
+      } },
+      // Three consecutive tool results → coalesce into ONE user turn carrying all.
+      { type: 'message', id: 'tr1', parentId: 'a1', timestamp: ts(3), message: { role: 'toolResult', toolCallId: CALL_A, toolName: 'bash', content: [{ type: 'text', text: 'needle found at line 42' }] } },
+      { type: 'message', id: 'tr2', parentId: 'a1', timestamp: ts(3), message: { role: 'toolResult', toolCallId: CALL_B, toolName: 'edit', content: [{ type: 'text', text: 'edited hay.txt' }] } },
+      { type: 'message', id: 'tr3', parentId: 'a1', timestamp: ts(3), message: { role: 'toolResult', toolCallId: CALL_C, toolName: 'read', content: [{ type: 'text', text: 'Read image file [image/png]' }, { type: 'image', data: PNG_B64, mimeType: 'image/png' }] } },
+      { type: 'message', id: 'a2', parentId: 'tr2', timestamp: ts(4), message: {
+        role: 'assistant', model: 'gpt-5.4-mini', provider: 'openai-codex',
+        content: [{ type: 'text', text: 'Found the needle.' }],
+        usage: { input: 500, output: 50, cacheRead: 1000, cacheWrite: 0, totalTokens: 1550 },
+      } },
+    ]),
+  );
+  return file;
+}
+
+let app: FastifyInstance;
+let closeConnection: () => Promise<void>;
+
+beforeAll(async () => {
+  mkdirSync(claudeDir, { recursive: true });
+  writeSession();
+
+  const Fastify = (await import('fastify')).default;
+  const { registerRoutes } = await import('../src/routes/index.js');
+  const { reindex } = await import('../src/data/index.js');
+  ({ closeConnection } = await import('../src/db/duckdb.js'));
+
+  app = Fastify();
+  await registerRoutes(app);
+  await reindex();
+  await app.ready();
+});
+
+afterAll(async () => {
+  await app?.close();
+  await closeConnection?.();
+  rmSync(work, { recursive: true, force: true });
+});
+
+const get = (url: string) => app.inject({ method: 'GET', url });
+
+describe('pi session indexing', () => {
+  it('lists the pi session with model from the assistant message and a pi agent tag', async () => {
+    const sessions = (await get('/api/sessions')).json();
+    expect(sessions.map((s: { id: string }) => s.id)).toEqual(['pi-sess-1']);
+    expect(sessions[0].models).toContain('gpt-5.4-mini');
+    expect(sessions[0].connectorId).toBe('pi');
+    // pi has no ai-title, so the title falls back to the first user message.
+    expect(sessions[0].title).toBe('find the needle in this pi haystack');
+  });
+
+  it('tags the project with its agent and groups analytics by agent', async () => {
+    const projects = (await get('/api/projects')).json();
+    expect(projects[0].connectorIds).toContain('pi');
+
+    const { rows } = (await get('/api/analytics?groupBy=agent')).json();
+    expect(rows.map((r: { key: string }) => r.key)).toContain('pi');
+  });
+
+  it('exposes the pi source directory via /api/sources', async () => {
+    const sources = (await get('/api/sources')).json();
+    expect(sources.some((s: { id: string }) => s.id === 'pi')).toBe(true);
+  });
+
+  it('maps usage directly (input excl. cache) and prices gpt-5.4-mini correctly', async () => {
+    const s = (await get('/api/sessions')).json()[0];
+    // input is cache-exclusive in pi → totalTokens = Σ(input+output+cacheRead+cacheWrite)
+    // = (1000+300+200+0) + (500+50+1000+0) = 3050.
+    expect(s.totalTokens).toBe(3050);
+    // gpt-5.4-mini @ 0.75/4.50/0.075 per 1M (cacheWrite 0):
+    //   turn1 (1000*0.75 + 300*4.5 + 200*0.075)/1e6 = 0.002115
+    //   turn2 (500*0.75  +  50*4.5 + 1000*0.075)/1e6 = 0.000675  → total 0.00279.
+    // (If it had mis-resolved to the `gpt` family 2.5/15 it would be ~0.00705.)
+    expect(s.totalCostUsd).toBeCloseTo(0.00279, 6);
+  });
+
+  it('groups analytics by the pi model id', async () => {
+    const { rows } = (await get('/api/analytics?groupBy=model')).json();
+    expect(rows.map((r: { key: string }) => r.key)).toContain('gpt-5.4-mini');
+  });
+
+  it('finds the pi session via full-text search', async () => {
+    const { sessions: results } = (await get('/api/search?q=needle')).json();
+    expect(results.some((r: { sessionId: string }) => r.sessionId === 'pi-sess-1')).toBe(true);
+  });
+});
+
+describe('pi session detail', () => {
+  it('renders plaintext thinking, maps pi tools to canonical shapes, and pairs by composite id', async () => {
+    const detail = (await get('/api/sessions/pi-sess-1')).json();
+    expect(detail.subagents).toEqual([]);
+
+    // The first turn is the user prompt: the synthesized chain starts at the user
+    // turn (parentUuid null), NOT dangling off the thinking_level_change record.
+    expect(detail.thread[0]).toMatchObject({ role: 'user', parentUuid: null });
+
+    const flat = detail.thread.flatMap((t: { blocks: Record<string, unknown>[] }) => t.blocks);
+
+    // pi thinking is PLAINTEXT — the reasoning text must survive (not be blanked).
+    const thinking = flat.find((b: Record<string, unknown>) => b.type === 'thinking');
+    expect(thinking).toBeTruthy();
+    expect(thinking.thinking).toContain('let me search the haystack');
+
+    // All three tool calls pair to their results by the verbatim composite id.
+    const tools = flat.filter((b: Record<string, unknown>) => b.kind === 'tool');
+    expect(tools.map((t: { id: string }) => t.id).sort()).toEqual([CALL_A, CALL_B, CALL_C].sort());
+
+    // pi `bash` → canonical `Bash` (renders command + output).
+    const bash = tools.find((t: { name: string }) => t.name === 'Bash');
+    expect(bash.result).toBeTruthy();
+    expect(JSON.stringify(bash.result.content)).toContain('needle found at line 42');
+
+    // pi `edit` → canonical `MultiEdit` so the Files-changed tab (changeset.ts)
+    // picks it up: file_path + edits[].old_string/new_string. This is the fix for
+    // the empty Files-changed tab on pi sessions.
+    const edit = tools.find((t: { name: string }) => t.name === 'MultiEdit');
+    expect(edit.input).toMatchObject({ file_path: '/tmp/piproj/hay.txt' });
+    expect(edit.input.edits[0]).toEqual({ old_string: 'hay', new_string: 'needle' });
+    expect(edit.result).toBeTruthy();
+
+    // pi screenshot: the image in the `read` result is preserved as a canonical
+    // base64 ImageBlock (so it embeds in the UI instead of being dropped).
+    const read = tools.find((t: { name: string }) => t.name === 'Read');
+    const img = read.result.content.find((b: { type: string }) => b.type === 'image');
+    expect(img).toBeTruthy();
+    expect(img.source).toEqual({ type: 'base64', media_type: 'image/png', data: PNG_B64 });
+
+    expect(JSON.stringify(detail.thread)).toContain('Found the needle.');
+  });
+});

--- a/packages/server/test/pricing.test.ts
+++ b/packages/server/test/pricing.test.ts
@@ -40,6 +40,7 @@ process.env.FETCHED_PRICING_PATH = fetchedPath;
 process.env.CLAUDE_PROJECTS_DIR = projectsDir;
 process.env.CODEX_SESSIONS_DIR = join(work, 'codex-empty');
 process.env.JUNIE_SESSIONS_DIR = join(work, 'junie-empty');
+process.env.PI_SESSIONS_DIR = join(work, 'pi-empty');
 process.env.DUCKDB_PATH = dbPath;
 process.env.CLAUDESCOPE_HOME = join(work, 'home');
 process.env.REINDEX_INTERVAL_MS = '0';

--- a/packages/web/src/components/AgentBadge.tsx
+++ b/packages/web/src/components/AgentBadge.tsx
@@ -4,6 +4,7 @@ const AGENT_LABELS: Record<string, string> = {
   'claude-code': 'Claude',
   codex: 'Codex',
   junie: 'Junie',
+  pi: 'pi',
 };
 
 /** Human-friendly short label for a connector id. */

--- a/packages/web/src/components/ToolBlock.tsx
+++ b/packages/web/src/components/ToolBlock.tsx
@@ -167,21 +167,18 @@ function ToolBody({
     case 'Read': {
       const fp = str(input.file_path);
       const text = resultText(tool.result);
-      // When the result has non-text blocks (e.g. an image from reading a PNG),
-      // resultText is empty — render via ResultSection so image blocks are shown
-      // properly instead of an empty code block.
+      // When the result carries non-text blocks (e.g. an image from reading a PNG —
+      // including pi screenshots, whose result has BOTH descriptive text and the
+      // image), render via ResultSection so the image is shown instead of being
+      // suppressed by the text. Plain text/code reads keep the highlighted Code view.
       const hasNonTextBlocks = tool.result
         ? tool.result.content.some((b) => b.type !== 'text' && b.type !== 'thinking')
         : false;
       return (
         <>
           {fp ? <FileHeader path={fp} /> : null}
-          {tool.result ? (
-            text || !hasNonTextBlocks ? (
-              <Code code={text} lang={extOf(fp)} forceExpand={forceOpen} />
-            ) : (
-              <ResultSection tool={tool} isError={isError} forceExpand={forceOpen} />
-            )
+          {tool.result && !hasNonTextBlocks ? (
+            <Code code={text} lang={extOf(fp)} forceExpand={forceOpen} />
           ) : (
             <ResultSection tool={tool} isError={isError} forceExpand={forceOpen} />
           )}

--- a/packages/web/src/pages/browse/browse.css
+++ b/packages/web/src/pages/browse/browse.css
@@ -232,6 +232,11 @@
   background: #3fb9501a;
   color: #56d964;
 }
+.tv-chip--agent.tv-agent--pi {
+  border-color: #8957e566;
+  background: #8957e51a;
+  color: #a371f7;
+}
 /* Light theme: keep the brand tints but darken the text so it stays legible on
    a light surface. */
 :root[data-theme='light'] .tv-chip--agent.tv-agent--claude-code {
@@ -242,4 +247,7 @@
 }
 :root[data-theme='light'] .tv-chip--agent.tv-agent--junie {
   color: #1a7f37;
+}
+:root[data-theme='light'] .tv-chip--agent.tv-agent--pi {
+  color: #6e40c9;
 }


### PR DESCRIPTION
## Summary

Adds a connector for [pi](https://pi.dev) (`@earendil-works/pi-coding-agent`), so its sessions (`~/.pi/agent/sessions/**/*.jsonl`) are indexed, browsable, searchable, costed, and rendered alongside Claude Code / Codex / Junie. Merged per `cwd` and tagged with a violet `pi` badge.

## What's included

- **pi connector** (`connectors/pi/`) — a `prepare()` pass normalizes pi's threaded JSONL to canonical NDJSON (the Codex pattern): `cwd` from the `session` line, per-turn `model` from the assistant message, **plaintext thinking preserved**, tool results paired to their `tool_use` by the composite `call_…|fc_…` id, and a synthesized `uuid`/`parentUuid` chain (pi's native chain threads through `model_change`/`thinking_level_change` records and would dangle).
- **Files-changed tab + tool rendering** — maps pi's tools to Claude's canonical shapes (`edit→MultiEdit`, `write→Write`, `read→Read`, `bash→Bash`; `path→file_path`, `oldText/newText→old_string/new_string`) so the changeset tab and diffs work (the Junie pattern).
- **Screenshot embedding** — preserves pi image content (returned inside the `read` result) as canonical base64 `ImageBlock`s; a small Claude-safe `Read`-renderer tweak shows image results even when pi includes descriptive text.
- **Official OpenAI pricing** — repopulates `pricing.json` from OpenAI's official tables (full GPT-5.x / 4.x / o-series / Codex lineup, exact-id, short-context rates), incl. `gpt-5.4-mini` (pi) and `gpt-5.4-mini-fast`. Fixes two pre-existing errors: `gpt-5` was half-price and `gpt-5.4` cached was `0.5` (official `0.25`). Schema bumped `1→2`.
- **No memory** — pi keeps none in its home dir, so the connector implements none.

## Testing

- `npm run typecheck` + `npm test` — **176 passing**, incl. a new `pi.integration.test.ts` covering cwd broadcast, plaintext thinking, composite-id tool pairing, the `MultiEdit` mapping (Files-changed), image preservation, dangling-parent avoidance, and correct `gpt-5.4-mini` cost.
- Validated the normalizer against real `~/.pi` sessions (cwd, tool counts, edits→MultiEdit, 790 KB screenshot→base64 ImageBlock).

Plan: `docs/plans/0019-pi-connector.md`. The opencode connector lands in a separate PR.