### PR TITLE
feat(web): render slash/bash command turns as clean command UI

### DIFF
--- a/docs/plans/0023-command-turn-rendering.md
+++ b/docs/plans/0023-command-turn-rendering.md
@@ -1,0 +1,89 @@
+# 0023 — Structured rendering for command turns
+
+- **Status:** done <!-- proposed | in-progress | done | superseded | abandoned -->
+- **Date:** 2026-06-17
+- **PR:** <link, once opened>
+
+## Context
+
+Claude Code records slash commands and `!` bash escapes by embedding XML-style
+markers directly in user message *text* — `<command-name>`, `<command-message>`,
+`<command-args>`, `<bash-input>`, `<bash-stdout>`, `<bash-stderr>`,
+`<local-command-stdout>` (the last often carrying raw ANSI escapes). The reader
+detected these as harness/system turns (`classifySystemText`) and collapsed them
+behind a generic label, but the expanded body printed the transcript text
+**verbatim** via `ClampedText`. The result, on every such turn:
+
+- literal tags shown as text (e.g. `<command-name>/clear</command-name>`),
+- the stray 12-space indentation baked into Claude Code's command format,
+- raw ANSI escapes rendering as garbage (`[1mOpus 4.7[22m`),
+- a generic header ("Slash command") that never said *which* command.
+
+These tags are **Claude-Code-specific**. Verified against the connector source
+and real on-disk transcripts: Codex, Junie, pi, opencode, and Copilot all record
+shell/slash interactions as real tool calls or plain text (pi even stores `/exit`
+as plain text), so none produce these tags. The fix is therefore Claude-Code-only
+and must be a clean no-op for everything else.
+
+## Goal
+
+Command turns render as clean command/terminal UI — the actual command visible in
+the collapsed header, tags and ANSI stripped — while non-command system turns and
+all other agents fall through to the existing verbatim rendering unchanged.
+
+## Decisions
+
+- **Parse in a pure helper, render in the view** — added `parseCommandTurn()` +
+  `stripAnsi()` to `pages/session/text.ts` (mirrors the existing
+  `stripImageMarkers` pattern: no React/DOM deps, cheap to unit-test). Returns a
+  discriminated union or `null`.
+- **`null` for anything unrecognized** — non-command system turns
+  (task-notification, system-reminder), truncated/unclosed tags, plain text, and
+  pi-style plain `/exit` all return `null` and keep the old `ClampedText` path.
+  This is the safety contract that keeps other agents untouched.
+- **Drop the redundant `<command-message>`** — it just repeats the command name
+  without the slash; the name + args carry everything.
+- **Surface the command in the collapsed header subtitle** — so `/plugin
+  marketplace add …` or `git pull` is legible without expanding.
+- **Did NOT merge bash input with its output** — `<bash-input>` and
+  `<bash-stdout>`/`<bash-stderr>` are *separate* parent/child transcript turns;
+  fusing them into one terminal block needs cross-turn correlation in the parser.
+  Left as a possible follow-up; each turn renders cleanly on its own.
+
+## Approach
+
+1. `text.ts`: `stripAnsi()`, `tagContent()` (newline-tolerant single-tag
+   extractor), `parseCommandTurn()` → `slash | bash-input | bash-output |
+   local-output | null`.
+2. `ThreadView.tsx`: `SystemTurn` parses the turn; on a hit it sets the header
+   subtitle to the command and renders `CommandBody` (slash pill / `$`-prompt
+   line / stdout+stderr blocks / ANSI-stripped local output), else the old
+   `ClampedText`.
+3. `session.css`: small classes (`.tv-cmd__slash`, `.tv-cmd__prompt`,
+   `.tv-cmd__stderr`, …) reusing existing mono/accent/danger tokens.
+4. Tests in `web/test/text.test.ts` cover the bug-prone edges.
+
+## Files affected
+
+- `packages/web/src/pages/session/text.ts` — parsers + `stripAnsi`.
+- `packages/web/src/pages/session/ThreadView.tsx` — structured `SystemTurn`
+  rendering (`CommandBody`, `CommandOutput`, `commandSubtitle`).
+- `packages/web/src/pages/session/session.css` — command/terminal styling.
+- `packages/web/test/text.test.ts` — parser unit tests.
+
+## Testing
+
+- `npm test` — 201 pass (8 new cases: empty/with args slash, bash-input,
+  multiline stdout, stderr-only, ANSI strip, truncated-tag → null, plain-text &
+  pi-`/exit` → null).
+- `npm run typecheck` — clean.
+- Manual: open a Claude Code session with slash/bash turns and confirm the header
+  shows the command and the body is tag/ANSI-free; confirm a Codex/pi session is
+  unchanged.
+
+## Risks / open questions
+
+- bash input/output remain two adjacent collapsibles (see decision above) —
+  optional future merge.
+- `stripAnsi` targets CSI/SGR sequences; exotic escapes (OSC hyperlinks) are left
+  as-is, acceptable for the observed data.

