### PR TITLE
Security & quality fixes (PR 1/2): image CSP, Junie path containment, deterministic PR link, error logging

### DIFF
--- a/docs/plans/0022-security-quality-fixes.md
+++ b/docs/plans/0022-security-quality-fixes.md
@@ -1,0 +1,221 @@
+# 0022 — Security & quality fixes: image CSP, Junie path containment, deterministic PR link, memory/search logging, Windows support
+
+- **Status:** in-progress <!-- proposed | in-progress | done | superseded | abandoned -->
+  - PR 1 (F3, F4, C7, C8) implemented; PR 2 (C6) pending.
+- **Date:** 2026-06-16
+- **PR:** <link, once opened>
+
+## Context
+
+Two reviews (a security pass and a non-security quality pass) were triaged
+against the actual code. After verification + adversarial challenge, the
+actionable set is five items. The rest of both reviews was dismissed as
+out-of-model, premature optimization, or already-mitigated (see the triage notes
+below for what was rejected and why).
+
+Threat model reminder: Claudescope is a local, single-user, read-only viewer
+bound to `127.0.0.1`. The only realistic adversarial surfaces are **(A)** a
+malicious webpage making cross-origin requests to the loopback server and
+**(B)** a poisoned/shared transcript the user opens. Home-dir tampering is out of
+model. Both security items below are surface-(B) bugs.
+
+The five items:
+
+| ID | What | Why it's real |
+| -- | ---- | ------------- |
+| **F3** | Remote image URLs render directly; no CSP | Surface (B): opening a shared transcript silently fires GETs to attacker/intranet URLs (tracking pixel / blind probe). `image.ts:26` returns the URL verbatim → `<img src>`; `Markdown.tsx` has no `urlTransform`; no CSP exists anywhere. |
+| **F4** | Junie connector reads arbitrary local files | Surface (B): a poisoned `events.jsonl` with `customAttachments:["/Users/you/.ssh/id_rsa"]` is `readFileSync`'d, base64'd, and rendered. Fires at index time too (`prepare()→parseSession`). No containment, no extension gate. |
+| **C7** | PR-link extraction is nondeterministic | `claude-code.ts:150` uses three independent unordered `last()` aggregates; on rare multi-PR sessions the displayed link can flip across reindexes and the three fields can come from different rows. |
+| **C8** | Two blind `catch → []` swallows | `memory.ts:30-44` and `search.ts:185-186` swallow with no log — a genuine memory/FTS regression surfaces as an undebuggable empty "no data" state. |
+| **C6** | Windows path handling + no Windows CI | Display-only today, but the maintainer expects Windows users. `displayNameFromCwd` splits on `/` only; `contractHome` matches only `~/`; CI has no Windows runner so nothing else is validated on Windows. |
+
+## Goal
+
+- F3/F4: a poisoned or shared transcript can no longer (F3) cause the browser to
+  fetch attacker-controlled remote URLs, nor (F4) coax the server into reading
+  files outside the Junie session directory.
+- C7: the PR link shown for a session is stable across reindexes and its fields
+  always come from a single record.
+- C8: a real failure in memory collection or session search leaves a log line
+  instead of a silent empty result. Behavior is otherwise unchanged (still `[]`,
+  still never 500s).
+- C6: native-Windows path display is correct, and a Windows CI runner validates
+  the full index/query pipeline so Windows is a supported target rather than an
+  untested hope.
+
+## Decisions
+
+- **F3 — CSP is the primary fix, not per-component sanitizing.** A single
+  `Content-Security-Policy` response header (`img-src 'self' data:; connect-src
+  'self'`) closes *both* the structured-image path (`image.ts`) and the markdown
+  path (`![](http://…)`) at once. A fix in `image.ts` alone would leave the
+  markdown vector open (verified: `Markdown.tsx` sets no `urlTransform` and no
+  rehype-sanitize). We add a markdown `urlTransform` as cheap defense-in-depth so
+  the markdown path is closed at the source even if the CSP is later relaxed.
+  **Implementation note:** the policy + hook live in a dedicated, testable
+  `packages/server/src/security.ts`; `main()` calls `registerSecurityHeaders(app)`
+  (an `onSend` hook — verified to ride `@fastify/static` responses). `index.html`
+  has one deliberate inline script (pre-paint theme bootstrap); rather than weaken
+  `script-src` to `'unsafe-inline'`, we allowlist that exact script by its SHA-256
+  hash, and a `security.test.ts` case fails if the script and hash ever drift.
+- **F3 — keep the CSP permissive enough to not break the SPA.** Shiki, Recharts,
+  and React inline styles require `style-src 'unsafe-inline'`. The directive set
+  must be validated against the *built* app, not just unit tests, before merge.
+- **F4 — containment under `JUNIE_HOME` (`~/.junie`), plus an extension
+  whitelist.** Resolve the candidate with `realpathSync` and refuse anything that
+  escapes Junie's home dir; gate on an image extension. **Implementation note:**
+  the plan originally said "under the session dir," but the Junie fixture shows
+  legitimate pasted images live at `<sessions>/clipboard-images/<id>/…` — a
+  *sibling* of the session dir, not under it. Session-dir containment would break
+  real images. `JUNIE_HOME` is the correct boundary: it's exactly the tree the
+  connector already declares it confines itself to ("STRICTLY READ-ONLY with
+  respect to ~/.junie"), so it allows clipboard images wherever Junie puts them
+  while still blocking `~/.ssh`, `/etc`, and sibling projects. No signature
+  threading needed — `normalize.ts` imports the constant. Also guard `discover()`
+  against a `sessionId` containing `..` or path separators (secondary, cheap).
+- **C7 — atomic, deterministic pick keyed on `prUrl`.** pr-link records carry no
+  `timestamp` (confirmed in the fixture), so there's no time order to use.
+  Final approach: `arg_max(prNumber, prUrl)`, `arg_max(prRepository, prUrl)`,
+  `max(prUrl)` — all three resolve to the single row with the maximum `prUrl`
+  (always present per the `WHERE`), so the fields always come from one record, the
+  choice is stable across reindexes, and a valid link is never dropped. Avoids
+  relying on `max`/`arg_max` over a STRUCT (DuckDB-version sensitivity) — keeps the
+  4-column contract `(session_id, pr_number, pr_repository, pr_url)` from
+  `types.ts:55`.
+- **C8 — warn, don't throw, don't change return shape.** One `console.warn`
+  (memory.ts, `c.id` in scope) and one `req.log.warn({ err }, …)` (search.ts,
+  `req.log` available). Still returns `[]`. **Do not touch** the other swallows:
+  `index.ts:369/444` already log, and the `discover()` / `parseJsonl()` /
+  pricing / normalize catches are documented "expected, not a bug" cases.
+- **C6 — fix display + add the runner; let the runner find the rest.** The two
+  display fixes are known. The bigger value is the Windows CI runner: it exercises
+  the real DuckDB path-interpolation, globbing, and fixture paths on Windows and
+  will surface anything else that breaks. Treat newly-surfaced Windows failures as
+  in-scope for this item.
+- **PR split (recommended):** ship **F3 + F4 + C7 + C8 as one focused PR** (all
+  small, security + correctness, low-risk, easy to review) and **C6 as a separate
+  PR** (exploratory — a new CI runner may surface follow-on path bugs and
+  shouldn't gate the security fixes). One plan doc, two PRs.
+
+## Approach
+
+Ordered, reviewable steps.
+
+### PR 1 — security + correctness (F3, F4, C7, C8)
+
+1. **C8 (warm-up, lowest risk):** add `console.warn` to `safeGlobal`/`safeProject`
+   in `data/memory.ts:30-44`; add `req.log.warn({ err }, 'session search failed')`
+   / `'memory search failed'` to the two `.catch(() => [])` in `routes/search.ts:185-186`.
+2. **F3:** add a `Content-Security-Policy` header to the SPA response in
+   `packages/server/src/index.ts` (a Fastify hook around the static/SPA serving at
+   `:113-123`). Start from `default-src 'self'; img-src 'self' data:; connect-src
+   'self'; style-src 'self' 'unsafe-inline'; script-src 'self'; font-src 'self'
+   data:; object-src 'none'; base-uri 'self'; frame-ancestors 'none'`. Then add a
+   `urlTransform` to `ReactMarkdown` in `packages/web/src/components/Markdown.tsx`
+   that allows only relative / `data:` image URLs. **Verify the built app renders**
+   (Shiki code blocks, Recharts analytics, markdown images, syntax themes) — adjust
+   `script-src`/`style-src` only as far as needed to keep it working.
+3. **F4:** in `packages/server/src/connectors/junie/normalize.ts`, change
+   `imageBlockFromPath` to take the session dir, `realpathSync` the candidate, and
+   return `null` unless it resolves under that dir *and* has an allowed image
+   extension. Thread the session dir through `attachmentImages` and
+   `extractPromptImages` (and their call sites in `parseSession`). Guard the
+   `sessionId` used to build paths in `junie.ts` `discover()` and
+   `readIndexMeta` against `..` / path separators.
+4. **C7:** rewrite the `prLinks` projection in
+   `packages/server/src/connectors/claude-code/claude-code.ts:149-153` to
+   `arg_max(struct_pack(prNumber, prRepository, prUrl), <order_key>)`, unpacking to
+   the 4-column contract. Add `timestamp` to the aux `read_ndjson` column set if
+   used as the order key.
+5. **Tests** (focused on the weird stuff, per repo convention):
+   - C7: a Claude fixture with two out-of-order `pr-link` records → assert a
+     stable, mutually-consistent pick. (Also closes the one real gap C11 named.)
+   - F4: a Junie fixture whose `customAttachments` / `@`-mention names an absolute
+     path *outside* the session dir → assert it is **not** read (no `ImageBlock`),
+     and a path *inside* the session dir with an image extension → assert it is.
+   - F3: a small assertion that the SPA response carries the CSP header (and,
+     optionally, that `urlTransform` drops a remote markdown image).
+6. `npm run typecheck && npm test`; manually run the built app for F3.
+
+### PR 2 — Windows support (C6)
+
+7. `displayNameFromCwd` (`data/project-id.ts:26`): split on `/[/\\]/` instead of
+   `/`. `contractHome` (`util/paths.ts:9`): accept a backslash home boundary
+   (e.g. compare with `path.sep`, or match `${home}[/\\]`).
+8. Add a `windows-latest` entry to the `test` job matrix in
+   `.github/workflows/ci.yml` (node 22 + 24).
+9. Run CI; triage whatever the Windows runner surfaces — likely candidates:
+   backslash paths interpolated into DuckDB `read_ndjson(...)`, glob patterns in
+   connector `discover()`, and any fixture/test that hardcodes POSIX paths. Fix
+   each, keeping changes minimal and Windows-specific where possible.
+10. Extend `packages/server/test/util.test.ts` with backslash-path cases for the
+    two helpers.
+
+## Files affected
+
+- `packages/server/src/security.ts` — F3: new module — CSP string + `registerSecurityHeaders`.
+- `packages/server/src/index.ts` — F3: call `registerSecurityHeaders(app)`.
+- `packages/web/index.html` — F3: note the inline theme script is CSP-hash-pinned.
+- `packages/web/src/components/Markdown.tsx` — F3: `urlTransform` (defense-in-depth).
+- `packages/server/src/connectors/junie/normalize.ts` — F4: realpath containment +
+  extension gate; thread session dir through image helpers.
+- `packages/server/src/connectors/junie/junie.ts` — F4: guard `sessionId` in
+  `discover()` / `readIndexMeta`.
+- `packages/server/src/connectors/claude-code/claude-code.ts` — C7: atomic,
+  ordered `prLinks` projection.
+- `packages/server/src/data/memory.ts` — C8: warn in `safeGlobal`/`safeProject`.
+- `packages/server/src/routes/search.ts` — C8: warn in the two `.catch(() => [])`.
+- `packages/server/src/data/project-id.ts` — C6: separator-agnostic `displayNameFromCwd`.
+- `packages/server/src/util/paths.ts` — C6: backslash-aware `contractHome`.
+- `.github/workflows/ci.yml` — C6: add `windows-latest` to the test matrix.
+- `packages/server/test/*` — new fixtures/cases for C7, F4, F3, and C6 helpers.
+
+## Testing
+
+- `npm run typecheck` and `npm test` green on every platform in the matrix
+  (incl. the new Windows runner for PR 2).
+- F3: launch the built app (`npm start`) and confirm code blocks, analytics
+  charts, markdown, and themes still render with the CSP active; confirm a
+  transcript carrying a remote image URL no longer triggers an outbound request
+  (DevTools network tab shows it blocked by CSP).
+- F4: the new Junie fixtures assert out-of-dir paths are not read and in-dir image
+  paths are.
+- C7: the new Claude fixture asserts a deterministic PR pick across record order.
+- C8: behavior unchanged (`[]` on failure) plus a warning is emitted — assert the
+  log call fires on a forced error, or verify by inspection.
+
+## Risks / open questions
+
+- **F3 CSP breaking the UI** — the main risk. Shiki/Recharts/React inline styles
+  need `style-src 'unsafe-inline'`; a Vite module-preload inline snippet *might*
+  need a `script-src` allowance. Mitigation: verify against the built app and
+  widen only as needed. The security-critical directives (`img-src`,
+  `connect-src`) are unaffected by style/script relaxations.
+- **C7 order key** — if Claude `pr-link` records carry no usable `timestamp`, the
+  fallback to physical scan order must be made explicit (a generated ordinal);
+  this is no worse than today's `last()` and removes the cross-field-mixing bug
+  regardless. Settle the exact key in step 4.
+- **C6 scope creep** — the Windows runner may surface DuckDB path-interpolation or
+  globbing bugs that are larger than the two display one-liners. This is exactly
+  why C6 is its own PR: it must not block or bloat the security fixes. If the
+  pipeline work turns out large, it can spin into its own follow-up plan.
+- **F4 legitimate paths** — confirm the containment check doesn't reject genuine
+  Junie attachment paths (Junie stores clipboard images under the session dir, so
+  containment should hold; verify against a real session if available).
+
+## Triage appendix — what was rejected (and why)
+
+Security review: **F1** (reindex CSRF) → harden-only (DoS collapses behind the
+`inFlight` lock + no-op fast path); **F2** (PID kill) → robustness-only, no
+in-model attack path; **F5** (pricing SQL) → not injectable in-model, only a
+robustness wedge on a hand-edit typo; **F6** (export redaction) → wording-only.
+These may be worth small follow-ups but are not in this plan.
+
+Quality review: **C1** (project lookup) O(tens) behind a filter — premature;
+**C2** (session re-parse) correct simple design, already benchmarked; **C3**
+(reindex poll) already mitigated; **C4** (FTS rebuild) DuckDB has no incremental
+mode; **C5** (search/memory rescan) search hits the index, memory-live is
+intentional; **C9** (indexer module) cohesive pipeline, splitting is speculative;
+**C10** (normalizer dup) only boilerplate, logic is correctly per-format; **C11**
+(test gaps) mostly covered — its one real gap (PR-link tie) is folded into C7;
+**C12** (global caches) every named hazard already mitigated.

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -46,3 +46,4 @@ decision, or a change worth explaining before doing. Skip it for one-line fixes.
 | 0019 | [pi connector](./0019-pi-connector.md) | done |
 | 0020 | [opencode connector](./0020-opencode-connector.md) | done |
 | 0021 | [GitHub Copilot CLI connector](./0021-copilot-connector.md) | done |
+| 0022 | [Security & quality fixes: image CSP, Junie path containment, deterministic PR link, memory/search logging, Windows support](./0022-security-quality-fixes.md) | proposed |

--- a/packages/server/src/connectors/claude-code/claude-code.ts
+++ b/packages/server/src/connectors/claude-code/claude-code.ts
@@ -145,9 +145,16 @@ function auxProjections(filePath: string): AuxProjections {
       FROM ${readFn}
       WHERE type = 'ai-title' AND sessionId IS NOT NULL AND aiTitle IS NOT NULL
       GROUP BY sessionId`,
-    // pr-link: latest pr per session.
+    // pr-link: one PR per session, picked deterministically. pr-link records
+    // carry no timestamp, and three independent last() aggregates could both flip
+    // across reindexes and stitch fields from different rows. Keying all three on
+    // the same max(prUrl) row (prUrl is always present per the WHERE) is a stable
+    // total order, so the fields always come from one record and never drop a link.
     prLinks: `
-      SELECT sessionId, last(prNumber), last(prRepository), last(prUrl)
+      SELECT sessionId,
+             arg_max(prNumber, prUrl) AS pr_number,
+             arg_max(prRepository, prUrl) AS pr_repository,
+             max(prUrl) AS pr_url
       FROM ${readFn}
       WHERE type = 'pr-link' AND sessionId IS NOT NULL AND prUrl IS NOT NULL
       GROUP BY sessionId`,

--- a/packages/server/src/connectors/junie/junie.ts
+++ b/packages/server/src/connectors/junie/junie.ts
@@ -53,7 +53,10 @@ function discover(): DiscoveredFile[] {
     } catch {
       continue;
     }
-    if (!sessionId) continue;
+    // sessionId is used to build a filesystem path, so reject anything from a
+    // poisoned index.jsonl that could escape JUNIE_SESSIONS_DIR (separators or a
+    // traversal segment). Real Junie ids are a single plain `session-…` segment.
+    if (!sessionId || /[/\\]/.test(sessionId) || sessionId === '.' || sessionId === '..') continue;
     const full = join(JUNIE_SESSIONS_DIR, sessionId, 'events.jsonl');
     try {
       const st = statSync(full);

--- a/packages/server/src/connectors/junie/normalize.ts
+++ b/packages/server/src/connectors/junie/normalize.ts
@@ -24,8 +24,8 @@
  * STRICTLY READ-ONLY with respect to ~/.junie — files are only ever read.
  */
 
-import { readFileSync } from 'node:fs';
-import { basename, dirname, join } from 'node:path';
+import { readFileSync, realpathSync } from 'node:fs';
+import { basename, dirname, join, sep } from 'node:path';
 import type {
   AssistantEvent,
   ContentBlock,
@@ -33,6 +33,7 @@ import type {
   MessageUsage,
   UserEvent,
 } from '@claudescope/shared';
+import { JUNIE_HOME } from '../../config.js';
 
 export interface JunieSession {
   sessionId: string;
@@ -78,11 +79,44 @@ interface StepAgg {
   status?: string;
 }
 
-/** Map an absolute image path to an inlined base64 ImageBlock, or null. */
+/** Image extensions we will inline (anything else is refused, not read). */
+const IMAGE_EXTS = new Set(['png', 'jpg', 'jpeg', 'gif', 'webp']);
+
+/** Real path of Junie's home dir, resolved once; attachment reads are confined here. */
+let junieRootReal: string | null = null;
+function junieRoot(): string {
+  if (junieRootReal === null) {
+    try {
+      junieRootReal = realpathSync(JUNIE_HOME);
+    } catch {
+      junieRootReal = JUNIE_HOME; // home absent — containment check below just won't match
+    }
+  }
+  return junieRootReal;
+}
+
+/**
+ * Map an absolute image path to an inlined base64 ImageBlock, or null.
+ *
+ * The path comes from transcript content (`customAttachments` / `@`-mentions),
+ * so it is UNTRUSTED: a poisoned session could name `/Users/you/.ssh/id_rsa` or
+ * `../../etc/passwd`. We therefore (1) require an image extension and (2) resolve
+ * the real path and refuse anything that escapes Junie's own home dir — the only
+ * tree this connector is ever allowed to read.
+ */
 function imageBlockFromPath(path: string): ImageBlock | null {
+  const ext = path.toLowerCase().split('.').pop() ?? '';
+  if (!IMAGE_EXTS.has(ext)) return null; // not an image we inline
+  let real: string;
   try {
-    const data = readFileSync(path).toString('base64');
-    const ext = path.toLowerCase().split('.').pop() ?? '';
+    real = realpathSync(path);
+  } catch {
+    return null; // image vanished, unreadable, or a broken symlink — skip it
+  }
+  const root = junieRoot();
+  if (real !== root && !real.startsWith(root + sep)) return null; // outside ~/.junie — refuse
+  try {
+    const data = readFileSync(real).toString('base64');
     const mediaType =
       ext === 'jpg' || ext === 'jpeg'
         ? 'image/jpeg'
@@ -93,7 +127,7 @@ function imageBlockFromPath(path: string): ImageBlock | null {
             : 'image/png';
     return { type: 'image', source: { type: 'base64', media_type: mediaType, data } };
   } catch {
-    return null; // image vanished or unreadable — skip it
+    return null; // unreadable after resolution — skip it
   }
 }
 

--- a/packages/server/src/data/memory.ts
+++ b/packages/server/src/data/memory.ts
@@ -30,7 +30,10 @@ export interface AttributedMemory {
 function safeGlobal(c: AgentConnector): MemorySource[] {
   try {
     return c.globalMemory?.() ?? [];
-  } catch {
+  } catch (err) {
+    // Connector memory readers already return [] for absent files, so a throw
+    // here is a genuine bug — warn so it doesn't masquerade as an empty Memory tab.
+    console.warn(`[memory] ${c.id} globalMemory failed:`, err);
     return [];
   }
 }
@@ -38,7 +41,8 @@ function safeGlobal(c: AgentConnector): MemorySource[] {
 function safeProject(c: AgentConnector) {
   try {
     return c.projectMemory?.() ?? [];
-  } catch {
+  } catch (err) {
+    console.warn(`[memory] ${c.id} projectMemory failed:`, err);
     return [];
   }
 }

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -19,6 +19,7 @@ import {
   ensureStateDir,
 } from './config.js';
 import { registerRoutes } from './routes/index.js';
+import { registerSecurityHeaders } from './security.js';
 import { reindex } from './data/index.js';
 import { refreshPricing } from './data/pricing-refresh.js';
 import { openBrowser } from './util/open-browser.js';
@@ -47,6 +48,10 @@ async function main(): Promise<void> {
   ensureStateDir();
 
   const app = Fastify({ logger: true });
+
+  // Lock down what the served SPA may load — notably block remote image fetches
+  // from transcript content (see security.ts).
+  registerSecurityHeaders(app);
 
   await registerRoutes(app);
 

--- a/packages/server/src/routes/search.ts
+++ b/packages/server/src/routes/search.ts
@@ -182,8 +182,21 @@ export async function registerSearchRoute(app: FastifyInstance): Promise<void> {
     // Each kind is guarded so a failure in one (e.g. an FTS edge case) still
     // returns the other rather than 500-ing the whole request.
     const sessions =
-      scope === 'memory' ? [] : await searchSessions(q, terms, type, project).catch(() => []);
-    const memory = scope === 'sessions' ? [] : await searchMemory(terms, project).catch(() => []);
+      scope === 'memory'
+        ? []
+        : await searchSessions(q, terms, type, project).catch((err) => {
+            // Don't 500 the whole request, but don't let a real FTS regression
+            // silently look like "no results" either — leave a trace.
+            req.log.warn({ err }, 'session search failed');
+            return [];
+          });
+    const memory =
+      scope === 'sessions'
+        ? []
+        : await searchMemory(terms, project).catch((err) => {
+            req.log.warn({ err }, 'memory search failed');
+            return [];
+          });
 
     return { sessions, memory };
   });

--- a/packages/server/src/security.ts
+++ b/packages/server/src/security.ts
@@ -1,0 +1,47 @@
+/**
+ * HTTP security headers for the served SPA.
+ *
+ * The one real attacker surface for this read-only, loopback-only viewer is a
+ * poisoned/shared transcript whose content makes the browser fetch a remote URL
+ * (a tracking pixel / read-receipt, or a blind intranet probe). The
+ * `img-src`/`connect-src 'self' data:` directives below close that at the network
+ * layer for every rendering path at once (structured image blocks AND markdown
+ * `![](http://…)`). `style-src 'unsafe-inline'` is required by Shiki, Recharts,
+ * and React inline styles; scripts stay `'self'` so an injected inline script
+ * still cannot execute.
+ */
+
+import type { FastifyInstance } from 'fastify';
+
+/**
+ * SHA-256 of the one inline `<script>` in `packages/web/index.html` (the
+ * pre-paint theme bootstrap that avoids a flash of the wrong theme). Allowlisting
+ * its hash lets that exact script run while keeping `script-src` otherwise strict
+ * — no `'unsafe-inline'`, so an injected inline script still can't execute. If you
+ * edit that script, update this hash; `security.test.ts` enforces the two match.
+ */
+export const THEME_BOOTSTRAP_SCRIPT_HASH = 'sha256-uVROy6kj/mNKownEAGZUVCYdHA4TIZ4PGgQn1EWD74Y=';
+
+/** The Content-Security-Policy applied to every response. */
+export const CONTENT_SECURITY_POLICY = [
+  "default-src 'self'",
+  "img-src 'self' data:",
+  "connect-src 'self'",
+  "style-src 'self' 'unsafe-inline'",
+  `script-src 'self' '${THEME_BOOTSTRAP_SCRIPT_HASH}'`,
+  "font-src 'self' data:",
+  "object-src 'none'",
+  "base-uri 'self'",
+  "frame-ancestors 'none'",
+].join('; ');
+
+/**
+ * Attach the CSP to every response. It's harmless on the JSON API (browsers only
+ * enforce CSP on documents); what matters is that it rides the served HTML.
+ */
+export function registerSecurityHeaders(app: FastifyInstance): void {
+  app.addHook('onSend', async (_req, reply, payload) => {
+    reply.header('Content-Security-Policy', CONTENT_SECURITY_POLICY);
+    return payload;
+  });
+}

--- a/packages/server/test/api.integration.test.ts
+++ b/packages/server/test/api.integration.test.ts
@@ -55,6 +55,11 @@ function writeFixtures(): string[] {
       { ...baseA, type: 'assistant', uuid: 'a3', parentUuid: 'u2', timestamp: '2026-01-01T10:00:35.000Z', isSidechain: false, message: { role: 'assistant', model: 'claude-opus-4-8', content: [{ type: 'tool_use', id: 'tu_wf', name: 'Workflow', input: { script: '...' } }], usage: { input_tokens: 30, output_tokens: 15 } } },
       { ...baseA, type: 'user', uuid: 'u3', parentUuid: 'a3', timestamp: '2026-01-01T10:02:00.000Z', isSidechain: false, message: { role: 'user', content: [{ type: 'tool_result', tool_use_id: 'tu_wf', content: 'Workflow launched. Run ID: wf_int1 — done.' }] } },
       { type: 'pr-link', sessionId: 'sessA', prNumber: 7, prRepository: 'me/repo', prUrl: 'https://example/pr/7' },
+      // A second pr-link for the SAME session, lower number, listed AFTER the
+      // first. The old last()-by-file-order picked whatever came last (#3); the
+      // deterministic arg_max/max(prUrl) must still resolve to #7 — verified by the
+      // prUrl assertion in the project listing test below.
+      { type: 'pr-link', sessionId: 'sessA', prNumber: 3, prRepository: 'me/repo', prUrl: 'https://example/pr/3' },
     ]),
   );
 

--- a/packages/server/test/junie.integration.test.ts
+++ b/packages/server/test/junie.integration.test.ts
@@ -20,6 +20,9 @@ const work = mkdtempSync(join(tmpdir(), 'claudescope-junie-'));
 const junieDir = join(work, 'junie');
 const codexDir = join(work, 'codex-empty');
 const claudeDir = join(work, 'claude-empty');
+// A directory OUTSIDE Junie's home, used to plant a file the connector must
+// refuse to read (F4 path-traversal containment).
+const outside = mkdtempSync(join(tmpdir(), 'claudescope-junie-outside-'));
 
 process.env.CLAUDE_PROJECTS_DIR = claudeDir;
 process.env.CODEX_SESSIONS_DIR = codexDir;
@@ -60,6 +63,14 @@ function writeSession(): void {
   writeFileSync(pngPath, Buffer.from(PNG_BASE64, 'base64'));
   writeFileSync(mentionPath, Buffer.from(PNG_BASE64, 'base64'));
 
+  // Two POISONED attachments the connector must refuse (F4): a real PNG OUTSIDE
+  // ~/.junie (arbitrary-file read / traversal), and a non-image file INSIDE the
+  // tree (extension gate). Both hold "secret" bytes that must never be inlined.
+  const secretImg = join(outside, 'secret.png');
+  const secretTxt = join(imgDir, 'secret.txt');
+  writeFileSync(secretImg, Buffer.from(PNG_BASE64, 'base64'));
+  writeFileSync(secretTxt, 'TOP SECRET');
+
   writeFileSync(
     join(junieDir, 'index.jsonl'),
     jsonl([
@@ -82,7 +93,7 @@ function writeSession(): void {
       {
         kind: 'UserPromptEvent',
         prompt: `look at this screenshot @${mentionPath} and the old one @${missingPath}`,
-        customAttachments: [pngPath, { kind: 'OnboardingMigrationAttachment' }],
+        customAttachments: [pngPath, secretImg, secretTxt, { kind: 'OnboardingMigrationAttachment' }],
       },
       { kind: 'SendToAgentEvent' },
       // Token usage for the assistant turn (haiku family → priced via substring).
@@ -170,6 +181,7 @@ afterAll(async () => {
   await app?.close();
   await closeConnection?.();
   rmSync(work, { recursive: true, force: true });
+  rmSync(outside, { recursive: true, force: true });
 });
 
 const get = (url: string) => app.inject({ method: 'GET', url });
@@ -250,8 +262,9 @@ describe('Junie session detail', () => {
       (b: Record<string, unknown>) =>
         b.kind === 'attachment' && (b.attachment as { type?: string })?.type === 'image',
     );
-    // Two present files (the `@mention` one + the customAttachments one); the
-    // purged mention embeds nothing.
+    // Exactly two: the `@mention` one + the in-tree customAttachments PNG. The
+    // poisoned attachments (a PNG outside ~/.junie and an in-tree .txt) are refused
+    // by the F4 containment + extension gate, and the purged mention embeds nothing.
     expect(images).toHaveLength(2);
     for (const img of images) {
       const source = (img.attachment as { source: { type: string; media_type: string; data: string } })

--- a/packages/server/test/security.test.ts
+++ b/packages/server/test/security.test.ts
@@ -42,9 +42,15 @@ describe('security headers', () => {
   it('allowlists exactly the inline theme-bootstrap script in web/index.html', () => {
     const htmlPath = fileURLToPath(new URL('../../web/index.html', import.meta.url));
     const html = readFileSync(htmlPath, 'utf8');
-    const m = html.match(/<script>([\s\S]*?)<\/script>/);
-    expect(m, 'expected one inline <script> in web/index.html').not.toBeNull();
-    const hash = 'sha256-' + createHash('sha256').update(m![1], 'utf8').digest('base64');
+    // The pre-paint theme bootstrap is the only attribute-less `<script>` (the app
+    // bundle is `<script type="module" src=…>`). Locate it with plain string ops,
+    // not an HTML-filtering regexp (which CodeQL rightly distrusts).
+    const OPEN = '<script>';
+    const start = html.indexOf(OPEN);
+    const end = html.indexOf('</script>', start);
+    expect(start, 'expected an inline <script> in web/index.html').toBeGreaterThanOrEqual(0);
+    const inline = html.slice(start + OPEN.length, end);
+    const hash = 'sha256-' + createHash('sha256').update(inline, 'utf8').digest('base64');
     // If this fails after editing the inline script, update THEME_BOOTSTRAP_SCRIPT_HASH.
     expect(hash).toBe(THEME_BOOTSTRAP_SCRIPT_HASH);
     expect(CONTENT_SECURITY_POLICY).toContain(`'${THEME_BOOTSTRAP_SCRIPT_HASH}'`);

--- a/packages/server/test/security.test.ts
+++ b/packages/server/test/security.test.ts
@@ -1,0 +1,52 @@
+/**
+ * Security-headers test: the served SPA must carry a Content-Security-Policy that
+ * blocks remote image/connect sources, so a poisoned/shared transcript can't make
+ * the browser fetch an attacker URL (tracking pixel / intranet probe). Also guards
+ * that the inline theme-bootstrap script's CSP hash stays in sync with the script.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { createHash } from 'node:crypto';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import Fastify from 'fastify';
+import {
+  CONTENT_SECURITY_POLICY,
+  THEME_BOOTSTRAP_SCRIPT_HASH,
+  registerSecurityHeaders,
+} from '../src/security.js';
+
+describe('security headers', () => {
+  it('sets a CSP that confines images and connections to self/data:', async () => {
+    const app = Fastify();
+    registerSecurityHeaders(app);
+    app.get('/anything', async () => ({ ok: true }));
+
+    const res = await app.inject({ method: 'GET', url: '/anything' });
+    const csp = res.headers['content-security-policy'];
+
+    expect(csp).toBe(CONTENT_SECURITY_POLICY);
+    expect(csp).toContain("default-src 'self'");
+    expect(csp).toContain("img-src 'self' data:");
+    expect(csp).toContain("connect-src 'self'");
+    // Remote http(s) image/connect sources must NOT be allowlisted anywhere.
+    expect(csp).not.toContain('http://');
+    expect(csp).not.toContain('https://');
+    // script-src must stay strict — no blanket inline allowance.
+    expect(csp).not.toContain("'unsafe-inline' 'unsafe-inline'");
+    expect(csp).not.toMatch(/script-src[^;]*'unsafe-inline'/);
+
+    await app.close();
+  });
+
+  it('allowlists exactly the inline theme-bootstrap script in web/index.html', () => {
+    const htmlPath = fileURLToPath(new URL('../../web/index.html', import.meta.url));
+    const html = readFileSync(htmlPath, 'utf8');
+    const m = html.match(/<script>([\s\S]*?)<\/script>/);
+    expect(m, 'expected one inline <script> in web/index.html').not.toBeNull();
+    const hash = 'sha256-' + createHash('sha256').update(m![1], 'utf8').digest('base64');
+    // If this fails after editing the inline script, update THEME_BOOTSTRAP_SCRIPT_HASH.
+    expect(hash).toBe(THEME_BOOTSTRAP_SCRIPT_HASH);
+    expect(CONTENT_SECURITY_POLICY).toContain(`'${THEME_BOOTSTRAP_SCRIPT_HASH}'`);
+  });
+});

--- a/packages/web/index.html
+++ b/packages/web/index.html
@@ -5,7 +5,10 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Claudescope</title>
     <!-- Resolve the stored theme choice before first paint to avoid a flash of
-         the wrong theme. Mirrors THEME_STORAGE_KEY in theme/ThemeProvider.tsx. -->
+         the wrong theme. Mirrors THEME_STORAGE_KEY in theme/ThemeProvider.tsx.
+         NOTE: this inline script is allowlisted in the CSP by its SHA-256
+         (THEME_BOOTSTRAP_SCRIPT_HASH in server/src/security.ts). If you edit it,
+         update that hash — security.test.ts fails until they match. -->
     <script>
       (function () {
         try {

--- a/packages/web/src/components/Markdown.tsx
+++ b/packages/web/src/components/Markdown.tsx
@@ -1,5 +1,5 @@
 import { memo, useState, type ReactNode } from 'react';
-import ReactMarkdown, { type Components } from 'react-markdown';
+import ReactMarkdown, { defaultUrlTransform, type Components } from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import { CodeBlock } from './CodeBlock.js';
 import { ClampedText } from './ClampedText.js';
@@ -54,6 +54,23 @@ const components: Components = {
 };
 
 /**
+ * Restrict image sources to same-origin/relative or `data:` URLs. Transcript
+ * markdown is untrusted content; a remote `![](http://attacker/x.png)` would
+ * otherwise make the browser fetch it (tracking pixel / intranet probe). The CSP
+ * already blocks this at the network layer — this closes it at the source so no
+ * request is even attempted. Non-image URLs (e.g. link hrefs) keep react-markdown's
+ * default sanitization, which still strips `javascript:` and friends.
+ */
+function urlTransform(url: string, _key: string, node: { tagName?: string }): string {
+  if (node.tagName === 'img') {
+    if (/^data:image\//i.test(url)) return url; // inlined image — safe
+    if (/^\/\//.test(url) || /^[a-z][a-z0-9+.-]*:/i.test(url)) return ''; // protocol-relative or schemed → remote
+    return url; // relative / same-origin path
+  }
+  return defaultUrlTransform(url);
+}
+
+/**
  * Safe markdown renderer: react-markdown + remark-gfm (tables, strikethrough,
  * task lists, autolinks) with Shiki-highlighted code fences. Raw HTML is NOT
  * enabled, so content is sanitized by default. Falls back to a <pre> block when
@@ -87,7 +104,7 @@ function MarkdownImpl({ children, markdown = true, className, forceExpand = fals
 
   return (
     <div className={cls}>
-      <ReactMarkdown remarkPlugins={[remarkGfm]} components={components}>
+      <ReactMarkdown remarkPlugins={[remarkGfm]} components={components} urlTransform={urlTransform}>
         {children}
       </ReactMarkdown>
     </div>


### PR DESCRIPTION
Implements **PR 1** of plan [`docs/plans/0022-security-quality-fixes.md`](docs/plans/0022-security-quality-fixes.md) — the security + correctness items from the two reviews. Windows support (**C6**) follows as PR 2.

All four items were verified against the code and triaged under this app's real threat model (local, single-user, `127.0.0.1`, read-only viewer): the only attacker surfaces are **(A)** a malicious webpage hitting the loopback server and **(B)** a poisoned/shared transcript the user opens. F3 and F4 are surface-(B) bugs.

### F3 — Block remote image fetches with a CSP *(security)*
A shared/poisoned transcript could embed a remote image URL — a structured image block (`image.ts` returned the URL verbatim) or markdown `![](http://…)` (`Markdown.tsx` had no `urlTransform`). With no CSP anywhere, rendering it made the browser silently `GET` the URL → tracking pixel / read-receipt + blind intranet probe.
- New `security.ts`: `Content-Security-Policy` (`img-src`/`connect-src 'self' data:`, …) on every response — closes both image paths at once.
- Markdown `urlTransform` drops remote image URLs (defense-in-depth).
- The one inline theme-bootstrap script is allowlisted by **SHA-256** so `script-src` stays strict (no `'unsafe-inline'`); a test fails if script & hash drift.
- Verified end-to-end: header rides the static SPA HTML + SPA fallback; built CSS/JS reference no remote resources, so nothing breaks.

### F4 — Contain Junie attachment reads to `~/.junie` *(security)*
`imageBlockFromPath` read any path named in transcript content (`customAttachments` / `@`-mentions) with no containment or extension check — a poisoned `events.jsonl` could name `~/.ssh/id_rsa`, get it base64-inlined and rendered (and the read fired at **index time** too). Now requires an image extension **and** a `realpath` under `JUNIE_HOME` (the tree the connector already declares it confines itself to — covers clipboard images, which live in a *sibling* of the session dir, while blocking escapes). `sessionId`s with separators / traversal segments are rejected.

### C7 — Deterministic PR-link selection *(correctness)*
The `prLinks` projection used three independent unordered `last()` aggregates, so on multi-PR sessions the displayed link could flip across reindexes and stitch fields from different rows. Now keys all three fields on the same `max(prUrl)` row → stable and atomic.

### C8 — Log swallowed memory/search errors *(observability)*
`safeGlobal`/`safeProject` and the two search-route catches returned `[]` with no trace, so a genuine memory/FTS regression looked like an undebuggable empty "no data" state. Added `warn` logs; return value unchanged (still `[]`, still never 500s).

### Tests
`npm run typecheck` + `npm test` green (190 tests). New/extended coverage:
- CSP header + inline-script hash drift guard (`security.test.ts`).
- Junie refuses an out-of-tree PNG and an in-tree non-image file (`junie.integration.test.ts`).
- PR-link determinism: a lower-numbered `pr-link` listed *after* the first must not win (`api.integration.test.ts`).

The dismissed findings (F1, F2, F5, F6 from the security review; C1–C5, C9–C12 from the quality review) are recorded with rationale in the plan's triage appendix.