### PR TITLE
feat: Windows support + windows-latest CI runner (plan 0022 / C6)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,7 @@
+# Normalize all text files to LF in the working tree on every platform. Some
+# content is byte-sensitive and must not be altered by a Windows CRLF checkout:
+#   - the CSP hash pinned for the inline <script> in packages/web/index.html
+#     (THEME_BOOTSTRAP_SCRIPT_HASH in packages/server/src/security.ts), and
+#   - the shebang'd scripts/*.mjs, which fail to parse with a CRLF shebang.
+# Binary files are auto-detected and left untouched.
+* text=auto eol=lf

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,10 +18,11 @@ permissions:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
+        os: [ubuntu-latest, windows-latest]
         node: [22, 24] # both supported LTS lines (22 = engines floor, 24 = latest)
     steps:
       - name: Checkout

--- a/docs/plans/0022-security-quality-fixes.md
+++ b/docs/plans/0022-security-quality-fixes.md
@@ -98,6 +98,16 @@ The five items:
   + a Windows-aware mention regex (best-effort pending real Windows-Junie data).
   DuckDB reads use exact file paths (no globs), so a backslash in the SQL string
   literal should be fine; the runner is the real confirmation.
+  **What the `windows-latest` runner surfaced** (DuckDB *did* read backslash paths
+  fine — Junie/api/codex/pi/opencode integration suites passed on Windows; these
+  were the unanticipated ones, all fixed on-branch):
+  1. The pinned CSP hash and the shebang'd `scripts/*.mjs` broke under git's CRLF
+     checkout (Windows-only `SyntaxError` / hash mismatch) → repo-wide
+     `.gitattributes` (`* text=auto eol=lf`) pins LF on every platform.
+  2. Parallel vitest workers race to `INSTALL` DuckDB extensions into the shared
+     `~/.duckdb` dir, which Windows file-locking rejects. Production is
+     single-process, so this is a test-only artifact → `fileParallelism: false`
+     on win32 only (Linux/macOS keep full parallelism).
 - **PR split (recommended):** ship **F3 + F4 + C7 + C8 as one focused PR** (all
   small, security + correctness, low-risk, easy to review) and **C6 as a separate
   PR** (exploratory — a new CI runner may surface follow-on path bugs and

--- a/docs/plans/0022-security-quality-fixes.md
+++ b/docs/plans/0022-security-quality-fixes.md
@@ -1,7 +1,8 @@
 # 0022 — Security & quality fixes: image CSP, Junie path containment, deterministic PR link, memory/search logging, Windows support
 
 - **Status:** in-progress <!-- proposed | in-progress | done | superseded | abandoned -->
-  - PR 1 (F3, F4, C7, C8) implemented; PR 2 (C6) pending.
+  - PR 1 (F3, F4, C7, C8) merged (#26; CSP/WASM + collapse-chevron follow-up #27).
+  - PR 2 (C6 — Windows support) implemented; pending `windows-latest` CI validation.
 - **Date:** 2026-06-16
 - **PR:** <link, once opened>
 
@@ -91,7 +92,12 @@ The five items:
   display fixes are known. The bigger value is the Windows CI runner: it exercises
   the real DuckDB path-interpolation, globbing, and fixture paths on Windows and
   will surface anything else that breaks. Treat newly-surfaced Windows failures as
-  in-scope for this item.
+  in-scope for this item. **Implementation note:** beyond the two display helpers,
+  the Junie connector also assumed POSIX paths (`startsWith('/')`, `split('/')`, a
+  `@/…`-only mention regex) — switched to `path.isAbsolute` + both-separator splits
+  + a Windows-aware mention regex (best-effort pending real Windows-Junie data).
+  DuckDB reads use exact file paths (no globs), so a backslash in the SQL string
+  literal should be fine; the runner is the real confirmation.
 - **PR split (recommended):** ship **F3 + F4 + C7 + C8 as one focused PR** (all
   small, security + correctness, low-risk, easy to review) and **C6 as a separate
   PR** (exploratory — a new CI runner may surface follow-on path bugs and

--- a/packages/server/src/connectors/junie/normalize.ts
+++ b/packages/server/src/connectors/junie/normalize.ts
@@ -25,7 +25,7 @@
  */
 
 import { readFileSync, realpathSync } from 'node:fs';
-import { basename, dirname, join, sep } from 'node:path';
+import { basename, dirname, isAbsolute, join, sep } from 'node:path';
 import type {
   AssistantEvent,
   ContentBlock,
@@ -136,7 +136,7 @@ function attachmentImages(customAttachments: unknown): ImageBlock[] {
   if (!Array.isArray(customAttachments)) return [];
   const out: ImageBlock[] = [];
   for (const a of customAttachments) {
-    if (typeof a === 'string' && a.startsWith('/')) {
+    if (typeof a === 'string' && isAbsolute(a)) {
       const img = imageBlockFromPath(a);
       if (img) out.push(img);
     }
@@ -144,10 +144,12 @@ function attachmentImages(customAttachments: unknown): ImageBlock[] {
   return out;
 }
 
-// Junie embeds a pasted screenshot as an `@/absolute/path.png` mention in the
+// Junie embeds a pasted screenshot as an `@<absolute-path>.png` mention in the
 // prompt text (not always in customAttachments). Match an absolute path with an
-// image extension so it can be inlined and the raw path cleaned from the text.
-const IMAGE_MENTION_RE = /@(\/\S+?\.(?:png|jpe?g|gif|webp))\b/gi;
+// image extension — POSIX (`/…`) or Windows (`C:\…` / `C:/…`) — so it can be
+// inlined and the raw path cleaned from the text. `\S` stops at whitespace
+// (a pre-existing limitation: paths with spaces aren't matched).
+const IMAGE_MENTION_RE = /@((?:[A-Za-z]:[\\/]|\/)\S+?\.(?:png|jpe?g|gif|webp))\b/gi;
 
 /**
  * Pull `@<image-path>` mentions out of a prompt: inline each as an ImageBlock
@@ -158,7 +160,7 @@ const IMAGE_MENTION_RE = /@(\/\S+?\.(?:png|jpe?g|gif|webp))\b/gi;
 function extractPromptImages(prompt: string): { text: string; images: ImageBlock[] } {
   const images: ImageBlock[] = [];
   const text = prompt.replace(IMAGE_MENTION_RE, (_match, path: string) => {
-    const name = path.split('/').pop() || 'image';
+    const name = path.split(/[/\\]/).pop() || 'image';
     const img = imageBlockFromPath(path);
     if (img) {
       images.push(img);

--- a/packages/server/src/data/project-id.ts
+++ b/packages/server/src/data/project-id.ts
@@ -21,8 +21,9 @@ export function projectIdFromCwd(cwd: string): string {
   return slug ? `${slug}-${hash8}` : hash8;
 }
 
-/** Human-friendly project name: the last non-empty path segment of the cwd. */
+/** Human-friendly project name: the last non-empty path segment of the cwd.
+ *  Splits on both `/` and `\` so Windows cwds (`C:\Users\me\proj`) name correctly. */
 export function displayNameFromCwd(cwd: string): string {
-  const segments = cwd.split('/').filter(Boolean);
+  const segments = cwd.split(/[/\\]/).filter(Boolean);
   return segments.length > 0 ? (segments[segments.length - 1] as string) : cwd;
 }

--- a/packages/server/src/util/paths.ts
+++ b/packages/server/src/util/paths.ts
@@ -2,9 +2,15 @@
 
 import { homedir } from 'node:os';
 
-/** Contract a leading home-dir prefix to `~` for display (e.g. `~/.claude/...`). */
+/** Contract a leading home-dir prefix to `~` for display (e.g. `~/.claude/...`).
+ *  Accepts either separator after the home prefix so it also works on Windows
+ *  (`C:\Users\me\.claude\...` → `~\.claude\...`). */
 export function contractHome(p: string): string {
   const home = homedir();
   if (p === home) return '~';
-  return p.startsWith(`${home}/`) ? `~${p.slice(home.length)}` : p;
+  const boundary = p[home.length];
+  if (p.startsWith(home) && (boundary === '/' || boundary === '\\')) {
+    return `~${p.slice(home.length)}`;
+  }
+  return p;
 }

--- a/packages/server/test/util.test.ts
+++ b/packages/server/test/util.test.ts
@@ -49,4 +49,9 @@ describe('displayNameFromCwd', () => {
   it('falls back to the cwd when there are no segments', () => {
     expect(displayNameFromCwd('/')).toBe('/');
   });
+
+  it('handles Windows backslash separators (and a trailing slash)', () => {
+    expect(displayNameFromCwd('C:\\Users\\me\\my-proj')).toBe('my-proj');
+    expect(displayNameFromCwd('C:\\Users\\me\\my-proj\\')).toBe('my-proj');
+  });
 });

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -19,5 +19,11 @@ export default defineConfig({
     // Integration tests build a DuckDB index from fixtures; give them room.
     testTimeout: 30_000,
     hookTimeout: 30_000,
+    // On Windows, parallel workers concurrently `INSTALL` DuckDB extensions into
+    // the shared ~/.duckdb dir, and the OS file-locking fails the simultaneous
+    // move ("Access is denied"). The app is single-process in production, so this
+    // is purely a test-concurrency artifact — serialize test files on Windows
+    // only; Linux/macOS keep full parallelism.
+    fileParallelism: process.platform !== 'win32',
   },
 });


### PR DESCRIPTION
PR 2 of plan [`0022`](docs/plans/0022-security-quality-fixes.md) — the **C6 (Windows)** item. The point is twofold: fix the POSIX-only path handling, and add a `windows-latest` CI runner so Windows is actually validated (the maintainer expects Windows users).

### Path-handling fixes
- `displayNameFromCwd` / `contractHome` now accept both `/` and `\`, so project names and `~`-contraction are correct on native Windows (`C:\Users\me\proj` → `proj`, `~\.claude\…`).
- Junie connector assumed POSIX paths too — `startsWith('/')` → `path.isAbsolute`, both-separator filename splits, and a Windows-aware `@<path>` mention regex. (Best-effort pending a real Windows-Junie session; POSIX behavior is unchanged.)
- `projectIdFromCwd` already slugs every separator, so project ids / grouping / search / cost are unaffected.

### CI
- `windows-latest` added to the `test` matrix (node 22 + 24), so Windows path handling, the `@duckdb/node-api` native binary, and the full index/query pipeline run on every PR.

### Exploratory note
This is the item the plan flagged as exploratory — I can't run Windows locally, so **the runner is the real validator**. The likely unknowns it probes: DuckDB reading backslash paths via `read_ndjson` (exact paths, no globs — should be fine), and any remaining POSIX assumption in the integration fixtures. If the Windows runner surfaces failures, I'll fix them on this branch (or split deeper pipeline work into a follow-up, per the plan).

Local: `npm run typecheck` + `npm test` green on macOS (191 tests, incl. a new backslash `displayNameFromCwd` case).