### PR TITLE
feat: continue session via terminal auto-open (resume/fork) — explored, not shipping

### DIFF
--- a/docs/plans/0024-continue-session.md
+++ b/docs/plans/0024-continue-session.md
@@ -1,0 +1,228 @@
+# 0024 — Continue session from transcript
+
+- **Status:** in-progress <!-- proposed | in-progress | done | superseded | abandoned -->
+- **Date:** 2026-06-17
+- **PR:** <link, once opened>
+
+## Context
+
+Claudescope is a read-only viewer. A natural next step while reading a transcript
+is to **pick the work back up** in the agent that produced it. Every agent we
+support can reopen a session from its own store, and **we already know which agent
+a session belongs to** (`connectorId`) — so we never guess. We just hand the user
+the right command for that agent and (on macOS) launch it.
+
+The hard constraint: **Claudescope must stay read-only w.r.t. agent sources**
+(`~/.claude`, `~/.codex`, …). We honor that by never writing to a source
+ourselves. Resuming appends to the agent's own store — but the *agent* does that
+write, invoked by the user; Claudescope only emits a command and (on macOS) opens
+a terminal. Fork mode mutates nothing.
+
+There is no portable "default terminal emulator" API on any OS. But on macOS we
+don't need one: `open foo.command` routes a shell-script file to whatever app is
+registered as the handler for `.command` (Terminal.app by default, or the user's
+chosen iTerm/Ghostty/…). That *is* their default terminal as the OS sees it, and
+it runs through a login shell, so the agent binary resolves on `PATH` normally.
+
+**Verified resume CLIs (June 2026 docs/repos).** All six supported agents have a
+non-interactive, by-id resume command; four also have a fork that leaves the
+original untouched:
+
+| Agent | Resume (append) | Fork (new session) | id passed |
+| --- | --- | --- | --- |
+| Claude Code | `claude --resume <id>` | `claude --resume <id> --fork-session` | `.jsonl` filename UUID |
+| Codex | `codex resume <id>` | `codex fork <id>` | rollout filename UUID |
+| opencode | `opencode --session <id>` | `opencode --session <id> --fork` | `ses_…` id |
+| pi | `pi --session <id>` | `pi --fork <id>` | session id (partial ok) |
+| Copilot CLI | `copilot --resume <id>` | — (no CLI fork) | `session-state/<uuid>` dir name |
+| Junie | `junie --session-id <id>` | — (no CLI fork) | `session-…` id |
+
+Each is wrapped as `cd '<cwd>' && <command>`. cwd is strictly required only for
+Claude Code (id lookup is scoped to the project dir); for the others it's not
+required but we still `cd` so the agent starts in the right project.
+
+## Goal
+
+From a session view, offer **Continue** — **Resume** (append) for every agent,
+plus **Fork** (new session) for the agents that support it. On **macOS**, clicking
+opens the user's default terminal already running the command. On **every other
+platform**, show the exact command with a **Copy** button.
+
+## Decisions
+
+- **All agents, per-connector — never guess** — the agent is known from
+  `connectorId`; each connector encodes its own resume command via an optional
+  `resumeSpec()` on the `AgentConnector` port. No `if connectorId === …` branching
+  in routes/UI; adding/adjusting an agent is a one-connector change.
+- **Resume for all six; fork only where verified** — Claude Code, Codex,
+  opencode, pi have a real fork/branch CLI; Copilot CLI and Junie don't (Copilot's
+  `/fork` is an in-session command, version-dependent and broken in some builds;
+  Junie's CLI has no fork flag). The Fork item appears only when the connector's
+  spec provides a fork command. Rejected: a cross-agent "handoff prompt" — lossy,
+  not asked for in v1.
+- **No install / PATH precheck — just try to launch** — we do not probe for the
+  agent binary, its version, or whether the session is resolvable. We build the
+  command and run it; if the binary is missing or the agent can't find the
+  session, the terminal shows the error. Simpler, and avoids a brittle probe that
+  could wrongly hide the action.
+- **macOS auto-open via a `.command` launcher + `open`** — respects the user's
+  default terminal without detecting it; login-shell `PATH` resolves the agent.
+  Rejected: spawning the agent directly from the server (non-login `PATH` often
+  can't find the binary, and no visible window); hardcoding Terminal.app (ignores
+  the user's choice); an embedded xterm.js terminal (heavy new surface for v1).
+- **Other platforms: copy-command only** — Linux has no reliable default-terminal
+  mechanism and Windows' is awkward to read; we degrade to a Copy button rather
+  than half-implement auto-open.
+- **Server is the single source of truth for the command** — the browser sends
+  only `{ mode }`; the server builds argv from the **indexed** `sessionId`/`cwd`
+  via the connector, never from a client-supplied string. This keeps the new exec
+  endpoint from becoming a "run anything" hole — a real concern to constrain even
+  on a localhost single-user app.
+- **Launcher lives in `~/.claudescope/launchers/`** — app-owned state, never an
+  agent source. Overwritten per `(session, mode)`; chmod `700`.
+
+## Approach
+
+1. **Shared types** (`packages/shared/src/api.ts`): add an optional `resume`
+   field to `SessionDetailResponse`:
+   ```ts
+   export interface ResumeInfo {
+     cwd: string;
+     /** POSIX command that appends to the original session. */
+     resumeCommand: string;
+     /** POSIX command that forks into a new session; absent when unsupported. */
+     forkCommand?: string;
+     /** True when this server can open a terminal itself (macOS only). */
+     canAutoOpen: boolean;
+   }
+   ```
+   Present for every session whose connector implements `resumeSpec` (all of them,
+   at launch). Add `ContinueRequest { mode: 'resume' | 'fork' }` /
+   `ContinueResponse { launched: boolean }` for the new endpoint.
+
+2. **Connector port** (`connectors/types.ts`): add
+   ```ts
+   /** Optional: how to reopen this session in the agent's own CLI, or null. */
+   resumeSpec?(sessionId: string, cwd: string): ResumeSpec | null;
+   interface ResumeSpec {
+     cwd: string;
+     /** argv to exec in cwd, e.g. ['claude','--resume','<id>']. */
+     resumeArgv: string[];
+     /** fork argv; omit when the agent has no CLI fork. */
+     forkArgv?: string[];
+   }
+   ```
+   Structured argv (not a pre-joined string) so the copy command and the launcher
+   script are both derived without re-quoting twice. The connector maps **our**
+   indexed `sessionId` to the agent's native resume id — important for opencode
+   (`ses_…`) and Junie (`session-…`), where the native id may differ from a naive
+   filename slug.
+
+3. **Per-connector `resumeSpec`** (one method each):
+   - `claude-code`: `['claude','--resume',id]` / `['claude','--resume',id,'--fork-session']`
+   - `codex`: `['codex','resume',id]` / `['codex','fork',id]`
+   - `opencode`: `['opencode','--session',nativeId]` / `[…,'--fork']`
+   - `pi`: `['pi','--session',id]` / `['pi','--fork',id]`
+   - `copilot`: `['copilot','--resume',id]` (no fork)
+   - `junie`: `['junie','--session-id',id]` (no fork)
+
+4. **Command construction** (new `connectors/resume.ts` — pure, testable): given a
+   `ResumeSpec`, produce (a) the POSIX display command `cd <q(cwd)> && <q(argv)>`
+   and (b) the `.command` launcher body. A single `shQuote()` helper (single-quote
+   + `'\''` escaping) handles arbitrary cwd paths; argv tokens are quoted the same
+   way.
+
+5. **Session detail route** (`routes/sessions.ts`): the handler already has the
+   session row → read `project_cwd`, resolve the connector, call
+   `resumeSpec(id, cwd)`. If non-null, attach `resume` to the response (commands
+   from step 4; `canAutoOpen = process.platform === 'darwin'`).
+
+6. **Continue endpoint** (`routes/sessions.ts`):
+   `POST /api/sessions/:id/continue` with `{ mode }`. Guards: 404 unknown session;
+   400 if the connector has no `resumeSpec` or `mode === 'fork'` without a fork
+   argv; 400 with a clear "macOS-only — use Copy" message when
+   `process.platform !== 'darwin'`. On success: write the launcher to
+   `~/.claudescope/launchers/<mode>-<id>.command` (script = `#!/bin/bash` +
+   `cd <q(cwd)> &&` + `exec <q(argv)>`), `chmod 0700`,
+   `spawn('open', [path], { detached:true }).unref()`, return `{ launched: true }`.
+   **No install/existence checks** beyond these — a missing binary surfaces in the
+   terminal. Keep the spawn behind a thin, injectable seam so command-building
+   stays unit-testable without launching anything.
+
+7. **Paths** (`paths.ts`): add `launchersDir()` under the app home; ensure it
+   exists before writing.
+
+8. **Web client** (`api/client.ts`): add `continueSession(id, mode)`.
+
+9. **Web UI** (`pages/session/`): a `ContinueMenu` next to `ExportMenu` in the
+   session header (`SessionPage.tsx:366`), mirroring `ExportMenu`'s dropdown.
+   Rendered whenever `data.resume` is present (all agents). Item **Resume** always;
+   **Fork to new session** only when `resume.forkCommand` exists.
+   - `canAutoOpen` → click POSTs `/continue`; toast on success ("Opening in your
+     terminal…"), and on error fall back to showing the command + Copy.
+   - else → reveal the command with a Copy-to-clipboard button and a "Run this in
+     your terminal" hint.
+
+## Files affected
+
+- `packages/shared/src/api.ts` — `ResumeInfo`, `resume?` on
+  `SessionDetailResponse`, `ContinueRequest`/`ContinueResponse`.
+- `packages/server/src/connectors/types.ts` — optional `resumeSpec()` + `ResumeSpec`.
+- `packages/server/src/connectors/{claude-code,codex,opencode,pi,copilot,junie}/*.ts`
+  — implement `resumeSpec` for each.
+- `packages/server/src/connectors/resume.ts` *(new)* — `shQuote`, display-command
+  and launcher-script builders (pure).
+- `packages/server/src/routes/sessions.ts` — attach `resume` to detail response;
+  add `POST /api/sessions/:id/continue`.
+- `packages/server/src/paths.ts` (or equivalent) — `launchersDir()`.
+- `packages/web/src/api/client.ts` — `continueSession()`.
+- `packages/web/src/pages/session/ContinueMenu.tsx` *(new)* + wiring in
+  `SessionPage.tsx`; small CSS in `session.css`.
+
+## Testing
+
+`npm test` + `npm run typecheck`. Focus on the bug-prone edges, not glue:
+
+- **Command construction (pure, the core):** for each connector's spec, the
+  resume/fork argv produce the expected POSIX command and launcher body; a cwd
+  with spaces, quotes, `$`, and an injection attempt (`'; rm -rf ~ #`) stays inert
+  inside the single-quote escaping.
+- **Per-connector mapping:** each connector returns the right verb/flag
+  (`resume`/`fork` for Codex, `--session`/`--fork` for opencode, `--session-id`
+  for Junie, no `forkArgv` for Copilot/Junie). opencode maps the indexed id to its
+  `ses_…` native id.
+- **Endpoint guards:** unknown id → 404; `mode:'fork'` on a fork-less connector →
+  400; non-darwin platform (simulated via the platform seam) → 400 "macOS-only";
+  invalid `mode` → 400. The `open` spawn is stubbed — no real launch in tests.
+- Manual (macOS): for at least Claude Code and one other agent, Resume opens the
+  default terminal in the right cwd; Fork (where present) adds the fork flag and
+  the original transcript is unchanged.
+
+## Risks / open questions
+
+- **Shell-injection via cwd** — the one real safety issue; mitigated by `shQuote`
+  on every interpolated value and never accepting a command string from the
+  client. Covered by tests.
+- **opencode native id** — the connector must pass the real `ses_…` id, not the
+  synthetic `<dbPath>#<id>` discovery key. Verify what the index stores as
+  `session_id` for opencode and map accordingly.
+- **Junie IDE-session interop** — `junie --session-id` is verified for Junie *CLI*
+  sessions; it's unconfirmed whether it can reopen an *IDE-originated* session
+  (what our connector reads). Per the "just try to launch" decision we emit it
+  anyway; if it can't, the terminal shows the error. (Also: CLAUDE.md's "Junie is
+  IDE-only" note is now outdated — a Junie CLI exists as of ~Apr 2026.)
+- **Copilot has no CLI fork** — Fork item hidden for Copilot and Junie; resume
+  only.
+- **Agent not installed / not on `PATH` / session unresolvable** — by decision we
+  don't precheck; the terminal window shows the shell/agent error. Acceptable and
+  visible.
+- **`open` honors a non-terminal `.command` handler** — if the user remapped
+  `.command`, behavior is theirs to own. Acceptable edge.
+- **Remote/SSH** — if the server runs on a different host than the browser,
+  "open terminal" opens on the *server* host. Out of scope; Claudescope is a local
+  single-user tool by design.
+- **Windows copy command** — we emit a POSIX `cd … && …` string; fine for
+  WSL/git-bash (where these agents typically run), not native `cmd`. Note it; don't
+  special-case unless asked.
+- **Launcher cleanup** — files are tiny and overwritten per `(session, mode)`;
+  prune on write if accumulation ever matters. Minor follow-up.

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -48,3 +48,4 @@ decision, or a change worth explaining before doing. Skip it for one-line fixes.
 | 0021 | [GitHub Copilot CLI connector](./0021-copilot-connector.md) | done |
 | 0022 | [Security & quality fixes: image CSP, Junie path containment, deterministic PR link, memory/search logging, Windows support](./0022-security-quality-fixes.md) | proposed |
 | 0023 | [Structured rendering for command turns (slash/bash tags)](./0023-command-turn-rendering.md) | done |
+| 0024 | [Continue session from transcript (resume / fork)](./0024-continue-session.md) | in-progress |

--- a/packages/server/src/config.ts
+++ b/packages/server/src/config.ts
@@ -132,6 +132,13 @@ export const CLAUDESCOPE_HOME = expandHome(
 export const DUCKDB_PATH = process.env.DUCKDB_PATH ?? join(CLAUDESCOPE_HOME, 'index.duckdb');
 
 /**
+ * App-owned dir for the macOS `.command` launcher scripts the "continue session"
+ * feature writes before `open`-ing them. Lives under the state dir, never any
+ * agent source. Files are tiny and overwritten per (session, mode).
+ */
+export const LAUNCHERS_DIR = join(CLAUDESCOPE_HOME, 'launchers');
+
+/**
  * Read-only pricing template shipped inside the package. Seeds the user copy on
  * first run and is the fallback when no user copy exists. Resolved for both the
  * bundled layout (`<pkg>/pricing.default.json` next to the bundle) and the dev

--- a/packages/server/src/connectors/claude-code/claude-code.ts
+++ b/packages/server/src/connectors/claude-code/claude-code.ts
@@ -296,4 +296,8 @@ export const claudeCodeConnector: AgentConnector = {
   loadSession,
   globalMemory,
   projectMemory,
+  resumeSpec: (id) => ({
+    resumeArgv: ['claude', '--resume', id],
+    forkArgv: ['claude', '--resume', id, '--fork-session'],
+  }),
 };

--- a/packages/server/src/connectors/codex/codex.ts
+++ b/packages/server/src/connectors/codex/codex.ts
@@ -100,4 +100,8 @@ export const codexConnector: AgentConnector = {
   auxProjections,
   loadSession,
   globalMemory: codexGlobalMemory,
+  resumeSpec: (id) => ({
+    resumeArgv: ['codex', 'resume', id],
+    forkArgv: ['codex', 'fork', id],
+  }),
 };

--- a/packages/server/src/connectors/copilot/copilot.ts
+++ b/packages/server/src/connectors/copilot/copilot.ts
@@ -110,4 +110,6 @@ export const copilotConnector: AgentConnector = {
   auxProjections,
   loadSession,
   globalMemory: copilotGlobalMemory,
+  // Copilot CLI has no command-line fork (only an in-session `/fork`), so resume only.
+  resumeSpec: (id) => ({ resumeArgv: ['copilot', '--resume', id] }),
 };

--- a/packages/server/src/connectors/junie/junie.ts
+++ b/packages/server/src/connectors/junie/junie.ts
@@ -149,4 +149,6 @@ export const junieConnector: AgentConnector = {
   auxProjections,
   loadSession,
   globalMemory,
+  // Junie CLI resumes by id; it has no command-line fork, so resume only.
+  resumeSpec: (id) => ({ resumeArgv: ['junie', '--session-id', id] }),
 };

--- a/packages/server/src/connectors/opencode/opencode.ts
+++ b/packages/server/src/connectors/opencode/opencode.ts
@@ -116,4 +116,8 @@ export const opencodeConnector: AgentConnector = {
   eventsProjectionSql,
   auxProjections,
   loadSession,
+  resumeSpec: (id) => ({
+    resumeArgv: ['opencode', '--session', id],
+    forkArgv: ['opencode', '--session', id, '--fork'],
+  }),
 };

--- a/packages/server/src/connectors/pi/pi.ts
+++ b/packages/server/src/connectors/pi/pi.ts
@@ -102,4 +102,8 @@ export const piConnector: AgentConnector = {
   eventsProjectionSql,
   auxProjections,
   loadSession,
+  resumeSpec: (id) => ({
+    resumeArgv: ['pi', '--session', id],
+    forkArgv: ['pi', '--fork', id],
+  }),
 };

--- a/packages/server/src/connectors/resume.ts
+++ b/packages/server/src/connectors/resume.ts
@@ -1,0 +1,112 @@
+/**
+ * Pure command construction for "continue session" — kept side-effect-free so it
+ * can be unit-tested without spawning anything. The impure part (writing the
+ * launcher and `open`-ing it) lives in `util/terminal.ts`.
+ *
+ * Security note: every interpolated value is shell-quoted here, and the only
+ * input that isn't a fixed argv token is the session's own indexed `cwd`. The
+ * HTTP layer never accepts a command string from the client — it sends a `mode`
+ * and the server rebuilds argv from the connector — so a hostile `cwd` is the
+ * only injection surface, and `shQuote` neutralizes it.
+ */
+
+import type { ResumeInfo } from '@claudescope/shared';
+import type { AgentConnector, ResumeSpec } from './types.js';
+
+/** Characters safe to leave unquoted in a POSIX shell (the shlex.quote allowlist). */
+const SHELL_SAFE = /^[A-Za-z0-9_@%+=:,./-]+$/;
+
+/**
+ * Quote a string for a POSIX shell, shlex-style: leave it bare when it's only
+ * safe characters (so the common command reads cleanly), otherwise single-quote
+ * it and neutralize any embedded quote with `'\''`. This is the injection guard
+ * for the session's `cwd`.
+ */
+export function shQuote(s: string): string {
+  if (s === '') return "''";
+  if (SHELL_SAFE.test(s)) return s;
+  return `'${s.replace(/'/g, `'\\''`)}'`;
+}
+
+/** Quote an argv into a single command fragment. */
+function quoteArgv(argv: string[]): string {
+  return argv.map(shQuote).join(' ');
+}
+
+/** The copy-paste command: cd into the project, then run the agent. */
+export function displayCommand(cwd: string, argv: string[]): string {
+  return `cd ${shQuote(cwd)} && ${quoteArgv(argv)}`;
+}
+
+/**
+ * A macOS `.command` launcher: a tiny bash script that cds into the project and
+ * execs the agent. `open`ing this routes it to the user's default terminal (the
+ * handler registered for `.command`), which runs it in a login shell — so the
+ * agent binary resolves on PATH as it normally would.
+ */
+export function launcherScript(cwd: string, argv: string[]): string {
+  return [
+    '#!/bin/bash',
+    // No path interpolation in the message → nothing to escape; the cd target is quoted.
+    `cd ${shQuote(cwd)} || { echo "claudescope: project directory not found"; exit 1; }`,
+    `exec ${quoteArgv(argv)}`,
+    '',
+  ].join('\n');
+}
+
+/**
+ * Assemble the client-facing {@link ResumeInfo} for a session, or `undefined`
+ * when it can't be resumed (no cwd, or the connector has no resume command).
+ */
+export function buildResumeInfo(
+  connector: AgentConnector,
+  sessionId: string,
+  cwd: string | null,
+  isMac: boolean,
+): ResumeInfo | undefined {
+  if (!cwd) return undefined;
+  const spec = connector.resumeSpec?.(sessionId);
+  if (!spec) return undefined;
+  const info: ResumeInfo = {
+    cwd,
+    resumeCommand: displayCommand(cwd, spec.resumeArgv),
+    canAutoOpen: isMac,
+  };
+  if (spec.forkArgv) info.forkCommand = displayCommand(cwd, spec.forkArgv);
+  return info;
+}
+
+/** Outcome of validating a /continue request — either the argv to launch, or an error. */
+export type ContinueResolution =
+  | { ok: true; cwd: string; argv: string[] }
+  | { ok: false; status: number; error: string };
+
+/**
+ * Pure guard logic for the auto-open endpoint. Resolves the argv to launch or an
+ * HTTP error, so the route stays thin and the rules are testable without
+ * touching the filesystem or spawning `open`. (The 404 for an unknown session is
+ * handled in the route, before this is reached.)
+ */
+export function resolveContinue(
+  spec: ResumeSpec | null | undefined,
+  opts: { cwd: string | null; mode: string; connectorLabel: string; isMac: boolean },
+): ContinueResolution {
+  if (opts.mode !== 'resume' && opts.mode !== 'fork') {
+    return { ok: false, status: 400, error: "mode must be 'resume' or 'fork'" };
+  }
+  if (!opts.isMac) {
+    return {
+      ok: false,
+      status: 400,
+      error: 'Auto-open is only available on macOS — copy the command and run it yourself.',
+    };
+  }
+  if (!spec || !opts.cwd) {
+    return { ok: false, status: 400, error: 'This session cannot be resumed.' };
+  }
+  const argv = opts.mode === 'fork' ? spec.forkArgv : spec.resumeArgv;
+  if (!argv) {
+    return { ok: false, status: 400, error: `Fork is not supported for ${opts.connectorLabel}.` };
+  }
+  return { ok: true, cwd: opts.cwd, argv };
+}

--- a/packages/server/src/connectors/types.ts
+++ b/packages/server/src/connectors/types.ts
@@ -124,6 +124,26 @@ export interface AgentConnector {
    * of scope: surfacing it would require reading arbitrary project dirs.)
    */
   projectMemory?(): AgentMemoryDir[];
+
+  /**
+   * Optional: how to reopen this session in the agent's own CLI. Returns the
+   * argv to exec (the server wraps it with `cd <cwd> && …`), or null when the
+   * agent has no resume command. `sessionId` is the indexed session id, which
+   * for every current connector is already the native id the CLI expects.
+   */
+  resumeSpec?(sessionId: string): ResumeSpec | null;
+}
+
+/**
+ * The command(s) to reopen a session in an agent's CLI, as structured argv so
+ * the copy-paste string and the macOS launcher script are both derived from the
+ * same tokens (quoted once, in `connectors/resume.ts`).
+ */
+export interface ResumeSpec {
+  /** argv that appends to the original session, e.g. `['claude','--resume',id]`. */
+  resumeArgv: string[];
+  /** argv that forks into a new session; omit when the agent has no CLI fork. */
+  forkArgv?: string[];
 }
 
 /**

--- a/packages/server/src/routes/sessions.ts
+++ b/packages/server/src/routes/sessions.ts
@@ -8,6 +8,7 @@
 
 import type { FastifyInstance } from 'fastify';
 import type {
+  ContinueResponse,
   SessionDetailResponse,
   SessionMeta,
   SessionSort,
@@ -18,6 +19,11 @@ import { displayNameFromCwd, projectIdFromCwd } from '../data/project-id.js';
 import { toIso } from './projects.js';
 import { assembleThread, buildSubagentRuns } from '../data/parser.js';
 import { loadSessionData } from '../data/session-loader.js';
+import { connectorById } from '../connectors/registry.js';
+import { buildResumeInfo, resolveContinue } from '../connectors/resume.js';
+import { launchTerminal } from '../util/terminal.js';
+
+const IS_MAC = process.platform === 'darwin';
 
 const SORT_SQL: Record<SessionSort, string> = {
   recent: 'ended_at DESC NULLS LAST',
@@ -111,7 +117,47 @@ export async function registerSessionsRoutes(app: FastifyInstance): Promise<void
       const thread = assembleThread(mainEvents);
       const subagents = buildSubagentRuns(thread, subagentSources);
 
-      return { meta, thread, subagents };
+      const cwd = readRow(rows[0] as Record<string, unknown>, 'sessions').str('project_cwd');
+      const resume = buildResumeInfo(connectorById(meta.connectorId), id, cwd || null, IS_MAC);
+
+      const res: SessionDetailResponse = { meta, thread, subagents };
+      if (resume) res.resume = resume;
+      return res;
+    },
+  );
+
+  // POST /api/sessions/:id/continue — open the session in the agent's own CLI by
+  // writing a launcher and `open`-ing it (macOS only). The client sends only a
+  // `mode`; the server rebuilds argv from the connector, so no command string
+  // ever crosses the wire. Non-macOS callers use the copy command instead.
+  app.post<{ Params: { id: string }; Body: { mode?: string } }>(
+    '/api/sessions/:id/continue',
+    async (req, reply): Promise<ContinueResponse | void> => {
+      const conn = await getConnection();
+      const id = req.params.id;
+
+      const rows = await queryRows(conn, `SELECT * FROM sessions WHERE id = ${sqlString(id)}`);
+      if (rows.length === 0) {
+        reply.code(404).send({ error: 'Session not found' });
+        return;
+      }
+      const rd = readRow(rows[0] as Record<string, unknown>, 'sessions');
+      const cwd = rd.str('project_cwd');
+      const connector = connectorById(rd.str('connector_id') || 'claude-code');
+
+      const resolved = resolveContinue(connector.resumeSpec?.(id), {
+        cwd: cwd || null,
+        mode: req.body?.mode ?? '',
+        connectorLabel: connector.label,
+        isMac: IS_MAC,
+      });
+      if (!resolved.ok) {
+        reply.code(resolved.status).send({ error: resolved.error });
+        return;
+      }
+
+      launchTerminal(id, req.body?.mode === 'fork' ? 'fork' : 'resume', resolved.cwd, resolved.argv);
+      return { launched: true };
     },
   );
 }

--- a/packages/server/src/util/terminal.ts
+++ b/packages/server/src/util/terminal.ts
@@ -1,0 +1,36 @@
+/**
+ * macOS terminal launcher for "continue session". Writes a `.command` script to
+ * the app state dir and `open`s it, which routes it to the user's default
+ * terminal (the registered handler for `.command`). Isolated here so the route's
+ * decision logic stays pure and testable; this module is the only side effect.
+ */
+
+import { spawn } from 'node:child_process';
+import { chmodSync, mkdirSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { LAUNCHERS_DIR } from '../config.js';
+import { launcherScript } from '../connectors/resume.js';
+
+/**
+ * Write the launcher for `(sessionId, mode)` and open it. We deliberately do NOT
+ * check whether the agent binary exists or the session is resolvable — a missing
+ * binary or unknown session surfaces as a visible error in the opened terminal.
+ */
+export function launchTerminal(
+  sessionId: string,
+  mode: 'resume' | 'fork',
+  cwd: string,
+  argv: string[],
+): void {
+  mkdirSync(LAUNCHERS_DIR, { recursive: true });
+  // Session ids can carry `/`, `#`, etc. (e.g. opencode keys); make a safe filename.
+  const safe = sessionId.replace(/[^A-Za-z0-9._-]/g, '_') || 'session';
+  const file = join(LAUNCHERS_DIR, `${mode}-${safe}.command`);
+  writeFileSync(file, launcherScript(cwd, argv), { mode: 0o700 });
+  chmodSync(file, 0o700); // ensure the exec bit even if umask stripped it
+  const child = spawn('open', [file], { detached: true, stdio: 'ignore' });
+  // A ChildProcess that emits 'error' (e.g. `open` not spawnable) with no
+  // listener throws an uncaught exception — fatal for the long-lived daemon.
+  child.on('error', (err) => console.error('[continue] failed to open terminal:', err));
+  child.unref();
+}

--- a/packages/server/test/api.integration.test.ts
+++ b/packages/server/test/api.integration.test.ts
@@ -200,6 +200,31 @@ describe('GET /api/sessions/:id', () => {
   it('404s on an unknown session', async () => {
     expect((await get('/api/sessions/does-not-exist')).statusCode).toBe(404);
   });
+
+  it('attaches resume/fork commands for a Claude session', async () => {
+    const detail = (await get('/api/sessions/sessA')).json();
+    expect(detail.resume).toMatchObject({
+      cwd: '/tmp/projA',
+      resumeCommand: 'cd /tmp/projA && claude --resume sessA',
+      forkCommand: 'cd /tmp/projA && claude --resume sessA --fork-session',
+      canAutoOpen: process.platform === 'darwin',
+    });
+  });
+});
+
+describe('POST /api/sessions/:id/continue (guards only — never launches)', () => {
+  // We exercise only the rejection paths so no real `open` is spawned: an
+  // unknown session 404s before any launch, and an invalid mode 400s first.
+  const post = (url: string, body: unknown) =>
+    app.inject({ method: 'POST', url, payload: body });
+
+  it('404s on an unknown session', async () => {
+    expect((await post('/api/sessions/nope/continue', { mode: 'resume' })).statusCode).toBe(404);
+  });
+
+  it('400s on an invalid mode', async () => {
+    expect((await post('/api/sessions/sessA/continue', { mode: 'bogus' })).statusCode).toBe(400);
+  });
 });
 
 describe('GET /api/search', () => {

--- a/packages/server/test/resume.test.ts
+++ b/packages/server/test/resume.test.ts
@@ -1,0 +1,154 @@
+/**
+ * "Continue session" command construction and guard logic. These are the
+ * bug-prone edges: shell-quoting an arbitrary cwd (injection safety), the
+ * per-connector resume/fork verbs, and the endpoint's pure decision matrix. The
+ * impure launcher (`open`) is not exercised here.
+ */
+
+import { describe, expect, it } from 'vitest';
+import {
+  buildResumeInfo,
+  displayCommand,
+  launcherScript,
+  resolveContinue,
+  shQuote,
+} from '../src/connectors/resume.js';
+import { connectorById, connectors } from '../src/connectors/registry.js';
+
+describe('shQuote', () => {
+  it('leaves safe tokens bare so the command reads cleanly', () => {
+    expect(shQuote('claude')).toBe('claude');
+    expect(shQuote('--fork-session')).toBe('--fork-session');
+    expect(shQuote('/Users/me/src/my-proj')).toBe('/Users/me/src/my-proj');
+    expect(shQuote('ses_2132abc')).toBe('ses_2132abc');
+  });
+
+  it('single-quotes anything containing shell-special characters', () => {
+    expect(shQuote('/tmp/my project')).toBe("'/tmp/my project'");
+    expect(shQuote('/tmp/a$b')).toBe("'/tmp/a$b'");
+    expect(shQuote('')).toBe("''");
+  });
+
+  it('neutralizes an embedded single quote (injection safety)', () => {
+    expect(shQuote("O'Brien")).toBe("'O'\\''Brien'");
+    // A cwd crafted to break out and run a command stays inert inside the quotes.
+    expect(shQuote("/tmp/a'; rm -rf ~ #")).toBe("'/tmp/a'\\''; rm -rf ~ #'");
+  });
+});
+
+describe('displayCommand', () => {
+  it('builds a clean cd && agent line for a normal cwd', () => {
+    expect(displayCommand('/tmp/projA', ['claude', '--resume', 'sessA'])).toBe(
+      'cd /tmp/projA && claude --resume sessA',
+    );
+  });
+
+  it('quotes a hostile cwd so nothing executes', () => {
+    const cmd = displayCommand("/tmp/a'; rm -rf ~ #", ['claude', '--resume', 'id']);
+    expect(cmd).toBe("cd '/tmp/a'\\''; rm -rf ~ #' && claude --resume id");
+    // The injected `rm` is inside the quoted cd argument, not a second command.
+    expect(cmd).not.toContain('&& rm');
+  });
+});
+
+describe('launcherScript', () => {
+  it('is a bash script that cds (guarded) and execs the agent', () => {
+    const s = launcherScript('/tmp/projA', ['claude', '--resume', 'sessA']);
+    expect(s.startsWith('#!/bin/bash\n')).toBe(true);
+    expect(s).toContain('cd /tmp/projA || {');
+    expect(s).toContain('exec claude --resume sessA');
+  });
+
+  it('keeps a hostile cwd inert in both the cd and the guard', () => {
+    const s = launcherScript("/tmp/a'; rm -rf ~ #", ['pi', '--session', 'x']);
+    expect(s).toContain("cd '/tmp/a'\\''; rm -rf ~ #' || {");
+    expect(s).not.toMatch(/\nrm -rf/);
+  });
+});
+
+describe('connector resumeSpec', () => {
+  const specOf = (id: string) => connectorById(id).resumeSpec?.('SID');
+
+  it('every registered connector exposes a resume command', () => {
+    for (const c of connectors) {
+      expect(c.resumeSpec, `${c.id} should implement resumeSpec`).toBeTypeOf('function');
+      expect(c.resumeSpec!('SID')?.resumeArgv.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('maps each agent to its verified resume verb/flag', () => {
+    expect(specOf('claude-code')?.resumeArgv).toEqual(['claude', '--resume', 'SID']);
+    expect(specOf('codex')?.resumeArgv).toEqual(['codex', 'resume', 'SID']);
+    expect(specOf('opencode')?.resumeArgv).toEqual(['opencode', '--session', 'SID']);
+    expect(specOf('pi')?.resumeArgv).toEqual(['pi', '--session', 'SID']);
+    expect(specOf('copilot')?.resumeArgv).toEqual(['copilot', '--resume', 'SID']);
+    expect(specOf('junie')?.resumeArgv).toEqual(['junie', '--session-id', 'SID']);
+  });
+
+  it('offers fork only for agents with a verified CLI fork', () => {
+    expect(specOf('claude-code')?.forkArgv).toEqual(['claude', '--resume', 'SID', '--fork-session']);
+    expect(specOf('codex')?.forkArgv).toEqual(['codex', 'fork', 'SID']);
+    expect(specOf('opencode')?.forkArgv).toEqual(['opencode', '--session', 'SID', '--fork']);
+    expect(specOf('pi')?.forkArgv).toEqual(['pi', '--fork', 'SID']);
+    // Copilot's only fork is a broken in-session slash command; Junie has none.
+    expect(specOf('copilot')?.forkArgv).toBeUndefined();
+    expect(specOf('junie')?.forkArgv).toBeUndefined();
+  });
+});
+
+describe('buildResumeInfo', () => {
+  const claude = connectorById('claude-code');
+
+  it('produces resume + fork commands and reflects platform in canAutoOpen', () => {
+    const info = buildResumeInfo(claude, 'sessA', '/tmp/projA', true);
+    expect(info).toEqual({
+      cwd: '/tmp/projA',
+      resumeCommand: 'cd /tmp/projA && claude --resume sessA',
+      forkCommand: 'cd /tmp/projA && claude --resume sessA --fork-session',
+      canAutoOpen: true,
+    });
+    expect(buildResumeInfo(claude, 'sessA', '/tmp/projA', false)?.canAutoOpen).toBe(false);
+  });
+
+  it('omits forkCommand for a fork-less connector', () => {
+    const info = buildResumeInfo(connectorById('copilot'), 'cop1', '/tmp/p', true);
+    expect(info?.resumeCommand).toBe('cd /tmp/p && copilot --resume cop1');
+    expect(info?.forkCommand).toBeUndefined();
+  });
+
+  it('returns undefined when the session has no cwd', () => {
+    expect(buildResumeInfo(claude, 'sessA', null, true)).toBeUndefined();
+    expect(buildResumeInfo(claude, 'sessA', '', true)).toBeUndefined();
+  });
+});
+
+describe('resolveContinue (endpoint guards)', () => {
+  const spec = { resumeArgv: ['claude', '--resume', 'id'], forkArgv: ['claude', '--resume', 'id', '--fork-session'] };
+  const ok = { cwd: '/tmp/p', connectorLabel: 'Claude Code', isMac: true };
+
+  it('rejects an invalid mode before anything else', () => {
+    expect(resolveContinue(spec, { ...ok, mode: 'bogus' })).toMatchObject({ ok: false, status: 400 });
+  });
+
+  it('rejects auto-open on non-macOS even for a valid request', () => {
+    const r = resolveContinue(spec, { ...ok, mode: 'resume', isMac: false });
+    expect(r).toMatchObject({ ok: false, status: 400 });
+    if (!r.ok) expect(r.error).toMatch(/macOS/);
+  });
+
+  it('rejects when there is no spec or no cwd', () => {
+    expect(resolveContinue(null, { ...ok, mode: 'resume' })).toMatchObject({ ok: false, status: 400 });
+    expect(resolveContinue(spec, { ...ok, mode: 'resume', cwd: null })).toMatchObject({ ok: false, status: 400 });
+  });
+
+  it('rejects fork when the connector has no fork argv', () => {
+    const r = resolveContinue({ resumeArgv: ['copilot', '--resume', 'id'] }, { ...ok, mode: 'fork', connectorLabel: 'GitHub Copilot CLI' });
+    expect(r).toMatchObject({ ok: false, status: 400 });
+    if (!r.ok) expect(r.error).toMatch(/Fork is not supported/);
+  });
+
+  it('resolves the right argv for a valid resume and fork', () => {
+    expect(resolveContinue(spec, { ...ok, mode: 'resume' })).toEqual({ ok: true, cwd: '/tmp/p', argv: spec.resumeArgv });
+    expect(resolveContinue(spec, { ...ok, mode: 'fork' })).toEqual({ ok: true, cwd: '/tmp/p', argv: spec.forkArgv });
+  });
+});

--- a/packages/shared/src/api.ts
+++ b/packages/shared/src/api.ts
@@ -150,6 +150,23 @@ export type ProjectsResponse = ProjectMeta[];
 /** GET /api/sessions */
 export type SessionsResponse = SessionMeta[];
 
+/**
+ * How to reopen a session in the agent's own CLI. Present only when the
+ * session's connector knows a resume command (all current agents). The server
+ * is the single source of truth: it builds these strings from the indexed
+ * session id + cwd, so the client never constructs a command itself.
+ */
+export interface ResumeInfo {
+  /** Working directory the command runs in. */
+  cwd: string;
+  /** POSIX command that appends to the original session. */
+  resumeCommand: string;
+  /** POSIX command that forks into a new session; absent when the agent has no CLI fork. */
+  forkCommand?: string;
+  /** True when this server can open a terminal itself (macOS only). */
+  canAutoOpen: boolean;
+}
+
 /** GET /api/sessions/:id */
 export interface SessionDetailResponse {
   meta: SessionMeta;
@@ -157,6 +174,18 @@ export interface SessionDetailResponse {
   thread: ThreadItem[];
   /** Subagent runs, each linked to its spawn point via `toolUseId`/`spawnUuid`. */
   subagents: SubagentRun[];
+  /** Resume/fork commands for this session, when the connector supports it. */
+  resume?: ResumeInfo;
+}
+
+/** POST /api/sessions/:id/continue — open the session in the agent's CLI (macOS). */
+export interface ContinueRequest {
+  mode: 'resume' | 'fork';
+}
+
+/** POST /api/sessions/:id/continue response. */
+export interface ContinueResponse {
+  launched: boolean;
 }
 
 /** A full-text search hit in agent memory (instruction file or distilled fact). */

--- a/packages/web/src/api/client.ts
+++ b/packages/web/src/api/client.ts
@@ -7,6 +7,7 @@
 import type {
   AnalyticsGroupBy,
   AnalyticsResponse,
+  ContinueResponse,
   HealthResponse,
   MemoryResponse,
   ProjectMemoryResponse,
@@ -120,6 +121,19 @@ export const api = {
   /** GET /api/sessions/:id */
   getSession(id: string, signal?: AbortSignal): Promise<SessionDetailResponse> {
     return request<SessionDetailResponse>(`/sessions/${encodeURIComponent(id)}`, { signal });
+  },
+
+  /** POST /api/sessions/:id/continue — open the session in the agent's CLI (macOS). */
+  continueSession(
+    id: string,
+    mode: 'resume' | 'fork',
+    signal?: AbortSignal,
+  ): Promise<ContinueResponse> {
+    return request<ContinueResponse>(`/sessions/${encodeURIComponent(id)}/continue`, {
+      method: 'POST',
+      body: { mode },
+      signal,
+    });
   },
 
   /** GET /api/search?q=&project=&type= */

--- a/packages/web/src/pages/session/ContinueMenu.tsx
+++ b/packages/web/src/pages/session/ContinueMenu.tsx
@@ -1,0 +1,131 @@
+import { useEffect, useRef, useState } from 'react';
+import type { ResumeInfo } from '@claudescope/shared';
+import { api } from '../../api/client.js';
+
+type Mode = 'resume' | 'fork';
+type LaunchState = 'idle' | 'launching' | 'launched' | 'error';
+
+/** A copy-paste command line with its own Copy button. */
+function CommandRow({ command }: { command: string }) {
+  const [copied, setCopied] = useState(false);
+  const copy = async () => {
+    try {
+      await navigator.clipboard.writeText(command);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1500);
+    } catch {
+      /* clipboard unavailable; ignore */
+    }
+  };
+  return (
+    <div className="tv-continue__cmd">
+      <code className="tv-continue__cmd-text">{command}</code>
+      <button type="button" className="tv-linkbtn" onClick={copy}>
+        {copied ? 'Copied!' : 'Copy'}
+      </button>
+    </div>
+  );
+}
+
+/**
+ * "Continue" dropdown: reopen a session in the agent's own CLI. On macOS the
+ * server opens the user's default terminal running the command; elsewhere we
+ * show the command to copy and run manually. Rendered only when the session's
+ * connector exposes a resume command.
+ */
+export function ContinueMenu({ sessionId, resume }: { sessionId: string; resume: ResumeInfo }) {
+  const [open, setOpen] = useState(false);
+  const [state, setState] = useState<LaunchState>('idle');
+  const ref = useRef<HTMLDetailsElement>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    const onDoc = (e: MouseEvent) => {
+      if (ref.current && !ref.current.contains(e.target as Node)) setOpen(false);
+    };
+    const onKey = (e: KeyboardEvent) => e.key === 'Escape' && setOpen(false);
+    document.addEventListener('mousedown', onDoc);
+    document.addEventListener('keydown', onKey);
+    return () => {
+      document.removeEventListener('mousedown', onDoc);
+      document.removeEventListener('keydown', onKey);
+    };
+  }, [open]);
+
+  const launch = async (mode: Mode) => {
+    setState('launching');
+    try {
+      await api.continueSession(sessionId, mode);
+      setState('launched');
+      setTimeout(() => setState('idle'), 2500);
+    } catch {
+      setState('error');
+    }
+  };
+
+  const commandFor = (mode: Mode) => (mode === 'fork' ? resume.forkCommand : resume.resumeCommand);
+
+  return (
+    <details ref={ref} className="tv-continue" open={open}>
+      <summary
+        onClick={(e) => {
+          e.preventDefault();
+          setOpen((o) => !o);
+        }}
+      >
+        ▷ Continue
+      </summary>
+      <div className="tv-continue__menu">
+        {resume.canAutoOpen ? (
+          <>
+            <p className="tv-continue__hint">Opens in your default terminal.</p>
+            <div className="tv-continue__actions">
+              <button
+                type="button"
+                className="tv-linkbtn"
+                disabled={state === 'launching'}
+                onClick={() => launch('resume')}
+              >
+                Resume
+              </button>
+              {resume.forkCommand ? (
+                <button
+                  type="button"
+                  className="tv-linkbtn"
+                  disabled={state === 'launching'}
+                  onClick={() => launch('fork')}
+                  title="Continue in a new session, leaving this transcript untouched"
+                >
+                  Fork to new session
+                </button>
+              ) : null}
+            </div>
+            {state === 'launched' ? (
+              <p className="tv-continue__status">Opening in your terminal…</p>
+            ) : null}
+            {state === 'error' ? (
+              <>
+                <p className="tv-continue__status tv-continue__status--err">
+                  Couldn’t open a terminal. Run it yourself:
+                </p>
+                <CommandRow command={resume.resumeCommand} />
+                {resume.forkCommand ? <CommandRow command={resume.forkCommand} /> : null}
+              </>
+            ) : null}
+          </>
+        ) : (
+          <>
+            <p className="tv-continue__hint">Run this in your terminal:</p>
+            <CommandRow command={commandFor('resume') as string} />
+            {resume.forkCommand ? (
+              <>
+                <p className="tv-continue__hint">Or fork into a new session:</p>
+                <CommandRow command={resume.forkCommand} />
+              </>
+            ) : null}
+          </>
+        )}
+      </div>
+    </details>
+  );
+}

--- a/packages/web/src/pages/session/SessionPage.tsx
+++ b/packages/web/src/pages/session/SessionPage.tsx
@@ -10,6 +10,7 @@ import { useProgressiveMount } from './useProgressiveMount.js';
 import { ChangesetPanel } from './ChangesetPanel.js';
 import { buildChangeset } from './changeset.js';
 import { ExportMenu } from './ExportMenu.js';
+import { ContinueMenu } from './ContinueMenu.js';
 import { SessionSearchContext } from './SearchContext.js';
 import {
   buildSearchCorpus,
@@ -363,6 +364,7 @@ function SessionView({
             ) : null}
           </nav>
           <SubagentJumpMenu subagents={subagents} />
+          {data.resume ? <ContinueMenu sessionId={meta.id} resume={data.resume} /> : null}
           <ExportMenu data={data} />
           <button
             type="button"

--- a/packages/web/src/pages/session/session.css
+++ b/packages/web/src/pages/session/session.css
@@ -443,6 +443,72 @@
   padding-top: var(--tv-space-2);
 }
 
+/* ── Continue (resume / fork) dropdown ────────────────────────────────── */
+
+.tv-continue {
+  position: relative;
+  display: inline-block;
+}
+.tv-continue > summary {
+  cursor: pointer;
+  list-style: none;
+  font-size: var(--tv-fs-sm);
+  color: var(--tv-accent);
+  user-select: none;
+}
+.tv-continue > summary::-webkit-details-marker {
+  display: none;
+}
+.tv-continue__menu {
+  position: absolute;
+  z-index: 20;
+  top: calc(100% + var(--tv-space-1));
+  left: 0;
+  width: 340px;
+  max-width: 80vw;
+  padding: var(--tv-space-2);
+  background: var(--tv-bg-elevated);
+  border: 1px solid var(--tv-border-strong);
+  border-radius: var(--tv-radius);
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.4);
+}
+.tv-continue__hint {
+  margin: 0 0 var(--tv-space-2);
+  font-size: var(--tv-fs-sm);
+  color: var(--tv-fg-muted);
+}
+.tv-continue__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--tv-space-3);
+}
+.tv-continue__status {
+  margin: var(--tv-space-2) 0 0;
+  font-size: var(--tv-fs-sm);
+  color: var(--tv-fg-muted);
+}
+.tv-continue__status--err {
+  color: var(--tv-danger, #e5534b);
+}
+.tv-continue__cmd {
+  display: flex;
+  align-items: center;
+  gap: var(--tv-space-2);
+  margin-bottom: var(--tv-space-2);
+}
+.tv-continue__cmd-text {
+  flex: 1;
+  min-width: 0;
+  overflow-x: auto;
+  white-space: nowrap;
+  padding: var(--tv-space-1) var(--tv-space-2);
+  background: var(--tv-bg-inset);
+  border: 1px solid var(--tv-border);
+  border-radius: var(--tv-radius-sm);
+  font-size: var(--tv-fs-sm);
+  color: var(--tv-fg);
+}
+
 /* ── In-session finder ────────────────────────────────────────────────── */
 
 .tv-finder {


### PR DESCRIPTION
## What this does

Adds a **Continue** action to the session view that reopens a session in the agent's own CLI:

- A per-connector `resumeSpec()` builds the command — **resume** for all six agents (Claude Code, Codex, opencode, pi, Copilot, Junie), **fork** for the four with a CLI fork (Claude/Codex/opencode/pi).
- On **macOS**, the server writes a `.command` launcher to `~/.claudescope/launchers/` and `open`s it; other platforms show the command to copy.
- The browser sends only `{ mode }`; the server rebuilds argv from the indexed session id + cwd, shell-quoting the cwd.

Plan: `docs/plans/0024-continue-session.md`. Tests: command construction (quoting/injection), per-connector verbs, endpoint guards. Verified end-to-end against an isolated synthetic dataset.

## ⚠️ Why this is being closed, not merged

Two problems surfaced that undermine the auto-open mechanism:

1. **Can't reliably open the user's default terminal.** macOS has no "default terminal" setting (unlike default browser). `open foo.command` routes to whatever handles `.command` — for virtually everyone who never changed it, that's **Terminal.app**, even when they live in iTerm/Ghostty/Warp. A cold Terminal.app launch is also slow. Using a `.sh` extension doesn't help: `open foo.sh` opens the file in the default `.sh` handler (usually a text editor), so it wouldn't run.

2. **Security.** The `/continue` endpoint writes an **executable script** and **spawns a process** to run it. Any web page in the user's browser can `POST http://127.0.0.1:4317/api/sessions/<id>/continue` (classic localhost CSRF) and make the machine open a terminal and run an agent command — a real escalation away from a read-only viewer.

## Follow-up

Superseded by a simpler approach: **copy-the-command only, on all platforms** — no exec endpoint, no executable scripts, server stays fully read-only. See the follow-up PR.