### PR TITLE
feat: add GitHub Copilot CLI connector

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,8 +6,10 @@ analyze AI coding-agent transcripts in one place — [Claude Code](https://claud
 (`~/.codex/sessions/**/rollout-*.jsonl`),
 [JetBrains Junie](https://www.jetbrains.com/junie/)
 (`~/.junie/sessions/session-*/events.jsonl`), [pi](https://pi.dev)
-(`~/.pi/agent/sessions/**/*.jsonl`), and [opencode](https://opencode.ai)
-(`~/.local/share/opencode/opencode.db`, SQLite). Sessions are merged by working
+(`~/.pi/agent/sessions/**/*.jsonl`), [opencode](https://opencode.ai)
+(`~/.local/share/opencode/opencode.db`, SQLite), and
+[GitHub Copilot CLI](https://github.com/features/copilot)
+(`~/.copilot/session-state/**/events.jsonl`). Sessions are merged by working
 directory into one project per `cwd`, each session tagged with its agent.
 Distributed as a single npm CLI (`@vladar107/claudescope`). This file is the
 source of truth for both humans and agents working in this repo; `AGENTS.md`
@@ -36,7 +38,7 @@ npm-workspaces monorepo (`packages/*`):
 ## Runtime state — critical
 
 - **NEVER write to any agent source** (`~/.claude`, `~/.codex`, `~/.junie`,
-  `~/.pi`, opencode's `opencode.db`). They are read-only data sources — and that
+  `~/.pi`, `~/.copilot`, opencode's `opencode.db`). They are read-only data sources — and that
   includes reading agent memory live from those home dirs.
 - All app-owned state lives in **`~/.claudescope/`** (override: `CLAUDESCOPE_HOME`):
   the DuckDB index, a user-editable `pricing.json` (seeded from a shipped
@@ -138,6 +140,21 @@ The CLI `update` command (`cli.ts`) detects the install method and defers to
   plaintext. Tokens are per-message (reasoning folded into output). `discover()`
   throws on a present-but-unreadable DB (the indexer isolates a throwing connector
   and preserves its sessions — it never wipes them). No memory.
+- **GitHub Copilot CLI connector** (`connectors/copilot/`) — event-sourced
+  `~/.copilot/session-state/<uuid>/events.jsonl` (Junie/pi-shaped lines of
+  `{type, data, id, timestamp, parentId}`); `prepare()` normalizes to canonical
+  NDJSON. `cwd`/branch from `session.start`, model from `assistant.message`, title
+  from the sibling `workspace.yaml` (`name`). **Tokens live ONLY in
+  `session.shutdown`** (session-level; there is no per-message usage) → attached to
+  the last assistant row, so a crashed/running session (no shutdown) costs zero.
+  Reasoning is encrypted (`reasoningOpaque`) → empty thinking (Codex-style).
+  `edit`/`create`→`Edit`/`Write` **only when the call succeeded** (a denied/failed
+  edit passes through under its raw name, so it never reaches the Files-changed
+  tab); `view`→`Read`, `bash`→`Bash`. Screenshots resolve from
+  `session-state/<uuid>/files/<displayName>` (screenshot-saving must be on) → base64
+  `ImageBlock`, else the inline `[📷 …]` marker remains. Global memory is
+  `~/.copilot/copilot-instructions.md`; "session-level memory" is session-scoped
+  (per-session `session.db` + `files/`), not cross-session, so no project memory.
 - **Junie transcripts read differently** — Junie stores an event-sourced UI
   stream (`events.jsonl`), not a chat log: no assistant prose and no thinking, so
   a session renders as tool/terminal/file blocks plus a final result. Expected,

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,8 +49,8 @@ process is killed mid-write) the app discards and rebuilds it automatically.
 
 Each agent is a **connector** (`packages/server/src/connectors/`). Claude Code
 JSONL is projected per-row; the others (Codex spreads a session across record
-types, Junie records an event-sourced UI stream, pi keeps `cwd`/tool-results on
-separate records, opencode is a single SQLite database) run a `prepare()` pass
+types, Junie and GitHub Copilot CLI record an event-sourced stream, pi keeps
+`cwd`/tool-results on separate records, opencode is a single SQLite database) run a `prepare()` pass
 that normalizes a session to canonical NDJSON first — after that the indexing,
 search, cost, and threading paths are all shared. Adding another agent is adding
 another connector (see [Adding an agent connector](#adding-an-agent-connector)).

--- a/README.md
+++ b/README.md
@@ -22,9 +22,10 @@ machine and only ever reads your transcripts.
 | [JetBrains Junie](https://www.jetbrains.com/junie/) | `~/.junie/sessions/session-*/events.jsonl`  |
 | [pi](https://pi.dev)                              | `~/.pi/agent/sessions/**/*.jsonl`             |
 | [opencode](https://opencode.ai)                   | `~/.local/share/opencode/opencode.db` (SQLite) |
+| [GitHub Copilot CLI](https://github.com/features/copilot) | `~/.copilot/session-state/**/events.jsonl` |
 
 Each source is optional — a directory that doesn't exist is simply skipped, so
-Claudescope works whether you use one agent or all five. Adding another is just
+Claudescope works whether you use one agent or all six. Adding another is just
 [adding another connector](./CONTRIBUTING.md#adding-an-agent-connector).
 
 ## What it can do
@@ -175,11 +176,12 @@ All optional — set via environment variables.
 | `JUNIE_SESSIONS_DIR`  | `~/.junie/sessions`    | Where to read JetBrains Junie transcripts from. A leading `~` is expanded.|
 | `PI_SESSIONS_DIR`     | `~/.pi/agent/sessions` | Where to read pi transcripts from. A leading `~` is expanded.          |
 | `OPENCODE_DATA_DIR`   | `~/.local/share/opencode` | Dir holding opencode's `opencode.db` (read-only). Honors `$XDG_DATA_HOME`; override the DB path directly with `OPENCODE_DB_PATH`. |
+| `COPILOT_SESSIONS_DIR`| `~/.copilot/session-state` | Where to read GitHub Copilot CLI transcripts from. A leading `~` is expanded. |
 | `CLAUDESCOPE_HOME`    | `~/.claudescope`       | Where the app keeps its own state (index, pricing copy, logs, PID).    |
 | `REINDEX_INTERVAL_MS` | `15000`                | How often to auto-pick-up new/updated sessions. Set `0` to disable.    |
 
 Each agent source is optional — if a directory doesn't exist it's simply skipped,
-so the app works whether you use one agent or all five.
+so the app works whether you use one agent or all six.
 
 Examples:
 
@@ -190,6 +192,7 @@ CODEX_SESSIONS_DIR=/path/to/codex/sessions claudescope   # point at Codex sessio
 JUNIE_SESSIONS_DIR=/path/to/junie/sessions claudescope   # point at Junie sessions elsewhere
 PI_SESSIONS_DIR=/path/to/pi/sessions claudescope         # point at pi sessions elsewhere
 OPENCODE_DATA_DIR=/path/to/opencode claudescope          # point at an opencode data dir elsewhere
+COPILOT_SESSIONS_DIR=/path/to/copilot/session-state claudescope  # point at Copilot CLI sessions elsewhere
 claudescope --no-open                                    # don't pop a browser tab
 ```
 
@@ -299,6 +302,14 @@ served from cache (legitimately high for Claude Code, which re-reads cached cont
   Node's built-in `node:sqlite`. Its reasoning renders in full (plaintext), its
   file edits (made via `apply_patch`) show in the **Files changed** tab and as
   diffs, and pasted screenshots embed. Like pi, it contributes no memory.
+- **GitHub Copilot CLI records an event-sourced stream**
+  (`~/.copilot/session-state/<id>/events.jsonl`). Cost is **session-level** — only
+  a cleanly-closed session reports tokens, so a crashed or still-running one shows
+  no cost. Reasoning is encrypted (renders empty, like Codex). File edits show in
+  the **Files changed** tab; a denied edit is shown but doesn't count as a change.
+  Pasted screenshots embed when screenshot-saving is enabled (otherwise a marker
+  remains). Its global `copilot-instructions.md` appears in the memory viewer; it
+  keeps no per-project memory.
 
 ---
 
@@ -316,7 +327,7 @@ local copy, see [Run from source](#run-from-source) above.
 ## Security & privacy
 
 Claudescope runs entirely on your machine. It treats every agent source
-(`~/.claude`, `~/.codex`, `~/.junie`, `~/.pi`, and opencode's database) as
+(`~/.claude`, `~/.codex`, `~/.junie`, `~/.pi`, `~/.copilot`, and opencode's database) as
 **read-only**, **binds to `127.0.0.1` only**, and sends **no telemetry**. Its only
 outbound requests are a cached npm-registry version check for the update notice
 and a daily fetch of public model pricing rates from LiteLLM (disable with
@@ -329,7 +340,7 @@ shell, and self-update behavior — and how to report a vulnerability.
 ## Troubleshooting
 
 - **App is empty / "sessions directory not found"** — none of `CLAUDE_PROJECTS_DIR`,
-  `CODEX_SESSIONS_DIR`, `JUNIE_SESSIONS_DIR`, `PI_SESSIONS_DIR`, or `OPENCODE_DATA_DIR` points at real transcripts. Check
+  `CODEX_SESSIONS_DIR`, `JUNIE_SESSIONS_DIR`, `PI_SESSIONS_DIR`, `OPENCODE_DATA_DIR`, or `COPILOT_SESSIONS_DIR` points at real transcripts. Check
   the banner and set them correctly. Any source can be absent; only the present
   ones are indexed.
 - **`Error: listen EADDRINUSE :4317`** — the port is taken; run `claudescope --port <n>`.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,7 +1,7 @@
 # Security Policy
 
 Claudescope is a **local, read-only** viewer for your AI coding-agent transcripts
-— Claude Code, OpenAI Codex, JetBrains Junie, pi, and opencode. It runs on your
+— Claude Code, OpenAI Codex, JetBrains Junie, pi, opencode, and GitHub Copilot CLI. It runs on your
 machine, binds to loopback only, and is designed to touch as little of your
 system as possible. This document describes exactly what it does so you can audit
 it, and how to report anything that looks wrong.
@@ -33,6 +33,7 @@ None of these are misused; they're listed here so you can verify that.
   - `~/.codex/sessions/**` — OpenAI Codex (override: `$CODEX_SESSIONS_DIR`)
   - `~/.junie/sessions/**` — JetBrains Junie (override: `$JUNIE_SESSIONS_DIR`)
   - `~/.pi/agent/sessions/**` — pi (override: `$PI_SESSIONS_DIR`)
+  - `~/.copilot/session-state/**` — GitHub Copilot CLI (override: `$COPILOT_SESSIONS_DIR`)
   - `~/.local/share/opencode/opencode.db` — opencode, a SQLite database opened
     **read-only** via Node's built-in `node:sqlite` (override:
     `$OPENCODE_DATA_DIR` / `$OPENCODE_DB_PATH`)

--- a/docs/plans/0021-copilot-connector.md
+++ b/docs/plans/0021-copilot-connector.md
@@ -1,0 +1,267 @@
+# 0021 — GitHub Copilot CLI connector
+
+- **Status:** in-progress <!-- proposed | in-progress | done | superseded | abandoned -->
+- **Date:** 2026-06-16
+- **PR:** <link, once opened>
+
+## Context
+
+Claudescope already ingests Claude Code, Codex, Junie, pi, and opencode. The next
+source is the **GitHub Copilot CLI** (`copilot`, package `@github/copilot`, the
+standalone terminal agent — **not** the IntelliJ/IDE Copilot at
+`~/.config/github-copilot`, which is out of scope here).
+
+Direct inspection of a real local install (`~/.copilot`, copilotVersion `1.0.62`)
+established the on-disk model:
+
+- **`~/.copilot/session-store.db`** (SQLite) — a *derived* summary/FTS index
+  (`sessions`, `turns`, `search_index`, mostly-empty `session_files` /
+  `forge_trajectory_events` / `dynamic_context_items`). **Not** the source of truth.
+- **`~/.copilot/session-state/<uuid>/events.jsonl`** — the **full transcript**, an
+  event-sourced stream (Junie/pi-shaped). Each line: `{type, data, id, timestamp,
+  parentId}`. This is what the connector reads.
+- **`~/.copilot/session-state/<uuid>/workspace.yaml`** — session metadata: `cwd`,
+  `git_root`, `repository`, `branch`, `name` (title), timestamps.
+- **`~/.copilot/session-state/<uuid>/files/`** — persisted attachments (screenshots
+  etc.), present **only when "store screenshots / session-level memory" is enabled**.
+  Each file's basename equals the attachment's `displayName` in `events.jsonl`
+  (e.g. `files/copilot-image-ae0f15.png`). The `user.message.attachments[].path` in
+  `events.jsonl` still points at the now-deleted `$TMPDIR` copy, so the persisted
+  file is resolved by `displayName`, not by that path.
+- **`~/.copilot/session-state/<uuid>/session.db`** (SQLite) — per-session `todos`,
+  `inbox_entries`, and `session_state(key,value)`. This is what **"session-level
+  memory"** populates (facts + todos + attachments) when enabled — but it is
+  **session-scoped** (deleted on `/clear`, never uploaded; Copilot states this
+  in-transcript), **not** cross-session project memory. Not read by the connector.
+- **`~/.copilot/copilot-instructions.md`** — the global, user-authored instruction
+  file (analog of `~/.claude/CLAUDE.md`). The only cross-session/global memory.
+
+Event types seen: `session.start` (carries `cwd`/`branch`/`repository`/`headCommit`),
+`session.model_change` (`gpt-5-mini`), `session.info`, `session.context_changed`,
+`system.message`, `user.message`, `assistant.turn_start|message|turn_end`,
+`tool.execution_start|complete`, `hook.start|end`, `permission.requested|completed`,
+`abort`, `session.shutdown`.
+
+This is the established connector seam (`docs/plans/0004-connector-seam.md`): add a
+connector under `packages/server/src/connectors/copilot/`, normalize in a
+`prepare()` pass to canonical NDJSON (the Codex/pi/junie/opencode pattern), and the
+shared index/FTS/cost paths stay untouched.
+
+## Goal
+
+A `copilot` connector that indexes Copilot CLI sessions into the shared schema:
+browse/read/search the threaded transcript, Files-changed tab, per-session cost,
+the agent badge in the UI, and global memory — all read-only, with `npm test` /
+`npm run typecheck` / `npm run build` green and docs updated.
+
+## Decisions
+
+Resolved up front (these were the open questions from the surface-mapping pass):
+
+- **Source = `events.jsonl`, not `session-store.db`.** The SQLite store is a lossy
+  summary; the per-session event stream is full fidelity (tools, model, edits,
+  tokens). Mirrors Junie/pi.
+- **Connector id `copilot`, label `GitHub Copilot CLI`.** Free-string agent id (the
+  shared package has no closed enum — confirmed), so no `packages/shared` change.
+  Label disambiguates from the IDE Copilot.
+- **`prepare()` → canonical NDJSON cache** under
+  `~/.claudescope/cache/copilot/<hash>.ndjson` (opencode/pi pattern). The DuckDB
+  projection reads the cache; YAML is parsed in TS (DuckDB can't read YAML), and
+  `workspace.yaml name` is carried into the NDJSON as a `title` column.
+- **File key = the `events.jsonl` absolute path** (Junie/pi style); session id =
+  the `<uuid>` directory name. No opencode-style `#` synthetic key — each session
+  is already its own file. `COPILOT_SESSIONS_DIR` env override covers multi-home.
+- **Cost is session-granular and attaches to the final assistant row only.** Tokens
+  exist *only* in `session.shutdown.modelMetrics`/`tokenDetails`; there is **no
+  per-message usage**. Map `tokenDetails.input→input_tokens`,
+  `cache_read→cache_read_tokens`, `output→output_tokens`,
+  `cache_write→cache_write_tokens` (absent ⇒ 0). `message_id` is `NULL` on every
+  row, so `electCanonicalUsage` treats all rows as canonical and the single
+  token-bearing row is counted exactly once (no double-count). Distributing across
+  rows was rejected — it complicates the cost SQL for no benefit.
+- **No-shutdown sessions ⇒ zero cost.** A killed/crashed/still-running session has
+  no `session.shutdown` (confirmed: one of the two local sessions had none). Leave
+  token columns at 0/NULL; `buildCostExpr` yields 0. Documented as expected.
+- **`gpt-5-mini` reasoning tokens are NOT added to output.** `tokenDetails.output`
+  already equals `modelMetrics.outputTokens` and already includes reasoning (OpenAI
+  semantics). Unlike opencode (which *adds* `reasoning` to `output`), here adding
+  `reasoningTokens` would double-count. Use `tokenDetails.output` verbatim. (Verify
+  during implementation against a fresh `session.shutdown`.)
+- **Pricing: no change needed.** `gpt-5-mini` is already an exact entry in
+  `packages/server/pricing.json` (`input 0.25 / output 2 / cacheRead 0.025 /
+  cacheWrite 0`, schemaVersion 2). LiteLLM refresh keeps it current.
+- **Screenshots → resolve from `files/<displayName>` to a real `ImageBlock`, with a
+  text-marker fallback.** When screenshot saving is on, the attachment is persisted
+  to `session-state/<uuid>/files/<displayName>`. In `loadSession`, for each image
+  attachment, read `<sessionDir>/files/<basename(displayName)>` (basename only — no
+  `..`/absolute traversal); if it exists, base64-encode and emit
+  `ImageBlock{source:{type:'base64', media_type:<from ext>, data}}` (media type from
+  extension: png/jpeg/gif/webp). If absent (saving was off — e.g. session
+  `b34f5b75`), preserve the inline `[📷 displayName]` marker Copilot embeds in the
+  message text. Image bytes are resolved at `loadSession` (session-detail) time, not
+  indexed — the canonical NDJSON / FTS keeps only the text marker. This matches how
+  Junie/Codex/opencode handle images and satisfies the "map images to ImageBlock"
+  connector rule. Earlier `$TMPDIR`-only data (before saving was enabled) is the
+  reason for the fallback, not a reason to skip image support. Non-image file
+  attachments → `[file: displayName]` marker (rendering them is out of scope for v1).
+- **Reasoning → empty thinking block (Codex pattern).** `reasoningOpaque` is
+  encrypted; emit `{type:'thinking', thinking:'', signature: reasoningOpaque}`.
+  `ThinkingBlock.signature` is optional and dropped at render, so the UI shows its
+  standard "thinking content isn't stored" state.
+- **Files-changed from successful edit tools (+ shutdown's `filesModified` as a
+  cross-check).** The web changeset derives from `tool_use` blocks named
+  `Edit`/`MultiEdit`/`Write` (`input.file_path` + `old_string`/`new_string`/`content`).
+  Map `edit{path,old_str,new_str}→Edit{file_path,old_string,new_string}`,
+  `create|write{path,content}→Write{file_path,content}`. A **denied** permission
+  (`permission.completed.result.kind = 'denied-…'`) produces no successful
+  execution, so denied edits never enter the changeset; render the attempt in-thread
+  as a tool block with its denial result, but it counts as no file change.
+- **Tool mapping by raw `toolName`** (lowercase), not `toolTitle` (a human phrase):
+  `edit→Edit`, `view→Read`, `bash→Bash`, `create|write→Write`, `sql`/`ask_user`/
+  others → passthrough tool blocks.
+- **Memory: `globalMemory()` only.** Read `~/.copilot/copilot-instructions.md`
+  (user-authored document). **Omit `projectMemory()`.** Enabling "session-level
+  memory" does *not* change this: it persists facts/todos/attachments in the
+  per-session `session.db` + `files/` (session-scoped, cleared on `/clear`), which
+  is session content, not a cross-session per-project store — confirmed empty
+  `dynamic_context_items` / `session_files` even after enabling it. Repo-local
+  `.github/copilot-instructions.md` is project-dir-resident and out of scope by the
+  Junie precedent. (Surfacing per-session todos/facts in the session-detail view is
+  a possible future enhancement, not part of the memory viewer.)
+- **Do NOT treat `session-state/<uuid>/session-config.json` as project memory.** When
+  asked to "enable memory for all sessions in this folder," the Copilot *model*
+  improvised that file (`{sessionMemoryEnabled, persist, autoSaveScreenshots}`) and
+  itself described it as "a local marker file the CLI will need to consult" — a
+  model-generated artifact, not a store Copilot maintains or reads back (and it's
+  written inside one session's dir, so it can't scope a folder anyway). Copilot's
+  real memory subsystem was `disabled` in every observed session (logs:
+  "Memory is not enabled; skipping memory tools"), so its genuine on-disk format is
+  **unconfirmed**. The connector must not infer memory from this file.
+- **Tolerate unknown event types.** New/unseen types (e.g. `session.context_changed`)
+  are skipped silently; the parser never throws on them.
+- **Agent color: GitHub blue** (`#0969da` / dark accent `#58a6ff`) — free hue (pi
+  is purple, Codex teal, Claude coral, Junie green).
+
+## Approach
+
+Ordered so each step type-checks before the next (config before connector before
+registry, per the critic's build-ordering note).
+
+1. **Confirm contracts (read-only).** Re-verify `CANONICAL_EVENT_COLUMNS`
+   (`connectors/types.ts`), the `read_ndjson` projection in `pi/pi.ts` /
+   `opencode/opencode.ts`, and `RawEvent`/block shapes in `shared/src/events.ts`.
+   Read `pi/normalize.ts` end-to-end as the closest template (event stream →
+   synthesized uuid chain → canonical rows + `SessionData`).
+2. **`config.ts`** — add `COPILOT_SESSIONS_DIR` (`~/.copilot/session-state`, env
+   override, `~` expanded) and `COPILOT_HOME = dirname(COPILOT_SESSIONS_DIR)`.
+3. **`connectors/copilot/normalize.ts`** — `parseSession(eventsPath)`:
+   - Read sibling `workspace.yaml` (lightweight TS YAML parse — title, cwd, branch,
+     repository; fall back to `session.start.context` and first user message).
+   - Stream `events.jsonl`; track current model from `session.model_change` /
+     `assistant.message.model`.
+   - Build `RawEvent[]` with a synthesized `<sessionId>-<seq>` uuid/parent chain:
+     `user.message` → user turn (text; for each image attachment, resolve
+     `<sessionDir>/files/<basename(displayName)>` → base64 `ImageBlock` when the file
+     exists, else keep the inline `[📷 …]` marker; non-image files → `[file: …]`);
+     `assistant.message` → assistant turn (text + `thinking` from `reasoningOpaque`
+     + `tool_use` blocks from `toolRequests`, mapped to canonical names);
+     `tool.execution_complete` → synthetic user turn with `tool_result` (paired by
+     `toolCallId`); `permission.*`/`hook.*`/`system.message`/`session.info`/unknown
+     → skipped (or denial annotated on the tool block).
+   - `toCanonicalRows()` — flatten to canonical columns; attach `session.shutdown`
+     token breakdown to the final assistant row only; `message_id`/`forked_from_session_id`
+     = NULL; `is_sidechain`=false; `service_tier`=null; carry `title`.
+4. **`connectors/copilot/memory.ts`** — `globalMemory()` reads
+   `~/.copilot/copilot-instructions.md` (mirror `codex/memory.ts`: `user-authored`,
+   `kind:'document'`, graceful-empty, `contractHome` path, mtime `updatedAt`).
+5. **`connectors/copilot/copilot.ts`** — `AgentConnector`: `discover()` walks
+   `COPILOT_SESSIONS_DIR/*/events.jsonl` (mtime/size); `prepare()` →
+   `parseSession`+`toCanonicalRows` → cache NDJSON; `eventsProjectionSql()` reads
+   the cache (clone pi/opencode `read_ndjson` projection, +`message_id`/`forked_from_session_id`
+   NULL); `auxProjections()` returns `titles` from the carried `title`; `loadSession()`
+   → `{ mainEvents, subagents: [] }`; wire `globalMemory`.
+6. **`connectors/registry.ts`** — import + append `copilotConnector`.
+7. `npm run typecheck` (server green before touching the web).
+8. **Web** — `AgentBadge.tsx`: `copilot: 'GitHub Copilot CLI'`; `browse.css`: dark +
+   light `.tv-agent--copilot` color rules. (Image placeholder, empty-thinking, memory
+   tab, and agent filter are already dynamic/graceful — no changes.)
+9. **`test/copilot.integration.test.ts`** — synthetic `~/.copilot/session-state/<id>/`
+   in a temp dir; build a real index; assert the weird edges (below).
+10. **Docs** — `CLAUDE.md` (connector table row + Gotchas), `README.md` (agents +
+    `COPILOT_SESSIONS_DIR` + privacy source list), `CONTRIBUTING.md` (format list),
+    `SECURITY.md` (read path). Set this plan to `in-progress`, then `done` + PR link
+    at PR time.
+11. `npm test` and `npm run build` green.
+
+## Files affected
+
+- `packages/server/src/config.ts` — `COPILOT_SESSIONS_DIR`, `COPILOT_HOME`.
+- `packages/server/src/connectors/copilot/copilot.ts` — **new**, the connector.
+- `packages/server/src/connectors/copilot/normalize.ts` — **new**, `events.jsonl` → canonical rows + `SessionData`.
+- `packages/server/src/connectors/copilot/memory.ts` — **new**, `globalMemory()`.
+- `packages/server/src/connectors/registry.ts` — register `copilotConnector`.
+- `packages/web/src/components/AgentBadge.tsx` — label entry.
+- `packages/web/src/pages/browse/browse.css` — agent color (dark + light).
+- `packages/server/test/copilot.integration.test.ts` — **new**, integration test.
+- `CLAUDE.md`, `README.md`, `CONTRIBUTING.md`, `SECURITY.md` — docs.
+- *No change:* `packages/shared/*` (free-string agent id), `pricing.json`
+  (`gpt-5-mini` already present), `data/index.ts` (generic cost/dedup already fit),
+  `scripts/bundle.mjs` (no per-connector asset).
+
+## Testing
+
+`npm test` + `npm run typecheck` + `npm run build`. The integration test builds a
+real DuckDB index from synthetic fixtures in a temp dir (never touches real
+`~/.copilot`), asserting the bug-prone edges:
+
+- **No `session.shutdown` ⇒ zero cost**, session still indexes and renders.
+- **Cost counted once** — multi-assistant-turn session, tokens on the final row only;
+  total cost == the session's shutdown tokens × rates (no inflation).
+- **`gpt-5-mini` resolves** to the priced rate (non-zero cost when shutdown present).
+- **Denied edit excluded** from Files-changed; **successful `edit`** appears as an
+  `Edit` change with correct add/remove counts.
+- **Saved screenshot resolves** — a session with `files/<displayName>.png` renders a
+  base64 `ImageBlock`; a session whose `files/` is empty/absent keeps the
+  `[📷 name]` marker and produces no broken image block. `displayName` containing
+  `..`/a slash is treated as basename only (no path traversal outside `files/`).
+- **Unknown event type** (`session.context_changed`) is skipped without error;
+  truncated/malformed trailing line tolerated.
+- **`globalMemory()`** returns the `copilot-instructions.md` doc; returns `[]` when absent.
+- **Title** = `workspace.yaml name`, with first-user-message fallback when empty.
+
+## Risks / open questions
+
+- **Token semantics for reasoning** — the plan assumes `tokenDetails.output` already
+  includes reasoning (so we don't add `reasoningTokens`). Verify against a fresh
+  `session.shutdown` during step 3; if reasoning is *additive*, fold it into output
+  to match the codebase convention.
+- **`workspace.yaml` parsing** — pick a minimal dependency-free YAML read (only a few
+  scalar keys needed); don't add a YAML dep without discussion. Missing/!readable
+  `workspace.yaml` must degrade to `session.start` + first-user-message, not crash.
+- **In-place rewrite on `rewind`** — Copilot has rewind snapshots; if `events.jsonl`
+  is ever rewritten in place, mtime/size change still triggers a full re-derive
+  (the cache NDJSON is rebuilt from scratch each `prepare()`), so it's robust by
+  design. If a real user reports stale tokens after a rewind, revisit.
+- **Screenshots added after indexing** — `files/` resolution happens live in
+  `loadSession`, so toggling screenshot saving on after a session is indexed needs
+  no re-index; the image just appears in the detail view. Conversely, the `files/`
+  dir is *not* part of change detection (only `events.jsonl` mtime/size is) — fine,
+  since image bytes aren't indexed. Reading `files/` is read-only; ignore the
+  `inuse.<pid>.lock` (we never lock or write).
+- **Session-level memory is session-scoped** — facts/todos in `session.db` are
+  per-session and `/clear`-able; deliberately not surfaced in the memory viewer.
+  Revisit only if Copilot adds a cross-session store (e.g. populates
+  `dynamic_context_items` or a documented per-project file).
+- **Copilot's real memory feature was never enabled on the inspected machine**
+  (logs: "Memory enablement check: disabled"), so the on-disk format of genuine
+  project/cross-session memory — if it ships one — is unconfirmed. The plan
+  implements `globalMemory()` only; if a user with the feature *enabled* surfaces a
+  real store (most likely `dynamic_context_items`), add `projectMemory()` then. Do
+  not build against the model-improvised `session-config.json`.
+- **Subagents** — not observed; `loadSession` returns `subagents: []`. If Copilot
+  adds nested agents later, extend then.
+- **Two Copilot products** — this connector is the CLI (`~/.copilot`) only; the
+  IntelliJ/IDE store (`~/.config/github-copilot`, `copilot-intellij.db`) is a
+  separate, future connector.
+- **Per-project memory** — deliberately omitted; revisit only if a real
+  `dynamic_context_items` population (or a documented per-project file) appears.

--- a/docs/plans/0021-copilot-connector.md
+++ b/docs/plans/0021-copilot-connector.md
@@ -1,8 +1,8 @@
 # 0021 — GitHub Copilot CLI connector
 
-- **Status:** in-progress <!-- proposed | in-progress | done | superseded | abandoned -->
+- **Status:** done <!-- proposed | in-progress | done | superseded | abandoned -->
 - **Date:** 2026-06-16
-- **PR:** <link, once opened>
+- **PR:** https://github.com/vladar107/claudescope/pull/25
 
 ## Context
 

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -45,4 +45,4 @@ decision, or a change worth explaining before doing. Skip it for one-line fixes.
 | 0018 | [Analytics breakdown by cost (Metric + Sort toggles)](./0018-analytics-breakdown-cost.md) | done |
 | 0019 | [pi connector](./0019-pi-connector.md) | done |
 | 0020 | [opencode connector](./0020-opencode-connector.md) | done |
-| 0021 | [GitHub Copilot CLI connector](./0021-copilot-connector.md) | proposed |
+| 0021 | [GitHub Copilot CLI connector](./0021-copilot-connector.md) | done |

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -45,3 +45,4 @@ decision, or a change worth explaining before doing. Skip it for one-line fixes.
 | 0018 | [Analytics breakdown by cost (Metric + Sort toggles)](./0018-analytics-breakdown-cost.md) | done |
 | 0019 | [pi connector](./0019-pi-connector.md) | done |
 | 0020 | [opencode connector](./0020-opencode-connector.md) | done |
+| 0021 | [GitHub Copilot CLI connector](./0021-copilot-connector.md) | proposed |

--- a/packages/server/src/config.ts
+++ b/packages/server/src/config.ts
@@ -82,6 +82,16 @@ export const OPENCODE_DB_PATH =
   process.env.OPENCODE_DB_PATH ?? join(OPENCODE_DATA_DIR, 'opencode.db');
 
 /**
+ * READ-ONLY source of GitHub Copilot CLI sessions. The app MUST NEVER write here.
+ * Defaults to `~/.copilot/session-state` (one `<uuid>/events.jsonl` per session,
+ * with a sibling `workspace.yaml` and an optional `files/` attachment dir).
+ * Override with COPILOT_SESSIONS_DIR. A leading `~` is expanded.
+ */
+export const COPILOT_SESSIONS_DIR = expandHome(
+  process.env.COPILOT_SESSIONS_DIR ?? join(homedir(), '.copilot', 'session-state'),
+);
+
+/**
  * READ-ONLY agent home directories — the parents of the session/project dirs
  * above, where each agent keeps its memory (`CLAUDE.md`, `AGENTS.md`, the Codex
  * `memories/` tree). Derived from the dirs above so the env overrides carry
@@ -91,6 +101,8 @@ export const OPENCODE_DB_PATH =
 export const CLAUDE_HOME = dirname(CLAUDE_PROJECTS_DIR);
 export const CODEX_HOME = dirname(CODEX_SESSIONS_DIR);
 export const JUNIE_HOME = dirname(JUNIE_SESSIONS_DIR);
+/** `~/.copilot` — holds the global `copilot-instructions.md` memory file. */
+export const COPILOT_HOME = dirname(COPILOT_SESSIONS_DIR);
 
 /** Whether to auto-open the default browser on startup (set by the launcher). */
 export const OPEN_BROWSER = process.env.OPEN_BROWSER === '1';

--- a/packages/server/src/connectors/copilot/copilot.ts
+++ b/packages/server/src/connectors/copilot/copilot.ts
@@ -1,0 +1,113 @@
+/**
+ * GitHub Copilot CLI connector.
+ *
+ * Source layout: `~/.copilot/session-state/<uuid>/events.jsonl` (one event-sourced
+ * stream per session) plus a sibling `workspace.yaml` (title/cwd/branch) and an
+ * optional `files/` attachment dir. Like Codex/Junie/pi, the stream can't be
+ * projected per-row by DuckDB, so `prepare()` normalizes a session to canonical
+ * NDJSON (in TS, via {@link parseCopilotSession}/{@link toCanonicalRows}) and
+ * `eventsProjectionSql` reads that 1:1 — the indexer/FTS/cost stay native.
+ *
+ * Global memory is the user-authored `~/.copilot/copilot-instructions.md`
+ * ({@link copilotGlobalMemory}); there is no cross-session per-project store.
+ *
+ * STRICTLY READ-ONLY with respect to ~/.copilot — files are only ever read.
+ */
+
+import { createHash } from 'node:crypto';
+import { existsSync, mkdirSync, readdirSync, statSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { CLAUDESCOPE_HOME, COPILOT_SESSIONS_DIR } from '../../config.js';
+import { sqlString } from '../../db/duckdb.js';
+import type { SessionData } from '../../data/session-loader.js';
+import type { AgentConnector, AuxProjections, DiscoveredFile } from '../types.js';
+import { parseCopilotSession, toCanonicalRows } from './normalize.js';
+import { copilotGlobalMemory } from './memory.js';
+
+const CACHE_DIR = join(CLAUDESCOPE_HOME, 'cache', 'copilot');
+
+/** Deterministic temp NDJSON path for a given session file. */
+function cachePath(filePath: string): string {
+  const hash = createHash('sha1').update(filePath).digest('hex').slice(0, 16);
+  return join(CACHE_DIR, `${hash}.ndjson`);
+}
+
+/** Collect every `<uuid>/events.jsonl` under the Copilot session-state dir. */
+function discover(): DiscoveredFile[] {
+  const out: DiscoveredFile[] = [];
+  let dirs: import('node:fs').Dirent[];
+  try {
+    dirs = readdirSync(COPILOT_SESSIONS_DIR, { withFileTypes: true });
+  } catch {
+    return out; // no Copilot install
+  }
+  for (const dir of dirs) {
+    if (!dir.isDirectory()) continue;
+    const full = join(COPILOT_SESSIONS_DIR, dir.name, 'events.jsonl');
+    try {
+      const st = statSync(full);
+      out.push({ path: full, mtimeMs: Math.floor(st.mtimeMs), size: st.size });
+    } catch {
+      /* a session-state dir without an events.jsonl yet; ignore */
+    }
+  }
+  return out;
+}
+
+/** Normalize a session to canonical NDJSON the projection will read. */
+async function prepare(filePath: string): Promise<void> {
+  const session = parseCopilotSession(filePath);
+  mkdirSync(CACHE_DIR, { recursive: true });
+  const rows = session ? toCanonicalRows(session, filePath) : [];
+  writeFileSync(cachePath(filePath), rows.map((r) => JSON.stringify(r)).join('\n') + '\n');
+}
+
+function eventsProjectionSql(filePath: string): string {
+  const path = sqlString(cachePath(filePath));
+  return `
+    SELECT
+      file_path, session_id, uuid, parent_uuid, role, type, ts, cwd, git_branch,
+      model, input_tokens, output_tokens, cache_read_tokens, cache_write_tokens,
+      service_tier, is_sidechain, tool_use_count, text_content,
+      CAST(NULL AS VARCHAR) AS message_id, CAST(NULL AS VARCHAR) AS forked_from_session_id
+    FROM read_ndjson(${path}, format='newline_delimited', maximum_object_size=268435456, ignore_errors=true, columns={
+      file_path:'VARCHAR', session_id:'VARCHAR', uuid:'VARCHAR', parent_uuid:'VARCHAR',
+      role:'VARCHAR', type:'VARCHAR', ts:'TIMESTAMP', cwd:'VARCHAR', git_branch:'VARCHAR',
+      model:'VARCHAR', input_tokens:'BIGINT', output_tokens:'BIGINT', cache_read_tokens:'BIGINT',
+      cache_write_tokens:'BIGINT', service_tier:'VARCHAR', is_sidechain:'BOOLEAN',
+      tool_use_count:'INTEGER', text_content:'VARCHAR'
+    })`;
+}
+
+/** Copilot carries a real session title (workspace.yaml `name`), threaded through
+ *  the cache NDJSON; the first-user-message fallback applies when it's empty. */
+function auxProjections(filePath: string): AuxProjections {
+  if (!existsSync(cachePath(filePath))) return {};
+  const path = sqlString(cachePath(filePath));
+  return {
+    titles: `
+      SELECT session_id, last(title) AS title
+      FROM read_ndjson(${path}, format='newline_delimited', maximum_object_size=268435456, ignore_errors=true,
+        columns={session_id:'VARCHAR', title:'VARCHAR'})
+      WHERE session_id IS NOT NULL AND title IS NOT NULL AND title <> ''
+      GROUP BY session_id`,
+  };
+}
+
+async function loadSession(_sessionId: string, paths: string[]): Promise<SessionData> {
+  // resolveImages: pull saved-attachment bytes off disk for the detail view.
+  const mainEvents = paths.flatMap((p) => parseCopilotSession(p, { resolveImages: true })?.events ?? []);
+  return { mainEvents, subagents: [] };
+}
+
+export const copilotConnector: AgentConnector = {
+  id: 'copilot',
+  label: 'GitHub Copilot CLI',
+  sourceDir: COPILOT_SESSIONS_DIR,
+  discover,
+  prepare,
+  eventsProjectionSql,
+  auxProjections,
+  loadSession,
+  globalMemory: copilotGlobalMemory,
+};

--- a/packages/server/src/connectors/copilot/memory.ts
+++ b/packages/server/src/connectors/copilot/memory.ts
@@ -1,0 +1,45 @@
+/**
+ * GitHub Copilot CLI memory — read live from `~/.copilot`, never indexed.
+ *
+ * One store surfaces: `~/.copilot/copilot-instructions.md` — the user-authored
+ * global instruction file (analog of `~/.claude/CLAUDE.md` / `~/.codex/AGENTS.md`).
+ *
+ * No per-project memory: Copilot's "session-level memory" persists facts/todos in
+ * the per-session `session.db` and attachments in `session-state/<uuid>/files/`,
+ * all session-scoped (cleared on `/clear`), not a cross-session per-project store.
+ * Its real memory subsystem was disabled in every observed install, so the on-disk
+ * shape of any genuine project memory is unconfirmed — `projectMemory()` is omitted
+ * until a user with it enabled surfaces a real store.
+ *
+ * STRICTLY READ-ONLY with respect to ~/.copilot — the file is only ever read.
+ */
+
+import { readFileSync, statSync } from 'node:fs';
+import { join } from 'node:path';
+import type { MemorySource } from '@claudescope/shared';
+import { COPILOT_HOME } from '../../config.js';
+import { contractHome } from '../../util/paths.js';
+
+/**
+ * Copilot's global, cross-project memory: the user-authored `copilot-instructions.md`.
+ * Absent for most users → `[]`, never an error.
+ */
+export function copilotGlobalMemory(): MemorySource[] {
+  const path = join(COPILOT_HOME, 'copilot-instructions.md');
+  try {
+    const markdown = readFileSync(path, 'utf8');
+    if (!markdown.trim()) return [];
+    return [
+      {
+        provenance: 'user-authored',
+        kind: 'document',
+        title: 'copilot-instructions.md (global)',
+        markdown,
+        sourcePath: contractHome(path),
+        updatedAt: new Date(statSync(path).mtimeMs).toISOString(),
+      },
+    ];
+  } catch {
+    return [];
+  }
+}

--- a/packages/server/src/connectors/copilot/normalize.ts
+++ b/packages/server/src/connectors/copilot/normalize.ts
@@ -1,0 +1,423 @@
+/**
+ * GitHub Copilot CLI session → canonical thread normalizer.
+ *
+ * Source layout: `~/.copilot/session-state/<uuid>/events.jsonl` — an event-sourced
+ * stream (Junie/pi-shaped) where each line is
+ * `{type, data, id, timestamp, parentId}`. The transcript is spread across record
+ * types: `session.start` carries cwd/branch/repository, `session.model_change`
+ * the model, `assistant.message` the text + tool calls (+ encrypted reasoning),
+ * `tool.execution_complete` the tool results, and `session.shutdown` the ONLY
+ * token counts (session-level — there is no per-message usage). The sibling
+ * `workspace.yaml` carries the session title; `files/<displayName>` holds persisted
+ * attachments (screenshots) when saving is enabled.
+ *
+ * This parses one session into Claude-shaped `RawEvent[]` so the thread assembler
+ * and the canonical index-row builder both reuse it (mirrors `pi`/`opencode`).
+ *
+ * Notable quirks:
+ *  - **Tokens only in `session.shutdown`** → attached to the LAST assistant turn;
+ *    `message.id` is never set, so the cost path counts the single token-bearing
+ *    row exactly once. A session with no shutdown (crash/kill/running) has zero cost.
+ *  - **Reasoning is encrypted** (`reasoningOpaque`) → empty `thinking` block carrying
+ *    the opaque blob as `signature` (renders empty, like Codex).
+ *  - **Screenshots**: the `events.jsonl` attachment path is a dead `$TMPDIR` copy, but
+ *    when saving is enabled the bytes live at `files/<displayName>`. Resolved to a
+ *    base64 `ImageBlock` ONLY in `loadSession` (`resolveImages`); the index keeps the
+ *    inline `[📷 …]` marker that Copilot embeds in the message text.
+ *  - **Files-changed**: an `edit`/`create`/`write` tool is mapped to a canonical
+ *    `Edit`/`Write` block ONLY when it actually succeeded (a granted, successful
+ *    `tool.execution_complete`); a denied/failed attempt passes through under its raw
+ *    name so it shows in-thread but never reaches the Files-changed tab.
+ *
+ * STRICTLY READ-ONLY with respect to ~/.copilot — files are only ever read.
+ */
+
+import { readFileSync, statSync } from 'node:fs';
+import { basename, dirname, extname, join } from 'node:path';
+import type {
+  AssistantEvent,
+  ContentBlock,
+  MessageUsage,
+  ToolResultBlock,
+  UserEvent,
+} from '@claudescope/shared';
+
+export interface CopilotSession {
+  sessionId: string;
+  cwd: string;
+  branch: string | null;
+  title: string;
+  events: (UserEvent | AssistantEvent)[];
+}
+
+const str = (v: unknown): string => (typeof v === 'string' ? v : '');
+const num = (v: unknown): number => (typeof v === 'number' && Number.isFinite(v) ? v : 0);
+const rec = (v: unknown): Record<string, unknown> =>
+  v && typeof v === 'object' ? (v as Record<string, unknown>) : {};
+
+/** Copilot stores token counts as `{tokenCount: N}` buckets. */
+const tokenCount = (v: unknown): number => num(rec(v).tokenCount);
+
+/**
+ * `session.shutdown.data.tokenDetails` → canonical usage. The breakdown is
+ * `input` (non-cached) + `cache_read` + `output`; `cache_write` is absent today
+ * (0). Reasoning is already folded into `output` by Copilot (OpenAI semantics),
+ * so we don't add `reasoningTokens` — that would double-count.
+ */
+function shutdownUsage(data: Record<string, unknown>): MessageUsage {
+  const td = rec(data.tokenDetails);
+  return {
+    input_tokens: tokenCount(td.input),
+    output_tokens: tokenCount(td.output),
+    cache_read_input_tokens: tokenCount(td.cache_read),
+    cache_creation_input_tokens: tokenCount(td.cache_write),
+  };
+}
+
+const zeroUsage = (): MessageUsage => ({
+  input_tokens: 0,
+  output_tokens: 0,
+  cache_read_input_tokens: 0,
+  cache_creation_input_tokens: 0,
+});
+
+/**
+ * Map a Copilot tool request to a canonical `tool_use` block. File-mutating tools
+ * (`edit`/`create`/`write`) only become canonical `Edit`/`Write` — which the
+ * Files-changed extractor (`changeset.ts`) keys off — when the call actually
+ * succeeded; otherwise they pass through under their raw name so a denied/failed
+ * attempt is visible in-thread but doesn't count as a file change. Read-only tools
+ * (`view`→`Read`, `bash`→`Bash`) map unconditionally. Unknown tools pass through.
+ */
+function toolUseBlock(
+  name: string,
+  args: Record<string, unknown>,
+  id: string,
+  succeeded: boolean,
+): ContentBlock {
+  switch (name) {
+    case 'edit':
+      if (succeeded) {
+        return {
+          type: 'tool_use',
+          id,
+          name: 'Edit',
+          input: { file_path: str(args.path), old_string: str(args.old_str), new_string: str(args.new_str) },
+        };
+      }
+      break;
+    case 'create':
+    case 'write':
+      if (succeeded) {
+        return {
+          type: 'tool_use',
+          id,
+          name: 'Write',
+          input: { file_path: str(args.path), content: str(args.content) },
+        };
+      }
+      break;
+    case 'view':
+      return {
+        type: 'tool_use',
+        id,
+        name: 'Read',
+        input: { file_path: str(args.path), offset: args.offset, limit: args.limit },
+      };
+    case 'bash':
+      return {
+        type: 'tool_use',
+        id,
+        name: 'Bash',
+        input: { command: str(args.command), timeout: args.timeout, description: str(args.description) },
+      };
+  }
+  // failed/denied edit, sql, ask_user, fetch_*, or any unknown tool → generic render
+  return { type: 'tool_use', id, name, input: args };
+}
+
+/** Cap an inline-embedded screenshot so a stray huge file can't bloat the
+ *  session-detail payload / exhaust memory when base64-encoded. */
+const MAX_IMAGE_BYTES = 20 * 1024 * 1024;
+
+const IMAGE_MIME: Record<string, string> = {
+  '.png': 'image/png',
+  '.jpg': 'image/jpeg',
+  '.jpeg': 'image/jpeg',
+  '.gif': 'image/gif',
+  '.webp': 'image/webp',
+};
+
+/**
+ * Resolve a persisted attachment (`files/<displayName>`) to a base64 `ImageBlock`.
+ * The `events.jsonl` attachment `path` is a deleted `$TMPDIR` copy, so we resolve by
+ * `displayName` (basename only — never escape the `files/` dir). Returns null for a
+ * non-image, or when the bytes weren't saved (screenshot-saving off) — the inline
+ * `[📷 …]` marker in the message text already conveys the attachment in that case.
+ */
+function resolveImage(sessionDir: string, displayName: string): ContentBlock | null {
+  const name = basename(displayName);
+  const mime = IMAGE_MIME[extname(name).toLowerCase()];
+  if (!name || !mime) return null;
+  try {
+    const full = join(sessionDir, 'files', name);
+    if (statSync(full).size > MAX_IMAGE_BYTES) return null; // don't inline an oversized file
+    const data = readFileSync(full).toString('base64');
+    return { type: 'image', source: { type: 'base64', media_type: mime, data } };
+  } catch {
+    return null;
+  }
+}
+
+/** A `user.message` → canonical blocks: the literal text (which already carries the
+ *  `[📷 name]` marker) plus any resolvable saved-image attachments. */
+function userBlocks(
+  data: Record<string, unknown>,
+  sessionDir: string,
+  resolveImages: boolean,
+): ContentBlock[] {
+  const out: ContentBlock[] = [];
+  const text = str(data.content);
+  if (text) out.push({ type: 'text', text });
+  if (resolveImages) {
+    const atts = Array.isArray(data.attachments) ? data.attachments : [];
+    for (const a of atts) {
+      const att = rec(a);
+      if (str(att.type) === 'file') {
+        const img = resolveImage(sessionDir, str(att.displayName));
+        if (img) out.push(img);
+      }
+    }
+  }
+  return out;
+}
+
+interface CopilotEvent {
+  type?: string;
+  data?: unknown;
+  id?: string;
+  timestamp?: string;
+  parentId?: string | null;
+}
+
+/** Minimal `workspace.yaml` reader — only a few scalar keys are needed. */
+function readWorkspaceYaml(path: string): { name?: string; cwd?: string; branch?: string } {
+  let raw: string;
+  try {
+    raw = readFileSync(path, 'utf8');
+  } catch {
+    return {};
+  }
+  const get = (key: string): string | undefined => {
+    const m = raw.match(new RegExp(`^${key}:[ \\t]*(.+?)[ \\t]*$`, 'm'));
+    return m?.[1]?.replace(/^['"]|['"]$/g, '');
+  };
+  return { name: get('name'), cwd: get('cwd'), branch: get('branch') };
+}
+
+/**
+ * Parse a Copilot `events.jsonl` into a Claude-shaped session, or null if
+ * unreadable. `resolveImages` (loadSession only) reads saved attachment bytes off
+ * disk; the index path leaves it off to avoid reading images it never embeds.
+ */
+export function parseCopilotSession(
+  path: string,
+  opts: { resolveImages?: boolean } = {},
+): CopilotSession | null {
+  let raw: string;
+  try {
+    raw = readFileSync(path, 'utf8');
+  } catch {
+    return null;
+  }
+  const lines: CopilotEvent[] = [];
+  for (const line of raw.split('\n')) {
+    const t = line.trim();
+    if (!t) continue;
+    try {
+      lines.push(JSON.parse(t) as CopilotEvent);
+    } catch {
+      /* tolerate a corrupt/partial trailing line */
+    }
+  }
+
+  const sessionDir = dirname(path);
+  const ws = readWorkspaceYaml(join(sessionDir, 'workspace.yaml'));
+  let sessionId = basename(sessionDir) || path;
+  let cwd = '';
+  let branch: string | null = null;
+
+  // Pass 1: session identity (session.start) + per-tool outcome (success/denied).
+  // The result/denial is needed when emitting a tool_use, which precedes its
+  // tool.execution_complete in the stream — so collect outcomes up front.
+  const resultById = new Map<string, { content: string; isError: boolean }>();
+  for (const ev of lines) {
+    const d = rec(ev.data);
+    if (ev.type === 'session.start') {
+      const ctx = rec(d.context);
+      if (str(d.sessionId)) sessionId = str(d.sessionId);
+      if (str(ctx.cwd)) cwd = str(ctx.cwd);
+      if (str(ctx.branch)) branch = str(ctx.branch);
+    } else if (ev.type === 'tool.execution_complete') {
+      const r = rec(d.result);
+      resultById.set(str(d.toolCallId), { content: str(r.content), isError: d.success === false });
+    } else if (ev.type === 'permission.completed') {
+      // A denied permission yields no tool.execution_complete; surface the denial
+      // as the tool's result so the (passthrough) tool_use isn't left dangling.
+      const r = rec(d.result);
+      const id = str(d.toolCallId);
+      if (str(r.kind).startsWith('denied') && !resultById.has(id)) {
+        resultById.set(id, { content: 'Permission denied by the user.', isError: true });
+      }
+    }
+  }
+  if (!cwd && ws.cwd) cwd = ws.cwd;
+  if (!branch && ws.branch) branch = ws.branch;
+  const title = ws.name ?? '';
+  const resolveImages = opts.resolveImages ?? false;
+
+  // Pass 2: build the threaded events with a synthesized uuid/parent chain.
+  const events: (UserEvent | AssistantEvent)[] = [];
+  let seq = 0;
+  let prevUuid: string | null = null;
+  const nextUuid = (): string => `${sessionId}-${seq++}`;
+  const envelope = (ts: string): Pick<
+    UserEvent,
+    'sessionId' | 'timestamp' | 'cwd' | 'gitBranch' | 'isSidechain'
+  > => ({
+    sessionId,
+    timestamp: ts,
+    cwd,
+    ...(branch ? { gitBranch: branch } : {}),
+    isSidechain: false,
+  });
+  let model = '';
+  let shutdown: MessageUsage | null = null;
+
+  for (const ev of lines) {
+    const d = rec(ev.data);
+    const ts = str(ev.timestamp);
+    if (ev.type === 'session.model_change') {
+      if (str(d.newModel)) model = str(d.newModel);
+    } else if (ev.type === 'user.message') {
+      const content = userBlocks(d, sessionDir, resolveImages);
+      const uuid = nextUuid();
+      events.push({ uuid, parentUuid: prevUuid, ...envelope(ts), type: 'user', message: { role: 'user', content } } as UserEvent);
+      prevUuid = uuid;
+    } else if (ev.type === 'assistant.message') {
+      if (str(d.model)) model = str(d.model);
+      const blocks: ContentBlock[] = [];
+      const reasoning = str(d.reasoningOpaque);
+      if (reasoning) blocks.push({ type: 'thinking', thinking: '', signature: reasoning });
+      const text = str(d.content);
+      if (text) blocks.push({ type: 'text', text });
+      const toolResults: ToolResultBlock[] = [];
+      const reqs = Array.isArray(d.toolRequests) ? d.toolRequests : [];
+      for (const r of reqs) {
+        const tr = rec(r);
+        const id = str(tr.toolCallId);
+        const outcome = resultById.get(id);
+        blocks.push(toolUseBlock(str(tr.name), rec(tr.arguments), id, !!outcome && !outcome.isError));
+        if (outcome) {
+          toolResults.push({
+            type: 'tool_result',
+            tool_use_id: id,
+            content: outcome.content,
+            ...(outcome.isError ? { is_error: true } : {}),
+          });
+        }
+      }
+      if (blocks.length === 0) continue; // empty assistant scaffolding turn — skip
+      const uuid = nextUuid();
+      events.push({
+        uuid,
+        parentUuid: prevUuid,
+        ...envelope(ts),
+        type: 'assistant',
+        message: { role: 'assistant', model, content: blocks, usage: zeroUsage() },
+      } as AssistantEvent);
+      prevUuid = uuid;
+      // Tool results ride a following synthetic user turn (assembler pairs by id).
+      if (toolResults.length > 0) {
+        const ruid = nextUuid();
+        events.push({ uuid: ruid, parentUuid: prevUuid, ...envelope(ts), type: 'user', message: { role: 'user', content: toolResults } } as UserEvent);
+        prevUuid = ruid;
+      }
+    } else if (ev.type === 'session.shutdown') {
+      shutdown = shutdownUsage(d);
+    }
+    // session.start (pass 1), system.message, session.info, hook.*, tool.*,
+    // permission.*, abort, and any unknown/new type are tolerated and skipped.
+  }
+
+  // Tokens exist only at session level → attach to the last assistant turn.
+  if (shutdown) {
+    for (let i = events.length - 1; i >= 0; i--) {
+      const e = events[i];
+      if (e && e.type === 'assistant') {
+        e.message.usage = shutdown;
+        break;
+      }
+    }
+  }
+
+  return { sessionId, cwd, branch, title, events };
+}
+
+/** A canonical index row (matches the events NDJSON the projection reads). */
+export interface CanonicalRow {
+  file_path: string;
+  session_id: string;
+  uuid: string;
+  parent_uuid: string | null;
+  role: string;
+  type: string;
+  ts: string;
+  cwd: string;
+  git_branch: string | null;
+  model: string | null;
+  input_tokens: number;
+  output_tokens: number;
+  cache_read_tokens: number;
+  cache_write_tokens: number;
+  service_tier: string | null;
+  is_sidechain: boolean;
+  tool_use_count: number;
+  text_content: string;
+  /** Session title (read by auxProjections; ignored by the events projection). */
+  title: string;
+}
+
+/** Flatten a parsed session into canonical index rows for one file. */
+export function toCanonicalRows(session: CopilotSession, filePath: string): CanonicalRow[] {
+  return session.events.map((e) => {
+    const msg = e.message;
+    const content = Array.isArray(msg.content) ? msg.content : [];
+    const usage = (msg as { usage?: MessageUsage }).usage;
+    const text = content
+      .map((b) => (b.type === 'text' ? b.text : b.type === 'thinking' ? b.thinking : ''))
+      .filter(Boolean)
+      .join(' ');
+    return {
+      file_path: filePath,
+      session_id: session.sessionId,
+      uuid: e.uuid,
+      parent_uuid: e.parentUuid,
+      role: msg.role,
+      type: e.type,
+      ts: e.timestamp,
+      cwd: session.cwd,
+      git_branch: session.branch,
+      model: (msg as { model?: string }).model ?? null,
+      input_tokens: num(usage?.input_tokens),
+      output_tokens: num(usage?.output_tokens),
+      cache_read_tokens: num(usage?.cache_read_input_tokens),
+      cache_write_tokens: num(usage?.cache_creation_input_tokens),
+      service_tier: null,
+      is_sidechain: false,
+      tool_use_count: content.filter((b) => b.type === 'tool_use').length,
+      text_content: text,
+      title: session.title,
+    };
+  });
+}

--- a/packages/server/src/connectors/registry.ts
+++ b/packages/server/src/connectors/registry.ts
@@ -9,6 +9,7 @@ import { codexConnector } from './codex/codex.js';
 import { junieConnector } from './junie/junie.js';
 import { piConnector } from './pi/pi.js';
 import { opencodeConnector } from './opencode/opencode.js';
+import { copilotConnector } from './copilot/copilot.js';
 
 export const connectors: AgentConnector[] = [
   claudeCodeConnector,
@@ -16,6 +17,7 @@ export const connectors: AgentConnector[] = [
   junieConnector,
   piConnector,
   opencodeConnector,
+  copilotConnector,
 ];
 
 /** The connector with the given id, falling back to Claude Code if unknown. */

--- a/packages/server/test/api.integration.test.ts
+++ b/packages/server/test/api.integration.test.ts
@@ -26,6 +26,7 @@ process.env.CODEX_SESSIONS_DIR = join(work, 'codex-empty');
 process.env.JUNIE_SESSIONS_DIR = join(work, 'junie-empty');
 process.env.PI_SESSIONS_DIR = join(work, 'pi-empty');
 process.env.OPENCODE_DATA_DIR = join(work, 'opencode-empty');
+process.env.COPILOT_SESSIONS_DIR = join(work, 'copilot-empty');
 process.env.DUCKDB_PATH = dbPath;
 process.env.CLAUDESCOPE_HOME = join(work, 'home');
 process.env.REINDEX_INTERVAL_MS = '0';

--- a/packages/server/test/codex.integration.test.ts
+++ b/packages/server/test/codex.integration.test.ts
@@ -24,6 +24,7 @@ process.env.CODEX_SESSIONS_DIR = codexDir;
 process.env.JUNIE_SESSIONS_DIR = join(work, 'junie-empty');
 process.env.PI_SESSIONS_DIR = join(work, 'pi-empty');
 process.env.OPENCODE_DATA_DIR = join(work, 'opencode-empty');
+process.env.COPILOT_SESSIONS_DIR = join(work, 'copilot-empty');
 process.env.DUCKDB_PATH = join(work, 'index.duckdb');
 process.env.CLAUDESCOPE_HOME = join(work, 'home');
 process.env.REINDEX_INTERVAL_MS = '0';

--- a/packages/server/test/copilot.integration.test.ts
+++ b/packages/server/test/copilot.integration.test.ts
@@ -1,0 +1,263 @@
+/**
+ * GitHub Copilot CLI connector integration test.
+ *
+ * Builds the index from two synthetic Copilot sessions (in an isolated temp
+ * COPILOT_SESSIONS_DIR, the other agents empty) and exercises the routes,
+ * verifying the Copilot-specific normalization:
+ *   - cwd/branch from `session.start`, model from `assistant.message`, title from
+ *     the sibling `workspace.yaml` (`name`);
+ *   - session-level tokens from `session.shutdown` (gpt-5-mini priced correctly),
+ *     and a session WITHOUT a shutdown event costing zero;
+ *   - encrypted reasoning (`reasoningOpaque`) → empty thinking block (Codex-style);
+ *   - a SAVED screenshot (`files/<displayName>`) → base64 ImageBlock, while an
+ *     unsaved one keeps only the inline `[📷 …]` marker;
+ *   - a SUCCESSFUL `edit` → canonical `Edit` (feeds Files-changed), while a DENIED
+ *     edit passes through under its raw name (excluded from Files-changed);
+ *   - an unknown event type (`session.context_changed`) tolerated;
+ *   - global memory read from `~/.copilot/copilot-instructions.md`.
+ */
+
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import type { FastifyInstance } from 'fastify';
+
+const work = mkdtempSync(join(tmpdir(), 'claudescope-copilot-'));
+const copilotHome = join(work, 'copilot');
+const sessionsDir = join(copilotHome, 'session-state');
+
+process.env.CLAUDE_PROJECTS_DIR = join(work, 'claude-empty');
+process.env.CODEX_SESSIONS_DIR = join(work, 'codex-empty');
+process.env.JUNIE_SESSIONS_DIR = join(work, 'junie-empty');
+process.env.PI_SESSIONS_DIR = join(work, 'pi-empty');
+process.env.OPENCODE_DATA_DIR = join(work, 'opencode-empty');
+process.env.COPILOT_SESSIONS_DIR = sessionsDir;
+process.env.DUCKDB_PATH = join(work, 'index.duckdb');
+process.env.CLAUDESCOPE_HOME = join(work, 'home');
+process.env.REINDEX_INTERVAL_MS = '0';
+
+const jsonl = (events: unknown[]): string => events.map((e) => JSON.stringify(e)).join('\n') + '\n';
+const ts = (s: number) => `2026-06-16T10:00:${String(s).padStart(2, '0')}.000Z`;
+let evtId = 0;
+/** Wrap a `{type, data}` pair into a Copilot event envelope. */
+const ev = (type: string, data: unknown) => ({ type, data, id: `e${evtId++}`, timestamp: ts(evtId), parentId: null });
+
+// 1x1 transparent PNG — stands in for a saved screenshot.
+const PNG_B64 =
+  'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYPhfDwAChwGA60e6kgAAAABJRU5ErkJggg==';
+
+/** Write a session dir: events.jsonl + workspace.yaml (+ optional saved files). */
+function writeSession(
+  uuid: string,
+  workspaceName: string,
+  events: unknown[],
+  files: Record<string, Buffer> = {},
+): void {
+  const dir = join(sessionsDir, uuid);
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(join(dir, 'events.jsonl'), jsonl(events));
+  writeFileSync(
+    join(dir, 'workspace.yaml'),
+    `id: ${uuid}\ncwd: /tmp/cproj\ngit_root: /tmp/cproj\nrepository: me/cproj\nbranch: main\nname: ${workspaceName}\nuser_named: false\n`,
+  );
+  const fileNames = Object.keys(files);
+  if (fileNames.length > 0) {
+    mkdirSync(join(dir, 'files'), { recursive: true });
+    for (const name of fileNames) writeFileSync(join(dir, 'files', name), files[name]!);
+  }
+}
+
+/** Session 1: clean shutdown, a successful edit, and a SAVED screenshot. */
+function writeSession1(): void {
+  writeSession(
+    'sa',
+    'Fix the bug',
+    [
+      ev('session.start', {
+        sessionId: 'copilot-sess-1',
+        copilotVersion: '1.0.62',
+        context: { cwd: '/tmp/cproj', gitRoot: '/tmp/cproj', branch: 'main', repository: 'me/cproj', hostType: 'github' },
+      }),
+      ev('session.model_change', { newModel: 'gpt-5-mini', reasoningEffort: 'medium' }),
+      ev('user.message', {
+        content: 'fix the bug and here is a shot [📷 shot.png]',
+        transformedContent: '<current_datetime>…</current_datetime>\n\nfix the bug…',
+        attachments: [{ type: 'file', path: '/var/folders/T/shot.png', displayName: 'shot.png' }],
+      }),
+      ev('assistant.message', {
+        messageId: 'm1',
+        model: 'gpt-5-mini',
+        content: "I'll fix it.",
+        reasoningOpaque: 'ENCRYPTED_REASONING_BLOB',
+        toolRequests: [
+          { toolCallId: 'call-edit', name: 'edit', arguments: { path: '/tmp/cproj/app.ts', old_str: 'bug', new_str: 'fixed' } },
+        ],
+      }),
+      ev('tool.execution_start', { toolCallId: 'call-edit', toolName: 'edit', arguments: { path: '/tmp/cproj/app.ts', old_str: 'bug', new_str: 'fixed' }, model: 'gpt-5-mini' }),
+      ev('tool.execution_complete', { toolCallId: 'call-edit', success: true, result: { content: 'File app.ts updated with changes.' } }),
+      // Unknown event type — must be tolerated and skipped without breaking indexing.
+      ev('session.context_changed', { reason: 'compaction' }),
+      ev('session.shutdown', {
+        tokenDetails: { input: { tokenCount: 100 }, cache_read: { tokenCount: 20 }, output: { tokenCount: 50 } },
+        codeChanges: { linesAdded: 1, linesRemoved: 1, filesModified: ['/tmp/cproj/app.ts'] },
+        modelMetrics: { 'gpt-5-mini': { requests: { count: 1, cost: 0 }, usage: { inputTokens: 120, outputTokens: 50, cacheReadTokens: 20, cacheWriteTokens: 0, reasoningTokens: 30 } } },
+      }),
+    ],
+    { 'shot.png': Buffer.from(PNG_B64, 'base64') },
+  );
+}
+
+/** Session 2: NO shutdown (→ zero cost), a DENIED edit, an UNSAVED screenshot. */
+function writeSession2(): void {
+  writeSession('sb', 'Audit the project', [
+    ev('session.start', {
+      sessionId: 'copilot-sess-2',
+      context: { cwd: '/tmp/cproj', branch: 'main', repository: 'me/cproj', hostType: 'github' },
+    }),
+    ev('session.model_change', { newModel: 'gpt-5-mini' }),
+    ev('user.message', {
+      content: 'audit the code and see this needle [📷 missing.png]',
+      attachments: [{ type: 'file', path: '/var/folders/T/missing.png', displayName: 'missing.png' }],
+    }),
+    ev('assistant.message', {
+      messageId: 'm2',
+      model: 'gpt-5-mini',
+      content: 'I will edit CLAUDE.md',
+      toolRequests: [
+        { toolCallId: 'call-deny', name: 'edit', arguments: { path: '/tmp/cproj/CLAUDE.md', old_str: 'x', new_str: 'y' } },
+      ],
+    }),
+    ev('permission.requested', {
+      requestId: 'r1',
+      permissionRequest: { kind: 'write', toolCallId: 'call-deny', intention: 'Edit file', fileName: '/tmp/cproj/CLAUDE.md', diff: '@@ -1 +1 @@\n-x\n+y' },
+    }),
+    ev('permission.completed', { requestId: 'r1', toolCallId: 'call-deny', result: { kind: 'denied-interactively-by-user' } }),
+    ev('abort', { reason: 'user_initiated' }),
+  ]);
+}
+
+let app: FastifyInstance;
+let closeConnection: () => Promise<void>;
+
+beforeAll(async () => {
+  writeSession1();
+  writeSession2();
+  // Global memory file in the Copilot home (parent of session-state).
+  writeFileSync(join(copilotHome, 'copilot-instructions.md'), '# User profile\nuser.name: Vlad\n');
+
+  const Fastify = (await import('fastify')).default;
+  const { registerRoutes } = await import('../src/routes/index.js');
+  const { reindex } = await import('../src/data/index.js');
+  ({ closeConnection } = await import('../src/db/duckdb.js'));
+
+  app = Fastify();
+  await registerRoutes(app);
+  await reindex();
+  await app.ready();
+});
+
+afterAll(async () => {
+  await app?.close();
+  await closeConnection?.();
+  rmSync(work, { recursive: true, force: true });
+});
+
+const get = (url: string) => app.inject({ method: 'GET', url });
+type Session = { id: string; connectorId: string; title: string; models: string[]; totalTokens: number; totalCostUsd: number };
+const sessionById = async (id: string): Promise<Session> =>
+  (await get('/api/sessions')).json().find((s: Session) => s.id === id);
+
+describe('copilot session indexing', () => {
+  it('lists both sessions tagged copilot, with model and workspace.yaml title', async () => {
+    const sessions: Session[] = (await get('/api/sessions')).json();
+    expect(sessions.map((s) => s.id).sort()).toEqual(['copilot-sess-1', 'copilot-sess-2']);
+    for (const s of sessions) {
+      expect(s.connectorId).toBe('copilot');
+      expect(s.models).toContain('gpt-5-mini');
+    }
+    expect((await sessionById('copilot-sess-1')).title).toBe('Fix the bug');
+    expect((await sessionById('copilot-sess-2')).title).toBe('Audit the project');
+  });
+
+  it('prices the shutdown session from tokenDetails and charges the no-shutdown session nothing', async () => {
+    const s1 = await sessionById('copilot-sess-1');
+    // tokenDetails: input 100 + cache_read 20 + output 50 = 170 (one billed row).
+    expect(s1.totalTokens).toBe(170);
+    // gpt-5-mini @ 0.25 / 2 / 0.025 per 1M (cacheWrite 0):
+    //   (100*0.25 + 50*2 + 20*0.025)/1e6 = (25 + 100 + 0.5)/1e6 = 0.0001255.
+    expect(s1.totalCostUsd).toBeCloseTo(0.0001255, 8);
+
+    // No session.shutdown → no token data → zero cost (not an error).
+    const s2 = await sessionById('copilot-sess-2');
+    expect(s2.totalTokens).toBe(0);
+    expect(s2.totalCostUsd).toBe(0);
+  });
+
+  it('exposes the copilot source and groups analytics by the copilot agent', async () => {
+    const sources = (await get('/api/sources')).json();
+    expect(sources.some((s: { id: string }) => s.id === 'copilot')).toBe(true);
+    const { rows } = (await get('/api/analytics?groupBy=agent')).json();
+    expect(rows.map((r: { key: string }) => r.key)).toContain('copilot');
+  });
+
+  it('finds a copilot session via full-text search', async () => {
+    const { sessions: results } = (await get('/api/search?q=needle')).json();
+    expect(results.some((r: { sessionId: string }) => r.sessionId === 'copilot-sess-2')).toBe(true);
+  });
+
+  it('surfaces the global copilot-instructions.md memory', async () => {
+    const { global } = (await get('/api/memory')).json();
+    const copilot = global.find((g: { connectorId: string }) => g.connectorId === 'copilot');
+    expect(copilot).toBeTruthy();
+    expect(copilot.label).toBe('GitHub Copilot CLI');
+    expect(JSON.stringify(copilot.sources)).toContain('copilot-instructions.md (global)');
+  });
+});
+
+describe('copilot session detail', () => {
+  it('renders empty thinking, a saved screenshot, and a canonical Edit feeding Files-changed', async () => {
+    const detail = (await get('/api/sessions/copilot-sess-1')).json();
+    expect(detail.subagents).toEqual([]);
+    expect(detail.thread[0]).toMatchObject({ role: 'user', parentUuid: null });
+
+    const flat = detail.thread.flatMap((t: { blocks: Record<string, unknown>[] }) => t.blocks);
+
+    // reasoningOpaque → empty thinking block (encrypted; Codex-style empty render).
+    const thinking = flat.find((b: Record<string, unknown>) => b.type === 'thinking');
+    expect(thinking).toBeTruthy();
+    expect(thinking.thinking).toBe('');
+
+    // Saved screenshot resolved from files/shot.png → base64 ImageBlock (carried
+    // in the thread as an attachment block).
+    const att = flat.find((b: Record<string, unknown>) => b.kind === 'attachment');
+    expect(att.attachment).toMatchObject({
+      type: 'image',
+      source: { type: 'base64', media_type: 'image/png', data: PNG_B64 },
+    });
+    // The inline marker the user typed survives in the message text.
+    expect(JSON.stringify(detail.thread)).toContain('[📷 shot.png]');
+
+    // Successful edit → canonical Edit (what changeset.ts keys off for Files-changed).
+    const tools = flat.filter((b: Record<string, unknown>) => b.kind === 'tool');
+    const edit = tools.find((t: { name: string }) => t.name === 'Edit');
+    expect(edit.input).toEqual({ file_path: '/tmp/cproj/app.ts', old_string: 'bug', new_string: 'fixed' });
+    expect(JSON.stringify(edit.result.content)).toContain('updated');
+  });
+
+  it('keeps a denied edit out of Files-changed and only marks the attachment when bytes are absent', async () => {
+    const detail = (await get('/api/sessions/copilot-sess-2')).json();
+    const flat = detail.thread.flatMap((t: { blocks: Record<string, unknown>[] }) => t.blocks);
+    const tools = flat.filter((b: Record<string, unknown>) => b.kind === 'tool');
+
+    // Denied edit must NOT become a canonical Edit/Write (else it'd show in Files-changed).
+    expect(tools.some((t: { name: string }) => t.name === 'Edit' || t.name === 'Write')).toBe(false);
+    const denied = tools.find((t: { name: string }) => t.name === 'edit');
+    expect(denied).toBeTruthy();
+    expect(JSON.stringify(denied.result.content)).toContain('denied');
+
+    // Unsaved screenshot: no attachment block, but the inline marker remains.
+    expect(flat.some((b: Record<string, unknown>) => b.kind === 'attachment')).toBe(false);
+    expect(JSON.stringify(detail.thread)).toContain('[📷 missing.png]');
+  });
+});

--- a/packages/server/test/dedup.integration.test.ts
+++ b/packages/server/test/dedup.integration.test.ts
@@ -43,6 +43,7 @@ process.env.CODEX_SESSIONS_DIR = join(work, 'codex-empty');
 process.env.JUNIE_SESSIONS_DIR = join(work, 'junie-empty');
 process.env.PI_SESSIONS_DIR = join(work, 'pi-empty');
 process.env.OPENCODE_DATA_DIR = join(work, 'opencode-empty');
+process.env.COPILOT_SESSIONS_DIR = join(work, 'copilot-empty');
 process.env.DUCKDB_PATH = dbPath;
 process.env.CLAUDESCOPE_HOME = join(work, 'home');
 process.env.REINDEX_INTERVAL_MS = '0';

--- a/packages/server/test/index-recovery.integration.test.ts
+++ b/packages/server/test/index-recovery.integration.test.ts
@@ -29,6 +29,7 @@ process.env.CODEX_SESSIONS_DIR = join(work, 'codex-empty');
 process.env.JUNIE_SESSIONS_DIR = join(work, 'junie-empty');
 process.env.PI_SESSIONS_DIR = join(work, 'pi-empty');
 process.env.OPENCODE_DATA_DIR = join(work, 'opencode-empty');
+process.env.COPILOT_SESSIONS_DIR = join(work, 'copilot-empty');
 process.env.CLAUDESCOPE_HOME = join(work, 'home');
 process.env.REINDEX_INTERVAL_MS = '0';
 process.env.PRICING_REFRESH_INTERVAL_MS = '0';

--- a/packages/server/test/junie.integration.test.ts
+++ b/packages/server/test/junie.integration.test.ts
@@ -26,6 +26,7 @@ process.env.CODEX_SESSIONS_DIR = codexDir;
 process.env.JUNIE_SESSIONS_DIR = junieDir;
 process.env.PI_SESSIONS_DIR = join(work, 'pi-empty');
 process.env.OPENCODE_DATA_DIR = join(work, 'opencode-empty');
+process.env.COPILOT_SESSIONS_DIR = join(work, 'copilot-empty');
 process.env.DUCKDB_PATH = join(work, 'index.duckdb');
 process.env.CLAUDESCOPE_HOME = join(work, 'home');
 process.env.REINDEX_INTERVAL_MS = '0';

--- a/packages/server/test/opencode.integration.test.ts
+++ b/packages/server/test/opencode.integration.test.ts
@@ -27,6 +27,7 @@ process.env.CODEX_SESSIONS_DIR = join(work, 'codex-empty');
 process.env.JUNIE_SESSIONS_DIR = join(work, 'junie-empty');
 process.env.PI_SESSIONS_DIR = join(work, 'pi-empty');
 process.env.OPENCODE_DATA_DIR = ocDataDir;
+process.env.COPILOT_SESSIONS_DIR = join(work, 'copilot-empty');
 process.env.DUCKDB_PATH = join(work, 'index.duckdb');
 process.env.CLAUDESCOPE_HOME = join(work, 'home');
 process.env.REINDEX_INTERVAL_MS = '0';

--- a/packages/server/test/pi.integration.test.ts
+++ b/packages/server/test/pi.integration.test.ts
@@ -25,6 +25,7 @@ process.env.CODEX_SESSIONS_DIR = join(work, 'codex-empty');
 process.env.JUNIE_SESSIONS_DIR = join(work, 'junie-empty');
 process.env.PI_SESSIONS_DIR = piDir;
 process.env.OPENCODE_DATA_DIR = join(work, 'opencode-empty');
+process.env.COPILOT_SESSIONS_DIR = join(work, 'copilot-empty');
 process.env.DUCKDB_PATH = join(work, 'index.duckdb');
 process.env.CLAUDESCOPE_HOME = join(work, 'home');
 process.env.REINDEX_INTERVAL_MS = '0';

--- a/packages/server/test/pricing.test.ts
+++ b/packages/server/test/pricing.test.ts
@@ -42,6 +42,7 @@ process.env.CODEX_SESSIONS_DIR = join(work, 'codex-empty');
 process.env.JUNIE_SESSIONS_DIR = join(work, 'junie-empty');
 process.env.PI_SESSIONS_DIR = join(work, 'pi-empty');
 process.env.OPENCODE_DATA_DIR = join(work, 'opencode-empty');
+process.env.COPILOT_SESSIONS_DIR = join(work, 'copilot-empty');
 process.env.DUCKDB_PATH = dbPath;
 process.env.CLAUDESCOPE_HOME = join(work, 'home');
 process.env.REINDEX_INTERVAL_MS = '0';

--- a/packages/web/src/components/AgentBadge.tsx
+++ b/packages/web/src/components/AgentBadge.tsx
@@ -6,6 +6,7 @@ const AGENT_LABELS: Record<string, string> = {
   junie: 'Junie',
   pi: 'pi',
   opencode: 'opencode',
+  copilot: 'Copilot',
 };
 
 /** Human-friendly short label for a connector id. */

--- a/packages/web/src/pages/browse/browse.css
+++ b/packages/web/src/pages/browse/browse.css
@@ -242,6 +242,11 @@
   background: #e3b3411a;
   color: #e3b341;
 }
+.tv-chip--agent.tv-agent--copilot {
+  border-color: #0969da66;
+  background: #0969da1a;
+  color: #58a6ff;
+}
 /* Light theme: keep the brand tints but darken the text so it stays legible on
    a light surface. */
 :root[data-theme='light'] .tv-chip--agent.tv-agent--claude-code {
@@ -258,4 +263,7 @@
 }
 :root[data-theme='light'] .tv-chip--agent.tv-agent--opencode {
   color: #9e6a03;
+}
+:root[data-theme='light'] .tv-chip--agent.tv-agent--copilot {
+  color: #0969da;
 }


### PR DESCRIPTION
## Summary

Adds a read-only connector for the **GitHub Copilot CLI** (`~/.copilot/session-state/<uuid>/events.jsonl`) — the sixth supported agent. The event-sourced stream is normalized to canonical NDJSON via `prepare()` (the Codex/pi/opencode pattern), so the shared index / FTS / cost / threading paths stay untouched.

Copilot specifics handled:
- **Cost is session-level** — tokens live only in `session.shutdown`, attached to the last assistant row; a session with no shutdown (crash/kill/running) costs zero. `gpt-5-mini` is already priced.
- **Encrypted reasoning** (`reasoningOpaque`) → empty thinking block (Codex-style).
- **Files-changed** — `edit`/`create` map to canonical `Edit`/`Write` **only when the call actually succeeded**, so a denied/failed edit stays out of the tab; `view`→`Read`, `bash`→`Bash`.
- **Screenshots** — resolved from `session-state/<uuid>/files/<displayName>` to base64 `ImageBlock`s (size-capped, basename-only), with the inline `[📷 …]` marker as fallback when bytes weren't saved.
- **Memory** — global `~/.copilot/copilot-instructions.md`; "session-level memory" is session-scoped (not cross-session), so no project memory.

Also wires config (`COPILOT_SESSIONS_DIR`/`COPILOT_HOME`), the connector registry, and the web agent badge/color, and isolates `COPILOT_SESSIONS_DIR` across the existing integration suites so they don't index a real `~/.copilot`.

## Plan

[`docs/plans/0021-copilot-connector.md`](docs/plans/0021-copilot-connector.md)

## Testing

- `npm run typecheck` ✅
- `npm test` ✅ — 188/188. New `copilot.integration.test.ts` covers session-level cost, no-shutdown → zero cost, denied-edit excluded from Files-changed, saved-vs-unsaved screenshot, empty thinking, unknown-event tolerance, workspace.yaml title, and global memory.
- `npm run build` ✅
- Adversarial multi-lens review of the diff; the one confirmed issue (unbounded image read) is fixed via a size cap.

## Checklist

- [x] I've read [`CONTRIBUTING.md`](../CONTRIBUTING.md)
- [x] I agree to the [Code of Conduct](../CODE_OF_CONDUCT.md)
- [x] `npm test` and `npm run typecheck` pass
- [x] Conventional commit messages; history is linear (rebased on `main`, no merge commits)
- [x] No AI co-author / "Generated with" trailers
- [x] Docs updated if behavior changed (incl. README / SECURITY.md / CLAUDE.md if the agent list changed)
- [x] Plan committed under `docs/plans/` and linked above (if an agent did the work)