### PR TITLE
feat(web): UI hierarchy pass — batch 1

### DIFF
--- a/docs/plans/0026-ui-ux-review-batches.md
+++ b/docs/plans/0026-ui-ux-review-batches.md
@@ -1,0 +1,190 @@
+# 0026 — UI/UX review: hierarchy pass across all screens
+
+- **Status:** in-progress <!-- proposed | in-progress | done | superseded | abandoned -->
+- **Date:** 2026-06-17
+- **PR:** Batch 1 — <link, once opened>
+
+## Context
+
+An external UI/UX review produced 11 annotated before/after mockups covering
+every main screen. They share one thesis — **hierarchy through subtraction**:
+one bold number per unit (cost), everything else demoted to muted meta, a summary
+strip to anchor each page, and raw values (BM25 scores, full-color emoji) replaced
+with quiet visual encodings (a relevance bar, monochrome glyphs). The consistency
+is the point; applied piecemeal each tweak is worth far less.
+
+Current state (verified against the code), screen by screen:
+
+- **Shell nav** (`App.tsx`) uses literal emoji icons (📁🧠🔍📊); the theme toggle
+  (🖥☀🌙) and session-header actions (🧩 ▷ ⟳) are emoji too.
+- **Browse** (`BrowsePage.tsx`) has no portfolio summary; cards mix agent badges
+  and numbers together.
+- **Project sessions** (`SessionList.tsx`) right-side chips can get ragged at
+  narrower widths; no project summary strip.
+- **Session view** (`SessionPage.tsx`, `ThreadView.tsx`) renders the header as one
+  flat chip row and tool calls as collapsible blocks with no shared token legend.
+- **Files changed** (`ChangesetPanel.tsx`) is a single-column accordion: per-file
+  +/− only, no session diffstat, no jump rail, no viewed state.
+- **Search** (`SearchPage.tsx`) shows flat rows with a raw BM25 `score X.XX`.
+- **Analytics** (`AnalyticsPage.tsx`) shows a headline token count that doesn't
+  obviously reconcile (cache reads dominate), a redundant cost chip, and chart
+  colors that don't match the token-chip vocabulary.
+- **Memory** (`MemoryPage.tsx`) shows bare counts and *hides* agents without
+  memory (they look broken at "0 facts").
+- **Continue popover** (`ContinueMenu.tsx`) truncates the command and doesn't
+  explain resume vs fork.
+- **Export** (`ExportMenu`) presents redaction as an opaque checkbox next to two
+  equal-weight actions.
+- **Codex/pi titles** fall back to the raw first message, markup and all
+  (`first_user` in `data/index.ts`).
+
+Most are pure presentation. Three carry **correctness/trust** obligations beyond
+the visuals (export redaction wording, the title-cleaning logic, viewed-state
+persistence) and are called out below.
+
+## Goal
+
+Ship the proposals across three batches, establishing one consistent visual
+hierarchy and an app-wide icon set.
+
+## Decisions
+
+- **Adopt one icon set across the whole app, not just the 4 nav items.** Swapping
+  only the nav trades emoji-nav for glyph-nav-next-to-emoji-toggle. Use a single
+  React icon library (lucide-react is the natural fit) for nav + theme toggle +
+  header actions + chevrons. **This adds a runtime dep** — flagged deliberately
+  (CLAUDE.md: discuss deps first), not a drive-by.
+- **Reuse one summary-strip component** for both the Browse portfolio header and
+  the Project detail header, so the pattern is identical at both altitudes.
+- **Cost stays the single bold figure per unit**, everything else muted — but keep
+  the "list-price estimate" caveat at least once (Analytics), since cost is a
+  local estimate (see cost gotchas).
+- **Clean the fallback title in the shared path, not a Codex special-case.** pi has
+  the identical no-stored-title behavior, so fixing `first_user` covers both
+  (and is deterministic, so titles stay stable across re-index).
+- **Viewed-state for Files-changed is client-only (localStorage).** It is ephemeral
+  review UI state; persisting it server-side would add an index/state surface for
+  no benefit and the read-only-sources rule stays untouched.
+- **Cap model chips at three, `+N` reveals the rest on hover.** Sessions/projects
+  can surface 1–5+ models; a shared `ModelChips` component owns the cap so the
+  session header, session rows, and any card stay consistent.
+- **Keep the redaction wording honest.** The toggle says it masks *likely* tokens /
+  keys, not *all* secrets — because path rewriting (`/Users/me/… → ~/…`) is exact,
+  but secret detection is pattern-matching that can miss a key it doesn't recognize.
+  The little before/after in the panel is an illustrative example of the
+  transformation, not a coverage promise. Don't reword it to imply a guarantee.
+- **Drop the "RECOMMENDED" label** on resume-in-place: resume (same history/id) vs
+  fork (branch safely) is intent-dependent; labeling one nudges with no
+  universally-right answer. Keep both neutral. (Per the user's explicit request.)
+
+## Approach
+
+### Batch 1 — visual hierarchy + low-risk clarity/correctness fixes
+
+1. **① Monochrome icon set** (`App.tsx`, theme toggle, session header, chevrons) —
+   replace all emoji glyphs with one lucide-react set. Add the dep.
+2. **Shared `ModelChips`** — a capped chip row (max three + a `+N` overflow that
+   lists the rest on hover); one component, reused by the session header and the
+   session rows. Sessions/projects can surface 1–5+ models, so the cap is the rule
+   everywhere models appear.
+3. **③ Project summary strip + one-line session meta** (`SessionList.tsx`,
+   `ProjectLayout.tsx`) — SESSIONS / TOKENS / COST / AGENTS strip up top; collapse
+   the right-side chips into one tidy meta line (`opus-4-8 · haiku-4-5 │ 24M
+   $20.22`) using `ModelChips`; PR link on its own line.
+4. **⑥ Browse portfolio summary + badge/number split** (`BrowsePage.tsx`,
+   `ProjectCard`) — PROJECTS / SESSIONS / SPEND / AGENTS strip; separate agent
+   badges (own row) from numbers (muted meta line); cost the one bold figure.
+5. **② Session header restructure** (`SessionPage.tsx`, session header) — two
+   tiers: **tier one** promotes title + subagents chip, agent badge, `ModelChips`,
+   cost, tokens, duration, with PR as a real action button and Continue / Subagents
+   / Export / Refresh in the top bar; **tier two** is a muted meta line (messages,
+   tools, branch, timestamps, size — present, not loud).
+6. **⑦ Analytics reconcile / dedupe / recolor** (`AnalyticsPage.tsx`) — headline
+   token count decomposed as in + out + cache with a mini stacked bar; remove the
+   redundant cost chip, replace with context ("list-price estimate · N% cache-read");
+   recolor charts to the token-chip blue (input) / violet (output).
+7. **⑨ Continue popover redesign** (`ContinueMenu.tsx`) — full untruncated command
+   (wraps), resume vs fork explained in a line each, context chips (agent / project
+   / branch), the trust line "Claudescope only copies a command — it never runs
+   anything", **no RECOMMENDED label**.
+8. **⑪ Fallback title cleaning** (`data/index.ts`, `first_user`) — strip markup /
+   wrapper tags / leading `#`, pick the first real user prose (skip
+   system/tool-injected blobs), collapse whitespace, truncate; surface an "untitled
+   · from first message" marker in the session header. Covers Codex and pi.
+
+### Batch 2 — grouping, previews, privacy
+
+9. **⑤ Search grouping + relevance bar** (`SearchPage.tsx`) — collapse N matches
+   into one session card ("7 matches"), "N matches across M sessions" framing,
+   replace raw BM25 with a relevance bar normalized per result-set (max → full).
+10. **⑧ Memory previews + "no memory store"** (`MemoryPage.tsx`,
+    `MemorySourceCard`) — each card previews real content (latest fact + category;
+    the parser already extracts facts); show agents *without* memory explicitly as
+    "no memory store" with a one-line explanation instead of hiding them.
+11. **⑩ Export redaction transparency** (`ExportMenu`) — explain what the toggle
+    does with an illustrative before/after example; Download primary, Copy
+    secondary; keep the "likely / best-effort" wording.
+12. **② Session thread polish** (`ThreadView.tsx`) — add the shared token legend up
+    top; demote tool calls / `call_…` ids to one quiet "details" line by default,
+    **ensuring expand still yields the existing rich rendering** (inline diffs,
+    highlighted code).
+
+### Batch 3 — biggest build (scope carefully)
+
+13. **④ Files-changed jump rail + diffstat + viewed** (`ChangesetPanel.tsx`,
+    `LineDiff`) — two-pane layout (file rail left, diff right), session-level
+    diffstat (`+412 −86`) up top, per-file +/− in the rail, and a "viewed" checkbox
+    per file (localStorage) with an "N of M viewed" progress indicator.
+
+## Files affected
+
+- `packages/web/src/App.tsx` — icon set, theme toggle glyphs.
+- `packages/web/src/pages/browse/BrowsePage.tsx` (+ `ProjectCard`) — portfolio
+  summary, badge/number split.
+- `packages/web/src/pages/browse/SessionList.tsx`, `ProjectLayout.tsx` — project
+  summary strip, one-line session meta.
+- `packages/web/src/pages/analytics/AnalyticsPage.tsx` — reconcile, dedupe, recolor.
+- `packages/web/src/pages/session/ContinueMenu.tsx` — popover redesign.
+- `packages/web/src/pages/session/ExportMenu*` — redaction UX, button hierarchy.
+- `packages/web/src/pages/session/SessionPage.tsx` (+ session header) — two-tier
+  header, cost/models promoted, counts/branch/size demoted.
+- `packages/web/src/pages/session/ThreadView.tsx` — token legend, tool-line demotion.
+- `packages/web/src/components/ModelChips.tsx` *(new)* — shared capped model-chip
+  row (max three + `+N` hover), reused by the header and session rows.
+- `packages/web/src/pages/search/SearchPage.tsx` — grouped results, relevance bar.
+- `packages/web/src/pages/memory/MemoryPage.tsx` (+ `MemorySourceCard`) — previews,
+  "no memory store".
+- `packages/web/src/pages/session/ChangesetPanel.tsx` (+ `LineDiff`) — jump rail,
+  diffstat, viewed state.
+- `packages/server/src/data/index.ts` (`first_user`) — shared title cleaning.
+- shared CSS (`session.css`, etc.) and possibly `packages/shared/src/api.ts` if the
+  relevance bar / grouped search shape needs a contract tweak.
+- `package.json` — add `lucide-react` (or chosen icon lib).
+
+## Testing
+
+`npm test` + `npm run typecheck` after each batch.
+
+- **Title cleaning** (server, deterministic) — markup/wrapper stripping, system-blob
+  skip, truncation, stability across re-index; covers a Codex *and* a pi fixture.
+- **Export redaction** — the live example reflects the real redactor; path rewrite
+  vs heuristic secret match behave as documented (no over-claim on misses).
+- **Search relevance normalization** — bar maps sensibly when BM25 scores are
+  large/unbounded; grouping collapses duplicate session rows correctly.
+- **Viewed state** — persists across reload, scoped per session, never written to
+  any agent source.
+- Mostly visual otherwise — manual check against the mockups per screen.
+
+## Risks / open questions
+
+- **New dependency.** `lucide-react` — confirmed by the maintainer.
+- **Redaction is best-effort for secrets.** Path rewriting is exact, but secret
+  masking is pattern-based and can miss an unrecognized key. The UI must not imply a
+  guarantee — the "likely" wording is load-bearing, not cosmetic. (A user who trusts
+  a "redacted" export and leaks a token is the failure mode to avoid.)
+- **ThreadView demotion must preserve rich expand.** Inline diffs / highlighted code
+  are a selling point; the one-line default must expand to the existing rendering,
+  not a degraded view.
+- **Session-row wrap discrepancy.** Current `SessionRow` chips are `flex` no-wrap in
+  code; the mockup reports ragged wrapping. Confirm at real widths — the one-line
+  meta is the right target regardless.

--- a/docs/plans/0026-ui-ux-review-batches.md
+++ b/docs/plans/0026-ui-ux-review-batches.md
@@ -2,7 +2,7 @@
 
 - **Status:** in-progress <!-- proposed | in-progress | done | superseded | abandoned -->
 - **Date:** 2026-06-17
-- **PR:** Batch 1 — <link, once opened>
+- **PR:** Batch 1 — [#32](https://github.com/vladar107/claudescope/pull/32)
 
 ## Context
 

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -50,3 +50,4 @@ decision, or a change worth explaining before doing. Skip it for one-line fixes.
 | 0023 | [Structured rendering for command turns (slash/bash tags)](./0023-command-turn-rendering.md) | done |
 | 0024 | [Continue session from transcript (terminal auto-open)](./0024-continue-session.md) | abandoned |
 | 0025 | [Continue session: copy the command](./0025-continue-session-copy-command.md) | done |
+| 0026 | [UI/UX review: hierarchy pass across all screens](./0026-ui-ux-review-batches.md) | in-progress |

--- a/flake.nix
+++ b/flake.nix
@@ -55,7 +55,7 @@
           # `nix build .#claudescope` and the mismatch error prints the new value.
           npmDeps = pkgs.fetchNpmDeps {
             src = depsLock;
-            hash = "sha256-8KdRYSpTbaS81+tfjbcCkoRC4F5omRq2yqV/HJMys0c=";
+            hash = "sha256-z/PkcwZDNf2CebDIH8SGYxI7QzjPfAsamtVsT7C4YkE=";
           };
 
           nodejs = node;

--- a/package-lock.json
+++ b/package-lock.json
@@ -2992,6 +2992,15 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/lucide-react": {
+      "version": "1.20.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-1.20.0.tgz",
+      "integrity": "sha512-jhXLeC/7m0/tjL1nzMdKk6x256zWA6AtbhTVreHOiKPoeX2d6MK4FbyIQPpVq0E6iPWBisyy1TW+pEge/uMEuQ==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/magic-string": {
       "version": "0.30.21",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
@@ -5347,6 +5356,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@claudescope/shared": "*",
+        "lucide-react": "^1.20.0",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
         "react-markdown": "^10.1.0",

--- a/packages/server/src/data/index.ts
+++ b/packages/server/src/data/index.ts
@@ -21,6 +21,7 @@ import { getConnection, queryRows, sqlString } from '../db/duckdb.js';
 import { connectors } from '../connectors/registry.js';
 import type { AgentConnector, DiscoveredFile } from '../connectors/types.js';
 import { loadPricing } from './pricing.js';
+import { cleanFallbackTitle } from './title.js';
 
 /** Tracks whether the initial index build has finished (server readiness). */
 let ready = false;
@@ -257,24 +258,14 @@ async function rebuildSessions(conn: DuckDBConnection): Promise<void> {
         bool_or(is_sidechain) AS has_sidechain,
         list_distinct(list(model) FILTER (WHERE model IS NOT NULL)) AS model_list
       FROM events GROUP BY session_id
-    ),
-    first_user AS (
-      -- Title fallback: the first user turn's text, whitespace-collapsed and
-      -- clipped. Used when there's no explicit ai-title (e.g. all Codex
-      -- sessions, and Claude sessions that were never auto-titled).
-      SELECT session_id, snippet FROM (
-        SELECT
-          session_id,
-          trim(left(regexp_replace(text_content, '\\s+', ' ', 'g'), 80)) AS snippet,
-          row_number() OVER (PARTITION BY session_id ORDER BY ts ASC NULLS LAST) AS rn
-        FROM events
-        WHERE role = 'user' AND text_content IS NOT NULL AND length(trim(text_content)) > 0
-      ) WHERE rn = 1
     )
     SELECT
       a.session_id AS id,
       mc.cwd AS project_cwd,
-      COALESCE(NULLIF(t.title, ''), NULLIF(fu.snippet, ''), '') AS title,
+      -- Real stored ai-title only; the cleaned first-message fallback (and the
+      -- title_derived flag) is applied by applyFallbackTitles below.
+      COALESCE(NULLIF(t.title, ''), '') AS title,
+      FALSE AS title_derived,
       a.started_at,
       a.ended_at,
       a.message_count,
@@ -294,7 +285,6 @@ async function rebuildSessions(conn: DuckDBConnection): Promise<void> {
     FROM agg a
     LEFT JOIN modal_cwd mc ON mc.session_id = a.session_id
     LEFT JOIN titles t ON t.session_id = a.session_id
-    LEFT JOIN first_user fu ON fu.session_id = a.session_id
     LEFT JOIN pr_links p ON p.session_id = a.session_id
     LEFT JOIN file_size fs ON fs.session_id = a.session_id
     LEFT JOIN session_connector sc ON sc.session_id = a.session_id
@@ -308,6 +298,44 @@ async function rebuildSessions(conn: DuckDBConnection): Promise<void> {
       ORDER BY ts DESC NULLS LAST LIMIT 1
     )
   `);
+
+  await applyFallbackTitles(conn);
+}
+
+/**
+ * Fill in fallback titles for sessions with no real stored title, by cleaning
+ * the first user message in TS (see {@link cleanFallbackTitle}). Runs after the
+ * derived `sessions` rebuild, so it only touches rows whose `title` came back
+ * empty. Cleaning happens in TS — not SQL — so markup/wrapper-blob stripping can
+ * be tested as a pure function and stays deterministic across re-index.
+ *
+ * The raw first user turn per untitled session is fetched in one query (capped
+ * to a few KB per row — cleaning only needs the head), then each cleaned title
+ * is written back with `title_derived = TRUE`.
+ */
+async function applyFallbackTitles(conn: DuckDBConnection): Promise<void> {
+  const rows = await queryRows(
+    conn,
+    `
+    SELECT session_id, raw FROM (
+      SELECT
+        e.session_id,
+        left(e.text_content, 4096) AS raw,
+        row_number() OVER (PARTITION BY e.session_id ORDER BY e.ts ASC NULLS LAST) AS rn
+      FROM events e
+      JOIN sessions s ON s.id = e.session_id AND COALESCE(s.title, '') = ''
+      WHERE e.role = 'user' AND e.text_content IS NOT NULL AND length(trim(e.text_content)) > 0
+    ) WHERE rn = 1
+    `,
+  );
+
+  for (const r of rows) {
+    const title = cleanFallbackTitle(r.raw != null ? String(r.raw) : null);
+    if (title.length === 0) continue;
+    await conn.run(
+      `UPDATE sessions SET title = ${sqlString(title)}, title_derived = TRUE WHERE id = ${sqlString(String(r.session_id))}`,
+    );
+  }
 }
 
 /** (Re)build the BM25 full-text index over event text. */

--- a/packages/server/src/data/title.ts
+++ b/packages/server/src/data/title.ts
@@ -1,0 +1,88 @@
+/**
+ * Fallback session-title cleaning.
+ *
+ * Codex and pi sessions store no title (and a Claude session may never have
+ * been auto-titled), so the indexer falls back to the session's first user
+ * message (see `first_user` in `index.ts`). That raw message is often markup or
+ * a tool-injected blob — a leading `# AGENTS.md instructions for /…` heading, a
+ * `<INSTRUCTIONS>…</INSTRUCTIONS>` wrapper, system reminders — which makes an
+ * ugly, leaky title.
+ *
+ * {@link cleanFallbackTitle} turns that raw text into a short, honest title. It
+ * is PURE and DETERMINISTIC — no time or randomness — so the derived title is
+ * stable across re-index (the index is a derived cache; same input → same
+ * output keeps it from churning).
+ */
+
+/**
+ * Max length of a fallback title before it's clipped with an ellipsis. Matches
+ * the original SQL `left(…, 80)` clip so titles don't get longer than before.
+ */
+export const TITLE_MAX_LENGTH = 80;
+
+const ELLIPSIS = '…';
+
+/**
+ * Lines that are clearly system/tool-injected rather than user prose. We skip
+ * them when picking the "first real line" so the title reflects what the user
+ * actually asked, not the harness scaffolding wrapped around it.
+ */
+const INJECTED_LINE = [
+  /^#{1,6}\s*\S.*\b(instructions?|guidelines?)\b.*\bfor\b/i, // "# AGENTS.md instructions for /…"
+  /^<\/?[a-z][\w-]*>?$/i, // a lone XML-ish tag line: <INSTRUCTIONS> or </INSTRUCTIONS>
+  /^<(system|system-reminder|instructions?|context|user[_-]instructions?)\b/i, // opening blob tag
+  /^(system reminder|caveat|important):/i, // common injected preambles
+];
+
+/** A line worth showing: has at least one word character once tags are gone. */
+function isProse(line: string): boolean {
+  if (line.length === 0) return false;
+  if (INJECTED_LINE.some((re) => re.test(line))) return false;
+  return /[A-Za-z0-9]/.test(stripTags(line));
+}
+
+/** Strip XML/HTML-ish tags (`<INSTRUCTIONS>`, `</foo>`) from a single line. */
+function stripTags(line: string): string {
+  return line.replace(/<\/?[a-z][\w-]*(?:\s[^>]*)?>/gi, ' ');
+}
+
+/**
+ * Strip leading markdown structure from a line: heading markers (`#`, `##`, …),
+ * blockquote (`>`), list bullets (`-`, `*`, `+`, `1.`), and surrounding
+ * emphasis (`*`, `_`, `` ` ``, `~`).
+ */
+function stripMarkdown(line: string): string {
+  let s = line.replace(/^\s*#{1,6}\s+/, ''); // ATX heading
+  s = s.replace(/^\s*>+\s*/, ''); // blockquote
+  s = s.replace(/^\s*(?:[-*+]|\d+[.)])\s+/, ''); // list bullet / ordered marker
+  s = s.replace(/^[*_~`]+/, '').replace(/[*_~`]+$/, ''); // surrounding emphasis
+  return s.trim();
+}
+
+/**
+ * Clean a raw first-user-message into a short fallback title.
+ *
+ * Strips markdown headings/emphasis and XML-ish wrapper tags, prefers the first
+ * line of real user prose (skipping injected instruction blobs), collapses all
+ * whitespace to single spaces, and clips to {@link TITLE_MAX_LENGTH} with an
+ * ellipsis. Returns `''` when nothing usable remains.
+ */
+export function cleanFallbackTitle(raw: string | null | undefined): string {
+  if (!raw) return '';
+
+  // Pick the first prose line; fall back to the first non-empty line so a
+  // single-line blob still yields something rather than nothing.
+  const lines = raw.split(/\r?\n/).map((l) => l.trim());
+  const chosen =
+    lines.find((l) => isProse(l)) ?? lines.find((l) => l.length > 0) ?? '';
+
+  // Strip tags first (so emphasis stripping sees real text), then markdown
+  // structure, then collapse remaining whitespace to single spaces.
+  const text = stripMarkdown(stripTags(chosen)).replace(/\s+/g, ' ').trim();
+  if (text.length === 0) return '';
+
+  if (text.length <= TITLE_MAX_LENGTH) return text;
+  // Clip to the limit (ellipsis included), trimming a dangling space so we
+  // don't render "word …".
+  return text.slice(0, TITLE_MAX_LENGTH - ELLIPSIS.length).trimEnd() + ELLIPSIS;
+}

--- a/packages/server/src/db/schema.ts
+++ b/packages/server/src/db/schema.ts
@@ -23,7 +23,8 @@
 // (a derived cache) is discarded and rebuilt from source — see db/duckdb.ts.
 // v5: Codex title fallback (first user message) + `<image …>` placeholder strip.
 // v6: usage dedup by billed API call (message_id / forked_from_session_id / usage_canonical).
-export const SCHEMA_VERSION = 6;
+// v7: fallback title cleaning (strip markup/wrapper blobs) + `title_derived` flag.
+export const SCHEMA_VERSION = 7;
 
 /** All DDL statements, executed in order at startup. Idempotent. */
 export const SCHEMA_DDL: readonly string[] = [
@@ -70,6 +71,9 @@ export const SCHEMA_DDL: readonly string[] = [
      id            VARCHAR PRIMARY KEY,
      project_cwd   VARCHAR,
      title         VARCHAR,
+     -- TRUE when title was derived from the first user message (cleaned) rather
+     -- than a real stored title -- lets the UI mark it "from first message".
+     title_derived BOOLEAN DEFAULT FALSE,
      started_at    TIMESTAMP,
      ended_at      TIMESTAMP,
      message_count BIGINT DEFAULT 0,

--- a/packages/server/src/routes/sessions.ts
+++ b/packages/server/src/routes/sessions.ts
@@ -49,6 +49,7 @@ function rowToSessionMeta(r: Record<string, unknown>): SessionMeta {
     hasSidechain: rd.bool('has_sidechain'),
     connectorId: rd.str('connector_id') || 'claude-code',
   };
+  if (rd.bool('title_derived')) meta.titleDerived = true;
   const gitBranch = rd.str('git_branch');
   if (gitBranch) meta.gitBranch = gitBranch;
   const prUrl = rd.str('pr_url');

--- a/packages/server/test/api.integration.test.ts
+++ b/packages/server/test/api.integration.test.ts
@@ -340,9 +340,10 @@ describe('stale aux row cleanup', () => {
 
     await reindex();
 
-    // Confirm the ai-title is picked up on first index.
+    // Confirm the ai-title is picked up on first index (a real title, not derived).
     const before = (await get('/api/sessions/sessC')).json();
     expect(before.meta.title).toBe('AI Generated Title');
+    expect(before.meta.titleDerived).toBeFalsy();
 
     // Rewrite the file WITHOUT the ai-title line. Change the content slightly
     // so mtime+size differ and the (mtime,size) check triggers a reload.
@@ -356,10 +357,12 @@ describe('stale aux row cleanup', () => {
 
     await reindex();
 
-    // The stale ai-title must be gone; title should fall back to first user message.
+    // The stale ai-title must be gone; title should fall back to the first user
+    // message and now be flagged derived.
     const after = (await get('/api/sessions/sessC')).json();
     expect(after.meta.title).not.toBe('AI Generated Title');
     expect(after.meta.title).toContain('first user message for sessC');
+    expect(after.meta.titleDerived).toBe(true);
   });
 });
 

--- a/packages/server/test/codex.integration.test.ts
+++ b/packages/server/test/codex.integration.test.ts
@@ -105,8 +105,10 @@ describe('Codex session indexing', () => {
     expect(sessions.map((s: { id: string }) => s.id)).toEqual(['codex-sess-1']);
     expect(sessions[0].models).toContain('gpt-5.4');
     expect(sessions[0].connectorId).toBe('codex');
-    // Codex has no ai-title, so the title falls back to the first user message.
+    // Codex has no ai-title, so the title falls back to the (cleaned) first user
+    // message and is flagged derived so the UI can mark it "from first message".
     expect(sessions[0].title).toBe('find the needle in this codex haystack');
+    expect(sessions[0].titleDerived).toBe(true);
   });
 
   it('tags the project with its agent and groups analytics by agent', async () => {

--- a/packages/server/test/title.test.ts
+++ b/packages/server/test/title.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from 'vitest';
+import { cleanFallbackTitle, TITLE_MAX_LENGTH } from '../src/data/title.js';
+
+describe('cleanFallbackTitle', () => {
+  it('returns empty for empty/nullish input', () => {
+    expect(cleanFallbackTitle('')).toBe('');
+    expect(cleanFallbackTitle(null)).toBe('');
+    expect(cleanFallbackTitle(undefined)).toBe('');
+    expect(cleanFallbackTitle('   \n\t  ')).toBe('');
+  });
+
+  it('strips leading markdown heading markers', () => {
+    expect(cleanFallbackTitle('# Fix the indexer bug')).toBe('Fix the indexer bug');
+    expect(cleanFallbackTitle('### deeply nested heading')).toBe('deeply nested heading');
+  });
+
+  it('strips surrounding markdown emphasis', () => {
+    expect(cleanFallbackTitle('**Bold ask**')).toBe('Bold ask');
+    expect(cleanFallbackTitle('`run the build`')).toBe('run the build');
+    expect(cleanFallbackTitle('_make it faster_')).toBe('make it faster');
+  });
+
+  it('strips wrapper/XML-ish tags inline', () => {
+    expect(cleanFallbackTitle('<INSTRUCTIONS>do the thing</INSTRUCTIONS>')).toBe('do the thing');
+  });
+
+  it('skips a clearly injected instructions blob and uses the real prose line', () => {
+    const raw = [
+      '# AGENTS.md instructions for /Users/vramazaev/src/transript-viewer',
+      '<INSTRUCTIONS>',
+      'Please add a fallback title cleaner',
+      '</INSTRUCTIONS>',
+    ].join('\n');
+    expect(cleanFallbackTitle(raw)).toBe('Please add a fallback title cleaner');
+  });
+
+  it('skips lone wrapper tag lines and system-reminder preambles', () => {
+    const raw = [
+      '<system-reminder>',
+      'Caveat: the harness injected this',
+      '',
+      'Refactor the connector registry',
+    ].join('\n');
+    expect(cleanFallbackTitle(raw)).toBe('Refactor the connector registry');
+  });
+
+  it('collapses internal whitespace and newlines to single spaces', () => {
+    expect(cleanFallbackTitle('hello   world')).toBe('hello world');
+    expect(cleanFallbackTitle('keep\tthe tabs   tidy')).toBe('keep the tabs tidy');
+  });
+
+  it('truncates long titles with an ellipsis, never exceeding the max length', () => {
+    const long = 'a'.repeat(200);
+    const out = cleanFallbackTitle(long);
+    expect(out.length).toBe(TITLE_MAX_LENGTH);
+    expect(out.endsWith('…')).toBe(true);
+    expect(out.startsWith('aaaa')).toBe(true);
+  });
+
+  it('does not truncate when at or under the limit', () => {
+    const exact = 'x'.repeat(TITLE_MAX_LENGTH);
+    expect(cleanFallbackTitle(exact)).toBe(exact);
+    expect(cleanFallbackTitle(exact).endsWith('…')).toBe(false);
+  });
+
+  it('trims a dangling space before the ellipsis on truncation', () => {
+    // Build text whose clip boundary lands right after a space, so a naive
+    // slice would yield "… " — the cleaner must trim it.
+    const word = 'word ';
+    const raw = word.repeat(40); // well over the limit, space-separated
+    const out = cleanFallbackTitle(raw);
+    expect(out.endsWith(' …')).toBe(false);
+    expect(out.endsWith('…')).toBe(true);
+  });
+
+  it('is deterministic: same input twice yields identical output', () => {
+    const raw = '# AGENTS.md instructions for /x\n<INSTRUCTIONS>\nDo work\n</INSTRUCTIONS>';
+    expect(cleanFallbackTitle(raw)).toBe(cleanFallbackTitle(raw));
+  });
+
+  it('falls back to the first non-empty line when no line is clean prose', () => {
+    // A single injected line with no prose alternative still yields something
+    // usable (its stripped text) rather than an empty title.
+    expect(cleanFallbackTitle('<INSTRUCTIONS>only a wrapped blob</INSTRUCTIONS>')).toBe(
+      'only a wrapped blob',
+    );
+  });
+});

--- a/packages/shared/src/api.ts
+++ b/packages/shared/src/api.ts
@@ -44,6 +44,12 @@ export interface SessionMeta {
   /** Human-friendly project name (last path segment of the project cwd). */
   projectDisplayName: string;
   title: string;
+  /**
+   * True when `title` was derived from the (cleaned) first user message rather
+   * than a real stored title — e.g. Codex/pi sessions, which store no title.
+   * Lets the UI mark it "untitled · from first message". Optional/back-compat.
+   */
+  titleDerived?: boolean;
   startedAt: string;
   endedAt: string;
   messageCount: number;

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -10,6 +10,7 @@
   },
   "dependencies": {
     "@claudescope/shared": "*",
+    "lucide-react": "^1.20.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "react-markdown": "^10.1.0",

--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react';
 import { NavLink, Route, Routes, useLocation } from 'react-router-dom';
+import { Cpu, FolderOpen, LineChart, Monitor, Moon, Search, Sun, type LucideIcon } from 'lucide-react';
 import type { SourceInfo } from '@claudescope/shared';
 import { ErrorBoundary } from './components';
 import { api } from './api/client.js';
@@ -18,22 +19,22 @@ import { ProjectMemoryPage } from './pages/memory/ProjectMemoryPage.js';
 interface NavItem {
   to: string;
   label: string;
-  icon: string;
+  icon: LucideIcon;
   /** `end` for routes that should only match exactly (the index route). */
   end?: boolean;
 }
 
 const NAV_ITEMS: NavItem[] = [
-  { to: '/', label: 'Browse', icon: '📁', end: true },
-  { to: '/memory', label: 'Memory', icon: '🧠' },
-  { to: '/search', label: 'Search', icon: '🔍' },
-  { to: '/analytics', label: 'Analytics', icon: '📊' },
+  { to: '/', label: 'Browse', icon: FolderOpen, end: true },
+  { to: '/memory', label: 'Memory', icon: Cpu },
+  { to: '/search', label: 'Search', icon: Search },
+  { to: '/analytics', label: 'Analytics', icon: LineChart },
 ];
 
-const THEME_OPTIONS: { value: ThemeChoice; label: string; icon: string }[] = [
-  { value: 'system', label: 'System', icon: '🖥' },
-  { value: 'light', label: 'Light', icon: '☀' },
-  { value: 'dark', label: 'Dark', icon: '🌙' },
+const THEME_OPTIONS: { value: ThemeChoice; label: string; icon: LucideIcon }[] = [
+  { value: 'system', label: 'System', icon: Monitor },
+  { value: 'light', label: 'Light', icon: Sun },
+  { value: 'dark', label: 'Dark', icon: Moon },
 ];
 
 /** Segmented System / Light / Dark theme control. */
@@ -41,18 +42,21 @@ function ThemeToggle() {
   const { theme, setTheme } = useTheme();
   return (
     <div className="tv-theme-toggle" role="group" aria-label="Theme">
-      {THEME_OPTIONS.map((o) => (
-        <button
-          key={o.value}
-          type="button"
-          className={theme === o.value ? 'tv-theme-toggle__btn is-active' : 'tv-theme-toggle__btn'}
-          onClick={() => setTheme(o.value)}
-          title={`${o.label} theme`}
-          aria-pressed={theme === o.value}
-        >
-          <span aria-hidden="true">{o.icon}</span>
-        </button>
-      ))}
+      {THEME_OPTIONS.map((o) => {
+        const Icon = o.icon;
+        return (
+          <button
+            key={o.value}
+            type="button"
+            className={theme === o.value ? 'tv-theme-toggle__btn is-active' : 'tv-theme-toggle__btn'}
+            onClick={() => setTheme(o.value)}
+            title={`${o.label} theme`}
+            aria-pressed={theme === o.value}
+          >
+            <Icon size={15} aria-hidden="true" />
+          </button>
+        );
+      })}
     </div>
   );
 }
@@ -76,15 +80,15 @@ function Sidebar() {
       <NavLink to="/" className="tv-nav__brand" end>
         Claudescope
       </NavLink>
-      {NAV_ITEMS.map((item) => (
+      {NAV_ITEMS.map(({ to, label, icon: Icon, end }) => (
         <NavLink
-          key={item.to}
-          to={item.to}
-          end={item.end}
+          key={to}
+          to={to}
+          end={end}
           className={({ isActive }) => (isActive ? 'tv-nav__link is-active' : 'tv-nav__link')}
         >
-          <span aria-hidden="true">{item.icon}</span>
-          {item.label}
+          <Icon size={16} aria-hidden="true" />
+          {label}
         </NavLink>
       ))}
       <div className="tv-nav__spacer" />

--- a/packages/web/src/components/Collapsible.tsx
+++ b/packages/web/src/components/Collapsible.tsx
@@ -1,4 +1,5 @@
 import { useState, type ReactNode } from 'react';
+import { ChevronRight } from 'lucide-react';
 
 /**
  * Generic collapsible panel used as the shell for tool and thinking blocks.
@@ -62,7 +63,7 @@ export function Collapsible({
         onClick={toggle}
       >
         <span className="tv-collapsible__chevron" aria-hidden="true">
-          ▶
+          <ChevronRight size={14} />
         </span>
         {icon ? <span className="tv-collapsible__icon">{icon}</span> : null}
         <span className="tv-collapsible__title">{title}</span>

--- a/packages/web/src/components/ModelChips.tsx
+++ b/packages/web/src/components/ModelChips.tsx
@@ -1,0 +1,44 @@
+/** A capped row of model chips, shared by the session list and the header. */
+
+/** Shorten a model id for chip display (drops the date suffix). */
+export function shortModel(model: string): string {
+  if (model === '<synthetic>') return 'synthetic';
+  // e.g. "claude-opus-4-8-20250101" -> "opus-4-8"
+  const stripped = model.replace(/^claude-/, '');
+  const m = /^([a-z]+-\d+-\d+)/.exec(stripped);
+  return m?.[1] ?? stripped;
+}
+
+export interface ModelChipsProps {
+  models: string[];
+  /** Max chips to show before collapsing the rest into a "+N" chip. */
+  max?: number;
+}
+
+/**
+ * Renders model ids as chips, capped at `max` (default 3). Sessions can span
+ * 1–5+ models; any beyond the cap collapse into a "+N" chip whose tooltip lists
+ * the remaining ids, so a busy session stays a single tidy line.
+ */
+export function ModelChips({ models, max = 3 }: ModelChipsProps) {
+  if (models.length === 0) return null;
+  const shown = models.slice(0, max);
+  const rest = models.slice(max);
+  return (
+    <span className="tv-chips">
+      {shown.map((m) => (
+        <span key={m} className="tv-chip tv-chip--model">
+          {shortModel(m)}
+        </span>
+      ))}
+      {rest.length > 0 ? (
+        <span
+          className="tv-chip tv-chip--model tv-chip--more"
+          title={rest.map(shortModel).join(', ')}
+        >
+          +{rest.length}
+        </span>
+      ) : null}
+    </span>
+  );
+}

--- a/packages/web/src/components/SummaryStrip.tsx
+++ b/packages/web/src/components/SummaryStrip.tsx
@@ -1,0 +1,24 @@
+import type { ReactNode } from 'react';
+
+export interface SummaryItem {
+  label: string;
+  value: ReactNode;
+}
+
+/**
+ * A compact row of stat tiles (label + bold value) that anchors the top of a
+ * list view. Shared by the Browse portfolio header and the project detail
+ * header so the two read as the same pattern at different altitudes.
+ */
+export function SummaryStrip({ items }: { items: SummaryItem[] }) {
+  return (
+    <div className="tv-summary">
+      {items.map((it) => (
+        <div key={it.label} className="tv-summary__tile">
+          <span className="tv-summary__label">{it.label}</span>
+          <span className="tv-summary__value">{it.value}</span>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/packages/web/src/components/index.ts
+++ b/packages/web/src/components/index.ts
@@ -13,4 +13,6 @@ export { Spinner, type SpinnerProps } from './Spinner.js';
 export { ErrorBox, type ErrorBoxProps } from './ErrorBox.js';
 export { ErrorBoundary, type ErrorBoundaryProps } from './ErrorBoundary.js';
 export { AgentBadge, agentLabel, type AgentBadgeProps } from './AgentBadge.js';
+export { ModelChips, shortModel, type ModelChipsProps } from './ModelChips.js';
+export { SummaryStrip, type SummaryItem } from './SummaryStrip.js';
 export { extractImage } from './image.js';

--- a/packages/web/src/pages/analytics/AnalyticsPage.tsx
+++ b/packages/web/src/pages/analytics/AnalyticsPage.tsx
@@ -22,7 +22,7 @@ import type {
   ProjectMeta,
 } from '@claudescope/shared';
 import { api } from '../../api/client.js';
-import { CostBadge, ErrorBox, Spinner } from '../../components/index.js';
+import { ErrorBox, Spinner } from '../../components/index.js';
 import { BreakdownChart } from './BreakdownChart.js';
 import type { BreakdownMetric, BreakdownSort } from './BreakdownChart.js';
 import { TimeSeriesChart } from './TimeSeriesChart.js';
@@ -287,14 +287,35 @@ function SummaryCards({
   }
   if (!totals) return null;
 
+  // Reconcile the headline: total = input + output + cache. Cache reads usually
+  // dominate, which is why the big number looks unexplained without the split.
+  const cacheTokens = totals.cacheReadTokens + totals.cacheCreationTokens;
+  const cacheReadShare = totals.totalTokens > 0 ? totals.cacheReadTokens / totals.totalTokens : 0;
+
   return (
     <div className="tv-analytics__cards">
       <StatCard
         label="Total tokens"
         value={formatCount(totals.totalTokens)}
-        sub={`${formatCount(totals.inputTokens)} in · ${formatCount(totals.outputTokens)} out`}
+        sub={
+          <span className="tv-stat-card__tokens">
+            <TokenMiniBar
+              input={totals.inputTokens}
+              output={totals.outputTokens}
+              cache={cacheTokens}
+            />
+            <span>
+              {formatCount(totals.inputTokens)} in · {formatCount(totals.outputTokens)} out ·{' '}
+              {formatCount(cacheTokens)} cache
+            </span>
+          </span>
+        }
       />
-      <StatCard label="Total cost" value={formatCost(totals.costUsd)} sub={<CostBadge usd={totals.costUsd} />} />
+      <StatCard
+        label="Total cost"
+        value={formatCost(totals.costUsd)}
+        sub={`list-price estimate · ${formatPct(cacheReadShare)} of tokens cache-read`}
+      />
       <StatCard
         label="Assistant messages"
         value={formatCount(totals.messageCount)}
@@ -353,6 +374,23 @@ function StatCard({ label, value, sub }: { label: string; value: string; sub?: R
       <span className="tv-stat-card__value">{value}</span>
       {sub != null && <span className="tv-stat-card__sub">{sub}</span>}
     </div>
+  );
+}
+
+/**
+ * A thin stacked bar showing how the total token count splits into input /
+ * output / cache, so the headline number visibly reconciles. Spans (not divs)
+ * so it nests inside the card's sub `<span>`; cache is muted since it dominates.
+ */
+function TokenMiniBar({ input, output, cache }: { input: number; output: number; cache: number }) {
+  const total = input + output + cache || 1;
+  const pct = (n: number) => `${(n / total) * 100}%`;
+  return (
+    <span className="tv-tokenbar" aria-hidden="true">
+      <span className="tv-tokenbar__seg tv-tokenbar__in" style={{ width: pct(input) }} />
+      <span className="tv-tokenbar__seg tv-tokenbar__out" style={{ width: pct(output) }} />
+      <span className="tv-tokenbar__seg tv-tokenbar__cache" style={{ width: pct(cache) }} />
+    </span>
   );
 }
 

--- a/packages/web/src/pages/analytics/analytics.css
+++ b/packages/web/src/pages/analytics/analytics.css
@@ -115,6 +115,32 @@
   font-size: var(--tv-fs-sm);
   color: var(--tv-fg-muted);
 }
+/* Total-tokens breakdown: a mini reconcile bar above the in/out/cache legend. */
+.tv-stat-card__tokens {
+  display: flex;
+  flex-direction: column;
+  gap: var(--tv-space-1);
+}
+.tv-tokenbar {
+  display: flex;
+  width: 100%;
+  height: 6px;
+  border-radius: 999px;
+  overflow: hidden;
+  background: var(--tv-bg-inset);
+}
+.tv-tokenbar__seg {
+  height: 100%;
+}
+.tv-tokenbar__in {
+  background: var(--tv-accent);
+}
+.tv-tokenbar__out {
+  background: var(--tv-assistant);
+}
+.tv-tokenbar__cache {
+  background: var(--tv-border-strong);
+}
 
 /* Chart cards */
 .tv-analytics__charts {

--- a/packages/web/src/pages/browse/BrowsePage.tsx
+++ b/packages/web/src/pages/browse/BrowsePage.tsx
@@ -2,7 +2,7 @@ import { useEffect, useMemo, useState } from 'react';
 import { Link } from 'react-router-dom';
 import type { ProjectMeta } from '@claudescope/shared';
 import { api, ApiError } from '../../api/client.js';
-import { AgentBadge, CostBadge, ErrorBox, Spinner, TokenChips } from '../../components';
+import { AgentBadge, ErrorBox, formatCost, formatCount, Spinner, SummaryStrip } from '../../components';
 import { timeAgo } from './format.js';
 import './browse.css';
 
@@ -74,6 +74,20 @@ export function BrowsePage() {
     return sortProjects(base, sort);
   }, [projects, filter, sort]);
 
+  // Portfolio totals — computed over ALL projects (not the filtered view) so the
+  // summary stays a stable anchor regardless of the filter box.
+  const portfolio = useMemo(() => {
+    const agents = new Set<string>();
+    let sessions = 0;
+    let cost = 0;
+    for (const p of projects) {
+      p.connectorIds.forEach((id) => agents.add(id));
+      sessions += p.sessionCount;
+      cost += p.totalCostUsd;
+    }
+    return { projects: projects.length, sessions, cost, agents: agents.size };
+  }, [projects]);
+
   return (
     <section>
       <header className="tv-browse__header">
@@ -103,6 +117,17 @@ export function BrowsePage() {
         </div>
       </header>
 
+      {!loading && !error && projects.length > 0 ? (
+        <SummaryStrip
+          items={[
+            { label: 'Projects', value: formatCount(portfolio.projects) },
+            { label: 'Sessions', value: formatCount(portfolio.sessions) },
+            { label: 'Spend', value: formatCost(portfolio.cost) },
+            { label: 'Agents', value: formatCount(portfolio.agents) },
+          ]}
+        />
+      ) : null}
+
       {loading ? (
         <Spinner size="lg" label="Loading projects…" />
       ) : error ? (
@@ -125,20 +150,27 @@ export function BrowsePage() {
 function ProjectCard({ project }: { project: ProjectMeta }) {
   return (
     <Link to={`/projects/${project.id}`} className="tv-card tv-project-card">
-      <div className="tv-project-card__name">{project.displayName}</div>
+      <div className="tv-project-card__top">
+        <div className="tv-project-card__name">{project.displayName}</div>
+        <span className="tv-project-card__time tv-muted">{timeAgo(project.lastActive)}</span>
+      </div>
       <div className="tv-project-card__cwd tv-muted tv-mono">{project.cwd}</div>
-      <div className="tv-project-card__stats">
+      {/* Agents (badges) read at a glance; the numbers live in their own muted
+          meta line below so the two stop competing. */}
+      <div className="tv-project-card__agents">
         {project.connectorIds.map((id) => (
           <AgentBadge key={id} connectorId={id} />
         ))}
-        <span className="tv-chip">
-          <span className="tv-chip__label">sessions</span>
-          <span className="tv-chip__value">{project.sessionCount}</span>
-        </span>
-        <TokenChips totalOnly total={project.totalTokens} />
-        <CostBadge usd={project.totalCostUsd} />
       </div>
-      <div className="tv-project-card__footer tv-muted">{timeAgo(project.lastActive)}</div>
+      <div className="tv-project-card__meta tv-muted">
+        <span>
+          {project.sessionCount} session{project.sessionCount === 1 ? '' : 's'}
+        </span>
+        <span>·</span>
+        <span>{formatCount(project.totalTokens)} tokens</span>
+        <span>·</span>
+        <span className="tv-project-card__cost">{formatCost(project.totalCostUsd)}</span>
+      </div>
     </Link>
   );
 }

--- a/packages/web/src/pages/browse/ProjectLayout.tsx
+++ b/packages/web/src/pages/browse/ProjectLayout.tsx
@@ -13,6 +13,7 @@ import { useEffect, useState } from 'react';
 import { Link, NavLink, Outlet, useOutletContext, useParams } from 'react-router-dom';
 import type { ProjectMeta } from '@claudescope/shared';
 import { api, ApiError } from '../../api/client.js';
+import { formatCost, formatCount, SummaryStrip } from '../../components';
 import '../memory/memory.css';
 
 export interface ProjectOutletContext {
@@ -76,6 +77,17 @@ export function ProjectLayout() {
           ) : null}
         </div>
       </header>
+
+      {project ? (
+        <SummaryStrip
+          items={[
+            { label: 'Sessions', value: formatCount(project.sessionCount) },
+            { label: 'Tokens', value: formatCount(project.totalTokens) },
+            { label: 'Cost', value: formatCost(project.totalCostUsd) },
+            { label: 'Agents', value: formatCount(project.connectorIds.length) },
+          ]}
+        />
+      ) : null}
 
       <div className="tv-memory-tabs" role="tablist" aria-label="Project view">
         <NavLink to={`/projects/${encodeURIComponent(projectId)}`} end className={tabClass} role="tab">

--- a/packages/web/src/pages/browse/SessionList.tsx
+++ b/packages/web/src/pages/browse/SessionList.tsx
@@ -2,8 +2,8 @@ import { useEffect, useMemo, useState } from 'react';
 import { Link } from 'react-router-dom';
 import type { SessionMeta, SessionSort } from '@claudescope/shared';
 import { api, ApiError } from '../../api/client.js';
-import { AgentBadge, agentLabel, CostBadge, ErrorBox, Spinner, TokenChips } from '../../components';
-import { formatBytes, formatDateTime, shortModel, timeAgo } from './format.js';
+import { AgentBadge, agentLabel, ErrorBox, formatCost, formatCount, ModelChips, Spinner } from '../../components';
+import { formatBytes, formatDateTime, timeAgo } from './format.js';
 import { useProjectContext } from './ProjectLayout.js';
 
 const SORT_OPTIONS: { value: SessionSort; label: string }[] = [
@@ -177,17 +177,17 @@ function SessionRow({ session }: { session: SessionMeta }) {
         </div>
       </Link>
       <div className="tv-session-row__side">
-        <div className="tv-chips">
+        {/* One tidy meta line: agent + models, then the numbers with cost bold. */}
+        <div className="tv-session-row__meta-line">
           <AgentBadge connectorId={session.connectorId} />
-          {session.models.map((m) => (
-            <span key={m} className="tv-chip tv-chip--model">
-              {shortModel(m)}
-            </span>
-          ))}
-        </div>
-        <div className="tv-session-row__numbers">
-          <TokenChips totalOnly total={session.totalTokens} />
-          <CostBadge usd={session.totalCostUsd} />
+          <ModelChips models={session.models} />
+          <span className="tv-session-row__sep" aria-hidden="true">
+            │
+          </span>
+          <span className="tv-session-row__tokens tv-muted">
+            {formatCount(session.totalTokens)}
+          </span>
+          <span className="tv-session-row__cost">{formatCost(session.totalCostUsd)}</span>
         </div>
         {session.prUrl ? (
           <a

--- a/packages/web/src/pages/browse/browse.css
+++ b/packages/web/src/pages/browse/browse.css
@@ -74,26 +74,47 @@
   background: var(--tv-bg-hover);
   text-decoration: none;
 }
+.tv-project-card__top {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: var(--tv-space-3);
+}
 .tv-project-card__name {
   font-size: var(--tv-fs-lg);
   font-weight: 600;
   word-break: break-word;
 }
+.tv-project-card__time {
+  flex: 0 0 auto;
+  font-size: var(--tv-fs-sm);
+}
 .tv-project-card__cwd {
   font-size: var(--tv-fs-sm);
   word-break: break-all;
 }
-.tv-project-card__stats {
+/* Agent badges on their own row… */
+.tv-project-card__agents {
   display: flex;
   flex-wrap: wrap;
   gap: var(--tv-space-1);
   align-items: center;
   margin-top: var(--tv-space-1);
 }
-.tv-project-card__footer {
+/* …numbers in a muted meta line pinned to the bottom, with cost the bold figure. */
+.tv-project-card__meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--tv-space-2);
+  align-items: center;
   font-size: var(--tv-fs-sm);
   margin-top: auto;
   padding-top: var(--tv-space-1);
+}
+.tv-project-card__cost {
+  color: var(--tv-fg);
+  font-weight: 600;
+  font-variant-numeric: tabular-nums;
 }
 
 /* Agent filter — shown inside a project that spans multiple agents. */
@@ -142,6 +163,7 @@
 }
 
 .tv-session-row {
+  position: relative;
   display: flex;
   align-items: center;
   justify-content: space-between;
@@ -151,6 +173,18 @@
 }
 .tv-session-row:hover {
   border-color: var(--tv-border-strong);
+}
+/* Make the WHOLE card the click target, not just the inner text: the main link
+   stretches an invisible overlay across the row. The right-hand meta sits under
+   it (clicks still open the session); only the PR link is lifted above. */
+.tv-session-row__main::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+}
+.tv-session-row__side a {
+  position: relative;
+  z-index: 1;
 }
 .tv-session-row__main {
   display: flex;
@@ -185,10 +219,25 @@
   gap: var(--tv-space-2);
   flex-shrink: 0;
 }
-.tv-session-row__numbers {
+/* One tidy meta line on the right: agent + models · tokens · cost (cost bold). */
+.tv-session-row__meta-line {
   display: flex;
+  flex-wrap: wrap;
   align-items: center;
+  justify-content: flex-end;
   gap: var(--tv-space-2);
+  font-size: var(--tv-fs-sm);
+}
+.tv-session-row__sep {
+  color: var(--tv-border-strong);
+}
+.tv-session-row__tokens {
+  font-variant-numeric: tabular-nums;
+}
+.tv-session-row__cost {
+  color: var(--tv-fg);
+  font-weight: 600;
+  font-variant-numeric: tabular-nums;
 }
 
 .tv-chip--model {

--- a/packages/web/src/pages/browse/format.ts
+++ b/packages/web/src/pages/browse/format.ts
@@ -46,6 +46,20 @@ export function timeAgo(iso: string | undefined): string {
   return `${Math.floor(mon / 12)}y ago`;
 }
 
+/** Compact elapsed duration between two ISO timestamps (e.g. "1h 23m", "45m", "30s"). */
+export function formatDuration(startIso: string | undefined, endIso: string | undefined): string {
+  if (!startIso || !endIso) return '';
+  const ms = new Date(endIso).getTime() - new Date(startIso).getTime();
+  if (!Number.isFinite(ms) || ms <= 0) return '';
+  const sec = Math.floor(ms / 1000);
+  if (sec < 60) return `${sec}s`;
+  const min = Math.floor(sec / 60);
+  if (min < 60) return `${min}m`;
+  const hr = Math.floor(min / 60);
+  const rem = min % 60;
+  return rem ? `${hr}h ${rem}m` : `${hr}h`;
+}
+
 /** Human-readable byte size (e.g. "1.3 MB"). */
 export function formatBytes(bytes: number): string {
   if (!Number.isFinite(bytes) || bytes <= 0) return '0 B';
@@ -59,11 +73,6 @@ export function formatBytes(bytes: number): string {
   return `${value.toFixed(value < 10 && unit > 0 ? 1 : 0)} ${units[unit]}`;
 }
 
-/** Shorten a model id for chip display (drops the date suffix). */
-export function shortModel(model: string): string {
-  if (model === '<synthetic>') return 'synthetic';
-  // e.g. "claude-opus-4-8-20250101" -> "opus-4-8"
-  const stripped = model.replace(/^claude-/, '');
-  const m = /^([a-z]+-\d+-\d+)/.exec(stripped);
-  return m?.[1] ?? stripped;
-}
+// `shortModel` now lives with the shared <ModelChips> component; re-exported
+// here so existing browse/session imports keep their path.
+export { shortModel } from '../../components/ModelChips.js';

--- a/packages/web/src/pages/session/ContinueMenu.tsx
+++ b/packages/web/src/pages/session/ContinueMenu.tsx
@@ -1,7 +1,9 @@
 import { useEffect, useRef, useState } from 'react';
+import { Copy, GitBranch, Play, RotateCcw } from 'lucide-react';
 import type { ResumeInfo } from '@claudescope/shared';
+import { AgentBadge } from '../../components';
 
-/** A copy-paste command line with its own Copy button. */
+/** A copy-paste command line with its own Copy button. The command wraps in full. */
 function CommandRow({ command }: { command: string }) {
   const [copied, setCopied] = useState(false);
   const copy = async () => {
@@ -16,8 +18,14 @@ function CommandRow({ command }: { command: string }) {
   return (
     <div className="tv-continue__cmd">
       <code className="tv-continue__cmd-text">{command}</code>
-      <button type="button" className="tv-linkbtn" onClick={copy}>
-        {copied ? 'Copied!' : 'Copy'}
+      <button type="button" className="tv-continue__copy" onClick={copy}>
+        {copied ? (
+          'Copied!'
+        ) : (
+          <>
+            <Copy size={13} aria-hidden="true" /> Copy
+          </>
+        )}
       </button>
     </div>
   );
@@ -25,10 +33,21 @@ function CommandRow({ command }: { command: string }) {
 
 /**
  * "Continue" dropdown: the command to reopen this session in the agent's own CLI,
- * for the user to copy and run in their terminal. Rendered only when the
- * session's connector exposes a resume command.
+ * for the user to copy and run in their terminal. Resume (append) is offered for
+ * every agent; Fork (a fresh, untouched copy) only when the CLI supports it.
+ * Claudescope only ever copies a string — it never executes anything.
  */
-export function ContinueMenu({ resume }: { resume: ResumeInfo }) {
+export function ContinueMenu({
+  resume,
+  connectorId,
+  projectName,
+  branch,
+}: {
+  resume: ResumeInfo;
+  connectorId: string;
+  projectName?: string;
+  branch?: string;
+}) {
   const [open, setOpen] = useState(false);
   const ref = useRef<HTMLDetailsElement>(null);
 
@@ -54,16 +73,46 @@ export function ContinueMenu({ resume }: { resume: ResumeInfo }) {
           setOpen((o) => !o);
         }}
       >
-        ▷ Continue
+        <Play size={14} aria-hidden="true" /> Continue
       </summary>
       <div className="tv-continue__menu">
-        <p className="tv-continue__hint">Run this in your terminal to resume the session:</p>
-        <CommandRow command={resume.resumeCommand} />
+        <div className="tv-continue__head">
+          <Play size={16} aria-hidden="true" />
+          <strong>Continue this session</strong>
+        </div>
+        <p className="tv-continue__lead">
+          Pick this run back up in your terminal. Claudescope only copies a command — it never runs
+          anything.
+        </p>
+        <div className="tv-continue__ctx">
+          <AgentBadge connectorId={connectorId} />
+          {projectName ? <span className="tv-chip">{projectName}</span> : null}
+          {branch ? <span className="tv-chip tv-mono">{branch}</span> : null}
+        </div>
+
+        <div className="tv-continue__opt">
+          <div className="tv-continue__opt-head">
+            <RotateCcw size={15} aria-hidden="true" />
+            <strong>Resume in place</strong>
+          </div>
+          <p className="tv-continue__opt-desc">
+            Continues the same session — same history and id. New turns append to this transcript.
+          </p>
+          <CommandRow command={resume.resumeCommand} />
+        </div>
+
         {resume.forkCommand ? (
-          <>
-            <p className="tv-continue__hint">Or fork into a new session, leaving this one untouched:</p>
+          <div className="tv-continue__opt">
+            <div className="tv-continue__opt-head">
+              <GitBranch size={15} aria-hidden="true" />
+              <strong>Fork to a new session</strong>
+            </div>
+            <p className="tv-continue__opt-desc">
+              Branches a copy and leaves this transcript untouched — for trying a different direction
+              safely.
+            </p>
             <CommandRow command={resume.forkCommand} />
-          </>
+          </div>
         ) : null}
       </div>
     </details>

--- a/packages/web/src/pages/session/ExportMenu.tsx
+++ b/packages/web/src/pages/session/ExportMenu.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef, useState } from 'react';
+import { Download } from 'lucide-react';
 import type { SessionDetailResponse } from '@claudescope/shared';
 import { sessionToMarkdown } from './export.js';
 
@@ -54,7 +55,7 @@ export function ExportMenu({ data }: { data: SessionDetailResponse }) {
           setOpen((o) => !o);
         }}
       >
-        ⤓ Export
+        <Download size={14} aria-hidden="true" /> Export
       </summary>
       <div className="tv-export__menu">
         <label className="tv-export__opt">

--- a/packages/web/src/pages/session/SessionFinder.tsx
+++ b/packages/web/src/pages/session/SessionFinder.tsx
@@ -1,4 +1,5 @@
 import type { RefObject } from 'react';
+import { Search } from 'lucide-react';
 import type { RoleFilter } from './search.js';
 
 export interface SessionFinderProps {
@@ -32,7 +33,9 @@ export function SessionFinder({
   const hasQuery = query.trim().length >= 2;
   return (
     <div className="tv-finder" role="search">
-      <span className="tv-finder__icon" aria-hidden="true">⌕</span>
+      <span className="tv-finder__icon" aria-hidden="true">
+        <Search size={14} />
+      </span>
       <input
         ref={inputRef}
         type="text"

--- a/packages/web/src/pages/session/SessionPage.tsx
+++ b/packages/web/src/pages/session/SessionPage.tsx
@@ -1,9 +1,10 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { Link, useParams, useSearchParams } from 'react-router-dom';
+import { ArrowUpRight, GitBranch, GitPullRequest, MessageSquare, RefreshCw, Wrench } from 'lucide-react';
 import type { SessionDetailResponse, SubagentRun } from '@claudescope/shared';
 import { api, ApiError } from '../../api/client.js';
-import { AgentBadge, CostBadge, ErrorBox, Spinner, TokenChips } from '../../components';
-import { formatBytes, formatDateTime, shortModel } from '../browse/format.js';
+import { AgentBadge, ErrorBox, formatCost, formatCount, ModelChips, Spinner } from '../../components';
+import { formatBytes, formatDateTime, formatDuration } from '../browse/format.js';
 import { hasRenderableContent } from './blocks.js';
 import { SubagentBlock, SubagentJumpMenu, ThreadList, useHashTarget } from './ThreadView.js';
 import { useProgressiveMount } from './useProgressiveMount.js';
@@ -119,6 +120,7 @@ function SessionView({
 }) {
   const { meta, thread, subagents } = data;
   const title = meta.title || 'Untitled session';
+  const duration = formatDuration(meta.startedAt, meta.endedAt);
   const [searchParams] = useSearchParams();
 
   // Only render turns that actually carry visible content.
@@ -364,11 +366,18 @@ function SessionView({
             ) : null}
           </nav>
           <SubagentJumpMenu subagents={subagents} />
-          {data.resume ? <ContinueMenu resume={data.resume} /> : null}
+          {data.resume ? (
+            <ContinueMenu
+              resume={data.resume}
+              connectorId={meta.connectorId}
+              projectName={meta.projectDisplayName}
+              branch={meta.gitBranch}
+            />
+          ) : null}
           <ExportMenu data={data} />
           <button
             type="button"
-            className="tv-linkbtn"
+            className="tv-session__action"
             onClick={onRefresh}
             disabled={refreshing}
             title="Reload the latest messages without losing your place (⌘R)"
@@ -376,7 +385,9 @@ function SessionView({
             {refreshing ? (
               <Spinner size="sm" label="Refreshing…" />
             ) : (
-              <>⟳ Refresh</>
+              <>
+                <RefreshCw size={14} aria-hidden="true" /> Refresh
+              </>
             )}
           </button>
           <SessionFinder
@@ -391,41 +402,67 @@ function SessionView({
             inputRef={inputRef}
           />
         </div>
-        <h1 className="tv-session__title" title={title}>
-          {title}
-          {meta.hasSidechain ? (
-            <span className="tv-chip tv-chip--sidechain" title="Includes subagent/sidechain transcripts">
-              {subagents.length} subagent{subagents.length === 1 ? '' : 's'}
-            </span>
-          ) : null}
-        </h1>
-        <div className="tv-session__meta">
-          <AgentBadge connectorId={meta.connectorId} />
-          <span className="tv-muted">{formatDateTime(meta.startedAt)}</span>
-          <span className="tv-muted">→ {formatDateTime(meta.endedAt)}</span>
-          <span className="tv-muted">{meta.messageCount} msgs</span>
-          <span className="tv-muted">{meta.toolCallCount} tools</span>
-          {meta.gitBranch ? <span className="tv-mono tv-muted">⎇ {meta.gitBranch}</span> : null}
-          <span className="tv-muted">{formatBytes(meta.sizeBytes)}</span>
-          <span className="tv-chips">
-            {meta.models.map((m) => (
-              <span key={m} className="tv-chip tv-chip--model">
-                {shortModel(m)}
+
+        {/* Tier one: the title, with the PR action promoted to the right. */}
+        <div className="tv-session__titlebar">
+          <h1 className="tv-session__title" title={title}>
+            {title}
+            {meta.titleDerived ? (
+              <span
+                className="tv-chip tv-session__derived"
+                title="No stored title — derived from the first message"
+              >
+                untitled · from first message
               </span>
-            ))}
-          </span>
-          <TokenChips totalOnly total={meta.totalTokens} />
-          <CostBadge usd={meta.totalCostUsd} />
+            ) : null}
+            {meta.hasSidechain ? (
+              <span className="tv-chip tv-chip--sidechain" title="Includes subagent/sidechain transcripts">
+                {subagents.length} subagent{subagents.length === 1 ? '' : 's'}
+              </span>
+            ) : null}
+          </h1>
           {meta.prUrl ? (
             <a
               href={meta.prUrl}
               target="_blank"
               rel="noopener noreferrer"
-              className="tv-chip tv-chip--pr"
+              className="tv-session__pr-btn"
             >
-              PR ↗
+              <GitPullRequest size={14} aria-hidden="true" /> PR
+              <ArrowUpRight size={12} aria-hidden="true" />
             </a>
           ) : null}
+        </div>
+
+        {/* Tier one stats: agent + models, then cost (the bold figure) + tokens + duration. */}
+        <div className="tv-session__primary">
+          <AgentBadge connectorId={meta.connectorId} />
+          <ModelChips models={meta.models} />
+          <span className="tv-session__sep" aria-hidden="true">
+            │
+          </span>
+          <span className="tv-session__cost">{formatCost(meta.totalCostUsd)}</span>
+          <span className="tv-session__tokens">{formatCount(meta.totalTokens)} tokens</span>
+          {duration ? <span className="tv-muted">{duration}</span> : null}
+        </div>
+
+        {/* Tier two: counts, branch, timestamps, size — present, not loud. */}
+        <div className="tv-session__meta tv-muted">
+          <span className="tv-session__meta-item">
+            <MessageSquare size={13} aria-hidden="true" /> {meta.messageCount} messages
+          </span>
+          <span className="tv-session__meta-item">
+            <Wrench size={13} aria-hidden="true" /> {meta.toolCallCount} tools
+          </span>
+          {meta.gitBranch ? (
+            <span className="tv-session__meta-item tv-mono" title="git branch">
+              <GitBranch size={13} aria-hidden="true" /> {meta.gitBranch}
+            </span>
+          ) : null}
+          <span>
+            {formatDateTime(meta.startedAt)} → {formatDateTime(meta.endedAt)}
+          </span>
+          <span>{formatBytes(meta.sizeBytes)}</span>
         </div>
       </header>
 

--- a/packages/web/src/pages/session/ThreadView.tsx
+++ b/packages/web/src/pages/session/ThreadView.tsx
@@ -1,4 +1,5 @@
 import { Fragment, memo, useContext, useEffect, useRef, useState } from 'react';
+import { Puzzle } from 'lucide-react';
 import type { SubagentRun, ThreadBlock, ThreadItem } from '@claudescope/shared';
 import { ClampedText, Collapsible, ErrorBoundary, ErrorBox, TokenChips } from '../../components';
 import { formatDateTime, shortModel } from '../browse/format.js';
@@ -322,7 +323,8 @@ export function SubagentJumpMenu({ subagents }: { subagents: SubagentRun[] }) {
           setOpen((o) => !o);
         }}
       >
-        🧩 Subagents <span className="tv-subagent-menu__count">{subagents.length}</span>
+        <Puzzle size={14} aria-hidden="true" /> Subagents{' '}
+        <span className="tv-subagent-menu__count">{subagents.length}</span>
       </summary>
       <ul className="tv-subagent-menu__list">
         {subagents.map((s) => (

--- a/packages/web/src/pages/session/session.css
+++ b/packages/web/src/pages/session/session.css
@@ -48,22 +48,111 @@
   min-width: 0;
 }
 
-.tv-session__title {
-  font-size: 18px;
-  font-weight: 600;
-  margin: 0 0 var(--tv-space-2);
-  display: flex;
+/* Refresh + (matches the menu summaries) — a quiet accent action in the top bar. */
+.tv-session__action {
+  display: inline-flex;
   align-items: center;
-  gap: var(--tv-space-2);
-  line-height: 1.3;
+  gap: var(--tv-space-1);
+  background: transparent;
+  border: 0;
+  padding: 0;
+  cursor: pointer;
+  font-size: var(--tv-fs-sm);
+  color: var(--tv-accent);
+}
+.tv-session__action:hover:not(:disabled) {
+  text-decoration: underline;
+}
+.tv-session__action:disabled {
+  cursor: default;
+  opacity: 0.7;
 }
 
-.tv-session__meta {
+/* Tier one: title row, with the PR action promoted to the right. */
+.tv-session__titlebar {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: var(--tv-space-3);
+  margin-bottom: var(--tv-space-2);
+}
+.tv-session__title {
+  flex: 1 1 auto;
+  min-width: 0;
+  font-size: 18px;
+  font-weight: 600;
+  margin: 0;
   display: flex;
   flex-wrap: wrap;
   align-items: center;
   gap: var(--tv-space-2);
+  line-height: 1.3;
+  word-break: break-word;
+}
+/* "untitled · from first message" — an honest, quiet marker, not a real title. */
+.tv-session__derived {
+  font-weight: 400;
+  color: var(--tv-fg-faint);
+}
+/* PR as a real bordered action, not a chip lost in the meta row. */
+.tv-session__pr-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--tv-space-1);
+  flex: 0 0 auto;
+  padding: var(--tv-space-1) var(--tv-space-3);
+  border: 1px solid var(--tv-accent);
+  border-radius: var(--tv-radius-sm);
+  color: var(--tv-accent);
   font-size: var(--tv-fs-sm);
+  font-weight: 600;
+  white-space: nowrap;
+}
+.tv-session__pr-btn:hover {
+  background: var(--tv-accent-muted);
+  text-decoration: none;
+}
+
+/* Tier one stats: cost is the boldest figure; models + tokens + duration follow. */
+.tv-session__primary {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: var(--tv-space-2);
+  font-size: var(--tv-fs-md);
+  margin-bottom: var(--tv-space-2);
+}
+.tv-session__sep {
+  color: var(--tv-border-strong);
+}
+.tv-session__cost {
+  font-size: var(--tv-fs-lg);
+  font-weight: 700;
+  font-variant-numeric: tabular-nums;
+}
+.tv-session__tokens {
+  color: var(--tv-fg-muted);
+  font-variant-numeric: tabular-nums;
+}
+
+/* Tier two: counts, branch, timestamps, size — muted, below a divider. The
+   divider is full-bleed (negative side margins cancel the header padding) so it
+   matches the header's full-width bottom border; a padded divider read as a
+   shorter "middle" line sandwiched between two full-width ones. */
+.tv-session__meta {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: var(--tv-space-2) var(--tv-space-3);
+  font-size: var(--tv-fs-sm);
+  border-top: 1px solid var(--tv-border);
+  margin: 0 calc(-1 * var(--tv-space-5));
+  padding: var(--tv-space-2) var(--tv-space-5) 0;
+}
+.tv-session__meta-item {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--tv-space-1);
 }
 
 /* Thread */
@@ -248,6 +337,9 @@
   display: inline-block;
 }
 .tv-subagent-menu > summary {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--tv-space-1);
   cursor: pointer;
   list-style: none;
   font-size: var(--tv-fs-sm);
@@ -407,6 +499,9 @@
   display: inline-block;
 }
 .tv-export > summary {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--tv-space-1);
   cursor: pointer;
   list-style: none;
   font-size: var(--tv-fs-sm);
@@ -450,6 +545,9 @@
   display: inline-block;
 }
 .tv-continue > summary {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--tv-space-1);
   cursor: pointer;
   list-style: none;
   font-size: var(--tv-fs-sm);
@@ -464,36 +562,81 @@
   z-index: 20;
   top: calc(100% + var(--tv-space-1));
   left: 0;
-  width: 340px;
-  max-width: 80vw;
-  padding: var(--tv-space-2);
+  width: 380px;
+  max-width: 86vw;
+  padding: var(--tv-space-3);
   background: var(--tv-bg-elevated);
   border: 1px solid var(--tv-border-strong);
   border-radius: var(--tv-radius);
   box-shadow: 0 8px 24px rgba(0, 0, 0, 0.4);
 }
-.tv-continue__hint {
-  margin: 0 0 var(--tv-space-2);
+.tv-continue__head {
+  display: flex;
+  align-items: center;
+  gap: var(--tv-space-2);
+  font-size: var(--tv-fs-md);
+}
+.tv-continue__lead {
+  margin: var(--tv-space-1) 0 var(--tv-space-2);
+  font-size: var(--tv-fs-sm);
+  color: var(--tv-fg-muted);
+}
+.tv-continue__ctx {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: var(--tv-space-1);
+  padding-bottom: var(--tv-space-3);
+  border-bottom: 1px solid var(--tv-border);
+}
+/* Each option (Resume / Fork) reads as its own block, explained in a line. */
+.tv-continue__opt {
+  padding-top: var(--tv-space-3);
+}
+.tv-continue__opt-head {
+  display: flex;
+  align-items: center;
+  gap: var(--tv-space-2);
+  font-size: var(--tv-fs-md);
+}
+.tv-continue__opt-desc {
+  margin: var(--tv-space-1) 0 var(--tv-space-2);
   font-size: var(--tv-fs-sm);
   color: var(--tv-fg-muted);
 }
 .tv-continue__cmd {
   display: flex;
-  align-items: center;
+  align-items: flex-start;
   gap: var(--tv-space-2);
-  margin-bottom: var(--tv-space-2);
 }
+/* Full command — wraps, never truncated. */
 .tv-continue__cmd-text {
   flex: 1;
   min-width: 0;
-  overflow-x: auto;
-  white-space: nowrap;
-  padding: var(--tv-space-1) var(--tv-space-2);
+  white-space: pre-wrap;
+  word-break: break-all;
+  padding: var(--tv-space-2);
   background: var(--tv-bg-inset);
   border: 1px solid var(--tv-border);
   border-radius: var(--tv-radius-sm);
   font-size: var(--tv-fs-sm);
   color: var(--tv-fg);
+}
+.tv-continue__copy {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--tv-space-1);
+  flex: 0 0 auto;
+  background: transparent;
+  border: 1px solid var(--tv-border-strong);
+  border-radius: var(--tv-radius-sm);
+  color: var(--tv-accent);
+  cursor: pointer;
+  padding: var(--tv-space-1) var(--tv-space-2);
+  font-size: var(--tv-fs-sm);
+}
+.tv-continue__copy:hover {
+  background: var(--tv-bg-hover);
 }
 
 /* ── In-session finder ────────────────────────────────────────────────── */
@@ -514,6 +657,8 @@
   box-shadow: 0 0 0 2px var(--tv-accent-muted);
 }
 .tv-finder__icon {
+  display: inline-flex;
+  align-items: center;
   color: var(--tv-fg-muted);
   font-size: var(--tv-fs-md);
 }

--- a/packages/web/src/pages/session/session.css
+++ b/packages/web/src/pages/session/session.css
@@ -411,7 +411,11 @@
 .tv-session__tabs {
   display: flex;
   gap: var(--tv-space-1);
-  margin-bottom: var(--tv-space-4);
+  /* Full-bleed border (negative side margins cancel the page padding, padding
+     re-insets the tab labels) so this line aligns with the header's full-width
+     dividers above it rather than stopping short at the content edge. */
+  margin: 0 calc(-1 * var(--tv-space-5)) var(--tv-space-4);
+  padding: 0 var(--tv-space-5);
   border-bottom: 1px solid var(--tv-border);
 }
 .tv-tab {

--- a/packages/web/src/styles/global.css
+++ b/packages/web/src/styles/global.css
@@ -304,6 +304,11 @@ button {
 .tv-chip--cache {
   border-color: #3fb95055;
 }
+/* Overflow chip ("+N") for capped lists like <ModelChips>; the rest are in its title. */
+.tv-chip--more {
+  cursor: default;
+  color: var(--tv-fg-muted);
+}
 
 .tv-cost-badge {
   display: inline-flex;
@@ -694,6 +699,36 @@ mark {
   font-family: var(--tv-font-mono);
 }
 
+/* Summary strip — compact stat tiles anchoring a list view (portfolio / project). */
+.tv-summary {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--tv-space-2);
+  margin-bottom: var(--tv-space-4);
+}
+.tv-summary__tile {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 92px;
+  padding: var(--tv-space-2) var(--tv-space-3);
+  background: var(--tv-bg-elevated);
+  border: 1px solid var(--tv-border);
+  border-radius: var(--tv-radius);
+}
+.tv-summary__label {
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--tv-fg-faint);
+}
+.tv-summary__value {
+  font-size: var(--tv-fs-lg);
+  font-weight: 600;
+  font-variant-numeric: tabular-nums;
+  line-height: 1.2;
+}
+
 /* --------------------------------------------------------------------------
    Responsive — desktop-first, adapting down to small laptops. The project /
    analytics grids already reflow (auto-fill/auto-fit), so this mainly tightens
@@ -715,15 +750,12 @@ mark {
     --tv-nav-width: 56px;
   }
   /* Collapse nav items to their icons. `font-size: 0` hides the bare label text
-     node while the icon span re-asserts its own size. */
+     node; the icon is an SVG with intrinsic dimensions, so it stays visible. */
   .tv-nav__link {
     justify-content: center;
     gap: 0;
     font-size: 0;
     padding: var(--tv-space-2);
-  }
-  .tv-nav__link > span[aria-hidden] {
-    font-size: var(--tv-fs-md);
   }
   .tv-nav__brand {
     font-size: 0;


### PR DESCRIPTION
Batch 1 of the UI/UX review (plan [`docs/plans/0026`](docs/plans/0026-ui-ux-review-batches.md)). One consistent **hierarchy-through-subtraction** pass: one bold number per unit (cost), everything else demoted to muted meta, summary strips to anchor list views, and raw values (emoji, ad-hoc chips) replaced with quiet monochrome encodings.

## What's in this batch

- **① Monochrome icons** — one `lucide-react` set across the nav, theme toggle, session-header actions, and collapsible chevrons (replaces per-OS emoji). *New dep: `lucide-react`.*
- **Shared `SummaryStrip`** — portfolio totals anchor Browse; project totals anchor the project header.
- **⑥ Browse cards** — agent badges separated from a muted numbers line; cost is the one bold figure.
- **③/④ Project detail** — summary strip + session rows collapsed to one tidy meta line (shared `ModelChips`, capped at 3 + `+N` on hover). Whole row is now the click target.
- **② Session header** — two tiers: cost/models/duration promoted; counts/branch/size demoted below a divider; PR is a real action button; `untitled · from first message` marks a derived title.
- **⑨ Continue popover** — full wrapping commands, resume vs fork each explained, trust line, **no "recommended" label**.
- **⑦ Analytics** — total tokens reconciles (in + out + cache) with a mini bar; duplicate cost chip dropped for a "list-price estimate · N% cache-read" caveat. (Chart series were already blue/violet.)
- **⑪ Fallback titles (server)** — Codex/pi raw first-message titles are cleaned (markdown/`<INSTRUCTIONS>` stripped, injected blobs skipped, truncated) and flagged `titleDerived`; deterministic, schema → v7.

## Review feedback addressed
- Header tier-1/tier-2 divider made full-bleed so it matches the header bottom border (was a shorter "middle line").
- Session row: whole card is clickable, not just the inner text.

## Verification
- `npm run typecheck` ✓, `npm test` ✓ (225), `npm run build` ✓.
- Visually verified Browse, project sessions, session header, Continue popover, and Analytics against the mockups in **light and dark** (via `scripts/screenshots.mjs` + a focused driver; no real agent data touched).

Batches 2 (search/memory/export/thread polish) and 3 (files-changed rail) follow in separate PRs.