### PR TITLE
docs: make README product-only and generalize agent docs

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -15,8 +15,10 @@
 
 ## Checklist
 
+- [ ] I've read [`CONTRIBUTING.md`](../CONTRIBUTING.md)
+- [ ] I agree to the [Code of Conduct](../CODE_OF_CONDUCT.md)
 - [ ] `npm test` and `npm run typecheck` pass
 - [ ] Conventional commit messages; history is linear (rebased on `main`, no merge commits)
 - [ ] No AI co-author / "Generated with" trailers
-- [ ] Docs updated if behavior changed
+- [ ] Docs updated if behavior changed (incl. README / SECURITY.md / CLAUDE.md if the agent list changed)
 - [ ] Plan committed under `docs/plans/` and linked above (if an agent did the work)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,7 +35,9 @@ npm-workspaces monorepo (`packages/*`):
 
 ## Runtime state — critical
 
-- **NEVER write to `~/.claude` or `~/.codex`.** They are read-only data sources.
+- **NEVER write to any agent source** (`~/.claude`, `~/.codex`, `~/.junie`,
+  `~/.pi`, opencode's `opencode.db`). They are read-only data sources — and that
+  includes reading agent memory live from those home dirs.
 - All app-owned state lives in **`~/.claudescope/`** (override: `CLAUDESCOPE_HOME`):
   the DuckDB index, a user-editable `pricing.json` (seeded from a shipped
   default; `loadPricing` falls back to the default if the copy is missing),
@@ -91,7 +93,7 @@ The CLI `update` command (`cli.ts`) detects the install method and defers to
 - **Don't touch unrelated code.** No drive-by refactors or "improvements."
 - **Tests:** run `npm test` and `npm run typecheck` after changes. Add tests only
   when the logic warrants it (the integration suite builds a real DuckDB index
-  from synthetic fixtures in a temp dir — never touches real `~/.claude`).
+  from synthetic fixtures in a temp dir — never touches any real agent source).
   **Keep tests focused on the weird stuff** — the hard, bug-prone domain edges,
   not happy-path glue: malformed/truncated JSONL, subagent correlation, cost
   dedup-by-`message.id`, stale-cache / index-corruption recovery, pricing refresh

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,8 @@ them merged. For architecture and conventions, see [`CLAUDE.md`](./CLAUDE.md)
 
 ## Prerequisites
 
