### PR TITLE
fix(web): restore syntax highlighting under CSP + fix nested collapse chevron

### DIFF
--- a/packages/server/src/security.ts
+++ b/packages/server/src/security.ts
@@ -28,7 +28,10 @@ export const CONTENT_SECURITY_POLICY = [
   "img-src 'self' data:",
   "connect-src 'self'",
   "style-src 'self' 'unsafe-inline'",
-  `script-src 'self' '${THEME_BOOTSTRAP_SCRIPT_HASH}'`,
+  // 'wasm-unsafe-eval' lets Shiki instantiate its WebAssembly regex engine
+  // (oniguruma) for syntax highlighting. It permits WASM compilation only — NOT
+  // general eval() or new Function() — so the anti-XSS guarantee is unchanged.
+  `script-src 'self' 'wasm-unsafe-eval' '${THEME_BOOTSTRAP_SCRIPT_HASH}'`,
   "font-src 'self' data:",
   "object-src 'none'",
   "base-uri 'self'",

--- a/packages/server/test/security.test.ts
+++ b/packages/server/test/security.test.ts
@@ -32,9 +32,11 @@ describe('security headers', () => {
     // Remote http(s) image/connect sources must NOT be allowlisted anywhere.
     expect(csp).not.toContain('http://');
     expect(csp).not.toContain('https://');
-    // script-src must stay strict — no blanket inline allowance.
-    expect(csp).not.toContain("'unsafe-inline' 'unsafe-inline'");
+    // script-src stays strict: WASM (for Shiki) is allowed, but NOT inline
+    // scripts or general eval — so an injected script still can't execute.
+    expect(csp).toContain("'wasm-unsafe-eval'");
     expect(csp).not.toMatch(/script-src[^;]*'unsafe-inline'/);
+    expect(csp).not.toContain("'unsafe-eval'"); // bare unsafe-eval (note: != wasm-unsafe-eval)
 
     await app.close();
   });

--- a/packages/web/src/styles/global.css
+++ b/packages/web/src/styles/global.css
@@ -421,7 +421,10 @@ button {
   color: var(--tv-fg-faint);
   font-size: 10px;
 }
-.tv-collapsible.is-open .tv-collapsible__chevron {
+/* Scope to this collapsible's OWN header chevron — a descendant selector would
+   also rotate the chevrons of nested closed blocks (e.g. tool calls inside an
+   open subagent), making them point down while collapsed. */
+.tv-collapsible.is-open > .tv-collapsible__header > .tv-collapsible__chevron {
   transform: rotate(90deg);
 }
 


### PR DESCRIPTION
Two small UI fixes; the first is a regression from #26.

### Syntax highlighting broken for all agents *(regression from #26)*
The CSP added in #26 set `script-src 'self' '<hash>'` but omitted **`'wasm-unsafe-eval'`**. Shiki highlights via its **oniguruma WebAssembly** regex engine (the `wasm-*.js` bundle chunk); the browser refuses to instantiate WASM without that source, so `getHighlighter()` threw and **every** code block silently fell back to plain text — across all agents, not just pi (which is what made it look agent-specific at first).

Fix: add `'wasm-unsafe-eval'` to `script-src`. Verified Shiki 4.2's engine uses `WebAssembly.instantiate`/`instantiateStreaming` with **no** `eval`/`new Function`, so this single token is sufficient and `'unsafe-eval'` stays out. WASM-compile-only does not reopen XSS: inline scripts are still hash-pinned, `eval` is still blocked, and the security-critical `img-src`/`connect-src` are untouched.

### Nested collapsed blocks showed a down-pointing chevron
`.tv-collapsible.is-open .tv-collapsible__chevron` used a **descendant** combinator, so an open collapsible (e.g. a `SubagentBlock`) rotated the chevrons of its nested **closed** tool blocks too — they pointed down (`▼`) while collapsed. Scoped the rotation to the collapsible's own header chevron (`> .tv-collapsible__header >`).

### Verification
- `npm run typecheck` + `npm test` green; `security.test.ts` updated to assert `'wasm-unsafe-eval'` is present and bare `'unsafe-eval'`/`'unsafe-inline'` are not in `script-src`.
- Built the app and confirmed the served SPA CSP is now `script-src 'self' 'wasm-unsafe-eval' 'sha256-…'`.
- After merge, a hard refresh (CSP/asset caching) restores highlighting.