--- a/docs/plans/0023-command-turn-rendering.md
+++ b/docs/plans/0023-command-turn-rendering.md
@@ -2,7 +2,7 @@
 
 - **Status:** done <!-- proposed | in-progress | done | superseded | abandoned -->
 - **Date:** 2026-06-17
-- **PR:** <link, once opened>
+- **PR:** https://github.com/vladar107/claudescope/pull/29
 
 ## Context
 

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -47,3 +47,4 @@ decision, or a change worth explaining before doing. Skip it for one-line fixes.
 | 0020 | [opencode connector](./0020-opencode-connector.md) | done |
 | 0021 | [GitHub Copilot CLI connector](./0021-copilot-connector.md) | done |
 | 0022 | [Security & quality fixes: image CSP, Junie path containment, deterministic PR link, memory/search logging, Windows support](./0022-security-quality-fixes.md) | proposed |
+| 0023 | [Structured rendering for command turns (slash/bash tags)](./0023-command-turn-rendering.md) | done |

--- a/packages/web/src/pages/session/ThreadView.tsx
+++ b/packages/web/src/pages/session/ThreadView.tsx
@@ -3,7 +3,7 @@ import type { SubagentRun, ThreadBlock, ThreadItem } from '@claudescope/shared';
 import { ClampedText, Collapsible, ErrorBoundary, ErrorBox, TokenChips } from '../../components';
 import { formatDateTime, shortModel } from '../browse/format.js';
 import { ThreadBlockView, hasRenderableContent } from './blocks.js';
-import { classifySystemText } from './text.js';
+import { classifySystemText, parseCommandTurn, type CommandTurn } from './text.js';
 import { SessionSearchContext } from './SearchContext.js';
 import { blockRevealId } from './search.js';
 
