### PR TITLE
feat: continue a session by copying the agent's resume command

### DIFF
--- a/docs/plans/0024-continue-session.md
+++ b/docs/plans/0024-continue-session.md
@@ -1,0 +1,247 @@
+# 0024 — Continue session from transcript (terminal auto-open)
+
+- **Status:** abandoned <!-- proposed | in-progress | done | superseded | abandoned -->
+- **Date:** 2026-06-17
+- **PR:** [#30](https://github.com/vladar107/claudescope/pull/30) (closed, not merged)
+
+> **Abandoned.** This plan's distinguishing idea — having the server **auto-open
+> the user's terminal** (write a macOS `.command` launcher and `open` it) — does
+> not work in practice and was dropped. Two reasons:
+>
+> 1. **No reliable "default terminal" on macOS.** `open foo.command` routes to
+>    whatever handles `.command`, which for virtually everyone is **Terminal.app**
+>    (slow cold start), not their iTerm/Ghostty/Warp. A `.sh` extension is worse —
+>    `open foo.sh` launches a text editor, not a shell.
+> 2. **Security.** The `POST /continue` endpoint writes an executable script and
+>    spawns a process to run it; a browser page could `POST` to `localhost:4317`
+>    (localhost CSRF) and trigger terminal execution — a real escalation away from
+>    a read-only viewer.
+>
+> The per-connector resume **commands** (`resumeSpec`) and the verified per-agent
+> CLI research below are still good and carry forward. Superseded by
+> [0025 — copy the command](./0025-continue-session-copy-command.md), which keeps
+> the commands but drops auto-open: the UI just shows the command to copy, on every
+> platform, and the server stays fully read-only.
+
+## Context
+
+Claudescope is a read-only viewer. A natural next step while reading a transcript
+is to **pick the work back up** in the agent that produced it. Every agent we
+support can reopen a session from its own store, and **we already know which agent
+a session belongs to** (`connectorId`) — so we never guess. We just hand the user
+the right command for that agent and (on macOS) launch it.
+
+The hard constraint: **Claudescope must stay read-only w.r.t. agent sources**
+(`~/.claude`, `~/.codex`, …). We honor that by never writing to a source
+ourselves. Resuming appends to the agent's own store — but the *agent* does that
+write, invoked by the user; Claudescope only emits a command and (on macOS) opens
+a terminal. Fork mode mutates nothing.
+
+There is no portable "default terminal emulator" API on any OS. But on macOS we
+don't need one: `open foo.command` routes a shell-script file to whatever app is
+registered as the handler for `.command` (Terminal.app by default, or the user's
+chosen iTerm/Ghostty/…). That *is* their default terminal as the OS sees it, and
+it runs through a login shell, so the agent binary resolves on `PATH` normally.
+
+**Verified resume CLIs (June 2026 docs/repos).** All six supported agents have a
+non-interactive, by-id resume command; four also have a fork that leaves the
+original untouched:
+
+| Agent | Resume (append) | Fork (new session) | id passed |
+| --- | --- | --- | --- |
+| Claude Code | `claude --resume <id>` | `claude --resume <id> --fork-session` | `.jsonl` filename UUID |
+| Codex | `codex resume <id>` | `codex fork <id>` | rollout filename UUID |
+| opencode | `opencode --session <id>` | `opencode --session <id> --fork` | `ses_…` id |
+| pi | `pi --session <id>` | `pi --fork <id>` | session id (partial ok) |
+| Copilot CLI | `copilot --resume <id>` | — (no CLI fork) | `session-state/<uuid>` dir name |
+| Junie | `junie --session-id <id>` | — (no CLI fork) | `session-…` id |
+
+Each is wrapped as `cd '<cwd>' && <command>`. cwd is strictly required only for
+Claude Code (id lookup is scoped to the project dir); for the others it's not
+required but we still `cd` so the agent starts in the right project.
+
+## Goal
+
+From a session view, offer **Continue** — **Resume** (append) for every agent,
+plus **Fork** (new session) for the agents that support it. On **macOS**, clicking
+opens the user's default terminal already running the command. On **every other
+platform**, show the exact command with a **Copy** button.
+
+## Decisions
+
+- **All agents, per-connector — never guess** — the agent is known from
+  `connectorId`; each connector encodes its own resume command via an optional
+  `resumeSpec()` on the `AgentConnector` port. No `if connectorId === …` branching
+  in routes/UI; adding/adjusting an agent is a one-connector change.
+- **Resume for all six; fork only where verified** — Claude Code, Codex,
+  opencode, pi have a real fork/branch CLI; Copilot CLI and Junie don't (Copilot's
+  `/fork` is an in-session command, version-dependent and broken in some builds;
+  Junie's CLI has no fork flag). The Fork item appears only when the connector's
+  spec provides a fork command. Rejected: a cross-agent "handoff prompt" — lossy,
+  not asked for in v1.
+- **No install / PATH precheck — just try to launch** — we do not probe for the
+  agent binary, its version, or whether the session is resolvable. We build the
+  command and run it; if the binary is missing or the agent can't find the
+  session, the terminal shows the error. Simpler, and avoids a brittle probe that
+  could wrongly hide the action.
+- **macOS auto-open via a `.command` launcher + `open`** — respects the user's
+  default terminal without detecting it; login-shell `PATH` resolves the agent.
+  Rejected: spawning the agent directly from the server (non-login `PATH` often
+  can't find the binary, and no visible window); hardcoding Terminal.app (ignores
+  the user's choice); an embedded xterm.js terminal (heavy new surface for v1).
+- **Other platforms: copy-command only** — Linux has no reliable default-terminal
+  mechanism and Windows' is awkward to read; we degrade to a Copy button rather
+  than half-implement auto-open.
+- **Server is the single source of truth for the command** — the browser sends
+  only `{ mode }`; the server builds argv from the **indexed** `sessionId`/`cwd`
+  via the connector, never from a client-supplied string. This keeps the new exec
+  endpoint from becoming a "run anything" hole — a real concern to constrain even
+  on a localhost single-user app.
+- **Launcher lives in `~/.claudescope/launchers/`** — app-owned state, never an
+  agent source. Overwritten per `(session, mode)`; chmod `700`.
+
+## Approach
+
+1. **Shared types** (`packages/shared/src/api.ts`): add an optional `resume`
+   field to `SessionDetailResponse`:
+   ```ts
+   export interface ResumeInfo {
+     cwd: string;
+     /** POSIX command that appends to the original session. */
+     resumeCommand: string;
+     /** POSIX command that forks into a new session; absent when unsupported. */
+     forkCommand?: string;
+     /** True when this server can open a terminal itself (macOS only). */
+     canAutoOpen: boolean;
+   }
+   ```
+   Present for every session whose connector implements `resumeSpec` (all of them,
+   at launch). Add `ContinueRequest { mode: 'resume' | 'fork' }` /
+   `ContinueResponse { launched: boolean }` for the new endpoint.
+
+2. **Connector port** (`connectors/types.ts`): add
+   ```ts
+   /** Optional: how to reopen this session in the agent's own CLI, or null. */
+   resumeSpec?(sessionId: string, cwd: string): ResumeSpec | null;
+   interface ResumeSpec {
+     cwd: string;
+     /** argv to exec in cwd, e.g. ['claude','--resume','<id>']. */
+     resumeArgv: string[];
+     /** fork argv; omit when the agent has no CLI fork. */
+     forkArgv?: string[];
+   }
+   ```
+   Structured argv (not a pre-joined string) so the copy command and the launcher
+   script are both derived without re-quoting twice. The connector maps **our**
+   indexed `sessionId` to the agent's native resume id — important for opencode
+   (`ses_…`) and Junie (`session-…`), where the native id may differ from a naive
+   filename slug.
+
+3. **Per-connector `resumeSpec`** (one method each):
+   - `claude-code`: `['claude','--resume',id]` / `['claude','--resume',id,'--fork-session']`
+   - `codex`: `['codex','resume',id]` / `['codex','fork',id]`
+   - `opencode`: `['opencode','--session',nativeId]` / `[…,'--fork']`
+   - `pi`: `['pi','--session',id]` / `['pi','--fork',id]`
+   - `copilot`: `['copilot','--resume',id]` (no fork)
+   - `junie`: `['junie','--session-id',id]` (no fork)
+
+4. **Command construction** (new `connectors/resume.ts` — pure, testable): given a
+   `ResumeSpec`, produce (a) the POSIX display command `cd <q(cwd)> && <q(argv)>`
+   and (b) the `.command` launcher body. A single `shQuote()` helper (single-quote
+   + `'\''` escaping) handles arbitrary cwd paths; argv tokens are quoted the same
+   way.
+
+5. **Session detail route** (`routes/sessions.ts`): the handler already has the
+   session row → read `project_cwd`, resolve the connector, call
+   `resumeSpec(id, cwd)`. If non-null, attach `resume` to the response (commands
+   from step 4; `canAutoOpen = process.platform === 'darwin'`).
+
+6. **Continue endpoint** (`routes/sessions.ts`):
+   `POST /api/sessions/:id/continue` with `{ mode }`. Guards: 404 unknown session;
+   400 if the connector has no `resumeSpec` or `mode === 'fork'` without a fork
+   argv; 400 with a clear "macOS-only — use Copy" message when
+   `process.platform !== 'darwin'`. On success: write the launcher to
+   `~/.claudescope/launchers/<mode>-<id>.command` (script = `#!/bin/bash` +
+   `cd <q(cwd)> &&` + `exec <q(argv)>`), `chmod 0700`,
+   `spawn('open', [path], { detached:true }).unref()`, return `{ launched: true }`.
+   **No install/existence checks** beyond these — a missing binary surfaces in the
+   terminal. Keep the spawn behind a thin, injectable seam so command-building
+   stays unit-testable without launching anything.
+
+7. **Paths** (`paths.ts`): add `launchersDir()` under the app home; ensure it
+   exists before writing.
+
+8. **Web client** (`api/client.ts`): add `continueSession(id, mode)`.
+
+9. **Web UI** (`pages/session/`): a `ContinueMenu` next to `ExportMenu` in the
+   session header (`SessionPage.tsx:366`), mirroring `ExportMenu`'s dropdown.
+   Rendered whenever `data.resume` is present (all agents). Item **Resume** always;
+   **Fork to new session** only when `resume.forkCommand` exists.
+   - `canAutoOpen` → click POSTs `/continue`; toast on success ("Opening in your
+     terminal…"), and on error fall back to showing the command + Copy.
+   - else → reveal the command with a Copy-to-clipboard button and a "Run this in
+     your terminal" hint.
+
+## Files affected
+
+- `packages/shared/src/api.ts` — `ResumeInfo`, `resume?` on
+  `SessionDetailResponse`, `ContinueRequest`/`ContinueResponse`.
+- `packages/server/src/connectors/types.ts` — optional `resumeSpec()` + `ResumeSpec`.
+- `packages/server/src/connectors/{claude-code,codex,opencode,pi,copilot,junie}/*.ts`
+  — implement `resumeSpec` for each.
+- `packages/server/src/connectors/resume.ts` *(new)* — `shQuote`, display-command
+  and launcher-script builders (pure).
+- `packages/server/src/routes/sessions.ts` — attach `resume` to detail response;
+  add `POST /api/sessions/:id/continue`.
+- `packages/server/src/paths.ts` (or equivalent) — `launchersDir()`.
+- `packages/web/src/api/client.ts` — `continueSession()`.
+- `packages/web/src/pages/session/ContinueMenu.tsx` *(new)* + wiring in
+  `SessionPage.tsx`; small CSS in `session.css`.
+
+## Testing
+
+`npm test` + `npm run typecheck`. Focus on the bug-prone edges, not glue:
+
+- **Command construction (pure, the core):** for each connector's spec, the
+  resume/fork argv produce the expected POSIX command and launcher body; a cwd
+  with spaces, quotes, `$`, and an injection attempt (`'; rm -rf ~ #`) stays inert
+  inside the single-quote escaping.
+- **Per-connector mapping:** each connector returns the right verb/flag
+  (`resume`/`fork` for Codex, `--session`/`--fork` for opencode, `--session-id`
+  for Junie, no `forkArgv` for Copilot/Junie). opencode maps the indexed id to its
+  `ses_…` native id.
+- **Endpoint guards:** unknown id → 404; `mode:'fork'` on a fork-less connector →
+  400; non-darwin platform (simulated via the platform seam) → 400 "macOS-only";
+  invalid `mode` → 400. The `open` spawn is stubbed — no real launch in tests.
+- Manual (macOS): for at least Claude Code and one other agent, Resume opens the
+  default terminal in the right cwd; Fork (where present) adds the fork flag and
+  the original transcript is unchanged.
+
+## Risks / open questions
+
+- **Shell-injection via cwd** — the one real safety issue; mitigated by `shQuote`
+  on every interpolated value and never accepting a command string from the
+  client. Covered by tests.
+- **opencode native id** — the connector must pass the real `ses_…` id, not the
+  synthetic `<dbPath>#<id>` discovery key. Verify what the index stores as
+  `session_id` for opencode and map accordingly.
+- **Junie IDE-session interop** — `junie --session-id` is verified for Junie *CLI*
+  sessions; it's unconfirmed whether it can reopen an *IDE-originated* session
+  (what our connector reads). Per the "just try to launch" decision we emit it
+  anyway; if it can't, the terminal shows the error. (Also: CLAUDE.md's "Junie is
+  IDE-only" note is now outdated — a Junie CLI exists as of ~Apr 2026.)
+- **Copilot has no CLI fork** — Fork item hidden for Copilot and Junie; resume
+  only.
+- **Agent not installed / not on `PATH` / session unresolvable** — by decision we
+  don't precheck; the terminal window shows the shell/agent error. Acceptable and
+  visible.
+- **`open` honors a non-terminal `.command` handler** — if the user remapped
+  `.command`, behavior is theirs to own. Acceptable edge.
+- **Remote/SSH** — if the server runs on a different host than the browser,
+  "open terminal" opens on the *server* host. Out of scope; Claudescope is a local
+  single-user tool by design.
+- **Windows copy command** — we emit a POSIX `cd … && …` string; fine for
+  WSL/git-bash (where these agents typically run), not native `cmd`. Note it; don't
+  special-case unless asked.
+- **Launcher cleanup** — files are tiny and overwritten per `(session, mode)`;
+  prune on write if accumulation ever matters. Minor follow-up.

--- a/docs/plans/0025-continue-session-copy-command.md
+++ b/docs/plans/0025-continue-session-copy-command.md
@@ -1,8 +1,8 @@
 # 0025 — Continue session: copy the command
 
-- **Status:** in-progress <!-- proposed | in-progress | done | superseded | abandoned -->
+- **Status:** done <!-- proposed | in-progress | done | superseded | abandoned -->
 - **Date:** 2026-06-17
-- **PR:** <link, once opened>
+- **PR:** [#31](https://github.com/vladar107/claudescope/pull/31)
 
 ## Context
 

--- a/docs/plans/0025-continue-session-copy-command.md
+++ b/docs/plans/0025-continue-session-copy-command.md
@@ -1,0 +1,93 @@
+# 0025 — Continue session: copy the command
+
+- **Status:** in-progress <!-- proposed | in-progress | done | superseded | abandoned -->
+- **Date:** 2026-06-17
+- **PR:** <link, once opened>
+
+## Context
+
+Supersedes [0024](./0024-continue-session.md), which tried to have the server
+**auto-open** the user's terminal. That was abandoned: macOS has no reliable
+"default terminal" (a `.command` launcher always lands in Terminal.app, slowly),
+and an endpoint that writes+executes a script is a localhost-CSRF risk — a real
+escalation away from a read-only viewer. See 0024 for the full write-up and the
+verified per-agent CLI research.
+
+What survives is the useful, safe half: we already know each session's agent
+(`connectorId`) and its native id, so we can show the exact command to reopen it.
+The user copies it and runs it in whatever terminal they already have.
+
+## Goal
+
+From a session view, a **Continue** dropdown shows the command to reopen the
+session in its agent's own CLI — **Resume** (append) for every agent, plus
+**Fork** (new session) for the agents whose CLI supports it — each with a Copy
+button. Same on every platform. The server only builds and returns strings; it
+never spawns anything.
+
+## Decisions
+
+- **Copy-only, no auto-open** — the server returns command strings; the UI shows
+  them with a Copy button. Drops the `POST /continue` endpoint, the `.command`
+  launcher, and the `open` spawn entirely, so the server stays fully read-only.
+  This is the whole point of the supersession (see 0024's abandonment note).
+- **All agents, per-connector** — an optional `resumeSpec()` on the connector
+  port returns the argv; the agent is taken from `connectorId`, never guessed.
+  Resume for all six; fork only where the CLI supports it (Claude Code, Codex,
+  opencode, pi — not Copilot or Junie).
+- **Verified per-agent commands** (carried over from 0024's research):
+  `claude --resume <id>` (`--fork-session`), `codex resume <id>` / `codex fork`,
+  `opencode --session <id>` (`--fork`), `pi --session <id>` / `pi --fork`,
+  `copilot --resume <id>`, `junie --session-id <id>`. Wrapped as
+  `cd <cwd> && <cmd>`.
+- **No id remapping needed** — every connector already indexes the agent's native
+  id as `session_id`, so `resumeSpec` uses it verbatim.
+- **Shell-quote the cwd** — the only free-form value in the command. `shQuote`
+  (shlex-style: bare when safe, else single-quoted with `'\''` escaping) keeps a
+  hostile cwd inert even though the string is only ever displayed.
+
+## Approach
+
+1. **Shared** (`packages/shared/src/api.ts`): `ResumeInfo { cwd, resumeCommand,
+   forkCommand? }` and optional `resume?` on `SessionDetailResponse`.
+2. **Connector port** (`connectors/types.ts`): optional
+   `resumeSpec(sessionId): ResumeSpec | null` with `ResumeSpec { resumeArgv,
+   forkArgv? }`; implement on all six connectors.
+3. **Pure builder** (`connectors/resume.ts`): `shQuote`, `displayCommand`,
+   `buildResumeInfo` — no side effects.
+4. **Route** (`routes/sessions.ts`): attach `resume` to the session detail
+   response (via `buildResumeInfo`). No new endpoint.
+5. **Web**: `ContinueMenu` dropdown next to Export — shows the resume command
+   (and fork command when present) with Copy buttons; rendered when
+   `data.resume` is set.
+
+## Files affected
+
+- `packages/shared/src/api.ts` — `ResumeInfo`, `resume?` on `SessionDetailResponse`.
+- `packages/server/src/connectors/types.ts` — `resumeSpec()` + `ResumeSpec`.
+- `packages/server/src/connectors/{claude-code,codex,opencode,pi,copilot,junie}/*.ts`
+  — implement `resumeSpec`.
+- `packages/server/src/connectors/resume.ts` *(new)* — pure command builders.
+- `packages/server/src/routes/sessions.ts` — attach `resume` to detail response.
+- `packages/web/src/api/client.ts` — (no new method; `resume` rides on the detail).
+- `packages/web/src/pages/session/ContinueMenu.tsx` *(new)* + wiring in
+  `SessionPage.tsx`; CSS in `session.css`.
+
+## Testing
+
+`npm test` + `npm run typecheck`.
+
+- **Command construction (pure):** cwd quoting/injection (spaces, `$`,
+  `'; rm -rf ~ #` stays inert), each connector's resume/fork verbs, fork omitted
+  for Copilot/Junie, `buildResumeInfo` returns undefined without a cwd.
+- **Integration:** the session detail response carries the right `resume` object
+  for a Claude fixture.
+
+## Risks / open questions
+
+- **Native id assumptions** — opencode (`ses_…`) and Junie (`session-…`) ids must
+  match what their CLI expects; verified against the indexed `session_id`. Junie
+  CLI resuming an *IDE-originated* session is still unconfirmed, but since we only
+  display the command, a wrong guess just means the pasted command errors visibly.
+- **Windows copy command** — emitted as POSIX `cd … && …`; fine for WSL/git-bash,
+  not native `cmd`. Acceptable; not special-cased.

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -49,4 +49,4 @@ decision, or a change worth explaining before doing. Skip it for one-line fixes.
 | 0022 | [Security & quality fixes: image CSP, Junie path containment, deterministic PR link, memory/search logging, Windows support](./0022-security-quality-fixes.md) | proposed |
 | 0023 | [Structured rendering for command turns (slash/bash tags)](./0023-command-turn-rendering.md) | done |
 | 0024 | [Continue session from transcript (terminal auto-open)](./0024-continue-session.md) | abandoned |
-| 0025 | [Continue session: copy the command](./0025-continue-session-copy-command.md) | in-progress |
+| 0025 | [Continue session: copy the command](./0025-continue-session-copy-command.md) | done |

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -48,3 +48,5 @@ decision, or a change worth explaining before doing. Skip it for one-line fixes.
 | 0021 | [GitHub Copilot CLI connector](./0021-copilot-connector.md) | done |
 | 0022 | [Security & quality fixes: image CSP, Junie path containment, deterministic PR link, memory/search logging, Windows support](./0022-security-quality-fixes.md) | proposed |
 | 0023 | [Structured rendering for command turns (slash/bash tags)](./0023-command-turn-rendering.md) | done |
+| 0024 | [Continue session from transcript (terminal auto-open)](./0024-continue-session.md) | abandoned |
+| 0025 | [Continue session: copy the command](./0025-continue-session-copy-command.md) | in-progress |

--- a/packages/server/src/connectors/claude-code/claude-code.ts
+++ b/packages/server/src/connectors/claude-code/claude-code.ts
@@ -296,4 +296,8 @@ export const claudeCodeConnector: AgentConnector = {
   loadSession,
   globalMemory,
   projectMemory,
+  resumeSpec: (id) => ({
+    resumeArgv: ['claude', '--resume', id],
+    forkArgv: ['claude', '--resume', id, '--fork-session'],
+  }),
 };

--- a/packages/server/src/connectors/codex/codex.ts
+++ b/packages/server/src/connectors/codex/codex.ts
@@ -100,4 +100,8 @@ export const codexConnector: AgentConnector = {
   auxProjections,
   loadSession,
   globalMemory: codexGlobalMemory,
+  resumeSpec: (id) => ({
+    resumeArgv: ['codex', 'resume', id],
+    forkArgv: ['codex', 'fork', id],
+  }),
 };

--- a/packages/server/src/connectors/copilot/copilot.ts
+++ b/packages/server/src/connectors/copilot/copilot.ts
@@ -110,4 +110,6 @@ export const copilotConnector: AgentConnector = {
   auxProjections,
   loadSession,
   globalMemory: copilotGlobalMemory,
+  // Copilot CLI has no command-line fork (only an in-session `/fork`), so resume only.
+  resumeSpec: (id) => ({ resumeArgv: ['copilot', '--resume', id] }),
 };

--- a/packages/server/src/connectors/junie/junie.ts
+++ b/packages/server/src/connectors/junie/junie.ts
@@ -149,4 +149,6 @@ export const junieConnector: AgentConnector = {
   auxProjections,
   loadSession,
   globalMemory,
+  // Junie CLI resumes by id; it has no command-line fork, so resume only.
+  resumeSpec: (id) => ({ resumeArgv: ['junie', '--session-id', id] }),
 };

--- a/packages/server/src/connectors/opencode/opencode.ts
+++ b/packages/server/src/connectors/opencode/opencode.ts
@@ -116,4 +116,8 @@ export const opencodeConnector: AgentConnector = {
   eventsProjectionSql,
   auxProjections,
   loadSession,
+  resumeSpec: (id) => ({
+    resumeArgv: ['opencode', '--session', id],
+    forkArgv: ['opencode', '--session', id, '--fork'],
+  }),
 };

--- a/packages/server/src/connectors/pi/pi.ts
+++ b/packages/server/src/connectors/pi/pi.ts
@@ -102,4 +102,8 @@ export const piConnector: AgentConnector = {
   eventsProjectionSql,
   auxProjections,
   loadSession,
+  resumeSpec: (id) => ({
+    resumeArgv: ['pi', '--session', id],
+    forkArgv: ['pi', '--fork', id],
+  }),
 };

--- a/packages/server/src/connectors/resume.ts
+++ b/packages/server/src/connectors/resume.ts
@@ -1,0 +1,58 @@
+/**
+ * Pure command construction for "continue session" — builds the copy-paste
+ * command that reopens a session in its agent's own CLI. Side-effect-free and
+ * fully unit-tested; the server only ever hands these strings to the UI to
+ * display, never executes them.
+ *
+ * Security note: the only free-form input is the session's own indexed `cwd`,
+ * and `shQuote` neutralizes it — so even if the user copies and runs the
+ * command, a hostile cwd can't break out of the `cd` argument.
+ */
+
+import type { ResumeInfo } from '@claudescope/shared';
+import type { AgentConnector } from './types.js';
+
+/** Characters safe to leave unquoted in a POSIX shell (the shlex.quote allowlist). */
+const SHELL_SAFE = /^[A-Za-z0-9_@%+=:,./-]+$/;
+
+/**
+ * Quote a string for a POSIX shell, shlex-style: leave it bare when it's only
+ * safe characters (so the command reads cleanly), otherwise single-quote it and
+ * neutralize any embedded quote with `'\''`. This is the injection guard for the
+ * session's `cwd`.
+ */
+export function shQuote(s: string): string {
+  if (s === '') return "''";
+  if (SHELL_SAFE.test(s)) return s;
+  return `'${s.replace(/'/g, `'\\''`)}'`;
+}
+
+/** Quote an argv into a single command fragment. */
+function quoteArgv(argv: string[]): string {
+  return argv.map(shQuote).join(' ');
+}
+
+/** The copy-paste command: cd into the project, then run the agent. */
+export function displayCommand(cwd: string, argv: string[]): string {
+  return `cd ${shQuote(cwd)} && ${quoteArgv(argv)}`;
+}
+
+/**
+ * Assemble the client-facing {@link ResumeInfo} for a session, or `undefined`
+ * when it can't be resumed (no cwd, or the connector has no resume command).
+ */
+export function buildResumeInfo(
+  connector: AgentConnector,
+  sessionId: string,
+  cwd: string | null,
+): ResumeInfo | undefined {
+  if (!cwd) return undefined;
+  const spec = connector.resumeSpec?.(sessionId);
+  if (!spec) return undefined;
+  const info: ResumeInfo = {
+    cwd,
+    resumeCommand: displayCommand(cwd, spec.resumeArgv),
+  };
+  if (spec.forkArgv) info.forkCommand = displayCommand(cwd, spec.forkArgv);
+  return info;
+}

--- a/packages/server/src/connectors/types.ts
+++ b/packages/server/src/connectors/types.ts
@@ -124,6 +124,26 @@ export interface AgentConnector {
    * of scope: surfacing it would require reading arbitrary project dirs.)
    */
   projectMemory?(): AgentMemoryDir[];
+
+  /**
+   * Optional: how to reopen this session in the agent's own CLI. Returns the
+   * argv to exec (the server wraps it with `cd <cwd> && …`), or null when the
+   * agent has no resume command. `sessionId` is the indexed session id, which
+   * for every current connector is already the native id the CLI expects.
+   */
+  resumeSpec?(sessionId: string): ResumeSpec | null;
+}
+
+/**
+ * The command(s) to reopen a session in an agent's CLI, as structured argv so
+ * the copy-paste string and the macOS launcher script are both derived from the
+ * same tokens (quoted once, in `connectors/resume.ts`).
+ */
+export interface ResumeSpec {
+  /** argv that appends to the original session, e.g. `['claude','--resume',id]`. */
+  resumeArgv: string[];
+  /** argv that forks into a new session; omit when the agent has no CLI fork. */
+  forkArgv?: string[];
 }
 
 /**

--- a/packages/server/src/routes/sessions.ts
+++ b/packages/server/src/routes/sessions.ts
@@ -18,6 +18,8 @@ import { displayNameFromCwd, projectIdFromCwd } from '../data/project-id.js';
 import { toIso } from './projects.js';
 import { assembleThread, buildSubagentRuns } from '../data/parser.js';
 import { loadSessionData } from '../data/session-loader.js';
+import { connectorById } from '../connectors/registry.js';
+import { buildResumeInfo } from '../connectors/resume.js';
 
 const SORT_SQL: Record<SessionSort, string> = {
   recent: 'ended_at DESC NULLS LAST',
@@ -111,7 +113,12 @@ export async function registerSessionsRoutes(app: FastifyInstance): Promise<void
       const thread = assembleThread(mainEvents);
       const subagents = buildSubagentRuns(thread, subagentSources);
 
-      return { meta, thread, subagents };
+      const cwd = readRow(rows[0] as Record<string, unknown>, 'sessions').str('project_cwd');
+      const resume = buildResumeInfo(connectorById(meta.connectorId), id, cwd || null);
+
+      const res: SessionDetailResponse = { meta, thread, subagents };
+      if (resume) res.resume = resume;
+      return res;
     },
   );
 }

--- a/packages/server/test/api.integration.test.ts
+++ b/packages/server/test/api.integration.test.ts
@@ -200,6 +200,15 @@ describe('GET /api/sessions/:id', () => {
   it('404s on an unknown session', async () => {
     expect((await get('/api/sessions/does-not-exist')).statusCode).toBe(404);
   });
+
+  it('attaches resume/fork commands for a Claude session', async () => {
+    const detail = (await get('/api/sessions/sessA')).json();
+    expect(detail.resume).toEqual({
+      cwd: '/tmp/projA',
+      resumeCommand: 'cd /tmp/projA && claude --resume sessA',
+      forkCommand: 'cd /tmp/projA && claude --resume sessA --fork-session',
+    });
+  });
 });
 
 describe('GET /api/search', () => {

--- a/packages/server/test/resume.test.ts
+++ b/packages/server/test/resume.test.ts
@@ -1,0 +1,98 @@
+/**
+ * "Continue session" command construction. The bug-prone edge is shell-quoting
+ * an arbitrary cwd (injection safety); the rest verifies the per-connector
+ * resume/fork verbs and the assembled ResumeInfo.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { buildResumeInfo, displayCommand, shQuote } from '../src/connectors/resume.js';
+import { connectorById, connectors } from '../src/connectors/registry.js';
+
+describe('shQuote', () => {
+  it('leaves safe tokens bare so the command reads cleanly', () => {
+    expect(shQuote('claude')).toBe('claude');
+    expect(shQuote('--fork-session')).toBe('--fork-session');
+    expect(shQuote('/Users/me/src/my-proj')).toBe('/Users/me/src/my-proj');
+    expect(shQuote('ses_2132abc')).toBe('ses_2132abc');
+  });
+
+  it('single-quotes anything containing shell-special characters', () => {
+    expect(shQuote('/tmp/my project')).toBe("'/tmp/my project'");
+    expect(shQuote('/tmp/a$b')).toBe("'/tmp/a$b'");
+    expect(shQuote('')).toBe("''");
+  });
+
+  it('neutralizes an embedded single quote (injection safety)', () => {
+    expect(shQuote("O'Brien")).toBe("'O'\\''Brien'");
+    // A cwd crafted to break out and run a command stays inert inside the quotes.
+    expect(shQuote("/tmp/a'; rm -rf ~ #")).toBe("'/tmp/a'\\''; rm -rf ~ #'");
+  });
+});
+
+describe('displayCommand', () => {
+  it('builds a clean cd && agent line for a normal cwd', () => {
+    expect(displayCommand('/tmp/projA', ['claude', '--resume', 'sessA'])).toBe(
+      'cd /tmp/projA && claude --resume sessA',
+    );
+  });
+
+  it('quotes a hostile cwd so nothing executes', () => {
+    const cmd = displayCommand("/tmp/a'; rm -rf ~ #", ['claude', '--resume', 'id']);
+    expect(cmd).toBe("cd '/tmp/a'\\''; rm -rf ~ #' && claude --resume id");
+    // The injected `rm` is inside the quoted cd argument, not a second command.
+    expect(cmd).not.toContain('&& rm');
+  });
+});
+
+describe('connector resumeSpec', () => {
+  const specOf = (id: string) => connectorById(id).resumeSpec?.('SID');
+
+  it('every registered connector exposes a resume command', () => {
+    for (const c of connectors) {
+      expect(c.resumeSpec, `${c.id} should implement resumeSpec`).toBeTypeOf('function');
+      expect(c.resumeSpec!('SID')?.resumeArgv.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('maps each agent to its verified resume verb/flag', () => {
+    expect(specOf('claude-code')?.resumeArgv).toEqual(['claude', '--resume', 'SID']);
+    expect(specOf('codex')?.resumeArgv).toEqual(['codex', 'resume', 'SID']);
+    expect(specOf('opencode')?.resumeArgv).toEqual(['opencode', '--session', 'SID']);
+    expect(specOf('pi')?.resumeArgv).toEqual(['pi', '--session', 'SID']);
+    expect(specOf('copilot')?.resumeArgv).toEqual(['copilot', '--resume', 'SID']);
+    expect(specOf('junie')?.resumeArgv).toEqual(['junie', '--session-id', 'SID']);
+  });
+
+  it('offers fork only for agents with a verified CLI fork', () => {
+    expect(specOf('claude-code')?.forkArgv).toEqual(['claude', '--resume', 'SID', '--fork-session']);
+    expect(specOf('codex')?.forkArgv).toEqual(['codex', 'fork', 'SID']);
+    expect(specOf('opencode')?.forkArgv).toEqual(['opencode', '--session', 'SID', '--fork']);
+    expect(specOf('pi')?.forkArgv).toEqual(['pi', '--fork', 'SID']);
+    // Copilot's only fork is a broken in-session slash command; Junie has none.
+    expect(specOf('copilot')?.forkArgv).toBeUndefined();
+    expect(specOf('junie')?.forkArgv).toBeUndefined();
+  });
+});
+
+describe('buildResumeInfo', () => {
+  const claude = connectorById('claude-code');
+
+  it('produces resume + fork commands for a normal session', () => {
+    expect(buildResumeInfo(claude, 'sessA', '/tmp/projA')).toEqual({
+      cwd: '/tmp/projA',
+      resumeCommand: 'cd /tmp/projA && claude --resume sessA',
+      forkCommand: 'cd /tmp/projA && claude --resume sessA --fork-session',
+    });
+  });
+
+  it('omits forkCommand for a fork-less connector', () => {
+    const info = buildResumeInfo(connectorById('copilot'), 'cop1', '/tmp/p');
+    expect(info?.resumeCommand).toBe('cd /tmp/p && copilot --resume cop1');
+    expect(info?.forkCommand).toBeUndefined();
+  });
+
+  it('returns undefined when the session has no cwd', () => {
+    expect(buildResumeInfo(claude, 'sessA', null)).toBeUndefined();
+    expect(buildResumeInfo(claude, 'sessA', '')).toBeUndefined();
+  });
+});

--- a/packages/shared/src/api.ts
+++ b/packages/shared/src/api.ts
@@ -150,6 +150,20 @@ export type ProjectsResponse = ProjectMeta[];
 /** GET /api/sessions */
 export type SessionsResponse = SessionMeta[];
 
+/**
+ * The command(s) to reopen a session in the agent's own CLI, for the user to
+ * copy and run. Present only when the session's connector knows a resume command
+ * (all current agents). Built server-side from the indexed session id + cwd.
+ */
+export interface ResumeInfo {
+  /** Working directory the command runs in. */
+  cwd: string;
+  /** POSIX command that appends to the original session. */
+  resumeCommand: string;
+  /** POSIX command that forks into a new session; absent when the agent has no CLI fork. */
+  forkCommand?: string;
+}
+
 /** GET /api/sessions/:id */
 export interface SessionDetailResponse {
   meta: SessionMeta;
@@ -157,6 +171,8 @@ export interface SessionDetailResponse {
   thread: ThreadItem[];
   /** Subagent runs, each linked to its spawn point via `toolUseId`/`spawnUuid`. */
   subagents: SubagentRun[];
+  /** Resume/fork commands for this session, when the connector supports it. */
+  resume?: ResumeInfo;
 }
 
 /** A full-text search hit in agent memory (instruction file or distilled fact). */

--- a/packages/web/src/pages/session/ContinueMenu.tsx
+++ b/packages/web/src/pages/session/ContinueMenu.tsx
@@ -1,0 +1,71 @@
+import { useEffect, useRef, useState } from 'react';
+import type { ResumeInfo } from '@claudescope/shared';
+
+/** A copy-paste command line with its own Copy button. */
+function CommandRow({ command }: { command: string }) {
+  const [copied, setCopied] = useState(false);
+  const copy = async () => {
+    try {
+      await navigator.clipboard.writeText(command);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1500);
+    } catch {
+      /* clipboard unavailable; ignore */
+    }
+  };
+  return (
+    <div className="tv-continue__cmd">
+      <code className="tv-continue__cmd-text">{command}</code>
+      <button type="button" className="tv-linkbtn" onClick={copy}>
+        {copied ? 'Copied!' : 'Copy'}
+      </button>
+    </div>
+  );
+}
+
+/**
+ * "Continue" dropdown: the command to reopen this session in the agent's own CLI,
+ * for the user to copy and run in their terminal. Rendered only when the
+ * session's connector exposes a resume command.
+ */
+export function ContinueMenu({ resume }: { resume: ResumeInfo }) {
+  const [open, setOpen] = useState(false);
+  const ref = useRef<HTMLDetailsElement>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    const onDoc = (e: MouseEvent) => {
+      if (ref.current && !ref.current.contains(e.target as Node)) setOpen(false);
+    };
+    const onKey = (e: KeyboardEvent) => e.key === 'Escape' && setOpen(false);
+    document.addEventListener('mousedown', onDoc);
+    document.addEventListener('keydown', onKey);
+    return () => {
+      document.removeEventListener('mousedown', onDoc);
+      document.removeEventListener('keydown', onKey);
+    };
+  }, [open]);
+
+  return (
+    <details ref={ref} className="tv-continue" open={open}>
+      <summary
+        onClick={(e) => {
+          e.preventDefault();
+          setOpen((o) => !o);
+        }}
+      >
+        ▷ Continue
+      </summary>
+      <div className="tv-continue__menu">
+        <p className="tv-continue__hint">Run this in your terminal to resume the session:</p>
+        <CommandRow command={resume.resumeCommand} />
+        {resume.forkCommand ? (
+          <>
+            <p className="tv-continue__hint">Or fork into a new session, leaving this one untouched:</p>
+            <CommandRow command={resume.forkCommand} />
+          </>
+        ) : null}
+      </div>
+    </details>
+  );
+}

--- a/packages/web/src/pages/session/SessionPage.tsx
+++ b/packages/web/src/pages/session/SessionPage.tsx
@@ -10,6 +10,7 @@ import { useProgressiveMount } from './useProgressiveMount.js';
 import { ChangesetPanel } from './ChangesetPanel.js';
 import { buildChangeset } from './changeset.js';
 import { ExportMenu } from './ExportMenu.js';
+import { ContinueMenu } from './ContinueMenu.js';
 import { SessionSearchContext } from './SearchContext.js';
 import {
   buildSearchCorpus,
@@ -363,6 +364,7 @@ function SessionView({
             ) : null}
           </nav>
           <SubagentJumpMenu subagents={subagents} />
+          {data.resume ? <ContinueMenu resume={data.resume} /> : null}
           <ExportMenu data={data} />
           <button
             type="button"

--- a/packages/web/src/pages/session/session.css
+++ b/packages/web/src/pages/session/session.css
@@ -443,6 +443,59 @@
   padding-top: var(--tv-space-2);
 }
 
+/* ── Continue (resume / fork) dropdown ────────────────────────────────── */
+
+.tv-continue {
+  position: relative;
+  display: inline-block;
+}
+.tv-continue > summary {
+  cursor: pointer;
+  list-style: none;
+  font-size: var(--tv-fs-sm);
+  color: var(--tv-accent);
+  user-select: none;
+}
+.tv-continue > summary::-webkit-details-marker {
+  display: none;
+}
+.tv-continue__menu {
+  position: absolute;
+  z-index: 20;
+  top: calc(100% + var(--tv-space-1));
+  left: 0;
+  width: 340px;
+  max-width: 80vw;
+  padding: var(--tv-space-2);
+  background: var(--tv-bg-elevated);
+  border: 1px solid var(--tv-border-strong);
+  border-radius: var(--tv-radius);
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.4);
+}
+.tv-continue__hint {
+  margin: 0 0 var(--tv-space-2);
+  font-size: var(--tv-fs-sm);
+  color: var(--tv-fg-muted);
+}
+.tv-continue__cmd {
+  display: flex;
+  align-items: center;
+  gap: var(--tv-space-2);
+  margin-bottom: var(--tv-space-2);
+}
+.tv-continue__cmd-text {
+  flex: 1;
+  min-width: 0;
+  overflow-x: auto;
+  white-space: nowrap;
+  padding: var(--tv-space-1) var(--tv-space-2);
+  background: var(--tv-bg-inset);
+  border: 1px solid var(--tv-border);
+  border-radius: var(--tv-radius-sm);
+  font-size: var(--tv-fs-sm);
+  color: var(--tv-fg);
+}
+
 /* ── In-session finder ────────────────────────────────────────────────── */
 
 .tv-finder {


### PR DESCRIPTION
Adds a **Continue** dropdown to the session view that shows the command to reopen a session in its agent's own CLI, for the user to copy and run.

- **Resume** for all six agents (`claude --resume`, `codex resume`, `opencode --session`, `pi --session`, `copilot --resume`, `junie --session-id`); **Fork** for the four whose CLI supports it (Claude/Codex/opencode/pi).
- The agent is taken from `connectorId` (never guessed) via a per-connector `resumeSpec()`; the command is `cd <cwd> && <agent cmd>`, with the cwd shell-quoted.
- The server only **builds and returns strings** — no new endpoint, no spawning, no executable scripts. It stays fully read-only.

### Why copy-only (not auto-open)

This supersedes the explored-but-abandoned auto-open approach in #30. On macOS there's no reliable way to open the user's *default* terminal (`.command` always lands in Terminal.app), and a server endpoint that writes+runs a script is a localhost-CSRF risk. Copy-the-command sidesteps both: the user pastes it into whatever terminal they already use.

### Tests

`resume.test.ts` — cwd quoting/injection safety, per-connector resume/fork verbs, fork omitted for Copilot/Junie, `buildResumeInfo` without a cwd. Integration — the session detail response carries the right `resume` object. typecheck clean, 213 tests pass.

Plans: `docs/plans/0025-continue-session-copy-command.md` (this); `docs/plans/0024-…` marked **abandoned** with the full auto-open write-up + why.