### PR TITLE
feat: add opencode connector (SQLite-backed)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,8 +5,9 @@ analyze AI coding-agent transcripts in one place — [Claude Code](https://claud
 [OpenAI Codex](https://openai.com/codex)
 (`~/.codex/sessions/**/rollout-*.jsonl`),
 [JetBrains Junie](https://www.jetbrains.com/junie/)
-(`~/.junie/sessions/session-*/events.jsonl`), and [pi](https://pi.dev)
-(`~/.pi/agent/sessions/**/*.jsonl`). Sessions are merged by working
+(`~/.junie/sessions/session-*/events.jsonl`), [pi](https://pi.dev)
+(`~/.pi/agent/sessions/**/*.jsonl`), and [opencode](https://opencode.ai)
+(`~/.local/share/opencode/opencode.db`, SQLite). Sessions are merged by working
 directory into one project per `cwd`, each session tagged with its agent.
 Distributed as a single npm CLI (`@vladar107/claudescope`). This file is the
 source of truth for both humans and agents working in this repo; `AGENTS.md`
@@ -124,6 +125,17 @@ The CLI `update` command (`cli.ts`) detects the install method and defers to
   attribution); the `uuid`/`parentUuid` chain is synthesized over message rows
   because pi's native chain threads through `model_change`/`thinking_level_change`
   records. pi has no home-dir memory, so the connector implements no memory.
+- **opencode connector** (`connectors/opencode/`) — the only **SQLite-backed**
+  source: one `opencode.db` (`session`/`message`/`part`), read read-only via
+  `node:sqlite` (built into Node 24 — no dep). Each session is a synthetic
+  `DiscoveredFile` (`<dbPath>#<id>`); `prepare()` extracts it to canonical NDJSON
+  (Codex pattern). File edits arrive via **`apply_patch`** (`state.metadata.files[]`
+  per-file unified diffs) → mapped to canonical `Write`/`Edit`/`MultiEdit` so the
+  Files-changed tab works; `read`→`Read`, `bash`→`Bash`, others passthrough; a
+  pasted screenshot is a `file` part (data-URL) → `ImageBlock`. Reasoning is
+  plaintext. Tokens are per-message (reasoning folded into output). `discover()`
+  throws on a present-but-unreadable DB (the indexer isolates a throwing connector
+  and preserves its sessions — it never wipes them). No memory.
 - **Junie transcripts read differently** — Junie stores an event-sourced UI
   stream (`events.jsonl`), not a chat log: no assistant prose and no thinking, so
   a session renders as tool/terminal/file blocks plus a final result. Expected,
@@ -139,4 +151,5 @@ The CLI `update` command (`cli.ts`) detects the install method and defers to
   OIDC). See `CONTRIBUTING.md`.
 
 See `CONTRIBUTING.md` for the full workflow and `README.md` for user-facing docs.
+
 

--- a/README.md
+++ b/README.md
@@ -21,14 +21,15 @@ machine and only ever reads your transcripts.
 | [OpenAI Codex](https://openai.com/codex)          | `~/.codex/sessions/**/rollout-*.jsonl`        |
 | [JetBrains Junie](https://www.jetbrains.com/junie/) | `~/.junie/sessions/session-*/events.jsonl`  |
 | [pi](https://pi.dev)                              | `~/.pi/agent/sessions/**/*.jsonl`             |
+| [opencode](https://opencode.ai)                   | `~/.local/share/opencode/opencode.db` (SQLite) |
 
 Each source is optional — a directory that doesn't exist is simply skipped, so
-Claudescope works whether you use one agent or all four. Adding another is just
+Claudescope works whether you use one agent or all five. Adding another is just
 [adding another connector](#how-it-works).
 
 ## What it can do
 
-- **Multi-agent** — Claude Code, Codex, Junie, and pi sessions side by side, each labeled with an **agent badge**. A project that several agents touched shows one card with all its agent tags; drill in and **filter the session list by agent**.
+- **Multi-agent** — Claude Code, Codex, Junie, pi, and opencode sessions side by side, each labeled with an **agent badge**. A project that several agents touched shows one card with all its agent tags; drill in and **filter the session list by agent**.
 - **Browse** every session grouped by project — titles, dates, message/tool counts, token totals, cost, git branch, PR links.
 - **Read** a session as a clean threaded conversation: markdown, syntax-highlighted code, collapsible thinking, paired tool calls + results, **syntax-highlighted red/green diffs** for edits, attachments, and sidechain/subagent turns. A built-in **find-in-session** bar (⌘/Ctrl+F) searches the whole transcript — including collapsed thinking, tool, and subagent content — auto-expanding and highlighting matches, with a user/assistant filter.
 - **Review changes** via a **Files changed** tab that aggregates every edit/write in the session by file, with per-file diffs and +/− counts (diffs load lazily per file).
@@ -174,11 +175,12 @@ All optional — set via environment variables.
 | `CODEX_SESSIONS_DIR`  | `~/.codex/sessions`    | Where to read OpenAI Codex transcripts from. A leading `~` is expanded.|
 | `JUNIE_SESSIONS_DIR`  | `~/.junie/sessions`    | Where to read JetBrains Junie transcripts from. A leading `~` is expanded.|
 | `PI_SESSIONS_DIR`     | `~/.pi/agent/sessions` | Where to read pi transcripts from. A leading `~` is expanded.          |
+| `OPENCODE_DATA_DIR`   | `~/.local/share/opencode` | Dir holding opencode's `opencode.db` (read-only). Honors `$XDG_DATA_HOME`; override the DB path directly with `OPENCODE_DB_PATH`. |
 | `CLAUDESCOPE_HOME`    | `~/.claudescope`       | Where the app keeps its own state (index, pricing copy, logs, PID).    |
 | `REINDEX_INTERVAL_MS` | `15000`                | How often to auto-pick-up new/updated sessions. Set `0` to disable.    |
 
 Each agent source is optional — if a directory doesn't exist it's simply skipped,
-so the app works whether you use one agent or all four.
+so the app works whether you use one agent or all five.
 
 Examples:
 
@@ -188,6 +190,7 @@ CLAUDE_PROJECTS_DIR=/path/to/exported/projects claudescope  # view someone else'
 CODEX_SESSIONS_DIR=/path/to/codex/sessions claudescope   # point at Codex sessions elsewhere
 JUNIE_SESSIONS_DIR=/path/to/junie/sessions claudescope   # point at Junie sessions elsewhere
 PI_SESSIONS_DIR=/path/to/pi/sessions claudescope         # point at pi sessions elsewhere
+OPENCODE_DATA_DIR=/path/to/opencode claudescope          # point at an opencode data dir elsewhere
 claudescope --no-open                                    # don't pop a browser tab
 ```
 
@@ -292,6 +295,11 @@ served from cache (legitimately high for Claude Code, which re-reads cached cont
   plaintext of its thinking blocks, so they show real reasoning rather than an
   empty placeholder. pi keeps no memory in its home dir, so it contributes nothing
   to the memory viewer.
+- **opencode is SQLite-backed.** opencode stores all sessions in one read-only
+  SQLite database (`opencode.db`), not per-session files; Claudescope reads it via
+  Node's built-in `node:sqlite`. Its reasoning renders in full (plaintext), its
+  file edits (made via `apply_patch`) show in the **Files changed** tab and as
+  diffs, and pasted screenshots embed. Like pi, it contributes no memory.
 
 ---
 
@@ -370,7 +378,7 @@ shell, and self-update behavior — and how to report a vulnerability.
 ## Troubleshooting
 
 - **App is empty / "sessions directory not found"** — none of `CLAUDE_PROJECTS_DIR`,
-  `CODEX_SESSIONS_DIR`, `JUNIE_SESSIONS_DIR`, or `PI_SESSIONS_DIR` points at real transcripts. Check
+  `CODEX_SESSIONS_DIR`, `JUNIE_SESSIONS_DIR`, `PI_SESSIONS_DIR`, or `OPENCODE_DATA_DIR` points at real transcripts. Check
   the banner and set them correctly. Any source can be absent; only the present
   ones are indexed.
 - **`Error: listen EADDRINUSE :4317`** — the port is taken; run `claudescope --port <n>`.

--- a/docs/plans/0020-opencode-connector.md
+++ b/docs/plans/0020-opencode-connector.md
@@ -1,0 +1,280 @@
+# 0020 — opencode connector
+
+- **Status:** done <!-- proposed | in-progress | done | superseded | abandoned -->
+- **Date:** 2026-06-15
+- **PR:** https://github.com/vladar107/claudescope/pull/23
+
+## Context
+
+[opencode](https://opencode.ai) (v1.17.7) is the first agent whose transcripts
+are **not** per-session files: it stores everything in **one SQLite database**,
+`~/.local/share/opencode/opencode.db` (+ `-wal`/`-shm`). Schema (verified):
+
+- `session(id, project_id, directory[=cwd], title, model, agent, tokens_input,
+  tokens_output, tokens_reasoning, tokens_cache_read, tokens_cache_write, cost,
+  parent_id, time_created, time_updated, …)`
+- `message(id, session_id, time_created, time_updated, data JSON)` —
+  `data: {role, time, agent, model:{providerID,modelID,variant}, tokens:{total,
+  input,output,reasoning,cache:{write,read}}, cost}`
+- `part(id, message_id, session_id, time_created, time_updated, data JSON)` —
+  `data.type ∈ {text, reasoning, tool, file, patch, step-start, step-finish}`.
+  Live transcript lives in `message`+`part` (the `event`/`event_sequence` tables
+  are an audit log, `session_message` is empty).
+  - **`tool`** parts: `{type:'tool', tool, callID, state:{status, input, output,
+    metadata, error, …}}`. opencode's tools (verified): `apply_patch`, `bash`,
+    `read`, `grep`, `glob`, `webfetch`, `skill`, `todowrite`. **File edits go
+    through `apply_patch`** — `state.input.patchText` is the OpenAI **V4A diff**
+    (`*** Begin Patch` … `*** Add/Update/Delete File: <path>` … `@@` hunks …
+    `*** End Patch`); completed patches also carry `state.metadata.files[]`
+    (`{type:'add'|'update'|'delete', patch, additions, deletions}`).
+  - **`file`** parts (images): `{type:'file', mime:'image/png', filename, url}`
+    where `url` is an inline `data:<mime>;base64,…` URL — this is how opencode
+    stores a **pasted screenshot** (on the user message), not a tool result.
+  - **`patch`** parts: `{type:'patch', hash, files:[paths]}` — git-style snapshot
+    markers (no diff content); dropped.
+
+The connector seam already supports this: `discover()` is the **sole source of
+truth** for what "files" exist and the indexer never `stat`s `file.path`, so each
+**session becomes a synthetic `DiscoveredFile`** and `prepare()` extracts it to a
+cache NDJSON — exactly the Codex pattern, just sourced from SQLite instead of a
+file. The hot path (DuckDB `read_ndjson` → FTS → cost) stays byte-identical.
+
+**Node 24 ships `node:sqlite` built-in → zero new dependencies.** A read-only
+`DatabaseSync({readOnly:true})` reads the live WAL'd DB cleanly (stress-tested:
+200 concurrent read-opens vs 1000 writes + checkpoints, 0 errors, always the
+latest committed value).
+
+## Goal
+
+opencode sessions are indexed, browsable, searchable, costed, and render with
+text, **plaintext reasoning**, tool calls + results, a populated **Files-changed
+tab**, and embedded **screenshots** — merged per `cwd`, tagged with an `opencode`
+badge — reading the SQLite DB strictly read-only, with correct incremental change
+detection and no cross-connector blast radius. Per the connector process rule
+(learned on pi), wiring the Files-changed tab and image embedding is mandatory,
+not optional — the Claude-centric web UI shows nothing for them otherwise.
+
+## Decisions
+
+- **SQLite via `node:sqlite`, read-only, no new dep.** Open `{readOnly:true}`,
+  read, close, in each entry point (`discover`/`prepare`/`loadSession`); never
+  open read-write; never touch `-wal`/`-shm`.
+- **One synthetic `DiscoveredFile` per session**, `path = "<dbPath>#<sessionId>"`
+  (opencode ids are `ses_<base62>` — no `#`, so the split is unambiguous).
+- **Change signal = `max(session.time_updated, max(message.time_updated),
+  max(part.time_updated))`** per session (computed in one SQL aggregate);
+  `size` = a monotonic-on-change integer (`count(parts)+count(messages)`).
+  `session.time_updated` alone **lags** the last turn (verified by ~66ms) and
+  would miss edits.
+- **🔴 Harden the prune loop against all-or-nothing wipeout.** The indexer's prune
+  loop (`index.ts` ~L375, `for (const path of existing.keys())` — **verified still
+  NOT connector-scoped in main**) deletes any indexed path not returned by
+  `discover()` this pass. Because all opencode sessions sit behind one DB handle, a
+  `discover()` that returns `[]` on a transient open failure
+  (`SQLITE_BUSY`/`CANTOPEN` during opencode's checkpoint/crash-recovery) would
+  **purge every opencode session at once**, then re-extract + full-rebuild next
+  pass. Two fixes (both still TODO):
+  1. **`existsSync`-guard `discover()`** — verified `DatabaseSync(path,
+     {readOnly:true})` **throws** `ERR_SQLITE_ERROR` on a missing file. So: DB file
+     absent → return `[]` (~0.008ms; opencode not installed); file present but
+     open/query fails → **throw** (the prune then treats nothing as deleted). This
+     is load-bearing precisely because the prune is not connector-scoped.
+  2. **Connector-scoped prune (general hardening):** scope the prune to files whose
+     `connector_id` discovered this pass — `files` already stores `connector_id`.
+     Bounds the blast radius so one connector's hiccup can't purge another's.
+     *(Touches `data/index.ts`; small.)*
+- **🟢 Files-changed tab — parse `apply_patch`, map the other tools** (mandatory;
+  the web `changeset.ts` + `ToolBlock` key off Claude tool names + `file_path`, so
+  without this the tab is empty and tools render as raw JSON). Extend pi's
+  `toolUseBlock()` switch (`pi/normalize.ts` is the template — pi maps 1:1; opencode
+  fans 1:N). A pure, fixture-tested `parseApplyPatch(patchText)` turns one
+  `apply_patch` part into 1..N canonical tool_use blocks:
+  - `*** Add File:` → **`Write`** `{file_path, content}` (body lines are `+`-only;
+    strip the single leading `+`).
+  - `*** Update File:` → **`MultiEdit`** `{file_path, edits:[{old_string,
+    new_string}]}`, one edit per **bare `@@`** hunk (no line numbers); carry context
+    (` `) lines into BOTH sides; strip exactly one prefix char (never trim — keep
+    leading whitespace).
+  - `*** Delete File:` → **`Edit`** `{file_path, old_string:<removed body>,
+    new_string:''}`. The removed body is **not** in `patchText` (V4A delete has no
+    body) — recover it from `state.metadata.files[]` (the matching `delete` entry's
+    `patch` `-` lines); fall back to `'(file deleted)'` only when metadata is absent
+    (the error/rejected case). `patchText` is the **primary** source for Add/Update;
+    `metadata.files[]` is the source for Delete bodies.
+  - Other tools: `read` → **`Read`** (rename `state.input.filePath` →`file_path`;
+    keep `offset`/`limit`); `bash` → **`Bash`** (`command`/`timeout`/`description`;
+    drop `workdir`); `grep`/`glob`/`webfetch`/`skill`/`todowrite` → **passthrough**
+    (no special `ToolBlock` renderer exists → generic JSON; acceptable). Pair
+    `tool_use`↔`tool_result` by **`callID`**; `state.status==='error'` (or
+    `state.error`) → `tool_result` `isError`, but still emit the canonical block so
+    the attempted edit shows. Drop the standalone `patch` snapshot parts (no diff;
+    would double-count files already covered by `apply_patch`).
+  - Tolerate malformed `patchText` (missing `@@`, mixed prefixes) — never throw;
+    fall back to a generic block (the codex/pi "tolerate corrupt line" discipline).
+  - **Avoid redundant result text**: `read` output is wrapped
+    `<path>…</path><type>…</type><content>…</content>` — unwrap to the `<content>`
+    body (the `Read` header already shows the path). And each `apply_patch` file
+    block gets a CONCISE per-file result (`Updated <file>`), not the shared
+    multi-file "Success. Updated …" summary repeated on every fanned block.
+  - *Sibling finding (out of scope):* Codex emits `apply_patch` as a heredoc inside
+    `exec_command`, so **Codex edits also miss the Files-changed tab today**.
+    Consider extracting `parseApplyPatch` to a shared `connectors/` util so a future
+    Codex sniffer can reuse it.
+- **🟢 Screenshots — implement now (verified present).** opencode stores a pasted
+  image as a **`file` part** on the user message: `{type:'file', mime:'image/png',
+  url:'data:image/png;base64,…'}`. Add a `part.data.type === 'file'` branch that,
+  when `mime` starts with `image/`, emits a canonical `ImageBlock`
+  `{type:'image', source:{type:'url', url: data.url}}` (a `data:` URL renders as a
+  `url` source via `extractImage`; no base64 splitting) into the message's content
+  array. Guard `typeof url === 'string' && url.length > 0`; pass non-image file
+  parts through as a text marker. (The earlier "no images in the DB" note was wrong
+  — there is a real clipboard screenshot file part.) The merged `ToolBlock` `Read`
+  tweak also covers any future image that arrives in a tool result.
+- **🟢 Pricing + lazy pricing-sync are ALREADY DONE in main** (pi PR #22): the full
+  OpenAI lineup incl. `gpt-5.4-mini-fast` is in `pricing.json` (so opencode cost
+  resolves), and the `pricing_rates` table now builds lazily (only on the first
+  file load), so opencode's per-poll no-op reindex pays no pricing cost. No pricing
+  work in this PR.
+- **Normalize at MESSAGE granularity, not part.** One `message` row per turn;
+  `message.data.tokens` == the lone `step-finish` part's tokens == per-turn billed
+  usage (verified: `SUM(message tokens)` equals the `session.tokens_*` columns
+  exactly). Summing `step-finish` parts on top would double-count. Add a dev
+  assertion that there's ≤1 `step-finish` per message so a future multi-step turn
+  is caught, not silently mis-costed.
+- **Token map differs from Codex — no input subtraction.** opencode `input` is
+  cache-**exclusive** (`total = input+output+reasoning+cacheR+cacheW`), so
+  `input_tokens = tokens.input` directly. **Fold reasoning into output:**
+  `output_tokens = tokens.output + tokens.reasoning` (no canonical reasoning
+  column; reasoning is output-side, billed at the output rate). `cache_read =
+  tokens.cache.read`, `cache_write = tokens.cache.write`, `service_tier = NULL`.
+- **Reasoning is PLAINTEXT** → `reasoning` part → `{type:'thinking',
+  thinking: part.data.text}` (renders content + FTS-searchable). The
+  "thinking renders empty" gotcha does **not** apply to opencode.
+- **`message_id = NULL`** (one row per billed turn, no multi-block/fork
+  duplication) → always usage-canonical, no dedup logic.
+- **Title from `session.title`** via `auxProjections` (opencode stores a real
+  per-session title, unlike Codex). Carry it through the cache NDJSON like Junie;
+  the first-user-message fallback still applies when blank.
+- **Synthesize a sequential `uuid`/`parentUuid` chain** in `time_created` order
+  (Codex pattern); don't trust `data.parentID`.
+- **`sourceDir` = the data dir** (`~/.local/share/opencode`, where the DB lives);
+  `/api/sources` only `existsSync`es it. No config-dir constant is needed (memory
+  is skipped — see below).
+- **Sub-sessions deferred.** `session.parent_id` exists but is unpopulated here;
+  ship `subagents: []` and index any child session as its own top-level session.
+
+## Memory — skipped (decided)
+
+opencode keeps **no agent-distilled memory in its own home/config dir**. What it
+reads at runtime is repo-local `CLAUDE.md`/`AGENTS.md` and the global
+`~/.claude/CLAUDE.md` — all out of scope under (or only relaxable by changing) the
+home-dir-only invariant. **Maintainer decision: skip memory for both pi and
+opencode.** The connector implements **neither** `globalMemory()` **nor**
+`projectMemory()`; opencode is a transcript-only source and does not appear in the
+memory viewer. Consequently `OPENCODE_CONFIG_DIR` is **not** needed — only the data
+dir (where the DB lives) matters.
+
+## Approach
+
+1. `config.ts` — `OPENCODE_DATA_DIR` (`~/.local/share/opencode`, honoring
+   `$XDG_DATA_HOME`) and derived `OPENCODE_DB_PATH = join(dataDir,'opencode.db')`,
+   env-overridable. (No config dir — memory skipped.)
+2. `connectors/opencode/db.ts` — tiny read-only `node:sqlite` helper (open/read/
+   close; `[]`/throw discipline from the prune-loop decision).
+3. `connectors/opencode/normalize.ts` — session rows → canonical NDJSON rows and
+   → `RawEvent[]` (shared builder): message-granular tokens (input direct, reasoning
+   folded into output; dev-assert ≤1 `step-finish`/message), plaintext `reasoning`
+   → thinking block, `tool` parts → canonical tool_use (incl. `parseApplyPatch()`
+   for `apply_patch`, `read`→`Read`, `bash`→`Bash`, rest passthrough) paired to
+   `tool_result` by `callID`, image `file` parts → canonical `ImageBlock`, drop
+   `patch`/`step-*` parts. `parseApplyPatch()` is a pure, fixture-tested helper
+   (consider a shared `connectors/` util — Codex can reuse later).
+4. `connectors/opencode/opencode.ts` — the `AgentConnector` (`discover` w/ synthetic
+   keys + aggregate mtime + `existsSync`-guard; `prepare` → cache NDJSON;
+   `eventsProjectionSql` identical to Codex; `auxProjections` → titles;
+   `loadSession`). No memory methods.
+5. `connectors/registry.ts` — register `opencodeConnector`.
+6. `data/index.ts` — connector-scoped prune guard (hardening decision #2; still
+   TODO — verified the prune loop is not connector-scoped in main).
+7. **Perf isolation** — `perf/run.ts` MUST set `OPENCODE_DB_PATH`/`OPENCODE_DATA_DIR`
+   to an empty temp path (alongside the existing `CODEX`/`PI` isolation) BEFORE
+   registering the connector, or a dev `npm run bench` on a machine with a real
+   `~/.local/share/opencode/opencode.db` pays the per-poll `discover()` query and
+   trips the noop-reindex gate (~+34% measured). CI (ubuntu, no DB) is safe; the
+   absent-DB `discover()` is ~0.008ms. Add the same isolation to the integration/
+   pricing/dedup/recovery suites.
+8. Web — `AgentBadge.tsx` `'opencode' → 'opencode'`; `browse.css`
+   `.tv-agent--opencode` colors. No other web changes: the `ToolBlock` `Read`
+   image tweak is already in main, and `grep`/`glob`/`webfetch`/`skill`/`todowrite`
+   intentionally render as generic JSON (no special renderer — acceptable).
+9. Docs — `README.md` (SQLite source row), `CLAUDE.md` (gotchas: SQLite-backed
+   source; opencode reasoning renders plaintext; `apply_patch`→canonical edits).
+
+## Files affected
+
+- `packages/server/src/config.ts` — `OPENCODE_DATA_DIR` + `OPENCODE_DB_PATH` (no
+  config dir — memory skipped).
+- `packages/server/src/connectors/opencode/{db,normalize,opencode}.ts` — new
+  connector incl. the `parseApplyPatch()` helper and the image `file`-part branch
+  (no `memory.ts`; memory skipped).
+- `packages/server/src/connectors/registry.ts` — register.
+- `packages/server/src/data/index.ts` — connector-scoped prune guard (still TODO).
+- `packages/web/src/components/AgentBadge.tsx`, `pages/browse/browse.css` — label +
+  badge color only (the `ToolBlock` `Read` image tweak is already in main).
+- `packages/server/perf/run.ts` + the integration/pricing/dedup/recovery suites —
+  add `OPENCODE_DB_PATH`/`OPENCODE_DATA_DIR` isolation (perf gate + determinism).
+- `packages/server/test/opencode.integration.test.ts` — new suite (build a
+  synthetic `opencode.db` in a temp dir; never touch real `~/.local/share`).
+- `README.md`, `CLAUDE.md`, `docs/plans/README.md`.
+
+## Testing
+
+`npm run typecheck` + `npm test`. Fixtures build a real throwaway SQLite DB and
+target the edges:
+
+- **token additivity** — per-message tokens (input direct, reasoning folded into
+  output) sum to the `session.tokens_*` columns; a `gpt-5.4-mini-fast` turn costs
+  at `0.75/4.50/0.075`.
+- **change detection** — appending a `part` (last-turn edit) bumps the aggregate
+  mtime so the session re-indexes; an untouched session is skipped.
+- **prune resilience** — a `discover()` that throws (DB present but unreadable)
+  must NOT purge previously-indexed opencode sessions (and must never touch other
+  connectors' files).
+- **plaintext reasoning** renders / reaches `text_content`.
+- **tool_use ↔ tool_result** pairing by `callID`; `step-*`/`patch` parts dropped.
+- **no double-count** — message-level aggregation vs `step-finish` parts.
+- **`parseApplyPatch()` weird cases** (pure unit test): a bare-`@@` Update hunk with
+  context lines carried into both sides; a multi-file patch (Add + Delete) fanning
+  one part → N canonical blocks; Add File → `Write`; Delete File → `Edit` with the
+  removed body from `metadata.files[]`; the error/rejected patch (no metadata →
+  `'(file deleted)'` marker + `isError`); CRLF normalization; strip exactly one
+  prefix char (preserve leading whitespace).
+- **Files-changed tab** — the parsed `apply_patch` edits appear in `buildChangeset`
+  (file_path + add/remove counts).
+- **screenshot** — an image `file` part becomes a canonical `ImageBlock`
+  (`source.type==='url'`, `data:` URL) on the message.
+- **OPENCODE_DB_PATH isolation** — bench/test harness points at an absent temp DB
+  so `discover()` returns `[]` cheaply and runs stay deterministic.
+
+## Risks / open questions
+
+- **Delete-File fidelity** — V4A `*** Delete File:` carries no body; the removed
+  content comes from `state.metadata.files[]`, which is absent on error/rejected
+  patches → those show as a `'(file deleted)'` marker rather than a full diff.
+  Best-effort, documented.
+- **`apply_patch` parse robustness** — bare `@@` hunks have no line numbers, so
+  old/new are reconstructed purely from prefixes; malformed `patchText` must be
+  tolerated (fall back to a generic block, never throw). Lock down with fixtures.
+- **Generic-rendered tools** — `ToolBlock` has no `Grep`/`Glob`/`WebFetch`/`Skill`/
+  `TodoWrite` case, so those render as JSON. Acceptable (not a bug); pretty
+  renderers would be separate web work, out of scope.
+- **Dev-bench perf** — only an issue if `perf/run.ts` isn't isolated (a real local
+  opencode DB makes `discover()` pay per poll, ~+34%). CI is unaffected. Mitigated
+  by the `OPENCODE_DB_PATH` isolation step.
+- **Sub-sessions** (`session.parent_id`) — none populated to validate nesting;
+  shipped as own-session for now.
+- **XDG / OS paths** — confirm the Linux/Windows data location beyond the macOS
+  `~/.local/share` tested here.
+- **Pricing** — resolved: `gpt-5.4-mini-fast` is priced (as standard `gpt-5.4-mini`,
+  no official `-fast` SKU) and the lineup/lazy-sync shipped in PR #22. Revisit only
+  if opencode is found to bill a priority tier.

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -44,3 +44,4 @@ decision, or a change worth explaining before doing. Skip it for one-line fixes.
 | 0017 | [Maintainer review fixes: resiliency tests, daemon hardening, render & contract guards](./0017-maintainer-review-fixes.md) | done |
 | 0018 | [Analytics breakdown by cost (Metric + Sort toggles)](./0018-analytics-breakdown-cost.md) | done |
 | 0019 | [pi connector](./0019-pi-connector.md) | done |
+| 0020 | [opencode connector](./0020-opencode-connector.md) | done |

--- a/packages/server/perf/run.ts
+++ b/packages/server/perf/run.ts
@@ -35,6 +35,7 @@ process.env.CLAUDE_PROJECTS_DIR = projectsDir;
 // Isolate from any real ~/.codex / ~/.pi so the bench corpus is exactly what we generate.
 process.env.CODEX_SESSIONS_DIR = join(work, 'codex-empty');
 process.env.PI_SESSIONS_DIR = join(work, 'pi-empty');
+process.env.OPENCODE_DATA_DIR = join(work, 'opencode-empty');
 process.env.DUCKDB_PATH = join(work, 'index.duckdb');
 process.env.CLAUDESCOPE_HOME = join(work, 'home');
 process.env.REINDEX_INTERVAL_MS = '0';

--- a/packages/server/src/config.ts
+++ b/packages/server/src/config.ts
@@ -67,6 +67,21 @@ export const PI_SESSIONS_DIR = expandHome(
 );
 
 /**
+ * READ-ONLY source of opencode sessions. The app MUST NEVER write here. Unlike the
+ * other agents, opencode stores everything in ONE SQLite DB. `OPENCODE_DATA_DIR`
+ * defaults to `$XDG_DATA_HOME/opencode` (else `~/.local/share/opencode`) and
+ * `OPENCODE_DB_PATH` is `<dataDir>/opencode.db`. The connector opens the DB
+ * strictly read-only (`node:sqlite`). Override either with its env var; a leading
+ * `~` is expanded.
+ */
+export const OPENCODE_DATA_DIR = expandHome(
+  process.env.OPENCODE_DATA_DIR ??
+    join(process.env.XDG_DATA_HOME ?? join(homedir(), '.local', 'share'), 'opencode'),
+);
+export const OPENCODE_DB_PATH =
+  process.env.OPENCODE_DB_PATH ?? join(OPENCODE_DATA_DIR, 'opencode.db');
+
+/**
  * READ-ONLY agent home directories — the parents of the session/project dirs
  * above, where each agent keeps its memory (`CLAUDE.md`, `AGENTS.md`, the Codex
  * `memories/` tree). Derived from the dirs above so the env overrides carry

--- a/packages/server/src/connectors/opencode/db.ts
+++ b/packages/server/src/connectors/opencode/db.ts
@@ -1,0 +1,111 @@
+/**
+ * Read-only opencode SQLite access via Node's built-in `node:sqlite` (Node 24 —
+ * no new dependency). opencode keeps all transcripts in one DB
+ * (`session`/`message`/`part`), so the connector reads it here and the normalizer
+ * turns a session into canonical rows / events.
+ *
+ * STRICTLY READ-ONLY: every open is `{readOnly:true}` and the handle is closed
+ * immediately; the app NEVER writes the DB or touches `-wal`/`-shm`.
+ */
+
+import { DatabaseSync } from 'node:sqlite';
+import { existsSync } from 'node:fs';
+
+/** One session's change signal, for incremental discovery. */
+export interface OpencodeSessionMeta {
+  id: string;
+  /** max(session, message, part).time_updated — `session.time_updated` lags the last turn. */
+  mtimeMs: number;
+  /** Monotonic-on-change size proxy: message + part counts. */
+  size: number;
+}
+
+/** One session's raw rows (JSON `data` left as strings for the normalizer to parse). */
+export interface OpencodeRawSession {
+  id: string;
+  directory: string;
+  title: string;
+  /** message rows in creation order. */
+  messages: { id: string; data: string }[];
+  /** part `data` strings grouped by message id, each list in creation order. */
+  partsByMessage: Map<string, string[]>;
+}
+
+function open(dbPath: string): InstanceType<typeof DatabaseSync> {
+  return new DatabaseSync(dbPath, { readOnly: true });
+}
+
+/**
+ * Enumerate every session with its change signal.
+ *
+ * Returns `[]` when the DB FILE is absent (opencode not installed). When the file
+ * EXISTS but can't be opened/queried, it THROWS — the indexer's prune loop is not
+ * connector-scoped, so a silent `[]` on a transient SQLite error would make it
+ * treat every opencode session as deleted and wipe them all (see plan 0020).
+ */
+export function listSessions(dbPath: string): OpencodeSessionMeta[] {
+  if (!existsSync(dbPath)) return [];
+  const db = open(dbPath);
+  try {
+    const rows = db
+      .prepare(
+        `SELECT s.id AS id,
+           max(
+             s.time_updated,
+             COALESCE((SELECT max(time_updated) FROM message m WHERE m.session_id = s.id), 0),
+             COALESCE((SELECT max(time_updated) FROM part    p WHERE p.session_id = s.id), 0)
+           ) AS mtime,
+           (
+             (SELECT count(*) FROM message m WHERE m.session_id = s.id) +
+             (SELECT count(*) FROM part    p WHERE p.session_id = s.id)
+           ) AS size
+         FROM session s`,
+      )
+      .all() as { id: string; mtime: number; size: number }[];
+    return rows.map((r) => ({
+      id: String(r.id),
+      mtimeMs: Math.floor(Number(r.mtime)),
+      size: Number(r.size),
+    }));
+  } finally {
+    db.close();
+  }
+}
+
+/** Read one session's metadata + messages + parts; `null` if the session is gone. */
+export function readSession(dbPath: string, sessionId: string): OpencodeRawSession | null {
+  if (!existsSync(dbPath)) return null;
+  const db = open(dbPath);
+  try {
+    const s = db.prepare('SELECT id, directory, title FROM session WHERE id = ?').get(sessionId) as
+      | { id: string; directory: string | null; title: string | null }
+      | undefined;
+    if (!s) return null;
+
+    const messages = (
+      db
+        .prepare('SELECT id, data FROM message WHERE session_id = ? ORDER BY time_created, id')
+        .all(sessionId) as { id: string; data: string }[]
+    ).map((m) => ({ id: String(m.id), data: String(m.data) }));
+
+    const partRows = db
+      .prepare('SELECT message_id AS mid, data FROM part WHERE session_id = ? ORDER BY time_created, id')
+      .all(sessionId) as { mid: string; data: string }[];
+    const partsByMessage = new Map<string, string[]>();
+    for (const p of partRows) {
+      const list = partsByMessage.get(String(p.mid)) ?? [];
+      list.push(String(p.data));
+      partsByMessage.set(String(p.mid), list);
+    }
+
+    return {
+      id: String(s.id),
+      directory: String(s.directory ?? ''),
+      title: String(s.title ?? ''),
+      messages,
+      partsByMessage,
+    };
+  } finally {
+    db.close();
+  }
+}

--- a/packages/server/src/connectors/opencode/normalize.ts
+++ b/packages/server/src/connectors/opencode/normalize.ts
@@ -1,0 +1,386 @@
+/**
+ * opencode session → canonical thread normalizer.
+ *
+ * opencode stores a session across `message` + `part` rows (see `db.ts`). This
+ * turns one session into Claude-shaped `RawEvent[]` (so the thread assembler and
+ * the canonical index rows reuse it), mirroring the Codex/pi normalizers.
+ *
+ * Key opencode specifics:
+ *  - **File edits go through `apply_patch`**, not edit/write. We translate each
+ *    `apply_patch` part into canonical `Write`/`Edit`/`MultiEdit` tool_use blocks
+ *    (one per touched file) so the Files-changed tab (`changeset.ts`) and tool
+ *    rendering work — preferring `state.metadata.files[]` (a typed per-file unified
+ *    diff, present on every COMPLETED patch) over the raw V4A `patchText`.
+ *  - **Reasoning is PLAINTEXT** (`reasoning` part → thinking block).
+ *  - **Screenshots** ride a `file` part (`{mime, url:data-URL}`) on the user
+ *    message → canonical base64/url `ImageBlock`.
+ *  - Tokens are per-message (`message.data.tokens`); reasoning folds into output.
+ *  - A tool part carries BOTH the call and its result, so we emit the `tool_use`
+ *    on the assistant turn and the `tool_result` on a following synthetic user
+ *    turn (the Claude/Codex/pi convention the assembler pairs by id).
+ */
+
+import type {
+  AssistantEvent,
+  ContentBlock,
+  MessageUsage,
+  ToolResultBlock,
+  ToolUseBlock,
+  UserEvent,
+} from '@claudescope/shared';
+import type { OpencodeRawSession } from './db.js';
+
+const str = (v: unknown): string => (typeof v === 'string' ? v : '');
+const num = (v: unknown): number => (typeof v === 'number' && Number.isFinite(v) ? v : 0);
+
+function parseJson(s: string): Record<string, unknown> {
+  try {
+    const v = JSON.parse(s) as unknown;
+    return v && typeof v === 'object' ? (v as Record<string, unknown>) : {};
+  } catch {
+    return {};
+  }
+}
+
+function isoFromMs(ms: unknown): string {
+  const n = num(ms);
+  return n > 0 ? new Date(n).toISOString() : '';
+}
+
+// --- apply_patch → canonical edit blocks ------------------------------------
+
+interface Hunk {
+  oldText: string;
+  newText: string;
+}
+
+/**
+ * Parse a unified diff (`metadata.files[].patch`: `Index:`/`---`/`+++`/`@@ … @@`)
+ * into hunks. Header lines before the first `@@` are skipped; within a hunk,
+ * ` ` = context (both sides), `-` = removed (old side), `+` = added (new side).
+ * Exactly one prefix char is stripped (leading whitespace in code is preserved).
+ */
+function parseHunks(patch: string): Hunk[] {
+  const lines = patch.replace(/\r\n/g, '\n').split('\n');
+  const hunks: Hunk[] = [];
+  let cur: { old: string[]; neu: string[] } | null = null;
+  const flush = (): void => {
+    if (cur) hunks.push({ oldText: cur.old.join('\n'), newText: cur.neu.join('\n') });
+  };
+  for (const line of lines) {
+    if (line.startsWith('@@')) {
+      flush();
+      cur = { old: [], neu: [] };
+      continue;
+    }
+    if (!cur) continue; // still in the diff header
+    const tag = line[0];
+    const body = line.slice(1);
+    if (tag === ' ') {
+      cur.old.push(body);
+      cur.neu.push(body);
+    } else if (tag === '-') {
+      cur.old.push(body);
+    } else if (tag === '+') {
+      cur.neu.push(body);
+    }
+    // '\' (no-newline marker) and stray lines: ignored
+  }
+  flush();
+  return hunks;
+}
+
+/**
+ * opencode's `read` tool wraps its output as
+ * `<path>…</path>\n<type>file</type>\n<content>\n1: …\n</content>\n(End of file …)`.
+ * The canonical `Read` block already shows the path (from `file_path`), so unwrap
+ * to just the `<content>` body (line numbers kept) and drop the redundant tags.
+ */
+function unwrapReadOutput(output: string): string {
+  const m = output.match(/<content>\n?([\s\S]*?)\n?<\/content>/);
+  return m?.[1] ?? output;
+}
+
+/** A concise per-file status for an apply_patch result (avoids repeating the
+ *  whole multi-file "Success. Updated …" summary on every fanned-out block). */
+function fileStatus(file: Record<string, unknown>): string {
+  const type = str(file.type);
+  const verb = type === 'add' ? 'Created' : type === 'delete' ? 'Deleted' : 'Updated';
+  return `${verb} ${str(file.relativePath) || str(file.filePath)}`;
+}
+
+/** One `metadata.files[]` entry → a canonical Write/Edit/MultiEdit tool_use block. */
+function fileToToolUse(file: Record<string, unknown>, id: string): ToolUseBlock {
+  const file_path = str(file.filePath) || str(file.relativePath);
+  const hunks = parseHunks(str(file.patch));
+  const type = str(file.type);
+  if (type === 'add') {
+    const content = hunks
+      .map((h) => h.newText)
+      .filter((t) => t.length > 0)
+      .join('\n');
+    return { type: 'tool_use', id, name: 'Write', input: { file_path, content } };
+  }
+  if (type === 'delete') {
+    const old = hunks
+      .map((h) => h.oldText)
+      .filter((t) => t.length > 0)
+      .join('\n');
+    return { type: 'tool_use', id, name: 'Edit', input: { file_path, old_string: old, new_string: '' } };
+  }
+  // update
+  const edits = hunks.map((h) => ({ old_string: h.oldText, new_string: h.newText }));
+  return { type: 'tool_use', id, name: 'MultiEdit', input: { file_path, edits } };
+}
+
+interface ToolBlocks {
+  uses: ContentBlock[];
+  results: ToolResultBlock[];
+}
+
+/**
+ * Map one `tool` part to canonical tool_use block(s) + their tool_result(s),
+ * paired by `callID`. `apply_patch` fans out to one block PER touched file (so
+ * each file is its own diff in the thread and in the Files-changed tab).
+ */
+function toolPartBlocks(data: Record<string, unknown>): ToolBlocks {
+  const tool = str(data.tool);
+  const callID = str(data.callID);
+  const state = (data.state ?? {}) as Record<string, unknown>;
+  const input = (state.input ?? {}) as Record<string, unknown>;
+  const output = str(state.output);
+  const isError = str(state.status) === 'error' || state.error != null;
+  const result = (id: string, content: string): ToolResultBlock => ({
+    type: 'tool_result',
+    tool_use_id: id,
+    content,
+    ...(isError ? { is_error: true } : {}),
+  });
+
+  if (tool === 'apply_patch') {
+    const metadata = (state.metadata ?? {}) as Record<string, unknown>;
+    const files = Array.isArray(metadata.files) ? (metadata.files as Record<string, unknown>[]) : [];
+    if (files.length > 0) {
+      const uses: ContentBlock[] = [];
+      const results: ToolResultBlock[] = [];
+      files.forEach((f, i) => {
+        const id = files.length === 1 ? callID : `${callID}#${i}`;
+        uses.push(fileToToolUse(f, id));
+        // Per-file status, NOT the shared multi-file summary (which would repeat
+        // identically on every fanned-out block).
+        results.push(result(id, fileStatus(f)));
+      });
+      return { uses, results };
+    }
+    // No metadata (the error/rejected case) — show the attempted patch + error.
+    return {
+      uses: [{ type: 'tool_use', id: callID, name: 'apply_patch', input }],
+      results: [result(callID, output || str(state.error) || 'patch failed')],
+    };
+  }
+
+  let use: ToolUseBlock;
+  if (tool === 'read') {
+    use = {
+      type: 'tool_use',
+      id: callID,
+      name: 'Read',
+      input: { file_path: str(input.filePath), offset: input.offset, limit: input.limit },
+    };
+  } else if (tool === 'bash') {
+    use = {
+      type: 'tool_use',
+      id: callID,
+      name: 'Bash',
+      input: { command: str(input.command), timeout: input.timeout, description: str(input.description) },
+    };
+  } else {
+    // grep / glob / webfetch / skill / todowrite / unknown → generic passthrough
+    use = { type: 'tool_use', id: callID, name: tool, input };
+  }
+  // `read` output is wrapped in <path>/<type>/<content> — unwrap it; others raw.
+  return { uses: [use], results: [result(callID, tool === 'read' ? unwrapReadOutput(output) : output)] };
+}
+
+// --- content blocks ---------------------------------------------------------
+
+/** A `file` part → canonical ImageBlock when it's an image; else null. */
+function imageBlock(data: Record<string, unknown>): ContentBlock | null {
+  const url = str(data.url);
+  if (!str(data.mime).startsWith('image/') || !url) return null;
+  // opencode stores a `data:<mime>;base64,…` URL — renders as a `url` source.
+  return { type: 'image', source: { type: 'url', url } };
+}
+
+/** message.data.tokens → canonical usage (reasoning folded into output). */
+function toUsage(tokens: unknown): MessageUsage {
+  const t = (tokens ?? {}) as Record<string, unknown>;
+  const cache = (t.cache ?? {}) as Record<string, unknown>;
+  return {
+    input_tokens: num(t.input),
+    output_tokens: num(t.output) + num(t.reasoning),
+    cache_read_input_tokens: num(cache.read),
+    cache_creation_input_tokens: num(cache.write),
+  };
+}
+
+// --- session → events -------------------------------------------------------
+
+export function buildEvents(session: OpencodeRawSession): (UserEvent | AssistantEvent)[] {
+  const events: (UserEvent | AssistantEvent)[] = [];
+  const cwd = session.directory;
+  let seq = 0;
+  let prevUuid: string | null = null;
+  const nextUuid = (): string => `${session.id}-${seq++}`;
+
+  for (const m of session.messages) {
+    const data = parseJson(m.data);
+    const role = str(data.role);
+    const ts = isoFromMs((data.time as Record<string, unknown> | undefined)?.created);
+    const parts = (session.partsByMessage.get(m.id) ?? []).map(parseJson);
+
+    if (role === 'assistant') {
+      const blocks: ContentBlock[] = [];
+      const toolResults: ToolResultBlock[] = [];
+      for (const p of parts) {
+        switch (str(p.type)) {
+          case 'text':
+            if (str(p.text)) blocks.push({ type: 'text', text: str(p.text) });
+            break;
+          case 'reasoning':
+            // plaintext reasoning — keep it (no empty-thinking gotcha for opencode)
+            blocks.push({ type: 'thinking', thinking: str(p.text) });
+            break;
+          case 'file': {
+            const img = imageBlock(p);
+            if (img) blocks.push(img);
+            break;
+          }
+          case 'tool': {
+            const { uses, results } = toolPartBlocks(p);
+            blocks.push(...uses);
+            toolResults.push(...results);
+            break;
+          }
+          default:
+            break; // step-start / step-finish / patch → dropped
+        }
+      }
+      const model =
+        str(data.modelID) || str((data.model as Record<string, unknown> | undefined)?.modelID);
+      const uuid = nextUuid();
+      const parentUuid = prevUuid;
+      prevUuid = uuid;
+      events.push({
+        uuid,
+        parentUuid,
+        sessionId: session.id,
+        timestamp: ts,
+        cwd,
+        isSidechain: false,
+        type: 'assistant',
+        message: { role: 'assistant', model, content: blocks, usage: toUsage(data.tokens) },
+      } as AssistantEvent);
+      // Tool results ride a following synthetic user turn (assembler pairs by id).
+      if (toolResults.length > 0) {
+        const ruid = nextUuid();
+        const rparent = prevUuid;
+        prevUuid = ruid;
+        events.push({
+          uuid: ruid,
+          parentUuid: rparent,
+          sessionId: session.id,
+          timestamp: ts,
+          cwd,
+          isSidechain: false,
+          type: 'user',
+          message: { role: 'user', content: toolResults },
+        } as UserEvent);
+      }
+    } else {
+      // user (or any non-assistant role) — text + pasted-image file parts
+      const blocks: ContentBlock[] = [];
+      for (const p of parts) {
+        if (str(p.type) === 'text') {
+          if (str(p.text)) blocks.push({ type: 'text', text: str(p.text) });
+        } else if (str(p.type) === 'file') {
+          const img = imageBlock(p);
+          if (img) blocks.push(img);
+        }
+      }
+      const uuid = nextUuid();
+      const parentUuid = prevUuid;
+      prevUuid = uuid;
+      events.push({
+        uuid,
+        parentUuid,
+        sessionId: session.id,
+        timestamp: ts,
+        cwd,
+        isSidechain: false,
+        type: 'user',
+        message: { role: 'user', content: blocks },
+      } as UserEvent);
+    }
+  }
+
+  return events;
+}
+
+/** A canonical index row (matches the events NDJSON the projection reads). */
+export interface CanonicalRow {
+  file_path: string;
+  session_id: string;
+  uuid: string;
+  parent_uuid: string | null;
+  role: string;
+  type: string;
+  ts: string;
+  cwd: string;
+  git_branch: string | null;
+  model: string | null;
+  input_tokens: number;
+  output_tokens: number;
+  cache_read_tokens: number;
+  cache_write_tokens: number;
+  service_tier: string | null;
+  is_sidechain: boolean;
+  tool_use_count: number;
+  text_content: string;
+  /** Session title (read by auxProjections; ignored by the events projection). */
+  title: string;
+}
+
+/** Flatten a parsed session into canonical index rows for one file. */
+export function toCanonicalRows(session: OpencodeRawSession, filePath: string): CanonicalRow[] {
+  return buildEvents(session).map((e) => {
+    const msg = e.message;
+    const content = Array.isArray(msg.content) ? msg.content : [];
+    const usage = (msg as { usage?: MessageUsage }).usage;
+    const text = content
+      .map((b) => (b.type === 'text' ? b.text : b.type === 'thinking' ? b.thinking : ''))
+      .filter(Boolean)
+      .join(' ');
+    return {
+      file_path: filePath,
+      session_id: session.id,
+      uuid: e.uuid,
+      parent_uuid: e.parentUuid,
+      role: msg.role,
+      type: e.type,
+      ts: e.timestamp,
+      cwd: session.directory,
+      git_branch: null,
+      model: (msg as { model?: string }).model ?? null,
+      input_tokens: num(usage?.input_tokens),
+      output_tokens: num(usage?.output_tokens),
+      cache_read_tokens: num(usage?.cache_read_input_tokens),
+      cache_write_tokens: num(usage?.cache_creation_input_tokens),
+      service_tier: null,
+      is_sidechain: false,
+      tool_use_count: content.filter((b) => b.type === 'tool_use').length,
+      text_content: text,
+      title: session.title,
+    };
+  });
+}

--- a/packages/server/src/connectors/opencode/opencode.ts
+++ b/packages/server/src/connectors/opencode/opencode.ts
@@ -1,0 +1,119 @@
+/**
+ * opencode connector.
+ *
+ * Unlike the other agents, opencode stores every transcript in ONE SQLite DB
+ * (`~/.local/share/opencode/opencode.db`). The connector seam still fits: each
+ * **session** is treated as a synthetic `DiscoveredFile` keyed `<dbPath>#<id>`,
+ * `prepare()` extracts that session from the DB to a canonical NDJSON (the Codex
+ * pattern), and `eventsProjectionSql` reads it 1:1. The DB is opened strictly
+ * read-only via `node:sqlite` (Node 24 — no new dependency).
+ *
+ * opencode keeps no memory in its home dir, so this connector contributes none.
+ *
+ * STRICTLY READ-ONLY with respect to the opencode DB — it is only ever read.
+ */
+
+import { createHash } from 'node:crypto';
+import { existsSync, mkdirSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { CLAUDESCOPE_HOME, OPENCODE_DATA_DIR, OPENCODE_DB_PATH } from '../../config.js';
+import { sqlString } from '../../db/duckdb.js';
+import type { SessionData } from '../../data/session-loader.js';
+import type { AgentConnector, AuxProjections, DiscoveredFile } from '../types.js';
+import { listSessions, readSession } from './db.js';
+import { buildEvents, toCanonicalRows } from './normalize.js';
+
+const CACHE_DIR = join(CLAUDESCOPE_HOME, 'cache', 'opencode');
+
+/** Synthetic per-session key → its DB path + session id. opencode ids are
+ *  `ses_<base62>` (no `#`), so splitting on the first `#` is unambiguous. */
+function makeKey(sessionId: string): string {
+  return `${OPENCODE_DB_PATH}#${sessionId}`;
+}
+function parseKey(filePath: string): { dbPath: string; sessionId: string } {
+  const i = filePath.indexOf('#');
+  return i === -1
+    ? { dbPath: filePath, sessionId: '' }
+    : { dbPath: filePath.slice(0, i), sessionId: filePath.slice(i + 1) };
+}
+
+/** Deterministic temp NDJSON path for a given synthetic session key. */
+function cachePath(filePath: string): string {
+  const hash = createHash('sha1').update(filePath).digest('hex').slice(0, 16);
+  return join(CACHE_DIR, `${hash}.ndjson`);
+}
+
+/**
+ * One synthetic `DiscoveredFile` per session, with the change signal from
+ * {@link listSessions}. Returns `[]` when the DB is absent; **throws** when the
+ * DB exists but can't be read, so the indexer never mistakes a transient SQLite
+ * failure for "all opencode sessions deleted" (the indexer isolates a throwing
+ * connector and preserves its prior files — see `data/index.ts`).
+ */
+function discover(): DiscoveredFile[] {
+  return listSessions(OPENCODE_DB_PATH).map((s) => ({
+    path: makeKey(s.id),
+    mtimeMs: s.mtimeMs,
+    size: s.size,
+  }));
+}
+
+/** Extract one session from the DB to a canonical NDJSON the projection reads. */
+async function prepare(filePath: string): Promise<void> {
+  const { dbPath, sessionId } = parseKey(filePath);
+  const session = readSession(dbPath, sessionId);
+  mkdirSync(CACHE_DIR, { recursive: true });
+  const rows = session ? toCanonicalRows(session, filePath) : [];
+  writeFileSync(cachePath(filePath), rows.map((r) => JSON.stringify(r)).join('\n') + '\n');
+}
+
+function eventsProjectionSql(filePath: string): string {
+  const path = sqlString(cachePath(filePath));
+  return `
+    SELECT
+      file_path, session_id, uuid, parent_uuid, role, type, ts, cwd, git_branch,
+      model, input_tokens, output_tokens, cache_read_tokens, cache_write_tokens,
+      service_tier, is_sidechain, tool_use_count, text_content,
+      CAST(NULL AS VARCHAR) AS message_id, CAST(NULL AS VARCHAR) AS forked_from_session_id
+    FROM read_ndjson(${path}, format='newline_delimited', maximum_object_size=268435456, ignore_errors=true, columns={
+      file_path:'VARCHAR', session_id:'VARCHAR', uuid:'VARCHAR', parent_uuid:'VARCHAR',
+      role:'VARCHAR', type:'VARCHAR', ts:'TIMESTAMP', cwd:'VARCHAR', git_branch:'VARCHAR',
+      model:'VARCHAR', input_tokens:'BIGINT', output_tokens:'BIGINT', cache_read_tokens:'BIGINT',
+      cache_write_tokens:'BIGINT', service_tier:'VARCHAR', is_sidechain:'BOOLEAN',
+      tool_use_count:'INTEGER', text_content:'VARCHAR'
+    })`;
+}
+
+/** opencode stores a real per-session title; carried through the cache NDJSON. */
+function auxProjections(filePath: string): AuxProjections {
+  if (!existsSync(cachePath(filePath))) return {};
+  const path = sqlString(cachePath(filePath));
+  return {
+    titles: `
+      SELECT session_id, last(title) AS title
+      FROM read_ndjson(${path}, format='newline_delimited', maximum_object_size=268435456, ignore_errors=true,
+        columns={session_id:'VARCHAR', title:'VARCHAR'})
+      WHERE session_id IS NOT NULL AND title IS NOT NULL AND title <> ''
+      GROUP BY session_id`,
+  };
+}
+
+async function loadSession(_sessionId: string, paths: string[]): Promise<SessionData> {
+  const mainEvents = paths.flatMap((p) => {
+    const { dbPath, sessionId } = parseKey(p);
+    const session = readSession(dbPath, sessionId);
+    return session ? buildEvents(session) : [];
+  });
+  return { mainEvents, subagents: [] };
+}
+
+export const opencodeConnector: AgentConnector = {
+  id: 'opencode',
+  label: 'opencode',
+  sourceDir: OPENCODE_DATA_DIR,
+  discover,
+  prepare,
+  eventsProjectionSql,
+  auxProjections,
+  loadSession,
+};

--- a/packages/server/src/connectors/registry.ts
+++ b/packages/server/src/connectors/registry.ts
@@ -8,12 +8,14 @@ import { claudeCodeConnector } from './claude-code/claude-code.js';
 import { codexConnector } from './codex/codex.js';
 import { junieConnector } from './junie/junie.js';
 import { piConnector } from './pi/pi.js';
+import { opencodeConnector } from './opencode/opencode.js';
 
 export const connectors: AgentConnector[] = [
   claudeCodeConnector,
   codexConnector,
   junieConnector,
   piConnector,
+  opencodeConnector,
 ];
 
 /** The connector with the given id, falling back to Claude Code if unknown. */

--- a/packages/server/src/data/index.ts
+++ b/packages/server/src/data/index.ts
@@ -356,24 +356,46 @@ async function doReindex(): Promise<ReindexResponse> {
   };
 
   // Discover across every registered connector, tagging each file with its owner.
+  // Isolate per-connector discovery failures: a connector that throws (e.g. a
+  // transient SQLite error from the single opencode DB) must NOT abort the whole
+  // reindex, NOR have its previously-indexed sessions pruned just because it
+  // returned nothing this pass. We record it as "failed this pass" and exclude its
+  // files from the prune below (its absence is transient, not a deletion).
   const discovered: { file: DiscoveredFile; connector: AgentConnector }[] = [];
+  const failedConnectors = new Set<string>();
   for (const connector of connectors) {
-    for (const file of connector.discover()) discovered.push({ file, connector });
+    try {
+      for (const file of connector.discover()) discovered.push({ file, connector });
+    } catch (err) {
+      failedConnectors.add(connector.id);
+      console.warn(
+        `claudescope: ${connector.id} discovery failed; preserving its indexed sessions this pass:`,
+        err,
+      );
+    }
   }
 
-  // Build a lookup of already-indexed (path -> mtime,size).
-  const existingRows = await queryRows(conn, 'SELECT path, mtime_ms, size_bytes FROM files');
-  const existing = new Map<string, { mtime: number; size: number }>();
+  // Build a lookup of already-indexed (path -> mtime,size,connector).
+  const existingRows = await queryRows(
+    conn,
+    'SELECT path, mtime_ms, size_bytes, connector_id FROM files',
+  );
+  const existing = new Map<string, { mtime: number; size: number; connectorId: string | null }>();
   for (const r of existingRows) {
-    existing.set(String(r.path), { mtime: Number(r.mtime_ms), size: Number(r.size_bytes) });
+    existing.set(String(r.path), {
+      mtime: Number(r.mtime_ms),
+      size: Number(r.size_bytes),
+      connectorId: r.connector_id != null ? String(r.connector_id) : null,
+    });
   }
 
   const discoveredPaths = new Set(discovered.map((d) => d.file.path));
 
-  // Drop files that no longer exist on disk (and their events).
+  // Drop files that no longer exist on disk (and their events) — but skip files
+  // owned by a connector whose discovery failed this pass (transient, not gone).
   let removed = 0;
-  for (const path of existing.keys()) {
-    if (!discoveredPaths.has(path)) {
+  for (const [path, meta] of existing) {
+    if (!discoveredPaths.has(path) && !(meta.connectorId && failedConnectors.has(meta.connectorId))) {
       // Delete stale aux rows before clearing events: the subquery reads events
       // to resolve session ids, so aux deletes must precede the events delete.
       await conn.run(`DELETE FROM titles   WHERE session_id IN (SELECT DISTINCT session_id FROM events WHERE file_path = ${sqlString(path)})`);

--- a/packages/server/test/api.integration.test.ts
+++ b/packages/server/test/api.integration.test.ts
@@ -25,6 +25,7 @@ process.env.CLAUDE_PROJECTS_DIR = projectsDir;
 process.env.CODEX_SESSIONS_DIR = join(work, 'codex-empty');
 process.env.JUNIE_SESSIONS_DIR = join(work, 'junie-empty');
 process.env.PI_SESSIONS_DIR = join(work, 'pi-empty');
+process.env.OPENCODE_DATA_DIR = join(work, 'opencode-empty');
 process.env.DUCKDB_PATH = dbPath;
 process.env.CLAUDESCOPE_HOME = join(work, 'home');
 process.env.REINDEX_INTERVAL_MS = '0';

--- a/packages/server/test/codex.integration.test.ts
+++ b/packages/server/test/codex.integration.test.ts
@@ -23,6 +23,7 @@ process.env.CODEX_SESSIONS_DIR = codexDir;
 // Isolate from the real ~/.junie and ~/.pi so this Codex-only suite stays deterministic.
 process.env.JUNIE_SESSIONS_DIR = join(work, 'junie-empty');
 process.env.PI_SESSIONS_DIR = join(work, 'pi-empty');
+process.env.OPENCODE_DATA_DIR = join(work, 'opencode-empty');
 process.env.DUCKDB_PATH = join(work, 'index.duckdb');
 process.env.CLAUDESCOPE_HOME = join(work, 'home');
 process.env.REINDEX_INTERVAL_MS = '0';

--- a/packages/server/test/dedup.integration.test.ts
+++ b/packages/server/test/dedup.integration.test.ts
@@ -42,6 +42,7 @@ process.env.CLAUDE_PROJECTS_DIR = projectsDir;
 process.env.CODEX_SESSIONS_DIR = join(work, 'codex-empty');
 process.env.JUNIE_SESSIONS_DIR = join(work, 'junie-empty');
 process.env.PI_SESSIONS_DIR = join(work, 'pi-empty');
+process.env.OPENCODE_DATA_DIR = join(work, 'opencode-empty');
 process.env.DUCKDB_PATH = dbPath;
 process.env.CLAUDESCOPE_HOME = join(work, 'home');
 process.env.REINDEX_INTERVAL_MS = '0';

--- a/packages/server/test/index-recovery.integration.test.ts
+++ b/packages/server/test/index-recovery.integration.test.ts
@@ -28,6 +28,7 @@ process.env.CLAUDE_PROJECTS_DIR = projectsDir;
 process.env.CODEX_SESSIONS_DIR = join(work, 'codex-empty');
 process.env.JUNIE_SESSIONS_DIR = join(work, 'junie-empty');
 process.env.PI_SESSIONS_DIR = join(work, 'pi-empty');
+process.env.OPENCODE_DATA_DIR = join(work, 'opencode-empty');
 process.env.CLAUDESCOPE_HOME = join(work, 'home');
 process.env.REINDEX_INTERVAL_MS = '0';
 process.env.PRICING_REFRESH_INTERVAL_MS = '0';

--- a/packages/server/test/junie.integration.test.ts
+++ b/packages/server/test/junie.integration.test.ts
@@ -25,6 +25,7 @@ process.env.CLAUDE_PROJECTS_DIR = claudeDir;
 process.env.CODEX_SESSIONS_DIR = codexDir;
 process.env.JUNIE_SESSIONS_DIR = junieDir;
 process.env.PI_SESSIONS_DIR = join(work, 'pi-empty');
+process.env.OPENCODE_DATA_DIR = join(work, 'opencode-empty');
 process.env.DUCKDB_PATH = join(work, 'index.duckdb');
 process.env.CLAUDESCOPE_HOME = join(work, 'home');
 process.env.REINDEX_INTERVAL_MS = '0';

--- a/packages/server/test/opencode.integration.test.ts
+++ b/packages/server/test/opencode.integration.test.ts
@@ -1,0 +1,213 @@
+/**
+ * opencode connector integration test.
+ *
+ * Builds a synthetic opencode SQLite DB (session/message/part) in a temp dir,
+ * indexes it, and exercises the routes — verifying the SQLite-sourced path: a
+ * session becomes one synthetic file, per-message tokens (reasoning folded into
+ * output) cost as `gpt-5.4-mini-fast`, plaintext reasoning renders, `apply_patch`
+ * fans out to canonical `MultiEdit`/`Write` (Files-changed tab), `read`→`Read`,
+ * and a pasted screenshot (`file` part, data URL) embeds.
+ *
+ * Never touches the real `~/.local/share/opencode`.
+ */
+
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { DatabaseSync } from 'node:sqlite';
+import { mkdirSync, mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import type { FastifyInstance } from 'fastify';
+
+const work = mkdtempSync(join(tmpdir(), 'claudescope-opencode-'));
+const ocDataDir = join(work, 'opencode');
+const claudeDir = join(work, 'claude-empty');
+
+process.env.CLAUDE_PROJECTS_DIR = claudeDir;
+process.env.CODEX_SESSIONS_DIR = join(work, 'codex-empty');
+process.env.JUNIE_SESSIONS_DIR = join(work, 'junie-empty');
+process.env.PI_SESSIONS_DIR = join(work, 'pi-empty');
+process.env.OPENCODE_DATA_DIR = ocDataDir;
+process.env.DUCKDB_PATH = join(work, 'index.duckdb');
+process.env.CLAUDESCOPE_HOME = join(work, 'home');
+process.env.REINDEX_INTERVAL_MS = '0';
+
+// 1x1 transparent PNG — stands in for a pasted clipboard screenshot.
+const PNG_URL =
+  'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYPhfDwAChwGA60e6kgAAAABJRU5ErkJggg==';
+
+const UPDATE_PATCH = [
+  'Index: /tmp/ocproj/a.txt',
+  '===================================================================',
+  '--- /tmp/ocproj/a.txt',
+  '+++ /tmp/ocproj/a.txt',
+  '@@ -1,2 +1,2 @@',
+  ' keep this line',
+  '-old line',
+  '+new line',
+].join('\n');
+
+const ADD_PATCH = [
+  'Index: /tmp/ocproj/new.txt',
+  '===================================================================',
+  '--- /tmp/ocproj/new.txt',
+  '+++ /tmp/ocproj/new.txt',
+  '@@ -0,0 +1,1 @@',
+  '+hello world',
+].join('\n');
+
+/** Build a minimal but realistic opencode.db (only the columns the connector reads). */
+function writeDb(): void {
+  mkdirSync(ocDataDir, { recursive: true });
+  const db = new DatabaseSync(join(ocDataDir, 'opencode.db'));
+  db.exec(`
+    CREATE TABLE session (id TEXT PRIMARY KEY, directory TEXT, title TEXT, time_created INTEGER, time_updated INTEGER);
+    CREATE TABLE message (id TEXT PRIMARY KEY, session_id TEXT, time_created INTEGER, time_updated INTEGER, data TEXT);
+    CREATE TABLE part (id TEXT PRIMARY KEY, message_id TEXT, session_id TEXT, time_created INTEGER, time_updated INTEGER, data TEXT);
+  `);
+  db.prepare('INSERT INTO session VALUES (?,?,?,?,?)').run(
+    'ses_test1', '/tmp/ocproj', 'Test session', 1000, 3000,
+  );
+
+  const msg = db.prepare('INSERT INTO message VALUES (?,?,?,?,?)');
+  msg.run('u1', 'ses_test1', 1000, 1000, JSON.stringify({ role: 'user', time: { created: 1000 } }));
+  msg.run('a1', 'ses_test1', 2000, 2000, JSON.stringify({
+    role: 'assistant', modelID: 'gpt-5.4-mini-fast', providerID: 'openai', time: { created: 2000 },
+    tokens: { total: 1550, input: 1000, output: 50, reasoning: 200, cache: { write: 0, read: 300 } },
+  }));
+
+  const part = db.prepare('INSERT INTO part VALUES (?,?,?,?,?,?)');
+  // user parts: prompt text + a pasted screenshot file part
+  part.run('p1', 'u1', 'ses_test1', 1001, 1001, JSON.stringify({ type: 'text', text: 'inspect and patch /tmp/ocproj — see screenshot' }));
+  part.run('p2', 'u1', 'ses_test1', 1002, 1002, JSON.stringify({ type: 'file', mime: 'image/png', filename: 'clipboard', url: PNG_URL }));
+  // assistant parts: reasoning + text + apply_patch (2 files) + read + step-finish
+  part.run('p3', 'a1', 'ses_test1', 2001, 2001, JSON.stringify({ type: 'reasoning', text: 'I will patch a.txt and add new.txt' }));
+  part.run('p4', 'a1', 'ses_test1', 2002, 2002, JSON.stringify({ type: 'text', text: 'Done — patched and read.' }));
+  part.run('p5', 'a1', 'ses_test1', 2003, 2003, JSON.stringify({
+    type: 'tool', tool: 'apply_patch', callID: 'call_p',
+    state: {
+      status: 'completed', input: { patchText: '*** Begin Patch\n…\n*** End Patch' },
+      // The shared multi-file summary must NOT end up duplicated on each block.
+      output: 'Success. Updated the following files:\nM a.txt\nA new.txt',
+      metadata: {
+        files: [
+          { filePath: '/tmp/ocproj/a.txt', relativePath: 'a.txt', type: 'update', patch: UPDATE_PATCH },
+          { filePath: '/tmp/ocproj/new.txt', relativePath: 'new.txt', type: 'add', patch: ADD_PATCH },
+        ],
+      },
+    },
+  }));
+  part.run('p6', 'a1', 'ses_test1', 2004, 2004, JSON.stringify({
+    type: 'tool', tool: 'read', callID: 'call_r',
+    state: {
+      status: 'completed', input: { filePath: '/tmp/ocproj/a.txt', offset: 1, limit: 10 },
+      // opencode wraps read output in <path>/<type>/<content> + line numbers.
+      output: '<path>/tmp/ocproj/a.txt</path>\n<type>file</type>\n<content>\n1: keep this line\n2: new line\n</content>\n\n(End of file - total 2 lines)',
+    },
+  }));
+  part.run('p7', 'a1', 'ses_test1', 2005, 2005, JSON.stringify({
+    type: 'step-finish', tokens: { total: 1550, input: 1000, output: 50, reasoning: 200, cache: { write: 0, read: 300 } }, cost: 0,
+  }));
+  db.close();
+}
+
+let app: FastifyInstance;
+let closeConnection: () => Promise<void>;
+
+beforeAll(async () => {
+  mkdirSync(claudeDir, { recursive: true });
+  writeDb();
+
+  const Fastify = (await import('fastify')).default;
+  const { registerRoutes } = await import('../src/routes/index.js');
+  const { reindex } = await import('../src/data/index.js');
+  ({ closeConnection } = await import('../src/db/duckdb.js'));
+
+  app = Fastify();
+  await registerRoutes(app);
+  await reindex();
+  await app.ready();
+});
+
+afterAll(async () => {
+  await app?.close();
+  await closeConnection?.();
+  rmSync(work, { recursive: true, force: true });
+});
+
+const get = (url: string) => app.inject({ method: 'GET', url });
+
+describe('opencode session indexing', () => {
+  it('lists the SQLite-sourced session with its stored title and an opencode tag', async () => {
+    const sessions = (await get('/api/sessions')).json();
+    expect(sessions.map((s: { id: string }) => s.id)).toEqual(['ses_test1']);
+    expect(sessions[0].connectorId).toBe('opencode');
+    expect(sessions[0].models).toContain('gpt-5.4-mini-fast');
+    expect(sessions[0].title).toBe('Test session'); // stored title, not first-message fallback
+  });
+
+  it('tags the project, exposes the source, and groups analytics by agent/model', async () => {
+    expect((await get('/api/projects')).json()[0].connectorIds).toContain('opencode');
+    expect((await get('/api/sources')).json().some((s: { id: string }) => s.id === 'opencode')).toBe(true);
+    const byAgent = (await get('/api/analytics?groupBy=agent')).json().rows.map((r: { key: string }) => r.key);
+    expect(byAgent).toContain('opencode');
+    const byModel = (await get('/api/analytics?groupBy=model')).json().rows.map((r: { key: string }) => r.key);
+    expect(byModel).toContain('gpt-5.4-mini-fast');
+  });
+
+  it('folds reasoning into output and prices gpt-5.4-mini-fast', async () => {
+    const s = (await get('/api/sessions')).json()[0];
+    // input 1000 + output(50)+reasoning(200)=250 + cacheRead 300 + cacheWrite 0 = 1550.
+    expect(s.totalTokens).toBe(1550);
+    // (1000*0.75 + 250*4.5 + 300*0.075) / 1e6 = 0.0018975.
+    expect(s.totalCostUsd).toBeCloseTo(0.0018975, 6);
+  });
+
+  it('finds the session via full-text search', async () => {
+    const { sessions: results } = (await get('/api/search?q=patched')).json();
+    expect(results.some((r: { sessionId: string }) => r.sessionId === 'ses_test1')).toBe(true);
+  });
+});
+
+describe('opencode session detail', () => {
+  it('renders reasoning, apply_patch→canonical edits, read, and the screenshot', async () => {
+    const detail = (await get('/api/sessions/ses_test1')).json();
+    expect(detail.subagents).toEqual([]);
+    const flat = detail.thread.flatMap((t: { blocks: Record<string, unknown>[] }) => t.blocks);
+
+    // plaintext reasoning survives.
+    const thinking = flat.find((b: Record<string, unknown>) => b.type === 'thinking');
+    expect(thinking?.thinking).toContain('I will patch');
+
+    // apply_patch → one canonical block per file: Update→MultiEdit, Add→Write.
+    const tools = flat.filter((b: Record<string, unknown>) => b.kind === 'tool');
+    const multi = tools.find((t: { name: string }) => t.name === 'MultiEdit');
+    expect(multi.input.file_path).toBe('/tmp/ocproj/a.txt');
+    expect(multi.input.edits[0]).toEqual({
+      old_string: 'keep this line\nold line',
+      new_string: 'keep this line\nnew line',
+    });
+    const write = tools.find((t: { name: string }) => t.name === 'Write');
+    expect(write.input).toMatchObject({ file_path: '/tmp/ocproj/new.txt', content: 'hello world' });
+
+    // apply_patch results are concise PER-FILE, not the repeated shared summary.
+    expect(JSON.stringify(multi.result.content)).toContain('Updated a.txt');
+    expect(JSON.stringify(write.result.content)).toContain('Created new.txt');
+    expect(JSON.stringify(detail.thread)).not.toContain('Success. Updated the following files');
+
+    // read → Read (filePath renamed to file_path); the <path>/<content> wrapper is
+    // unwrapped so the result isn't redundant with the header.
+    const read = tools.find((t: { name: string }) => t.name === 'Read');
+    expect(read.input.file_path).toBe('/tmp/ocproj/a.txt');
+    const readResult = JSON.stringify(read.result.content);
+    expect(readResult).toContain('keep this line');
+    expect(readResult).not.toContain('<path>');
+    expect(readResult).not.toContain('<content>');
+
+    // pasted screenshot embeds (file part → image, surfaced as an attachment).
+    const img = flat.find(
+      (b: Record<string, unknown>) =>
+        b.kind === 'attachment' && (b.attachment as { type?: string })?.type === 'image',
+    );
+    expect((img.attachment as { source: { url: string } }).source.url).toBe(PNG_URL);
+  });
+});

--- a/packages/server/test/pi.integration.test.ts
+++ b/packages/server/test/pi.integration.test.ts
@@ -24,6 +24,7 @@ process.env.CLAUDE_PROJECTS_DIR = claudeDir;
 process.env.CODEX_SESSIONS_DIR = join(work, 'codex-empty');
 process.env.JUNIE_SESSIONS_DIR = join(work, 'junie-empty');
 process.env.PI_SESSIONS_DIR = piDir;
+process.env.OPENCODE_DATA_DIR = join(work, 'opencode-empty');
 process.env.DUCKDB_PATH = join(work, 'index.duckdb');
 process.env.CLAUDESCOPE_HOME = join(work, 'home');
 process.env.REINDEX_INTERVAL_MS = '0';

--- a/packages/server/test/pricing.test.ts
+++ b/packages/server/test/pricing.test.ts
@@ -41,6 +41,7 @@ process.env.CLAUDE_PROJECTS_DIR = projectsDir;
 process.env.CODEX_SESSIONS_DIR = join(work, 'codex-empty');
 process.env.JUNIE_SESSIONS_DIR = join(work, 'junie-empty');
 process.env.PI_SESSIONS_DIR = join(work, 'pi-empty');
+process.env.OPENCODE_DATA_DIR = join(work, 'opencode-empty');
 process.env.DUCKDB_PATH = dbPath;
 process.env.CLAUDESCOPE_HOME = join(work, 'home');
 process.env.REINDEX_INTERVAL_MS = '0';

--- a/packages/web/src/components/AgentBadge.tsx
+++ b/packages/web/src/components/AgentBadge.tsx
@@ -5,6 +5,7 @@ const AGENT_LABELS: Record<string, string> = {
   codex: 'Codex',
   junie: 'Junie',
   pi: 'pi',
+  opencode: 'opencode',
 };
 
 /** Human-friendly short label for a connector id. */

--- a/packages/web/src/pages/browse/browse.css
+++ b/packages/web/src/pages/browse/browse.css
@@ -237,6 +237,11 @@
   background: #8957e51a;
   color: #a371f7;
 }
+.tv-chip--agent.tv-agent--opencode {
+  border-color: #e3b34166;
+  background: #e3b3411a;
+  color: #e3b341;
+}
 /* Light theme: keep the brand tints but darken the text so it stays legible on
    a light surface. */
 :root[data-theme='light'] .tv-chip--agent.tv-agent--claude-code {
@@ -250,4 +255,7 @@
 }
 :root[data-theme='light'] .tv-chip--agent.tv-agent--pi {
   color: #6e40c9;
+}
+:root[data-theme='light'] .tv-chip--agent.tv-agent--opencode {
+  color: #9e6a03;
 }


### PR DESCRIPTION
## Summary

Adds a connector for [opencode](https://opencode.ai), the first **SQLite-backed** source: opencode stores every transcript in one `opencode.db` (`session`/`message`/`part`), not per-session files. Read strictly read-only via Node 24's built-in `node:sqlite` (**no new dependency**). Sessions merge per `cwd` and tag with an `opencode` badge.

## How it fits the connector seam

Each **session** is a synthetic `DiscoveredFile` (`<dbPath>#<id>`); `prepare()` extracts it to canonical NDJSON (the Codex pattern), so the index / FTS / cost paths stay byte-identical. `discover()` enumerates sessions with a `max(session, message, part).time_updated` change signal.

## What's included

- **Normalization** — per-message tokens (reasoning folded into output), **plaintext reasoning**, `message_id=NULL`, synthesized `uuid`/`parentUuid` chain, stored session title.
- **Files-changed tab + tool rendering** — opencode edits via **`apply_patch`**; the normalizer parses `state.metadata.files[]` (per-file unified diffs) into canonical `Write`/`Edit`/`MultiEdit` (one block per file), plus `read`→`Read`, `bash`→`Bash`, others passthrough, paired by `callID`.
- **Screenshots** — pasted images are `file` parts with a `data:` URL → canonical `ImageBlock` (embed in the thread).
- **Indexer hardening** — a connector whose `discover()` throws (transient SQLite error) is isolated: the reindex no longer aborts, and its sessions are preserved instead of pruned (the all-or-nothing wipeout risk from the plan).
- **Perf** — `perf/run.ts` + all suites isolate `OPENCODE_DATA_DIR` so a real local DB can't trip the noop-reindex gate (CI has no DB).
- **Web/docs** — `opencode` badge; README + CLAUDE.md.
- **No memory** — opencode keeps none in its home dir.

(Pricing incl. `gpt-5.4-mini-fast` and the lazy pricing-table sync already landed in #22.)

## Testing

- `npm run typecheck` + `npm test` — **181 passing**, incl. a new `opencode.integration.test.ts` (synthetic SQLite DB): `apply_patch`→`MultiEdit`/`Write`, screenshot embed, plaintext reasoning, `gpt-5.4-mini-fast` cost, tool pairing.
- Validated the normalizer against the real `opencode.db`: 3 sessions parse cleanly — `apply_patch`→`Write`/`Edit`/`MultiEdit`, a real screenshot embeds, reasoning renders.

Plan: `docs/plans/0020-opencode-connector.md`.