@@ -142,6 +142,10 @@ function classifySystemTurn(item: ThreadItem): string | null {
 /** Compact, collapsed-by-default rendering for a harness/system user turn. */
 function SystemTurn({ item, label }: { item: ThreadItem; label: string }) {
   const text = turnText(item);
+  // Claude Code wraps slash/bash turns in XML-style tags; parse them into clean
+  // command/terminal UI. Non-command system turns (task notifications, system
+  // reminders) and other agents return null → verbatim fallback below.
+  const cmd = parseCommandTurn(text);
   return (
     <article id={item.uuid} className="tv-turn tv-turn--system">
       <div className="tv-turn__gutter" aria-hidden="true">
@@ -152,7 +156,7 @@ function SystemTurn({ item, label }: { item: ThreadItem; label: string }) {
           className="tv-collapsible--system"
           icon="⚙︎"
           title={label}
-          subtitle="system / harness message"
+          subtitle={cmd ? commandSubtitle(cmd) : 'system / harness message'}
           headerExtra={
             item.timestamp ? (
               <a className="tv-turn__time tv-muted" href={`#${item.uuid}`}>
@@ -161,10 +165,68 @@ function SystemTurn({ item, label }: { item: ThreadItem; label: string }) {
             ) : null
           }
         >
-          <ClampedText className="tv-system-turn__pre" text={text} />
+          {cmd ? (
+            <CommandBody cmd={cmd} />
+          ) : (
+            <ClampedText className="tv-system-turn__pre" text={text} />
+          )}
         </Collapsible>
       </div>
     </article>
+  );
+}
+
+/** The actual command, surfaced in the collapsed header so it's legible unexpanded. */
+function commandSubtitle(cmd: CommandTurn) {
+  if (cmd.kind === 'slash')
+    return <span className="tv-mono">{cmd.name + (cmd.args ? ` ${cmd.args}` : '')}</span>;
+  if (cmd.kind === 'bash-input') return <span className="tv-mono">{cmd.command}</span>;
+  return 'system / harness message';
+}
+
+/** Structured body for a parsed command turn — prompt line(s) or terminal output. */
+function CommandBody({ cmd }: { cmd: CommandTurn }) {
+  switch (cmd.kind) {
+    case 'slash':
+      return (
+        <div className="tv-cmd">
+          <code className="tv-cmd__slash">
+            {cmd.name}
+            {cmd.args ? <span className="tv-cmd__args"> {cmd.args}</span> : null}
+          </code>
+        </div>
+      );
+    case 'bash-input':
+      return (
+        <div className="tv-cmd">
+          <code className="tv-cmd__line">
+            <span className="tv-cmd__prompt" aria-hidden="true">$ </span>
+            {cmd.command}
+          </code>
+        </div>
+      );
+    case 'bash-output':
+      return <CommandOutput stdout={cmd.stdout} stderr={cmd.stderr} />;
+    case 'local-output':
+      return <ClampedText className="tv-system-turn__pre" text={cmd.text} />;
+  }
+}
+
+/** stdout/stderr of a bash turn; empty streams are omitted, stderr flagged. */
+function CommandOutput({ stdout, stderr }: { stdout: string; stderr: string }) {
+  const out = stdout.replace(/\s+$/, '');
+  const err = stderr.replace(/\s+$/, '');
+  if (!out && !err) return <p className="tv-system-turn__empty tv-muted">(no output)</p>;
+  return (
+    <>
+      {out ? <ClampedText className="tv-system-turn__pre" text={out} /> : null}
+      {err ? (
+        <div className="tv-cmd__stderr">
+          {out ? <span className="tv-cmd__stderr-label">stderr</span> : null}
+          <ClampedText className="tv-system-turn__pre" text={err} />
+        </div>
+      ) : null}
+    </>
   );
 }
 

--- a/packages/web/src/pages/session/session.css
+++ b/packages/web/src/pages/session/session.css
@@ -540,3 +540,50 @@
   color: var(--tv-fg-muted);
   font-family: var(--tv-font-mono, monospace);
 }
+.tv-system-turn__empty {
+  margin: 0;
+  padding: var(--tv-space-2) var(--tv-space-3);
+  font-size: var(--tv-fs-sm);
+  font-style: italic;
+}
+
+/* Parsed command turns (slash / bash) rendered as clean prompt + output. */
+.tv-cmd {
+  padding: var(--tv-space-2) var(--tv-space-3);
+}
+.tv-cmd__slash,
+.tv-cmd__line {
+  display: block;
+  font-family: var(--tv-font-mono, monospace);
+  font-size: var(--tv-fs-sm);
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+.tv-cmd__slash {
+  padding: var(--tv-space-1) var(--tv-space-2);
+  border-radius: var(--tv-radius-sm);
+  background: var(--tv-bg-inset);
+  color: var(--tv-accent);
+  width: fit-content;
+  max-width: 100%;
+}
+.tv-cmd__args {
+  color: var(--tv-fg-muted);
+  font-weight: 400;
+}
+.tv-cmd__prompt {
+  color: var(--tv-success);
+  user-select: none;
+}
+.tv-cmd__stderr {
+  border-left: 2px solid var(--tv-danger);
+}
+.tv-cmd__stderr-label {
+  display: block;
+  padding: var(--tv-space-1) var(--tv-space-3) 0;
+  font-size: var(--tv-fs-sm);
+  color: var(--tv-danger);
+}
+.tv-cmd__stderr .tv-system-turn__pre {
+  color: var(--tv-danger);
+}

--- a/packages/web/src/pages/session/text.ts
+++ b/packages/web/src/pages/session/text.ts
@@ -35,3 +35,83 @@ export function classifySystemText(text: string): string | null {
   const hit = SYSTEM_TURN_TAGS.find((t) => trimmed.startsWith(t.tag));
   return hit ? hit.label : null;
 }
+
+/**
+ * ANSI/CSI escape sequences (SGR colours, cursor moves). Claude Code's
+ * `local-command-stdout` carries raw escapes like `[1m…[22m` that
+ * would otherwise render as garbage.
+ */
+// eslint-disable-next-line no-control-regex
+const ANSI_RE = /\x1b\[[0-9;?]*[ -/]*[@-~]/g;
+
+/** Strip ANSI escape sequences from terminal text. */
+export function stripAnsi(text: string): string {
+  return text.replace(ANSI_RE, '');
+}
+
+/** Inner content of the first `<tag>…</tag>` (newline-tolerant), or null. */
+function tagContent(text: string, tag: string): string | null {
+  const m = new RegExp(`<${tag}>([\\s\\S]*?)</${tag}>`).exec(text);
+  return m?.[1] ?? null;
+}
+
+/**
+ * A harness command turn parsed out of Claude Code's XML-style markers. These
+ * tags are Claude-Code-specific; other agents record shell/slash interactions
+ * as real tool calls or plain text, so {@link parseCommandTurn} returns null
+ * for everything else and the turn falls back to verbatim rendering.
+ */
+export type CommandTurn =
+  | { kind: 'slash'; name: string; args: string }
+  | { kind: 'bash-input'; command: string }
+  | { kind: 'bash-output'; stdout: string; stderr: string }
+  | { kind: 'local-output'; text: string };
+
+/**
+ * Parse a harness command turn from its leading tag. Returns null when the text
+ * isn't a recognized command turn (or a tag is truncated/unclosed), so callers
+ * cleanly fall through to plain rendering.
+ */
+export function parseCommandTurn(text: string): CommandTurn | null {
+  const trimmed = text.trimStart();
+
+  // Slash command: <command-name>/foo</command-name> … <command-args>…</command-args>.
+  // The redundant <command-message> (the name sans slash) is intentionally dropped.
+  if (trimmed.startsWith('<command-name>')) {
+    const name = tagContent(trimmed, 'command-name');
+    if (name === null) return null;
+    return { kind: 'slash', name: name.trim(), args: (tagContent(trimmed, 'command-args') ?? '').trim() };
+  }
+
+  // Bash input: a single <bash-input>…</bash-input> turn (the `!` shell escape).
+  if (trimmed.startsWith('<bash-input>')) {
+    const command = tagContent(trimmed, 'bash-input');
+    if (command === null) return null;
+    return { kind: 'bash-input', command: command.trim() };
+  }
+
+  // Bash output: <bash-stdout>…</bash-stdout><bash-stderr>…</bash-stderr>; either may be empty.
+  if (trimmed.startsWith('<bash-stdout>') || trimmed.startsWith('<bash-stderr>')) {
+    return {
+      kind: 'bash-output',
+      stdout: stripAnsi(tagContent(trimmed, 'bash-stdout') ?? ''),
+      stderr: stripAnsi(tagContent(trimmed, 'bash-stderr') ?? ''),
+    };
+  }
+
+  // Local command output (slash-command stdout/stderr/caveat), often ANSI-coloured.
+  if (
+    trimmed.startsWith('<local-command-stdout>') ||
+    trimmed.startsWith('<local-command-stderr>') ||
+    trimmed.startsWith('<local-command-caveat>')
+  ) {
+    const inner =
+      tagContent(trimmed, 'local-command-stdout') ??
+      tagContent(trimmed, 'local-command-stderr') ??
+      tagContent(trimmed, 'local-command-caveat');
+    if (inner === null) return null;
+    return { kind: 'local-output', text: stripAnsi(inner).trim() };
+  }
+
+  return null;
+}

--- a/packages/web/test/text.test.ts
+++ b/packages/web/test/text.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from 'vitest';
-import { classifySystemText, stripImageMarkers } from '../src/pages/session/text.js';
+import {
+  classifySystemText,
+  parseCommandTurn,
+  stripAnsi,
+  stripImageMarkers,
+} from '../src/pages/session/text.js';
 
 describe('stripImageMarkers', () => {
   it('removes an inline [Image #N] marker but keeps the message', () => {
@@ -42,5 +47,76 @@ describe('classifySystemText', () => {
   it('returns null for ordinary user text', () => {
     expect(classifySystemText('please fix the bug')).toBeNull();
     expect(classifySystemText('here is some <html> in my message')).toBeNull();
+  });
+});
+
+describe('stripAnsi', () => {
+  it('removes SGR colour codes but keeps the text', () => {
+    expect(stripAnsi('Kept model as [1mOpus 4.7[22m')).toBe('Kept model as Opus 4.7');
+  });
+
+  it('leaves plain text untouched', () => {
+    expect(stripAnsi('no escapes here')).toBe('no escapes here');
+  });
+});
+
+describe('parseCommandTurn', () => {
+  it('parses a slash command with empty args', () => {
+    // The redundant <command-message> and the 12-space indentation are dropped.
+    const raw =
+      '<command-name>/clear</command-name>\n            <command-message>clear</command-message>\n            <command-args></command-args>';
+    expect(parseCommandTurn(raw)).toEqual({ kind: 'slash', name: '/clear', args: '' });
+  });
+
+  it('parses a slash command with args', () => {
+    const raw =
+      '<command-name>/plugin</command-name>\n            <command-message>plugin</command-message>\n            <command-args>marketplace add foo/bar</command-args>';
+    expect(parseCommandTurn(raw)).toEqual({
+      kind: 'slash',
+      name: '/plugin',
+      args: 'marketplace add foo/bar',
+    });
+  });
+
+  it('parses a bash-input turn', () => {
+    expect(parseCommandTurn('<bash-input>git pull</bash-input>')).toEqual({
+      kind: 'bash-input',
+      command: 'git pull',
+    });
+  });
+
+  it('parses multiline bash-stdout and keeps the newlines', () => {
+    const raw = '<bash-stdout>line one\nline two</bash-stdout><bash-stderr></bash-stderr>';
+    expect(parseCommandTurn(raw)).toEqual({
+      kind: 'bash-output',
+      stdout: 'line one\nline two',
+      stderr: '',
+    });
+  });
+
+  it('parses a stderr-only bash output', () => {
+    const raw = "<bash-stdout></bash-stdout><bash-stderr>error: nope\n</bash-stderr>";
+    expect(parseCommandTurn(raw)).toEqual({
+      kind: 'bash-output',
+      stdout: '',
+      stderr: 'error: nope\n',
+    });
+  });
+
+  it('strips ANSI codes from local-command output', () => {
+    const raw = '<local-command-stdout>Kept model as [1mOpus 4.7[22m</local-command-stdout>';
+    expect(parseCommandTurn(raw)).toEqual({ kind: 'local-output', text: 'Kept model as Opus 4.7' });
+  });
+
+  it('returns null on a truncated/unclosed tag (graceful fallback to raw)', () => {
+    expect(parseCommandTurn('<bash-input>git pull')).toBeNull();
+    expect(parseCommandTurn('<command-name>/clear')).toBeNull();
+  });
+
+  it('returns null for non-command text and plain-text slash (other agents)', () => {
+    // pi stores `/exit` as plain text, not a tag — must not be mistaken for a command turn.
+    expect(parseCommandTurn('/exit')).toBeNull();
+    expect(parseCommandTurn('please fix the bug')).toBeNull();
+    expect(parseCommandTurn('<system-reminder>noise</system-reminder>')).toBeNull();
   });
 });


### PR DESCRIPTION
## Problem

Claude Code embeds XML-style markers in user message **text** for slash and `!`-bash turns — `<command-name>`, `<command-message>`, `<command-args>`, `<bash-input>`, `<bash-stdout>`/`<bash-stderr>`, `<local-command-stdout>`. The reader detected these as system turns but printed the raw text, so every such turn showed:

- literal tags (`<command-name>/clear</command-name>`),
- the stray 12-space indentation baked into the command format,
- raw ANSI escapes rendering as garbage (`[1mOpus 4.7[22m`),
- a generic header that never said *which* command.

## Fix

Parse the markers into clean command/terminal UI:

- **`pages/session/text.ts`** — new pure, unit-tested `parseCommandTurn()` (→ `slash | bash-input | bash-output | local-output | null`) and `stripAnsi()`. Returns `null` for non-command text, so non-command system turns (task-notification, system-reminder), truncated tags, and **all other agents** fall through to the existing verbatim rendering unchanged.
- **`ThreadView.tsx`** — `SystemTurn` surfaces the command in the collapsed header subtitle (legible without expanding) and renders a slash pill, a `$`-prompt bash line, stdout + flagged stderr blocks (empties omitted), or ANSI-stripped local output.
- **`session.css`** — small command/terminal classes reusing existing accent/danger/mono tokens.

## Scope note

These tags are **Claude-Code-specific**. Verified against connector source and real transcripts: Codex, Junie, pi, opencode, and Copilot record shell/slash interactions as real tool calls or plain text (pi even stores `/exit` as plain text), so this is a no-op for them. A regression test asserts `parseCommandTurn` returns `null` for plain text and pi-style `/exit`.

`<bash-input>` and its `<bash-stdout>`/`<bash-stderr>` are separate transcript turns, so they render as two clean adjacent collapsibles rather than one fused block — noted as an optional follow-up in the plan doc.

## Testing

- `npm test` → **201 passed** (8 new edge cases: empty/with-args slash, bash-input, multiline stdout, stderr-only, ANSI strip, truncated-tag → null, plain-text & pi-`/exit` → null).
- `npm run typecheck` → clean.
- Manual: drove a headless browser over real Claude Code sessions and confirmed each command type (slash pill, `$`-prompt, clean stdout, red-bordered stderr, ANSI-stripped local output) renders with no leftover tags and no console errors.

Plan: `docs/plans/0023-command-turn-rendering.md`.