-- [Node.js](https://nodejs.org) **20 or newer** (`node -v`).
+- [Node.js](https://nodejs.org) **22.12 or newer** (`node -v`) — matches the
+  `engines` field in `package.json`.
 
 ## Setup & dev loop
 
@@ -20,16 +21,49 @@ server. Useful commands:
 
 ```bash
 npm run build       # production build (shared → web → server)
+npm run serve       # run the already-built server without rebuilding
 npm test            # Vitest (run once)   |  npm run test:watch
 npm run typecheck   # tsc -b across all packages
 npm run bundle      # assemble the publishable single package into dist/
+npm run screenshots # regenerate the README screenshots from synthetic demo data
 ```
 
-## Project layout
+`npm run screenshots` seeds the synthetic demo data, boots the app, and captures
+every view in both light and dark themes via Playwright — run it when a UI change
+makes the README screenshots stale.
 
-npm-workspaces monorepo: `packages/shared` (types), `packages/server` (Fastify +
-DuckDB), `packages/web` (Vite + React). See `CLAUDE.md` for details. Key rule:
-the app is **read-only** over `~/.claude`; its own state lives in `~/.claudescope/`.
+## How it works
+
+npm-workspaces monorepo:
+
+| Package           | Role                                                                 |
+| ----------------- | -------------------------------------------------------------------- |
+| `packages/shared` | TypeScript types — the API + data contract shared by server and web. |
+| `packages/server` | Fastify API + DuckDB index (`@duckdb/node-api`); serves the built UI. |
+| `packages/web`    | Vite + React UI (react-markdown, Shiki, Recharts).                   |
+
+DuckDB reads the JSONL natively (`read_ndjson`) for indexing, full-text search,
+and analytics; a small TypeScript parser assembles the threaded view for a single
+session. The index is a **derived cache** — if it's ever corrupted (e.g. the
+process is killed mid-write) the app discards and rebuilds it automatically.
+
+Each agent is a **connector** (`packages/server/src/connectors/`). Claude Code
+JSONL is projected per-row; the others (Codex spreads a session across record
+types, Junie records an event-sourced UI stream, pi keeps `cwd`/tool-results on
+separate records, opencode is a single SQLite database) run a `prepare()` pass
+that normalizes a session to canonical NDJSON first — after that the indexing,
+search, cost, and threading paths are all shared. Adding another agent is adding
+another connector (see [Adding an agent connector](#adding-an-agent-connector)).
+
+Tests use [Vitest](https://vitest.dev). Unit tests cover the thread/subagent
+parser and pure helpers; the **integration suite** builds a real DuckDB index
+from synthetic fixtures in a temp dir / temp DB — your real agent directories are
+never touched — and exercises every API endpoint end-to-end via Fastify
+`inject()`.
+
+**Key rule:** the app is **read-only** over every agent source (`~/.claude`,
+`~/.codex`, `~/.junie`, `~/.pi`, opencode's database); its own state lives in
+`~/.claudescope/`. See [`CLAUDE.md`](./CLAUDE.md) for the full architecture.
 
 ## Making changes
 
@@ -41,6 +75,81 @@ the app is **read-only** over `~/.claude`; its own state lives in `~/.claudescop
   cost dedup-by-`message.id`, stale-cache / index-corruption recovery, pricing
   refresh and fallback, connector quirks — not happy-path glue that can't fail.
 - **Validate at boundaries** (user input, external data); trust internal code.
+
+## Adding an agent connector
+
+Supporting another coding agent means adding one **connector** — the index, FTS,
+cost, threading, and UI paths are all shared, so you only implement the seam.
+Use an existing connector as a template (`connectors/opencode/` is the most
+complete: SQLite source, `prepare()` normalization, file-edit and image mapping).
+Work through this checklist — the starred items are the ones that are easy to
+forget and silently render nothing in the UI.
+
+1. **Implement the `AgentConnector` port** in
+   `packages/server/src/connectors/<agent>/` (interface in
+   [`connectors/types.ts`](./packages/server/src/connectors/types.ts)): `id`,
+   `label`, `sourceDir`, `discover()`, `eventsProjectionSql()`, `loadSession()`,
+   and `auxProjections()` (titles / PR links). If the raw format can't be
+   projected per-row by DuckDB (multiple record types, a separate `cwd`/result
+   record, a SQLite DB), add a `prepare()` pass that normalizes a session to
+   **canonical NDJSON** first (the Codex / pi / opencode pattern). The projection
+   must emit the `CANONICAL_EVENT_COLUMNS` contract.
+
+2. **Register it** in
+   [`connectors/registry.ts`](./packages/server/src/connectors/registry.ts) (the
+   `connectors` array).
+
+3. **Resolve its source dir from an env var** in
+   [`config.ts`](./packages/server/src/config.ts) (e.g. `FOO_SESSIONS_DIR`,
+   defaulting under `homedir()`, run through `expandHome`), and set the
+   connector's `sourceDir` from it. The startup banner / sidebar
+   (`routes/sources.ts`) then lists it automatically.
+
+4. **★ Map tools to canonical names so the reader and tabs work.** The UI keys
+   off canonical tool names, so normalize the agent's tools (see
+   `connectors/opencode/normalize.ts`):
+   - **File edits/writes → `Write` / `Edit` / `MultiEdit`.** This is what feeds
+     the **Files changed** tab and the per-file red/green diffs. An agent that
+     edits via some other mechanism (opencode's `apply_patch`, a custom tool)
+     **must** be translated, or the tab silently shows nothing.
+   - **`read` → `Read`, shell → `Bash`**, so those blocks get the right preview;
+     pass other tools through by name.
+   - **★ Pasted screenshots / images → `ImageBlock`** (`{ type: 'image', source:
+     { type: 'url' | 'base64', … } }`, see
+     [`shared/src/events.ts`](./packages/shared/src/events.ts)), or images won't
+     embed in the transcript.
+
+5. **★ Add the agent badge** — without it the agent shows a raw id with no color:
+   - A short label in `AGENT_LABELS` in
+     [`components/AgentBadge.tsx`](./packages/web/src/components/AgentBadge.tsx).
+   - Brand-color CSS in
+     [`pages/browse/browse.css`](./packages/web/src/pages/browse/browse.css)
+     (`.tv-chip--agent.tv-agent--<id>`). **Use the agent's official/corporate
+     brand hue** (matching the existing ones: Anthropic coral, OpenAI teal-green,
+     JetBrains green, …). Follow the established pattern — border at `<hex>66`,
+     background at `<hex>1a`, a legible accent for the text — and add the
+     `:root[data-theme='light']` override that darkens the text for the light
+     theme.
+
+6. **Memory (optional).** If the agent persists long-lived memory, implement
+   `globalMemory()` and/or `projectMemory()`. **Invariant: read only from the
+   agent's own home dir** — never from the user's project directories. Return
+   `[]` when there's none (the empty state is first-class).
+
+7. **Tests.** Add synthetic fixtures in a temp dir / DB (never touch real agent
+   dirs) and **focus on the weird stuff** — the normalization quirks, malformed /
+   truncated input, cost dedup, threading edges — not happy-path glue.
+
+8. **★ Update every doc that enumerates the agents — keep them in sync:**
+   - [`README.md`](./README.md): the **Supported agents** table, the
+     **Configuration** env-var table, the **Usage notes** (any format quirk worth
+     calling out), and the **privacy + Security & privacy** source lists.
+   - [`SECURITY.md`](./SECURITY.md): the **Filesystem → Reads** list of read-only
+     source dirs.
+   - [`CLAUDE.md`](./CLAUDE.md): the architecture/connector notes and the
+     **Gotchas** + read-only-source list.
+   - The **How it works** list of normalized formats above, if `prepare()` is
+     involved.
 
 ## Commits & history
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ machine and only ever reads your transcripts.
 
 Each source is optional — a directory that doesn't exist is simply skipped, so
 Claudescope works whether you use one agent or all five. Adding another is just
-[adding another connector](#how-it-works).
+[adding another connector](./CONTRIBUTING.md#adding-an-agent-connector).
 
 ## What it can do
 
@@ -34,12 +34,14 @@ Claudescope works whether you use one agent or all five. Adding another is just
 - **Read** a session as a clean threaded conversation: markdown, syntax-highlighted code, collapsible thinking, paired tool calls + results, **syntax-highlighted red/green diffs** for edits, attachments, and sidechain/subagent turns. A built-in **find-in-session** bar (⌘/Ctrl+F) searches the whole transcript — including collapsed thinking, tool, and subagent content — auto-expanding and highlighting matches, with a user/assistant filter.
 - **Review changes** via a **Files changed** tab that aggregates every edit/write in the session by file, with per-file diffs and +/− counts (diffs load lazily per file).
 - **Export / share** a session to Markdown — download or copy it, with an optional toggle to **redact** home-dir paths and likely secrets.
+- **Memory** — browse each agent's long-lived **instruction files** (`CLAUDE.md`, `AGENTS.md`, …) and **agent-distilled per-project memory**, read live from each agent's home directory; Claude Code facts deep-link back to the session that produced them.
 - **Search** full-text across all sessions, all agents (DuckDB BM25), with highlighted snippets that deep-link to the exact message.
 - **Analyze** token usage and cost over time, by project, by model, and **by agent** — including cache-hit ratio.
 - **Light & dark themes** — follows your system appearance, with a manual toggle.
 
 > **Privacy:** Everything runs locally on `127.0.0.1`. The app **never** writes to
-> `~/.claude`, `~/.codex`, or `~/.junie` — all are read-only sources. Its only persistent
+> any agent's data — every source (`~/.claude`, `~/.codex`, `~/.junie`, `~/.pi`, and
+> opencode's database) is treated as strictly read-only. Its only persistent
 > state lives in `~/.claudescope/` — a DuckDB index, a copy of the pricing file, and
 > a cached pricing snapshot (`pricing.fetched.json`), all safe to delete anytime. The
 > sole outbound requests are an optional daily check for a newer published version
@@ -52,9 +54,7 @@ Claudescope works whether you use one agent or all five. Adding another is just
 
 > The screenshots below use **synthetic demo data** — every project name, path,
 > and message is fabricated (`acme-web` is a multi-agent project: Claude Code +
-> Codex). They render light or dark to match your system. Regenerate them with
-> **`npm run screenshots`** (seeds the demo data, boots the app, and captures
-> every view in both themes via Playwright).
+> Codex). They render light or dark to match your system.
 
 **Browse** — every project and its sessions at a glance, each tagged with the
 agents that worked in it: titles, dates, message & tool counts, token totals,
@@ -98,39 +98,37 @@ agent**, with a cache-read breakdown. Click a chart legend to toggle a series.
 
 ## Quick start
 
-**Prerequisite:** [Node.js](https://nodejs.org) **22 or newer** (`node -v`).
+Install from any one of three channels — all wrap the same package. However you
+install it, `claudescope` serves the whole app (UI + API) from a single port
+(**http://localhost:4317** by default), runs in the **background**, and opens
+your browser. Run it once and forget it; new sessions appear automatically.
 
-### Install (recommended)
+### npm (recommended)
+
+**Prerequisite:** [Node.js](https://nodejs.org) **22.12 or newer** (`node -v`).
 
 ```bash
 npm install -g @vladar107/claudescope
 claudescope            # starts the app in the background and opens your browser
 ```
 
-`claudescope` serves the whole app (UI + API) from a single port
-(**http://localhost:4317** by default), runs in the **background**, and opens
-your browser. Run it once and forget it; new sessions appear automatically.
+No global install? `npx @vladar107/claudescope` runs the published CLI once
+without installing it.
 
-Try it without installing:
-
-```bash
-npx @vladar107/claudescope
-```
-
-### Other install methods
+### Homebrew (macOS / Linux)
 
 ```bash
-# Homebrew (macOS / Linux)
 brew tap vladar107/tap
 brew install claudescope
-
-# Nix (any platform) — run without installing, or add to a profile
-nix run github:vladar107/claudescope
-nix profile install github:vladar107/claudescope
+claudescope
 ```
 
-All channels wrap the same package; `claudescope update` detects how you
-installed it and points you at the right upgrade command.
+### Nix (any platform)
+
+```bash
+nix run github:vladar107/claudescope               # run without installing
+nix profile install github:vladar107/claudescope   # or add it to your profile
+```
 
 ### Commands
 
@@ -160,7 +158,8 @@ npm install      # installs all workspace dependencies
 npm start        # builds on first run, then serves the app in the foreground
 ```
 
-`npm start` runs in the foreground (`Ctrl-C` to stop) — handy for development.
+`npm start` runs in the foreground (`Ctrl-C` to stop). For the watch-mode dev
+loop and how to contribute, see [`CONTRIBUTING.md`](./CONTRIBUTING.md).
 
 ---
 
@@ -303,70 +302,22 @@ served from cache (legitimately high for Claude Code, which re-reads cached cont
 
 ---
 
-## How it works
+## Contributing & development
 
-npm-workspaces monorepo:
-
-| Package            | Role                                                                  |
-| ------------------ | --------------------------------------------------------------------- |
-| `packages/shared`  | TypeScript types — the API + data contract shared by server and web.  |
-| `packages/server`  | Fastify API + DuckDB index (`@duckdb/node-api`). Serves the built UI.  |
-| `packages/web`     | Vite + React UI (react-markdown, Shiki, Recharts).                     |
-
-DuckDB reads the JSONL natively (`read_ndjson`) for indexing, full-text search,
-and analytics; a small TypeScript parser assembles the threaded view for a single
-session. The index is a derived cache — if it's ever corrupted (e.g. the process
-is killed mid-write) the app discards and rebuilds it automatically.
-
-Each agent is a **connector** (`packages/server/src/connectors/`). Claude Code
-JSONL is projected per-row; Codex spreads a session across record types and Junie
-records an event-sourced UI stream, so those connectors normalize a session to
-canonical NDJSON first — after that the indexing, search, cost, and threading
-paths are shared. Adding another agent is adding another connector.
-
----
-
-## Development
-
-```bash
-npm run dev        # server (watch) on :4317 + Vite dev server on :5317 with HMR
-npm run typecheck  # tsc -b across all packages
-npm run build      # production build (shared → web → server)
-npm run serve      # run the built server without rebuilding
-npm test           # run the test suite (Vitest)
-npm run test:watch # watch mode
-```
-
-Tests use [Vitest](https://vitest.dev). Unit tests cover the thread/subagent
-parser and pure helpers; the **integration suite** builds a real DuckDB index
-from synthetic fixtures (in a temp dir / temp DB — your real `~/.claude` is never
-touched) and exercises every API endpoint end-to-end via Fastify `inject()`.
-
-In dev, open the **Vite** URL (http://localhost:5317); it proxies `/api` to the
-server.
-
-### Releasing
-
-The published package is a single bundle assembled by `npm run bundle` (esbuild
-inlines the server + shared lib; the web build and a default pricing file are
-copied alongside; only `@duckdb/node-api` stays an external native dependency).
-Releases are **tag-only** — never published from a laptop:
-
-```bash
-npm version patch        # bumps package.json + creates the vX.Y.Z tag
-git push --follow-tags   # the tag triggers .github/workflows/release.yml → npm publish
-```
-
-The release workflow verifies the tag matches `package.json`, runs the tests,
-bundles, and publishes. Auth uses npm **Trusted Publishing** (OIDC) — no
-`NPM_TOKEN` secret — and provenance is attached automatically.
+Claudescope is open source and contributions are welcome. How it works (the
+DuckDB index, the per-agent **connectors**, and the threading parser), the local
+dev loop, the test suite, **how to add a connector for another agent**, and the
+release process all live in [`CONTRIBUTING.md`](./CONTRIBUTING.md), with
+[`CLAUDE.md`](./CLAUDE.md) as the deeper architectural source of truth. To run a
+local copy, see [Run from source](#run-from-source) above.
 
 ---
 
 ## Security & privacy
 
-Claudescope runs entirely on your machine. It treats `~/.claude`, `~/.codex`, and
-`~/.junie` as **read-only**, **binds to `127.0.0.1` only**, and sends **no telemetry**. Its only
+Claudescope runs entirely on your machine. It treats every agent source
+(`~/.claude`, `~/.codex`, `~/.junie`, `~/.pi`, and opencode's database) as
+**read-only**, **binds to `127.0.0.1` only**, and sends **no telemetry**. Its only
 outbound requests are a cached npm-registry version check for the update notice
 and a daily fetch of public model pricing rates from LiteLLM (disable with
 `PRICING_REFRESH_INTERVAL_MS=0`). See
@@ -382,7 +333,7 @@ shell, and self-update behavior — and how to report a vulnerability.
   the banner and set them correctly. Any source can be absent; only the present
   ones are indexed.
 - **`Error: listen EADDRINUSE :4317`** — the port is taken; run `claudescope --port <n>`.
-- **Node version errors** — you need Node ≥ 22 (`node -v`).
+- **Node version errors** — you need Node ≥ 22.12 (`node -v`).
 - **Stale or wrong data** — delete `~/.claudescope/index.duckdb*` and
   `claudescope restart` to rebuild the index from scratch.
 - **`@duckdb/node-api` install issues** — it ships prebuilt native binaries;

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,9 +1,10 @@
 # Security Policy
 
-Claudescope is a **local, read-only** viewer for your Claude Code transcripts.
-It runs on your machine, binds to loopback only, and is designed to touch as
-little of your system as possible. This document describes exactly what it does
-so you can audit it, and how to report anything that looks wrong.
+Claudescope is a **local, read-only** viewer for your AI coding-agent transcripts
+— Claude Code, OpenAI Codex, JetBrains Junie, pi, and opencode. It runs on your
+machine, binds to loopback only, and is designed to touch as little of your
+system as possible. This document describes exactly what it does so you can audit
+it, and how to report anything that looks wrong.
 
 ## Reporting a vulnerability
 
@@ -25,9 +26,19 @@ None of these are misused; they're listed here so you can verify that.
 
 ### Filesystem
 
-- **Reads** your transcripts from `~/.claude/projects/**` (override:
-  `$CLAUDE_PROJECTS_DIR`). This directory is treated as **strictly read-only** —
-  Claudescope never writes to `~/.claude`.
+- **Reads** your transcripts from each agent's own directory, every one treated
+  as **strictly read-only** — Claudescope never writes to any of them. Each
+  source is optional; a directory that doesn't exist is simply skipped:
+  - `~/.claude/projects/**` — Claude Code (override: `$CLAUDE_PROJECTS_DIR`)
+  - `~/.codex/sessions/**` — OpenAI Codex (override: `$CODEX_SESSIONS_DIR`)
+  - `~/.junie/sessions/**` — JetBrains Junie (override: `$JUNIE_SESSIONS_DIR`)
+  - `~/.pi/agent/sessions/**` — pi (override: `$PI_SESSIONS_DIR`)
+  - `~/.local/share/opencode/opencode.db` — opencode, a SQLite database opened
+    **read-only** via Node's built-in `node:sqlite` (override:
+    `$OPENCODE_DATA_DIR` / `$OPENCODE_DB_PATH`)
+- **Reads** agent **memory** live (never indexed) from those same read-only home
+  dirs — long-lived instruction files and any agent-distilled memory — strictly
+  within each agent's own directory, never from your project folders.
 - **Writes** only inside its own state dir `~/.claudescope/` (override:
   `$CLAUDESCOPE_HOME`): the DuckDB index (a rebuildable cache), a user-editable
   `pricing.json`, the daemon PID/port file, and logs.


### PR DESCRIPTION
## Summary

Documentation-consistency pass to make the docs coherent across the repo:

- **README is now product-only.** Dropped the `How it works` and `Development`/`Releasing` sections down to a short `Contributing & development` pointer (modeled on the `Security & privacy` pointer). Added a **Memory** feature bullet to *What it can do*.
- **Quick start split into three install channels** — `npm (recommended)`, `Homebrew (macOS / Linux)`, `Nix (any platform)`. The Node prerequisite is now scoped to the npm channel only (Homebrew and Nix provide their own Node), and `npx` is a one-line note rather than a prominent block.
- **CONTRIBUTING absorbs the architecture prose** (`How it works`) and gains a new **`Adding an agent connector`** guide: canonical tool mapping (`Write`/`Edit`/`MultiEdit` → Files-changed tab, `Read`/`Bash`, images → `ImageBlock`), the agent badge + official brand-color CSS (dark + light), home-dir-only memory, env-var wiring, weird-stuff tests, and an explicit "update **every** doc" checklist.
- **Generalized Claude-only phrasing to all five sources** (Claude Code, Codex, Junie, pi, opencode) in README (privacy + Security callouts), `SECURITY.md` (intro + Filesystem→Reads list), and `CLAUDE.md` (read-only rule + integration-test note).
- **Node requirement is consistently `22.12+`** across docs (was a mix of `20`/`22`; matches `package.json` engines).
- **PR template** gains `CONTRIBUTING.md` + Code of Conduct acknowledgement checkboxes.

## Plan

n/a — documentation-only consistency pass; no architectural decision to record under `docs/plans/`.

## Testing

- `npm run typecheck` — passes (exit 0).
- `npm test` — 21 files, **181 tests pass**.
- Internal link/anchor integrity verified (no dangling section anchors after the README restructure); connector-guide code references checked against the actual source.

## Checklist

- [x] I've read [`CONTRIBUTING.md`](../CONTRIBUTING.md)
- [x] I agree to the [Code of Conduct](../CODE_OF_CONDUCT.md)
- [x] `npm test` and `npm run typecheck` pass
- [x] Conventional commit messages; history is linear (rebased on `main`, no merge commits)
- [x] No AI co-author / "Generated with" trailers
- [x] Docs updated if behavior changed (incl. README / SECURITY.md / CLAUDE.md if the agent list changed)
- [ ] Plan committed under `docs/plans/` and linked above (if an agent did the work) — n/a, docs-only
