### PR TITLE
feat(web): UI hierarchy pass — batch 2

### DIFF
--- a/docs/plans/0026-ui-ux-review-batches.md
+++ b/docs/plans/0026-ui-ux-review-batches.md
@@ -2,7 +2,7 @@
 
 - **Status:** in-progress <!-- proposed | in-progress | done | superseded | abandoned -->
 - **Date:** 2026-06-17
-- **PR:** Batch 1 — [#32](https://github.com/vladar107/claudescope/pull/32)
+- **PR:** Batch 1 — [#32](https://github.com/vladar107/claudescope/pull/32) · Batch 2 — [#33](https://github.com/vladar107/claudescope/pull/33)
 
 ## Context
 

--- a/packages/server/src/data/memory.ts
+++ b/packages/server/src/data/memory.ts
@@ -9,7 +9,7 @@
  * the facts that were actually learned in it.
  */
 
-import type { MemorySource } from '@claudescope/shared';
+import type { MemoryConnectorOverview, MemoryPreview, MemorySource } from '@claudescope/shared';
 import { getConnection, queryRows } from '../db/duckdb.js';
 import { connectors } from '../connectors/registry.js';
 import type { AgentConnector } from '../connectors/types.js';
@@ -102,4 +102,101 @@ export async function collectMemory(): Promise<AttributedMemory[]> {
   }
 
   return out;
+}
+
+/**
+ * Whether a connector exposes a memory provider at all. Derived from the
+ * connector port: a memory store exists iff the connector implements
+ * `globalMemory` and/or `projectMemory`. Connectors with neither (pi, opencode)
+ * keep no memory store, so their card is marked `supported: false`.
+ */
+function hasMemoryProvider(c: AgentConnector): boolean {
+  return Boolean(c.globalMemory || c.projectMemory);
+}
+
+/**
+ * Collapse a markdown body to a short single-line excerpt for the preview.
+ * Strips a leading `---` frontmatter block, common inline/structural markdown
+ * (headings, list/quote markers, emphasis, links, inline code), collapses all
+ * whitespace, and truncates to ~140 chars with an ellipsis. Deterministic.
+ */
+function excerptFromMarkdown(markdown: string): string {
+  let body = markdown;
+  // Drop a leading YAML frontmatter block (`---` … `---`).
+  const fm = body.match(/^---\n[\s\S]*?\n---\n?/);
+  if (fm) body = body.slice(fm[0].length);
+  const text = body
+    .replace(/`+/g, '') // inline/fenced code ticks
+    .replace(/!?\[([^\]]*)\]\([^)]*\)/g, '$1') // links/images → their text
+    .replace(/^\s*[#>\-*+]+\s*/gm, '') // headings, quotes, list markers
+    .replace(/[*_~]/g, '') // emphasis markers
+    .replace(/\s+/g, ' ')
+    .trim();
+  return text.length > 140 ? `${text.slice(0, 139).trimEnd()}…` : text;
+}
+
+/** Map a memory source to a one-line preview, deriving the excerpt when needed. */
+function toPreview(it: AttributedMemory): MemoryPreview {
+  const { source } = it;
+  const description = source.description?.trim() || excerptFromMarkdown(source.markdown) || undefined;
+  return {
+    title: source.title,
+    ...(source.category ? { category: source.category } : {}),
+    ...(description ? { description } : {}),
+    provenance: source.provenance,
+    kind: source.kind,
+    scope: it.scope,
+  };
+}
+
+/**
+ * Roll up {@link collectMemory} items into one {@link MemoryConnectorOverview}
+ * per KNOWN connector (every registered agent, including those with no memory
+ * store). Pure given its `items` input — the route passes `collectMemory()`.
+ *
+ * Counts mirror the web's prior `summarize()`: `globalFiles` = the connector's
+ * global sources; `projectsWithFacts` = distinct projects with ≥1 of its
+ * sources; `totalFacts` = total project sources. `preview` is the connector's
+ * most-recently-updated source (by `source.updatedAt`) across BOTH global and
+ * project items, omitted when it has none. Sort: supported-with-content first,
+ * then supported-empty, then unsupported; ties broken by label.
+ */
+export function buildConnectorOverviews(items: AttributedMemory[]): MemoryConnectorOverview[] {
+  const byConnector = new Map<string, AttributedMemory[]>();
+  for (const it of items) {
+    const list = byConnector.get(it.connectorId);
+    if (list) list.push(it);
+    else byConnector.set(it.connectorId, [it]);
+  }
+
+  const overviews = connectors.map((c): MemoryConnectorOverview => {
+    const mine = byConnector.get(c.id) ?? [];
+    const globalFiles = mine.filter((it) => it.scope === 'global').length;
+    const projectItems = mine.filter((it) => it.scope === 'project');
+    const projectsWithFacts = new Set(projectItems.map((it) => it.projectId)).size;
+
+    // Latest by mtime across all scopes; deterministic tie-break on title so a
+    // stable item wins when two share an `updatedAt`.
+    const latest = mine.reduce<AttributedMemory | undefined>((best, it) => {
+      if (!best) return it;
+      if (it.source.updatedAt > best.source.updatedAt) return it;
+      if (it.source.updatedAt === best.source.updatedAt && it.source.title < best.source.title) return it;
+      return best;
+    }, undefined);
+
+    return {
+      connectorId: c.id,
+      label: c.label,
+      supported: hasMemoryProvider(c),
+      globalFiles,
+      projectsWithFacts,
+      totalFacts: projectItems.length,
+      ...(latest ? { preview: toPreview(latest) } : {}),
+    };
+  });
+
+  // Supported-with-content first, then supported-empty, then unsupported.
+  const rank = (o: MemoryConnectorOverview) =>
+    o.supported && o.preview ? 0 : o.supported ? 1 : 2;
+  return overviews.sort((a, b) => rank(a) - rank(b) || a.label.localeCompare(b.label));
 }

--- a/packages/server/src/routes/memory.ts
+++ b/packages/server/src/routes/memory.ts
@@ -1,9 +1,13 @@
 /**
  * Memory routes — surface each connector's live (NOT indexed) memory.
  *
- *   - GET /api/memory                       → global memory per connector plus a
+ *   - GET /api/memory                       → global memory per connector, a
  *                                             per-project summary of which agents
- *                                             have any project memory.
+ *                                             have any project memory, and a
+ *                                             per-connector overview (counts +
+ *                                             content preview) for the landing
+ *                                             cards — including agents that keep
+ *                                             no memory store (`supported: false`).
  *   - GET /api/projects/:projectId/memory   → per-agent memory for one project.
  *
  * Attribution (origin-session → project, dir slug fallback) lives in
@@ -13,7 +17,7 @@
 
 import type { FastifyInstance } from 'fastify';
 import type { GlobalMemory, MemoryResponse, MemorySource, ProjectMemoryResponse } from '@claudescope/shared';
-import { collectMemory, type AttributedMemory } from '../data/memory.js';
+import { buildConnectorOverviews, collectMemory, type AttributedMemory } from '../data/memory.js';
 
 /** Group attributed memory by `projectId` then `connectorId`. */
 function projectBuckets(items: AttributedMemory[]) {
@@ -66,7 +70,7 @@ export async function registerMemoryRoute(app: FastifyInstance): Promise<void> {
       .sort((a, b) => b.total - a.total || a.displayName.localeCompare(b.displayName))
       .map(({ projectId, displayName, counts }) => ({ projectId, displayName, counts }));
 
-    return { global: [...globalByConnector.values()], projects };
+    return { global: [...globalByConnector.values()], projects, connectors: buildConnectorOverviews(items) };
   });
 
   app.get<{ Params: { projectId: string } }>(

--- a/packages/server/test/memory-overview.test.ts
+++ b/packages/server/test/memory-overview.test.ts
@@ -1,0 +1,136 @@
+/**
+ * Unit tests for the memory landing rollup (`buildConnectorOverviews`). Pure
+ * over synthetic `AttributedMemory[]` — no DuckDB index, no agent home dirs.
+ * Covers the bug-prone edges: newest-preview selection, instructions-only vs
+ * no-provider connectors, and the markdown excerpt derivation.
+ */
+
+import { describe, expect, it } from 'vitest';
+import type { AttributedMemory } from '../src/data/memory.js';
+import { buildConnectorOverviews } from '../src/data/memory.js';
+
+/** A project fact with sensible defaults; override what each case cares about. */
+function fact(over: Partial<AttributedMemory> & { connectorId: string; updatedAt: string; title: string }): AttributedMemory {
+  const { connectorId, updatedAt, title, label, projectId, ...rest } = over;
+  return {
+    connectorId,
+    label: label ?? connectorId,
+    scope: 'project',
+    projectId: projectId ?? 'proj-a',
+    source: {
+      provenance: 'agent-authored',
+      kind: 'fact',
+      title,
+      markdown: `# ${title}\n\nbody`,
+      sourcePath: `~/.x/${title}.md`,
+      updatedAt,
+    },
+    ...rest,
+  };
+}
+
+describe('buildConnectorOverviews', () => {
+  it('previews the newest project fact and counts distinct projects + total facts', () => {
+    const items: AttributedMemory[] = [
+      fact({ connectorId: 'claude-code', title: 'old', updatedAt: '2026-01-01T00:00:00.000Z', projectId: 'proj-a' }),
+      fact({ connectorId: 'claude-code', title: 'newest', updatedAt: '2026-03-01T00:00:00.000Z', projectId: 'proj-b' }),
+      fact({ connectorId: 'claude-code', title: 'mid', updatedAt: '2026-02-01T00:00:00.000Z', projectId: 'proj-b' }),
+    ];
+    const overviews = buildConnectorOverviews(items);
+    const cc = overviews.find((o) => o.connectorId === 'claude-code')!;
+    expect(cc.supported).toBe(true);
+    expect(cc.globalFiles).toBe(0);
+    expect(cc.totalFacts).toBe(3);
+    expect(cc.projectsWithFacts).toBe(2); // proj-a + proj-b, distinct
+    // Preview is the newest by updatedAt, regardless of input order.
+    expect(cc.preview?.title).toBe('newest');
+    expect(cc.preview?.scope).toBe('project');
+  });
+
+  it('gives an instructions-only connector (global source, no facts) a preview and supported=true', () => {
+    const items: AttributedMemory[] = [
+      {
+        connectorId: 'codex',
+        label: 'Codex',
+        scope: 'global',
+        source: {
+          provenance: 'user-authored',
+          kind: 'document',
+          title: 'AGENTS.md (global)',
+          description: 'House rules for the repo.',
+          markdown: '# AGENTS\n\nrules',
+          sourcePath: '~/.codex/AGENTS.md',
+          updatedAt: '2026-04-01T00:00:00.000Z',
+        },
+      },
+    ];
+    const codex = buildConnectorOverviews(items).find((o) => o.connectorId === 'codex')!;
+    expect(codex.supported).toBe(true);
+    expect(codex.globalFiles).toBe(1);
+    expect(codex.totalFacts).toBe(0);
+    expect(codex.projectsWithFacts).toBe(0);
+    expect(codex.preview).toBeDefined();
+    expect(codex.preview?.scope).toBe('global');
+    expect(codex.preview?.description).toBe('House rules for the repo.');
+  });
+
+  it('marks a no-provider connector supported=false with no preview', () => {
+    // pi and opencode implement neither globalMemory nor projectMemory.
+    const overviews = buildConnectorOverviews([]);
+    for (const id of ['pi', 'opencode']) {
+      const o = overviews.find((x) => x.connectorId === id)!;
+      expect(o, id).toBeDefined();
+      expect(o.supported, id).toBe(false);
+      expect(o.preview, id).toBeUndefined();
+      expect(o.totalFacts).toBe(0);
+    }
+  });
+
+  it('derives a one-line excerpt from markdown when description is absent', () => {
+    const items: AttributedMemory[] = [
+      {
+        connectorId: 'claude-code',
+        label: 'Claude Code',
+        scope: 'project',
+        projectId: 'proj-a',
+        source: {
+          provenance: 'agent-authored',
+          kind: 'fact',
+          title: 'no-claude-co-author',
+          // No description → excerpt comes from the body, with frontmatter and
+          // markdown structure stripped and whitespace collapsed.
+          markdown:
+            '---\nname: no-claude-co-author\ntype: feedback\n---\n\n## Heading\n\nCommit as the *user* only and omit the [trailer](http://x).',
+          sourcePath: '~/.claude/projects/x/memory/no-claude-co-author.md',
+          updatedAt: '2026-05-01T00:00:00.000Z',
+        },
+      },
+    ];
+    const cc = buildConnectorOverviews(items).find((o) => o.connectorId === 'claude-code')!;
+    expect(cc.preview?.description).toBe(
+      'Heading Commit as the user only and omit the trailer.',
+    );
+  });
+
+  it('includes every registered connector and orders content > supported-empty > unsupported', () => {
+    const items: AttributedMemory[] = [
+      // claude-code has content (a fact) → rank 0.
+      fact({ connectorId: 'claude-code', title: 'f', updatedAt: '2026-01-01T00:00:00.000Z' }),
+      // codex/junie/copilot are supported but empty here → rank 1.
+      // pi/opencode are unsupported → rank 2.
+    ];
+    const overviews = buildConnectorOverviews(items);
+    // Every registered agent appears (claude-code, codex, junie, pi, opencode, copilot).
+    expect(overviews.map((o) => o.connectorId).sort()).toEqual(
+      ['claude-code', 'codex', 'copilot', 'junie', 'opencode', 'pi'].sort(),
+    );
+    const rank = (o: { supported: boolean; preview?: unknown }) =>
+      o.supported && o.preview ? 0 : o.supported ? 1 : 2;
+    const ranks = overviews.map(rank);
+    // Non-decreasing rank → the documented sort order holds.
+    expect([...ranks].sort((a, b) => a - b)).toEqual(ranks);
+    expect(overviews[0].connectorId).toBe('claude-code');
+    // Unsupported ones sit last.
+    expect(rank(overviews[overviews.length - 1])).toBe(2);
+  });
+});

--- a/packages/shared/src/api.ts
+++ b/packages/shared/src/api.ts
@@ -315,10 +315,46 @@ export interface ProjectMemorySummary {
   counts: { connectorId: string; count: number }[];
 }
 
+/**
+ * A one-line content preview of a connector's most-recently-updated memory item,
+ * for the memory landing card. Absent on the parent when the agent has no content.
+ */
+export interface MemoryPreview {
+  title: string;
+  category?: string;
+  /** One-line description if present, else a short plain-text excerpt of the body. */
+  description?: string;
+  provenance: MemoryProvenance;
+  kind: MemoryKind;
+  scope: 'global' | 'project';
+}
+
+/**
+ * Per-connector rollup for the memory landing page: counts plus a content
+ * preview, listed for EVERY known agent so the UI can mark agents that keep no
+ * memory store at all (`supported: false`).
+ */
+export interface MemoryConnectorOverview {
+  connectorId: string;
+  label: string;
+  /** False when this agent keeps no memory store at all (no memory provider). */
+  supported: boolean;
+  /** Count of global user-authored instruction files (global sources). */
+  globalFiles: number;
+  /** Number of projects where this agent has any memory. */
+  projectsWithFacts: number;
+  /** Total memory items this agent contributes across all projects. */
+  totalFacts: number;
+  /** Most-recently-updated memory item (by mtime), for a one-line content preview. Absent when the agent has no content. */
+  preview?: MemoryPreview;
+}
+
 /** GET /api/memory */
 export interface MemoryResponse {
   global: GlobalMemory[];
   projects: ProjectMemorySummary[];
+  /** One rollup per known agent connector, for the landing-page cards. */
+  connectors: MemoryConnectorOverview[];
 }
 
 /** GET /api/projects/:projectId/memory */

--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -114,8 +114,9 @@ export function App() {
     <div className="tv-app">
       <Sidebar />
       <main className="tv-main">
-        <ErrorBoundary resetKeys={[pathname]} title="This page failed to render">
-          <Routes>
+        <div className="tv-main__inner">
+          <ErrorBoundary resetKeys={[pathname]} title="This page failed to render">
+            <Routes>
             <Route path="/" element={<BrowsePage />} />
             <Route path="/projects/:projectId" element={<ProjectLayout />}>
               <Route index element={<SessionListPage />} />
@@ -127,8 +128,9 @@ export function App() {
             <Route path="/memory" element={<MemoryPage />} />
             <Route path="/memory/:connectorId" element={<AgentMemoryPage />} />
             <Route path="/memory/:connectorId/:projectId" element={<AgentProjectMemoryPage />} />
-          </Routes>
-        </ErrorBoundary>
+            </Routes>
+          </ErrorBoundary>
+        </div>
       </main>
     </div>
   );

--- a/packages/web/src/components/ModelChips.tsx
+++ b/packages/web/src/components/ModelChips.tsx
@@ -1,3 +1,5 @@
+import { useEffect, useRef, useState } from 'react';
+
 /** A capped row of model chips, shared by the session list and the header. */
 
 /** Shorten a model id for chip display (drops the date suffix). */
@@ -11,19 +13,37 @@ export function shortModel(model: string): string {
 
 export interface ModelChipsProps {
   models: string[];
-  /** Max chips to show before collapsing the rest into a "+N" chip. */
+  /** Max chips to show before collapsing the rest into a clickable "+N" chip. */
   max?: number;
 }
 
 /**
  * Renders model ids as chips, capped at `max` (default 3). Sessions can span
- * 1–5+ models; any beyond the cap collapse into a "+N" chip whose tooltip lists
- * the remaining ids, so a busy session stays a single tidy line.
+ * 1–5+ models; any beyond the cap collapse into a "+N" chip that opens a small
+ * popover listing the rest, so a busy session stays a single tidy line.
  */
 export function ModelChips({ models, max = 3 }: ModelChipsProps) {
+  const [open, setOpen] = useState(false);
+  const ref = useRef<HTMLSpanElement>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    const onDoc = (e: MouseEvent) => {
+      if (ref.current && !ref.current.contains(e.target as Node)) setOpen(false);
+    };
+    const onKey = (e: KeyboardEvent) => e.key === 'Escape' && setOpen(false);
+    document.addEventListener('mousedown', onDoc);
+    document.addEventListener('keydown', onKey);
+    return () => {
+      document.removeEventListener('mousedown', onDoc);
+      document.removeEventListener('keydown', onKey);
+    };
+  }, [open]);
+
   if (models.length === 0) return null;
   const shown = models.slice(0, max);
   const rest = models.slice(max);
+
   return (
     <span className="tv-chips">
       {shown.map((m) => (
@@ -32,11 +52,29 @@ export function ModelChips({ models, max = 3 }: ModelChipsProps) {
         </span>
       ))}
       {rest.length > 0 ? (
-        <span
-          className="tv-chip tv-chip--model tv-chip--more"
-          title={rest.map(shortModel).join(', ')}
-        >
-          +{rest.length}
+        <span className="tv-modelchips__more-wrap" ref={ref}>
+          <button
+            type="button"
+            className="tv-chip tv-chip--model tv-chip--more"
+            aria-expanded={open}
+            aria-label={`Show ${rest.length} more model${rest.length === 1 ? '' : 's'}`}
+            onClick={(e) => {
+              e.preventDefault();
+              e.stopPropagation();
+              setOpen((o) => !o);
+            }}
+          >
+            +{rest.length}
+          </button>
+          {open ? (
+            <span className="tv-modelchips__pop">
+              {rest.map((m) => (
+                <span key={m} className="tv-chip tv-chip--model">
+                  {shortModel(m)}
+                </span>
+              ))}
+            </span>
+          ) : null}
         </span>
       ) : null}
     </span>

--- a/packages/web/src/components/SearchField.tsx
+++ b/packages/web/src/components/SearchField.tsx
@@ -1,0 +1,54 @@
+import type { RefObject } from 'react';
+import { Search, X } from 'lucide-react';
+
+export interface SearchFieldProps {
+  value: string;
+  onChange: (value: string) => void;
+  placeholder?: string;
+  autoFocus?: boolean;
+  ariaLabel?: string;
+  /** Extra class on the wrapper, e.g. `tv-field--grow`. */
+  className?: string;
+  inputRef?: RefObject<HTMLInputElement | null>;
+}
+
+/**
+ * Shared search/filter input: a magnifier inside the field and a clear button,
+ * so every search box across the app (Browse/project filters, global Search)
+ * reads as the same control.
+ */
+export function SearchField({
+  value,
+  onChange,
+  placeholder,
+  autoFocus,
+  ariaLabel,
+  className,
+  inputRef,
+}: SearchFieldProps) {
+  return (
+    <div className={className ? `tv-field ${className}` : 'tv-field'}>
+      <Search size={15} className="tv-field__icon" aria-hidden="true" />
+      <input
+        ref={inputRef}
+        type="text"
+        className="tv-field__input"
+        placeholder={placeholder}
+        aria-label={ariaLabel ?? placeholder}
+        value={value}
+        autoFocus={autoFocus}
+        onChange={(e) => onChange(e.target.value)}
+      />
+      {value ? (
+        <button
+          type="button"
+          className="tv-field__clear"
+          aria-label="Clear"
+          onClick={() => onChange('')}
+        >
+          <X size={14} aria-hidden="true" />
+        </button>
+      ) : null}
+    </div>
+  );
+}

--- a/packages/web/src/components/TokenChips.tsx
+++ b/packages/web/src/components/TokenChips.tsx
@@ -48,32 +48,24 @@ export function TokenChips(props: TokenChipsProps) {
     );
   }
 
+  // Compact form: colored dots for input/output (matching the thread's token
+  // legend), then grouped cache (read · write), shown only when non-zero.
   return (
-    <span className="tv-chips">
-      <Chip className="tv-chip--input" label="in" value={input} />
-      <Chip className="tv-chip--output" label="out" value={output} />
-      <Chip className="tv-chip--cache" label="cw" value={cacheWrite} hideZero />
-      <Chip className="tv-chip--cache" label="cr" value={cacheRead} hideZero />
-    </span>
-  );
-}
-
-function Chip({
-  className,
-  label,
-  value,
-  hideZero,
-}: {
-  className?: string;
-  label: string;
-  value: number;
-  hideZero?: boolean;
-}) {
-  if (hideZero && value <= 0) return null;
-  return (
-    <span className={className ? `tv-chip ${className}` : 'tv-chip'}>
-      <span className="tv-chip__label">{label}</span>
-      <span className="tv-chip__value">{formatCount(value)}</span>
+    <span className="tv-tok">
+      <span className="tv-tok__seg">
+        <span className="tv-tok__dot tv-tok__dot--in" />
+        {formatCount(input)}
+      </span>
+      <span className="tv-tok__seg">
+        <span className="tv-tok__dot tv-tok__dot--out" />
+        {formatCount(output)}
+      </span>
+      {cacheRead > 0 || cacheWrite > 0 ? (
+        <span className="tv-tok__seg tv-tok__seg--cache">
+          <span className="tv-tok__dot tv-tok__dot--cache" />
+          cache {formatCount(cacheRead)} · {formatCount(cacheWrite)}
+        </span>
+      ) : null}
     </span>
   );
 }

--- a/packages/web/src/components/ToolBlock.tsx
+++ b/packages/web/src/components/ToolBlock.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import { FilePen, FilePlus, FileText, SquareTerminal, Wrench, type LucideIcon } from 'lucide-react';
 import type { ContentBlock, ToolInteraction } from '@claudescope/shared';
 import { Collapsible } from './Collapsible.js';
 import { CodeBlock } from './CodeBlock.js';
@@ -244,30 +245,68 @@ function ToolBody({
   }
 }
 
+/** Per-tool glyph, so a collapsed tool line reads at a glance. */
+const TOOL_ICONS: Record<string, LucideIcon> = {
+  Read: FileText,
+  Edit: FilePen,
+  MultiEdit: FilePen,
+  Write: FilePlus,
+  Bash: SquareTerminal,
+};
+
+/** Strip common id prefixes and clip, so a call id reads as a short tag. */
+function shortToolId(id: string): string {
+  const stripped = id.replace(/^(call_|toolu_|tool_)/i, '');
+  return stripped.length > 10 ? stripped.slice(0, 8) : stripped;
+}
+
+/** A short, quiet descriptor for the collapsed tool line (file name, else call id). */
+function toolDescriptor(tool: ToolInteraction): string {
+  const fp = str(asRecord(tool.input).file_path);
+  if (fp) return fp.split(/[/\\]/).filter(Boolean).pop() ?? fp;
+  return tool.id ? `call · ${shortToolId(tool.id)}` : '';
+}
+
 /**
- * Collapsible shell for a single tool call. The body is tool-aware: Edit/
- * MultiEdit render a red/green diff, Write/Read/Bash render syntax-highlighted
- * code, and everything else falls back to highlighted JSON + text.
+ * Collapsible shell for a single tool call — quiet by default (one line: an
+ * icon, the tool name, a short descriptor, and a "details" hint), expanding to
+ * the tool-aware body: Edit/MultiEdit render a red/green diff, Write/Read/Bash
+ * render syntax-highlighted code, and everything else highlighted JSON + text.
  */
 export function ToolBlock({ tool, defaultOpen = false, forceOpen = false }: ToolBlockProps) {
   const isError = tool.result?.isError === true;
-  const className = isError ? 'tv-collapsible--tool tv-collapsible--error' : 'tv-collapsible--tool';
   const [userOpen, setUserOpen] = useState(defaultOpen);
+  const open = userOpen || forceOpen;
+  const Icon = TOOL_ICONS[tool.name] ?? Wrench;
+  const className = [
+    'tv-collapsible--tool',
+    'tv-collapsible--quiet',
+    isError ? 'tv-collapsible--error' : '',
+  ]
+    .filter(Boolean)
+    .join(' ');
 
   return (
     <Collapsible
       className={className}
-      open={userOpen || forceOpen}
+      open={open}
       onToggle={setUserOpen}
-      icon="⚙"
+      icon={<Icon size={14} aria-hidden="true" />}
       title={tool.name}
-      subtitle={tool.id}
+      subtitle={toolDescriptor(tool)}
       headerExtra={
-        isError ? (
-          <span className="tv-chip" style={{ color: 'var(--tv-danger)' }}>
-            error
-          </span>
-        ) : null
+        <>
+          {isError ? (
+            <span className="tv-chip" style={{ color: 'var(--tv-danger)' }}>
+              error
+            </span>
+          ) : null}
+          {!open ? (
+            <span className="tv-collapsible__details" aria-hidden="true">
+              details
+            </span>
+          ) : null}
+        </>
       }
     >
       <ToolBody tool={tool} isError={isError} forceOpen={forceOpen} />

--- a/packages/web/src/components/index.ts
+++ b/packages/web/src/components/index.ts
@@ -15,4 +15,5 @@ export { ErrorBoundary, type ErrorBoundaryProps } from './ErrorBoundary.js';
 export { AgentBadge, agentLabel, type AgentBadgeProps } from './AgentBadge.js';
 export { ModelChips, shortModel, type ModelChipsProps } from './ModelChips.js';
 export { SummaryStrip, type SummaryItem } from './SummaryStrip.js';
+export { SearchField, type SearchFieldProps } from './SearchField.js';
 export { extractImage } from './image.js';

--- a/packages/web/src/pages/analytics/analytics.css
+++ b/packages/web/src/pages/analytics/analytics.css
@@ -58,8 +58,9 @@
   color: var(--tv-fg);
 }
 .tv-segmented__btn.is-active {
-  background: var(--tv-accent-muted);
+  background: var(--tv-bg-inset);
   color: var(--tv-fg);
+  font-weight: 600;
 }
 
 .tv-analytics__date {

--- a/packages/web/src/pages/browse/BrowsePage.tsx
+++ b/packages/web/src/pages/browse/BrowsePage.tsx
@@ -2,7 +2,7 @@ import { useEffect, useMemo, useState } from 'react';
 import { Link } from 'react-router-dom';
 import type { ProjectMeta } from '@claudescope/shared';
 import { api, ApiError } from '../../api/client.js';
-import { AgentBadge, ErrorBox, formatCost, formatCount, Spinner, SummaryStrip } from '../../components';
+import { AgentBadge, ErrorBox, formatCost, formatCount, SearchField, Spinner, SummaryStrip } from '../../components';
 import { timeAgo } from './format.js';
 import './browse.css';
 
@@ -95,12 +95,11 @@ export function BrowsePage() {
           Projects
         </h1>
         <div className="tv-browse__controls">
-          <input
-            className="tv-input"
-            type="search"
-            placeholder="Filter projects…"
+          <SearchField
             value={filter}
-            onChange={(e) => setFilter(e.target.value)}
+            onChange={setFilter}
+            placeholder="Filter projects…"
+            ariaLabel="Filter projects"
           />
           <select
             className="tv-select"

--- a/packages/web/src/pages/browse/ProjectLayout.tsx
+++ b/packages/web/src/pages/browse/ProjectLayout.tsx
@@ -76,18 +76,17 @@ export function ProjectLayout() {
             </div>
           ) : null}
         </div>
+        {project ? (
+          <SummaryStrip
+            items={[
+              { label: 'Sessions', value: formatCount(project.sessionCount) },
+              { label: 'Tokens', value: formatCount(project.totalTokens) },
+              { label: 'Cost', value: formatCost(project.totalCostUsd) },
+              { label: 'Agents', value: formatCount(project.connectorIds.length) },
+            ]}
+          />
+        ) : null}
       </header>
-
-      {project ? (
-        <SummaryStrip
-          items={[
-            { label: 'Sessions', value: formatCount(project.sessionCount) },
-            { label: 'Tokens', value: formatCount(project.totalTokens) },
-            { label: 'Cost', value: formatCost(project.totalCostUsd) },
-            { label: 'Agents', value: formatCount(project.connectorIds.length) },
-          ]}
-        />
-      ) : null}
 
       <div className="tv-memory-tabs" role="tablist" aria-label="Project view">
         <NavLink to={`/projects/${encodeURIComponent(projectId)}`} end className={tabClass} role="tab">

--- a/packages/web/src/pages/browse/SessionList.tsx
+++ b/packages/web/src/pages/browse/SessionList.tsx
@@ -2,7 +2,7 @@ import { useEffect, useMemo, useState } from 'react';
 import { Link } from 'react-router-dom';
 import type { SessionMeta, SessionSort } from '@claudescope/shared';
 import { api, ApiError } from '../../api/client.js';
-import { AgentBadge, agentLabel, ErrorBox, formatCost, formatCount, ModelChips, Spinner } from '../../components';
+import { AgentBadge, agentLabel, ErrorBox, formatCost, formatCount, ModelChips, SearchField, Spinner } from '../../components';
 import { formatBytes, formatDateTime, timeAgo } from './format.js';
 import { useProjectContext } from './ProjectLayout.js';
 
@@ -73,12 +73,11 @@ export function SessionListPage() {
   return (
     <>
       <div className="tv-browse__controls" style={{ marginBottom: 'var(--tv-space-3)' }}>
-        <input
-          className="tv-input"
-          type="search"
-          placeholder="Filter sessions…"
+        <SearchField
           value={filter}
-          onChange={(e) => setFilter(e.target.value)}
+          onChange={setFilter}
+          placeholder="Filter sessions…"
+          ariaLabel="Filter sessions"
         />
         <select
           className="tv-select"

--- a/packages/web/src/pages/browse/browse.css
+++ b/packages/web/src/pages/browse/browse.css
@@ -8,6 +8,10 @@
   margin-bottom: var(--tv-space-4);
   flex-wrap: wrap;
 }
+/* Summary tiles sit top-right beside the title (not as a row below). */
+.tv-browse__header .tv-summary {
+  margin-bottom: 0;
+}
 
 .tv-browse__controls {
   display: flex;

--- a/packages/web/src/pages/browse/browse.css
+++ b/packages/web/src/pages/browse/browse.css
@@ -147,13 +147,17 @@
   color: var(--tv-fg);
 }
 .tv-agent-filter__btn.is-active {
-  border-color: var(--tv-accent);
-  color: var(--tv-fg);
-  background: var(--tv-accent-muted);
+  border-color: var(--tv-btn-primary);
+  background: var(--tv-btn-primary);
+  color: var(--tv-on-accent);
 }
 .tv-agent-filter__count {
   color: var(--tv-fg-faint);
   font-variant-numeric: tabular-nums;
+}
+.tv-agent-filter__btn.is-active .tv-agent-filter__count {
+  color: var(--tv-on-accent);
+  opacity: 0.8;
 }
 
 /* Session list */

--- a/packages/web/src/pages/browse/browse.css
+++ b/packages/web/src/pages/browse/browse.css
@@ -190,7 +190,8 @@
   position: absolute;
   inset: 0;
 }
-.tv-session-row__side a {
+.tv-session-row__side a,
+.tv-session-row__side .tv-modelchips__more-wrap {
   position: relative;
   z-index: 1;
 }

--- a/packages/web/src/pages/browse/format.ts
+++ b/packages/web/src/pages/browse/format.ts
@@ -46,7 +46,11 @@ export function timeAgo(iso: string | undefined): string {
   return `${Math.floor(mon / 12)}y ago`;
 }
 
-/** Compact elapsed duration between two ISO timestamps (e.g. "1h 23m", "45m", "30s"). */
+/**
+ * Compact elapsed duration between two ISO timestamps, rolled up to the two
+ * largest sensible units: "30s", "45m", "1h 23m", "3d 4h", "2w 4d". Keeps long
+ * sessions readable (e.g. "436h 55m" → "2w 4d").
+ */
 export function formatDuration(startIso: string | undefined, endIso: string | undefined): string {
   if (!startIso || !endIso) return '';
   const ms = new Date(endIso).getTime() - new Date(startIso).getTime();
@@ -56,8 +60,18 @@ export function formatDuration(startIso: string | undefined, endIso: string | un
   const min = Math.floor(sec / 60);
   if (min < 60) return `${min}m`;
   const hr = Math.floor(min / 60);
-  const rem = min % 60;
-  return rem ? `${hr}h ${rem}m` : `${hr}h`;
+  if (hr < 24) {
+    const m = min % 60;
+    return m ? `${hr}h ${m}m` : `${hr}h`;
+  }
+  const day = Math.floor(hr / 24);
+  if (day < 7) {
+    const h = hr % 24;
+    return h ? `${day}d ${h}h` : `${day}d`;
+  }
+  const week = Math.floor(day / 7);
+  const d = day % 7;
+  return d ? `${week}w ${d}d` : `${week}w`;
 }
 
 /** Human-readable byte size (e.g. "1.3 MB"). */

--- a/packages/web/src/pages/memory/MemoryPage.tsx
+++ b/packages/web/src/pages/memory/MemoryPage.tsx
@@ -1,65 +1,32 @@
 /**
- * Memory landing (`/memory`) — a folder grid, one card per agent (connector)
- * that has any memory, mirroring the BrowsePage project-card look. Each card
- * drills into that agent's memory at `/memory/:connectorId`.
+ * Memory landing (`/memory`) — a folder grid, one card per agent (connector).
+ * Each card previews real content (the latest memory item) so the screen is
+ * never just bare counts; agents that keep no memory store are shown explicitly
+ * as such rather than hidden (so "no store" reads as a fact, not a bug).
  *
  * Memory is read LIVE from the agent home dirs on the server (never indexed), so
  * this page just fetches and renders. Every store is usually absent/empty —
  * "no memory" is a normal, first-class state here, never an error.
  */
 
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { Link } from 'react-router-dom';
-import type { MemoryResponse } from '@claudescope/shared';
+import type { MemoryConnectorOverview, MemoryPreview, MemoryResponse } from '@claudescope/shared';
 import { api } from '../../api/client.js';
-import { AgentBadge, agentLabel, ErrorBox, Spinner } from '../../components';
+import { AgentBadge, ErrorBox, Spinner } from '../../components';
 import { isBenignError } from './shared.js';
 import './memory.css';
 
-/** Per-agent rollup driving one folder card on the landing page. */
-interface AgentSummary {
-  connectorId: string;
-  label: string;
-  /** Number of global user-authored instruction files. */
-  globalFiles: number;
-  /** Number of projects where this agent has any memory. */
-  projectsWithFacts: number;
-  /** Total facts this agent contributes across all projects. */
-  totalFacts: number;
+/** Short label above the preview body. */
+function previewLabel(p: MemoryPreview): string {
+  if (p.kind === 'fact') return `Latest fact${p.category ? ` · ${p.category}` : ''}`;
+  return p.title; // a document (instruction file) — its name is the label
 }
 
-/**
- * Roll the global + project response into one summary per connector that has
- * any memory. A connector qualifies if it appears in `global` with sources, or
- * in any project's per-agent counts.
- */
-function summarize(data: MemoryResponse): AgentSummary[] {
-  const byId = new Map<string, AgentSummary>();
-
-  const ensure = (connectorId: string, label: string): AgentSummary => {
-    let s = byId.get(connectorId);
-    if (!s) {
-      s = { connectorId, label, globalFiles: 0, projectsWithFacts: 0, totalFacts: 0 };
-      byId.set(connectorId, s);
-    }
-    return s;
-  };
-
-  for (const g of data.global) {
-    if (g.sources.length === 0) continue;
-    ensure(g.connectorId, g.label).globalFiles += g.sources.length;
-  }
-
-  for (const p of data.projects) {
-    for (const c of p.counts) {
-      if (c.count === 0) continue;
-      const s = ensure(c.connectorId, agentLabel(c.connectorId));
-      s.projectsWithFacts += 1;
-      s.totalFacts += c.count;
-    }
-  }
-
-  return [...byId.values()];
+/** The preview body line: fact name + description, or a document excerpt. */
+function previewBody(p: MemoryPreview): string {
+  if (p.kind === 'fact') return p.description ? `${p.title} — ${p.description}` : p.title;
+  return p.description || p.title;
 }
 
 export function MemoryPage() {
@@ -86,8 +53,6 @@ export function MemoryPage() {
     return () => controller.abort();
   }, [reloadKey]);
 
-  const agents = useMemo(() => (data ? summarize(data) : []), [data]);
-
   return (
     <div className="tv-memory">
       <h1 className="tv-page-title">Memory</h1>
@@ -101,12 +66,12 @@ export function MemoryPage() {
         <Spinner size="lg" label="Loading memory…" />
       ) : error ? (
         <ErrorBox error={error} title="Failed to load memory" onRetry={() => setReloadKey((k) => k + 1)} />
-      ) : agents.length === 0 ? (
+      ) : !data || data.connectors.length === 0 ? (
         <p className="tv-muted">No memory found yet.</p>
       ) : (
         <div className="tv-project-grid">
-          {agents.map((a) => (
-            <AgentMemoryCard key={a.connectorId} summary={a} />
+          {data.connectors.map((c) => (
+            <AgentMemoryCard key={c.connectorId} c={c} />
           ))}
         </div>
       )}
@@ -114,27 +79,56 @@ export function MemoryPage() {
   );
 }
 
-function AgentMemoryCard({ summary }: { summary: AgentSummary }) {
-  return (
-    <Link to={`/memory/${encodeURIComponent(summary.connectorId)}`} className="tv-card tv-project-card">
+function AgentMemoryCard({ c }: { c: MemoryConnectorOverview }) {
+  const body = (
+    <>
       <div className="tv-memory-card__head">
-        <AgentBadge connectorId={summary.connectorId} />
-        <span className="tv-project-card__name">{summary.label}</span>
+        <AgentBadge connectorId={c.connectorId} />
+        <span className="tv-project-card__name">{c.label}</span>
+        {!c.supported ? (
+          <span className="tv-chip tv-memory-card__nostore" title="This agent keeps no memory store">
+            no memory store
+          </span>
+        ) : null}
       </div>
-      <div className="tv-project-card__stats">
-        <span className="tv-chip">
-          <span className="tv-chip__label">instruction files</span>
-          <span className="tv-chip__value">{summary.globalFiles}</span>
-        </span>
-        <span className="tv-chip">
-          <span className="tv-chip__label">projects</span>
-          <span className="tv-chip__value">{summary.projectsWithFacts}</span>
-        </span>
-        <span className="tv-chip">
-          <span className="tv-chip__label">facts</span>
-          <span className="tv-chip__value">{summary.totalFacts}</span>
-        </span>
-      </div>
+
+      {c.supported ? (
+        <>
+          <div className="tv-memory-card__counts tv-muted">
+            {c.globalFiles} instruction file{c.globalFiles === 1 ? '' : 's'} · {c.projectsWithFacts}{' '}
+            project{c.projectsWithFacts === 1 ? '' : 's'} · {c.totalFacts} fact
+            {c.totalFacts === 1 ? '' : 's'}
+          </div>
+          {c.preview ? (
+            <div className="tv-memory-card__preview">
+              <span className="tv-memory-card__preview-label">{previewLabel(c.preview)}</span>
+              <span className="tv-memory-card__preview-body">{previewBody(c.preview)}</span>
+            </div>
+          ) : (
+            <div className="tv-memory-card__empty tv-muted">
+              No distilled facts yet — they appear as the agent works in a project.
+            </div>
+          )}
+        </>
+      ) : (
+        <div className="tv-memory-card__empty tv-muted">
+          {c.label} keeps no memory in its home directory. Its reasoning and edits still render
+          inside sessions.
+        </div>
+      )}
+    </>
+  );
+
+  // Supported agents drill into their memory; unsupported ones have nothing to
+  // open, so they render as a plain (non-clickable) card.
+  return c.supported ? (
+    <Link
+      to={`/memory/${encodeURIComponent(c.connectorId)}`}
+      className="tv-card tv-project-card tv-memory-card"
+    >
+      {body}
     </Link>
+  ) : (
+    <div className="tv-card tv-project-card tv-memory-card tv-memory-card--nostore">{body}</div>
   );
 }

--- a/packages/web/src/pages/memory/memory.css
+++ b/packages/web/src/pages/memory/memory.css
@@ -30,6 +30,49 @@
   align-items: center;
   gap: var(--tv-space-2);
 }
+.tv-memory-card__nostore {
+  margin-left: auto;
+  color: var(--tv-fg-faint);
+}
+.tv-memory-card__counts {
+  font-size: var(--tv-fs-sm);
+}
+/* Content preview — a quiet quote rail with a label + the latest item. */
+.tv-memory-card__preview {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  margin-top: var(--tv-space-1);
+  padding-left: var(--tv-space-3);
+  border-left: 2px solid var(--tv-border-strong);
+}
+.tv-memory-card__preview-label {
+  font-size: var(--tv-fs-sm);
+  color: var(--tv-fg-faint);
+}
+.tv-memory-card__preview-body {
+  font-size: var(--tv-fs-sm);
+  color: var(--tv-fg);
+  line-height: 1.45;
+  display: -webkit-box;
+  -webkit-line-clamp: 3;
+  line-clamp: 3;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+.tv-memory-card__empty {
+  font-size: var(--tv-fs-sm);
+  line-height: 1.45;
+}
+/* "No memory store" agents aren't clickable — neutralize the project-card hover. */
+.tv-memory-card--nostore {
+  cursor: default;
+  opacity: 0.9;
+}
+.tv-memory-card--nostore:hover {
+  border-color: var(--tv-border);
+  background: var(--tv-bg-elevated);
+}
 
 /* Project memory list (top-level / per-agent pages) */
 .tv-memory__project-main {

--- a/packages/web/src/pages/search/SearchPage.tsx
+++ b/packages/web/src/pages/search/SearchPage.tsx
@@ -26,7 +26,7 @@ import type {
   SearchType,
 } from '@claudescope/shared';
 import { api, ApiError } from '../../api/client.js';
-import { AgentBadge, ErrorBox, Spinner } from '../../components';
+import { AgentBadge, ErrorBox, SearchField, Spinner } from '../../components';
 import './search.css';
 
 /** A session's matches, grouped from the flat result list. */
@@ -295,76 +295,52 @@ export function SearchPage() {
       <h1 className="tv-page-title">Search</h1>
 
       <div className="tv-search__controls">
-        <div className="tv-search__field tv-search__field--grow">
-          <label className="tv-search__label" htmlFor="tv-search-q">
-            Query
-          </label>
-          <input
-            id="tv-search-q"
-            className="tv-search__input"
-            type="search"
-            placeholder="Search transcripts…"
-            value={query}
-            autoFocus
-            onChange={(e) => patchParams({ q: e.target.value })}
-          />
-        </div>
-
-        <div className="tv-search__field">
-          <label className="tv-search__label" htmlFor="tv-search-project">
-            Project
-          </label>
+        <SearchField
+          className="tv-field--grow"
+          value={query}
+          onChange={(v) => patchParams({ q: v })}
+          placeholder="Search transcripts…"
+          ariaLabel="Search transcripts"
+          autoFocus
+        />
+        <select
+          className="tv-search__select"
+          value={project}
+          aria-label="Project"
+          onChange={(e) => patchParams({ project: e.target.value })}
+        >
+          <option value="">All projects</option>
+          {projectOptions.map((p) => (
+            <option key={p.id} value={p.id}>
+              {p.displayName}
+            </option>
+          ))}
+        </select>
+        <select
+          className="tv-search__select"
+          value={scope}
+          aria-label="Scope"
+          onChange={(e) => patchParams({ scope: e.target.value })}
+        >
+          {SCOPE_OPTIONS.map((opt) => (
+            <option key={opt.value} value={opt.value}>
+              {opt.label}
+            </option>
+          ))}
+        </select>
+        {showRoleFilter ? (
           <select
-            id="tv-search-project"
             className="tv-search__select"
-            value={project}
-            onChange={(e) => patchParams({ project: e.target.value })}
+            value={type}
+            aria-label="Role"
+            onChange={(e) => patchParams({ type: e.target.value })}
           >
-            <option value="">All projects</option>
-            {projectOptions.map((p) => (
-              <option key={p.id} value={p.id}>
-                {p.displayName}
-              </option>
-            ))}
-          </select>
-        </div>
-
-        <div className="tv-search__field">
-          <label className="tv-search__label" htmlFor="tv-search-scope">
-            Scope
-          </label>
-          <select
-            id="tv-search-scope"
-            className="tv-search__select"
-            value={scope}
-            onChange={(e) => patchParams({ scope: e.target.value })}
-          >
-            {SCOPE_OPTIONS.map((opt) => (
+            {TYPE_OPTIONS.map((opt) => (
               <option key={opt.value} value={opt.value}>
                 {opt.label}
               </option>
             ))}
           </select>
-        </div>
-
-        {showRoleFilter ? (
-          <div className="tv-search__field">
-            <label className="tv-search__label" htmlFor="tv-search-type">
-              Role
-            </label>
-            <select
-              id="tv-search-type"
-              className="tv-search__select"
-              value={type}
-              onChange={(e) => patchParams({ type: e.target.value })}
-            >
-              {TYPE_OPTIONS.map((opt) => (
-                <option key={opt.value} value={opt.value}>
-                  {opt.label}
-                </option>
-              ))}
-            </select>
-          </div>
         ) : null}
       </div>
 

--- a/packages/web/src/pages/search/SearchPage.tsx
+++ b/packages/web/src/pages/search/SearchPage.tsx
@@ -17,6 +17,7 @@
 
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { Link, useSearchParams } from 'react-router-dom';
+import { ChevronDown, MessageSquare } from 'lucide-react';
 import type {
   MemorySearchHit,
   ProjectMeta,
@@ -27,6 +28,98 @@ import type {
 import { api, ApiError } from '../../api/client.js';
 import { AgentBadge, ErrorBox, Spinner } from '../../components';
 import './search.css';
+
+/** A session's matches, grouped from the flat result list. */
+interface SessionGroup {
+  sessionId: string;
+  projectId: string;
+  title: string;
+  matches: SearchResult[];
+}
+
+/** Abbreviated role label for a match pill. */
+function shortRole(role: string): string {
+  if (role === 'assistant') return 'Asst';
+  if (role === 'user') return 'User';
+  return role;
+}
+
+/** A quiet bar standing in for the raw BM25 number; width = score / set max. */
+function RelevanceBar({ ratio }: { ratio: number }) {
+  const pct = Math.max(8, Math.min(100, Math.round(ratio * 100)));
+  const tier = ratio >= 0.5 ? 'high' : 'low';
+  return (
+    <span
+      className={`tv-relbar tv-relbar--${tier}`}
+      title={`relevance ${Math.round(ratio * 100)}%`}
+      aria-hidden="true"
+    >
+      <span className="tv-relbar__fill" style={{ width: `${pct}%` }} />
+    </span>
+  );
+}
+
+/** Number of matches shown before a session group collapses the rest. */
+const GROUP_COLLAPSE = 2;
+
+/** One session card with its matches nested under it. */
+function SearchGroup({
+  group,
+  projectName,
+  maxScore,
+}: {
+  group: SessionGroup;
+  projectName?: string;
+  maxScore: number;
+}) {
+  const [expanded, setExpanded] = useState(false);
+  const shown = expanded ? group.matches : group.matches.slice(0, GROUP_COLLAPSE);
+  const hidden = group.matches.length - shown.length;
+  return (
+    <div className="tv-card tv-search__group">
+      <div className="tv-search__group-head">
+        <MessageSquare size={15} aria-hidden="true" className="tv-search__group-icon" />
+        <Link
+          to={`/sessions/${encodeURIComponent(group.sessionId)}`}
+          className={
+            group.title
+              ? 'tv-search__group-title'
+              : 'tv-search__group-title tv-search__result-title--untitled'
+          }
+        >
+          {group.title || 'Untitled session'}
+        </Link>
+        {projectName ? <span className="tv-chip">{projectName}</span> : null}
+        <span className="tv-search__group-count">
+          {group.matches.length} match{group.matches.length === 1 ? '' : 'es'}
+        </span>
+      </div>
+      <div className="tv-search__matches">
+        {shown.map((m) => (
+          <Link
+            key={m.messageUuid}
+            to={`/sessions/${encodeURIComponent(group.sessionId)}#${encodeURIComponent(m.messageUuid)}`}
+            className="tv-search__match"
+          >
+            {m.role ? <span className={roleClass(m.role)}>{shortRole(m.role)}</span> : null}
+            <span
+              className="tv-search__snippet"
+              // Server snippet is HTML-escaped except <mark> wraps (safe).
+              dangerouslySetInnerHTML={{ __html: m.snippet }}
+            />
+            <RelevanceBar ratio={m.score / maxScore} />
+          </Link>
+        ))}
+        {hidden > 0 ? (
+          <button type="button" className="tv-search__more" onClick={() => setExpanded(true)}>
+            <ChevronDown size={14} aria-hidden="true" /> Show {hidden} more match
+            {hidden === 1 ? '' : 'es'}
+          </button>
+        ) : null}
+      </div>
+    </div>
+  );
+}
 
 /** Debounce delay (ms) before firing a search after the query box settles. */
 const SEARCH_DEBOUNCE_MS = 300;
@@ -170,6 +263,27 @@ export function SearchPage() {
     [projects],
   );
 
+  const projectNameById = useMemo(() => {
+    const m = new Map<string, string>();
+    for (const p of projects) m.set(p.id, p.displayName);
+    return m;
+  }, [projects]);
+
+  // Group the flat session hits by session so one session reads as one card
+  // (not N near-identical rows). Insertion order preserves BM25 ranking.
+  const sessionGroups = useMemo(() => {
+    const map = new Map<string, SessionGroup>();
+    for (const r of sessions) {
+      const g = map.get(r.sessionId);
+      if (g) g.matches.push(r);
+      else map.set(r.sessionId, { sessionId: r.sessionId, projectId: r.projectId, title: r.title, matches: [r] });
+    }
+    return [...map.values()];
+  }, [sessions]);
+
+  // Normalize the relevance bar against the strongest hit in this result set.
+  const maxScore = useMemo(() => sessions.reduce((m, r) => Math.max(m, r.score), 0) || 1, [sessions]);
+
   // The active scope decides which sections are visible and what the count means.
   const showSessions = scope !== 'memory';
   const showMemory = scope !== 'sessions';
@@ -268,38 +382,31 @@ export function SearchPage() {
       ) : (
         <>
           <div className="tv-search__meta">
-            {totalCount} result{totalCount === 1 ? '' : 's'}
+            {showSessions && sessions.length > 0 ? (
+              <>
+                {sessions.length} match{sessions.length === 1 ? '' : 'es'} across{' '}
+                {sessionGroups.length} session{sessionGroups.length === 1 ? '' : 's'}
+                {showMemory && memory.length > 0
+                  ? ` · ${memory.length} in memory`
+                  : ''}
+              </>
+            ) : (
+              <>
+                {totalCount} result{totalCount === 1 ? '' : 's'}
+              </>
+            )}
           </div>
 
-          {showSessions && sessions.length > 0 ? (
+          {showSessions && sessionGroups.length > 0 ? (
             <section className="tv-search__section">
-              <h2 className="tv-search__section-title">Sessions ({sessions.length})</h2>
               <div className="tv-search__results">
-                {sessions.map((r) => (
-                  <Link
-                    key={`${r.sessionId}:${r.messageUuid}`}
-                    to={`/sessions/${encodeURIComponent(r.sessionId)}#${encodeURIComponent(r.messageUuid)}`}
-                    className="tv-card tv-search__result"
-                  >
-                    <div className="tv-search__result-head">
-                      <span
-                        className={
-                          r.title
-                            ? 'tv-search__result-title'
-                            : 'tv-search__result-title tv-search__result-title--untitled'
-                        }
-                      >
-                        {r.title || 'Untitled session'}
-                      </span>
-                      {r.role ? <span className={roleClass(r.role)}>{r.role}</span> : null}
-                      <span className="tv-search__score">score {r.score.toFixed(2)}</span>
-                    </div>
-                    <div
-                      className="tv-search__snippet"
-                      // Server snippet is HTML-escaped except <mark> wraps (safe).
-                      dangerouslySetInnerHTML={{ __html: r.snippet }}
-                    />
-                  </Link>
+                {sessionGroups.map((g) => (
+                  <SearchGroup
+                    key={g.sessionId}
+                    group={g}
+                    projectName={projectNameById.get(g.projectId)}
+                    maxScore={maxScore}
+                  />
                 ))}
               </div>
             </section>

--- a/packages/web/src/pages/search/search.css
+++ b/packages/web/src/pages/search/search.css
@@ -4,7 +4,7 @@
   display: flex;
   flex-wrap: wrap;
   gap: var(--tv-space-3);
-  align-items: flex-end;
+  align-items: center;
   margin-bottom: var(--tv-space-4);
 }
 

--- a/packages/web/src/pages/search/search.css
+++ b/packages/web/src/pages/search/search.css
@@ -109,11 +109,102 @@
   border-color: #bc8cff55;
 }
 
-.tv-search__score {
-  margin-left: auto;
-  font-size: var(--tv-fs-sm);
+/* Grouped session results — one card per session, matches nested under it. */
+.tv-search__group {
+  padding: 0;
+  overflow: hidden;
+}
+.tv-search__group-head {
+  display: flex;
+  align-items: center;
+  gap: var(--tv-space-2);
+  padding: var(--tv-space-3) var(--tv-space-4);
+  border-bottom: 1px solid var(--tv-border);
+}
+.tv-search__group-icon {
+  flex: 0 0 auto;
   color: var(--tv-fg-faint);
-  font-variant-numeric: tabular-nums;
+}
+.tv-search__group-title {
+  font-size: var(--tv-fs-md);
+  font-weight: 600;
+  color: var(--tv-fg);
+  text-decoration: none;
+}
+.tv-search__group-title:hover {
+  text-decoration: underline;
+}
+.tv-search__group-count {
+  margin-left: auto;
+  flex: 0 0 auto;
+  font-size: var(--tv-fs-sm);
+  font-weight: 600;
+  color: var(--tv-accent);
+}
+.tv-search__matches {
+  display: flex;
+  flex-direction: column;
+}
+.tv-search__match {
+  display: flex;
+  align-items: center;
+  gap: var(--tv-space-3);
+  padding: var(--tv-space-2) var(--tv-space-4);
+  text-decoration: none;
+  color: inherit;
+}
+.tv-search__match + .tv-search__match,
+.tv-search__more {
+  border-top: 1px solid var(--tv-border);
+}
+.tv-search__match:hover {
+  background: var(--tv-bg-hover);
+}
+.tv-search__match .tv-search__role {
+  flex: 0 0 auto;
+}
+.tv-search__match .tv-search__snippet {
+  flex: 1 1 auto;
+}
+.tv-search__more {
+  display: flex;
+  align-items: center;
+  gap: var(--tv-space-1);
+  width: 100%;
+  background: transparent;
+  border-left: 0;
+  border-right: 0;
+  border-bottom: 0;
+  color: var(--tv-accent);
+  cursor: pointer;
+  padding: var(--tv-space-2) var(--tv-space-4);
+  font-size: var(--tv-fs-sm);
+  font-family: inherit;
+  text-align: left;
+}
+.tv-search__more:hover {
+  background: var(--tv-bg-hover);
+}
+
+/* Relevance bar — a quiet stand-in for the raw BM25 score. */
+.tv-relbar {
+  flex: 0 0 auto;
+  width: 56px;
+  height: 6px;
+  border-radius: 999px;
+  background: var(--tv-bg-inset);
+  overflow: hidden;
+}
+.tv-relbar__fill {
+  display: block;
+  height: 100%;
+  border-radius: 999px;
+}
+.tv-relbar--high .tv-relbar__fill {
+  background: var(--tv-success);
+}
+.tv-relbar--low .tv-relbar__fill {
+  background: var(--tv-warning);
 }
 
 .tv-search__mem-scope {

--- a/packages/web/src/pages/session/ContinueMenu.tsx
+++ b/packages/web/src/pages/session/ContinueMenu.tsx
@@ -18,7 +18,7 @@ function CommandRow({ command }: { command: string }) {
   return (
     <div className="tv-continue__cmd">
       <code className="tv-continue__cmd-text">{command}</code>
-      <button type="button" className="tv-continue__copy" onClick={copy}>
+      <button type="button" className="tv-btn tv-btn--secondary tv-btn--sm" onClick={copy}>
         {copied ? (
           'Copied!'
         ) : (

--- a/packages/web/src/pages/session/ExportMenu.tsx
+++ b/packages/web/src/pages/session/ExportMenu.tsx
@@ -1,9 +1,9 @@
 import { useEffect, useRef, useState } from 'react';
-import { Download } from 'lucide-react';
+import { Copy, Download } from 'lucide-react';
 import type { SessionDetailResponse } from '@claudescope/shared';
 import { sessionToMarkdown } from './export.js';
 
-/** A small "Export" dropdown: download the session as Markdown, or copy it. */
+/** An "Export" dropdown: download the session as Markdown, or copy it. */
 export function ExportMenu({ data }: { data: SessionDetailResponse }) {
   const [open, setOpen] = useState(false);
   const [redact, setRedact] = useState(false);
@@ -58,16 +58,44 @@ export function ExportMenu({ data }: { data: SessionDetailResponse }) {
         <Download size={14} aria-hidden="true" /> Export
       </summary>
       <div className="tv-export__menu">
-        <label className="tv-export__opt">
-          <input type="checkbox" checked={redact} onChange={(e) => setRedact(e.target.checked)} />
-          Redact paths &amp; secrets
+        <div className="tv-export__head">
+          <Download size={16} aria-hidden="true" />
+          <strong>Export session</strong>
+          <span className="tv-chip tv-export__fmt">Markdown ·md</span>
+        </div>
+
+        <label className="tv-export__redact">
+          <span className="tv-export__redact-top">
+            <input
+              type="checkbox"
+              className="tv-switch__input"
+              checked={redact}
+              onChange={(e) => setRedact(e.target.checked)}
+            />
+            <span className="tv-switch" aria-hidden="true" />
+            <strong>Redact paths &amp; secrets</strong>
+          </span>
+          <span className="tv-export__redact-desc">
+            Replaces home-dir paths with <code>~</code> and masks likely tokens / keys before
+            export. Best-effort — an unrecognized secret can still slip through.
+          </span>
+          <span className="tv-export__example tv-mono" aria-hidden="true">
+            /Users/you/… → ~/… · sk-… → «redacted-key»
+          </span>
         </label>
+
         <div className="tv-export__actions">
-          <button type="button" className="tv-linkbtn" onClick={download}>
-            Download .md
+          <button type="button" className="tv-export__download" onClick={download}>
+            <Download size={14} aria-hidden="true" /> Download .md
           </button>
-          <button type="button" className="tv-linkbtn" onClick={copy}>
-            {copied ? 'Copied!' : 'Copy'}
+          <button type="button" className="tv-export__copy" onClick={copy}>
+            {copied ? (
+              'Copied!'
+            ) : (
+              <>
+                <Copy size={14} aria-hidden="true" /> Copy
+              </>
+            )}
           </button>
         </div>
       </div>

--- a/packages/web/src/pages/session/ExportMenu.tsx
+++ b/packages/web/src/pages/session/ExportMenu.tsx
@@ -85,10 +85,10 @@ export function ExportMenu({ data }: { data: SessionDetailResponse }) {
         </label>
 
         <div className="tv-export__actions">
-          <button type="button" className="tv-export__download" onClick={download}>
+          <button type="button" className="tv-btn tv-btn--primary tv-export__download" onClick={download}>
             <Download size={14} aria-hidden="true" /> Download .md
           </button>
-          <button type="button" className="tv-export__copy" onClick={copy}>
+          <button type="button" className="tv-btn tv-btn--secondary" onClick={copy}>
             {copied ? (
               'Copied!'
             ) : (

--- a/packages/web/src/pages/session/SessionPage.tsx
+++ b/packages/web/src/pages/session/SessionPage.tsx
@@ -316,6 +316,20 @@ function SessionView({
     () => (
       <SessionSearchContext.Provider value={reveal}>
         <div className="tv-session__thread" ref={threadRef}>
+          {items.length > 0 ? (
+            <div className="tv-token-legend" aria-hidden="true">
+              <span className="tv-token-legend__label">Tokens</span>
+              <span className="tv-token-legend__item">
+                <span className="tv-token-legend__dot tv-token-legend__dot--in" /> input
+              </span>
+              <span className="tv-token-legend__item">
+                <span className="tv-token-legend__dot tv-token-legend__dot--out" /> output
+              </span>
+              <span className="tv-token-legend__item">
+                <span className="tv-token-legend__dot tv-token-legend__dot--cache" /> cache read · write
+              </span>
+            </div>
+          ) : null}
           {items.length === 0 ? (
             <p className="tv-muted">This session has no renderable messages.</p>
           ) : (

--- a/packages/web/src/pages/session/session.css
+++ b/packages/web/src/pages/session/session.css
@@ -612,40 +612,9 @@
   padding-top: var(--tv-space-3);
   border-top: 1px solid var(--tv-border);
 }
-/* Download is primary (filled), Copy secondary (bordered). */
+/* Download (primary) stretches; Copy (secondary) sits beside it. */
 .tv-export__download {
   flex: 1 1 auto;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  gap: var(--tv-space-1);
-  background: var(--tv-accent);
-  border: 1px solid var(--tv-accent);
-  color: #fff;
-  border-radius: var(--tv-radius-sm);
-  padding: var(--tv-space-2) var(--tv-space-3);
-  font-size: var(--tv-fs-sm);
-  font-weight: 600;
-  cursor: pointer;
-}
-.tv-export__download:hover {
-  filter: brightness(1.08);
-}
-.tv-export__copy {
-  flex: 0 0 auto;
-  display: inline-flex;
-  align-items: center;
-  gap: var(--tv-space-1);
-  background: transparent;
-  border: 1px solid var(--tv-border-strong);
-  color: var(--tv-fg);
-  border-radius: var(--tv-radius-sm);
-  padding: var(--tv-space-2) var(--tv-space-3);
-  font-size: var(--tv-fs-sm);
-  cursor: pointer;
-}
-.tv-export__copy:hover {
-  background: var(--tv-bg-hover);
 }
 
 /* Toggle switch (the redact option). The real <input> is visually hidden. */
@@ -772,21 +741,8 @@
   font-size: var(--tv-fs-sm);
   color: var(--tv-fg);
 }
-.tv-continue__copy {
-  display: inline-flex;
-  align-items: center;
-  gap: var(--tv-space-1);
+.tv-continue__cmd .tv-btn {
   flex: 0 0 auto;
-  background: transparent;
-  border: 1px solid var(--tv-border-strong);
-  border-radius: var(--tv-radius-sm);
-  color: var(--tv-accent);
-  cursor: pointer;
-  padding: var(--tv-space-1) var(--tv-space-2);
-  font-size: var(--tv-fs-sm);
-}
-.tv-continue__copy:hover {
-  background: var(--tv-bg-hover);
 }
 
 /* ── In-session finder ────────────────────────────────────────────────── */
@@ -798,7 +754,7 @@
   margin-left: auto; /* pin to the right edge of the crumbs row */
   background: var(--tv-bg-inset);
   border: 1px solid var(--tv-border);
-  border-radius: 999px;
+  border-radius: var(--tv-radius); /* match the shared search field, not a pill */
   padding: 3px 6px 3px 10px;
   transition: border-color 0.12s ease, box-shadow 0.12s ease;
 }

--- a/packages/web/src/pages/session/session.css
+++ b/packages/web/src/pages/session/session.css
@@ -163,6 +163,42 @@
   padding-bottom: var(--tv-space-6);
 }
 
+/* Token legend — explains the per-turn token chips once, above the thread. */
+.tv-token-legend {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: var(--tv-space-1) var(--tv-space-3);
+  font-size: var(--tv-fs-sm);
+  color: var(--tv-fg-muted);
+}
+.tv-token-legend__label {
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  font-size: 10px;
+  color: var(--tv-fg-faint);
+}
+.tv-token-legend__item {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+.tv-token-legend__dot {
+  display: inline-block;
+  width: 8px;
+  height: 8px;
+  border-radius: 2px;
+}
+.tv-token-legend__dot--in {
+  background: var(--tv-user);
+}
+.tv-token-legend__dot--out {
+  background: var(--tv-assistant);
+}
+.tv-token-legend__dot--cache {
+  background: var(--tv-success);
+}
+
 .tv-turn {
   display: grid;
   grid-template-columns: 24px 1fr;
@@ -520,26 +556,139 @@
   z-index: 20;
   top: calc(100% + var(--tv-space-1));
   left: 0;
-  width: 220px;
-  padding: var(--tv-space-2);
+  width: 340px;
+  max-width: 86vw;
+  padding: var(--tv-space-3);
   background: var(--tv-bg-elevated);
   border: 1px solid var(--tv-border-strong);
   border-radius: var(--tv-radius);
   box-shadow: 0 8px 24px rgba(0, 0, 0, 0.4);
 }
-.tv-export__opt {
+.tv-export__head {
   display: flex;
   align-items: center;
   gap: var(--tv-space-2);
-  font-size: var(--tv-fs-sm);
+  font-size: var(--tv-fs-md);
+  margin-bottom: var(--tv-space-3);
+}
+.tv-export__fmt {
+  margin-left: auto;
+  color: var(--tv-fg-muted);
+}
+/* Redact option: a switch + label, then an explanation and a truthful example. */
+.tv-export__redact {
+  display: flex;
+  flex-direction: column;
+  gap: var(--tv-space-1);
   cursor: pointer;
-  margin-bottom: var(--tv-space-2);
+}
+.tv-export__redact-top {
+  display: flex;
+  align-items: center;
+  gap: var(--tv-space-2);
+  font-size: var(--tv-fs-md);
+}
+.tv-export__redact-desc {
+  font-size: var(--tv-fs-sm);
+  color: var(--tv-fg-muted);
+  line-height: 1.45;
+}
+.tv-export__redact-desc code {
+  font-family: var(--tv-font-mono);
+  font-size: 0.92em;
+}
+.tv-export__example {
+  margin-top: var(--tv-space-1);
+  padding: var(--tv-space-1) var(--tv-space-2);
+  background: var(--tv-bg-inset);
+  border: 1px solid var(--tv-border);
+  border-radius: var(--tv-radius-sm);
+  font-size: var(--tv-fs-sm);
+  color: var(--tv-fg-faint);
+  white-space: nowrap;
+  overflow-x: auto;
 }
 .tv-export__actions {
   display: flex;
-  gap: var(--tv-space-3);
+  gap: var(--tv-space-2);
+  margin-top: var(--tv-space-3);
+  padding-top: var(--tv-space-3);
   border-top: 1px solid var(--tv-border);
-  padding-top: var(--tv-space-2);
+}
+/* Download is primary (filled), Copy secondary (bordered). */
+.tv-export__download {
+  flex: 1 1 auto;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: var(--tv-space-1);
+  background: var(--tv-accent);
+  border: 1px solid var(--tv-accent);
+  color: #fff;
+  border-radius: var(--tv-radius-sm);
+  padding: var(--tv-space-2) var(--tv-space-3);
+  font-size: var(--tv-fs-sm);
+  font-weight: 600;
+  cursor: pointer;
+}
+.tv-export__download:hover {
+  filter: brightness(1.08);
+}
+.tv-export__copy {
+  flex: 0 0 auto;
+  display: inline-flex;
+  align-items: center;
+  gap: var(--tv-space-1);
+  background: transparent;
+  border: 1px solid var(--tv-border-strong);
+  color: var(--tv-fg);
+  border-radius: var(--tv-radius-sm);
+  padding: var(--tv-space-2) var(--tv-space-3);
+  font-size: var(--tv-fs-sm);
+  cursor: pointer;
+}
+.tv-export__copy:hover {
+  background: var(--tv-bg-hover);
+}
+
+/* Toggle switch (the redact option). The real <input> is visually hidden. */
+.tv-switch__input {
+  position: absolute;
+  opacity: 0;
+  width: 0;
+  height: 0;
+}
+.tv-switch {
+  position: relative;
+  flex: 0 0 auto;
+  width: 30px;
+  height: 18px;
+  border-radius: 999px;
+  background: var(--tv-bg-inset);
+  border: 1px solid var(--tv-border-strong);
+  transition: background 0.12s ease, border-color 0.12s ease;
+}
+.tv-switch::after {
+  content: '';
+  position: absolute;
+  top: 2px;
+  left: 2px;
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  background: var(--tv-fg-muted);
+  transition: transform 0.12s ease, background 0.12s ease;
+}
+.tv-switch__input:checked + .tv-switch {
+  background: var(--tv-success);
+  border-color: var(--tv-success);
+}
+.tv-switch__input:checked + .tv-switch::after {
+  transform: translateX(12px);
+  background: #fff;
+}
+.tv-switch__input:focus-visible + .tv-switch {
+  box-shadow: 0 0 0 2px var(--tv-accent-muted);
 }
 
 /* ── Continue (resume / fork) dropdown ────────────────────────────────── */

--- a/packages/web/src/pages/session/session.css
+++ b/packages/web/src/pages/session/session.css
@@ -1,14 +1,11 @@
 /* Session reader — threaded conversation view. Relies on global tokens. */
 
-.tv-session {
-  /* Capped for transcript readability, but roomy enough for code blocks, diffs,
-     and tool output — 920px was tight once a session has wide content. */
-  max-width: 1100px;
-  margin: 0 auto;
-}
+/* The session fills the shared, capped, left-aligned content box
+   (.tv-main__inner) — no separate cap/centering, so its left edge lines up with
+   every other page and the header full-bleeds cleanly to that box's edges. */
 
-/* Sticky header: offsets the .tv-main padding via negative margins so it
-   spans full width and pins to the top while scrolling long sessions. */
+/* Sticky header: offsets the .tv-main__inner padding via negative margins so it
+   spans the full content width and pins to the top while scrolling. */
 .tv-session__header {
   position: sticky;
   top: calc(-1 * var(--tv-space-5));

--- a/packages/web/src/pages/session/session.css
+++ b/packages/web/src/pages/session/session.css
@@ -8,7 +8,10 @@
    spans the full content width and pins to the top while scrolling. */
 .tv-session__header {
   position: sticky;
-  top: calc(-1 * var(--tv-space-5));
+  /* Pin flush to the scroll container top. (The page padding now lives on
+     .tv-main__inner, not the scroll container, so a negative offset would lift
+     the header above the viewport and clip the top breadcrumb row.) */
+  top: 0;
   z-index: 5;
   background: var(--tv-bg);
   margin: calc(-1 * var(--tv-space-5)) calc(-1 * var(--tv-space-5)) var(--tv-space-4);

--- a/packages/web/src/styles/global.css
+++ b/packages/web/src/styles/global.css
@@ -255,6 +255,12 @@ button {
 
 .tv-main {
   overflow-y: auto;
+}
+/* Cap + left-align the content so it doesn't stretch edge-to-edge on wide
+   screens (which left titles/meta far apart). The padding lives here, so the
+   session header's negative-margin full-bleed resolves to this box's edges. */
+.tv-main__inner {
+  max-width: 1200px;
   padding: var(--tv-space-5);
 }
 
@@ -308,6 +314,40 @@ button {
 .tv-chip--more {
   cursor: default;
   color: var(--tv-fg-muted);
+}
+
+/* Per-turn token chips — compact dots (input/output) + grouped cache, matching
+   the thread's token legend. */
+.tv-tok {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--tv-space-2);
+  font-size: var(--tv-fs-sm);
+  font-variant-numeric: tabular-nums;
+}
+.tv-tok__seg {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  color: var(--tv-fg);
+}
+.tv-tok__seg--cache {
+  color: var(--tv-fg-muted);
+}
+.tv-tok__dot {
+  display: inline-block;
+  width: 7px;
+  height: 7px;
+  border-radius: 999px;
+}
+.tv-tok__dot--in {
+  background: var(--tv-user);
+}
+.tv-tok__dot--out {
+  background: var(--tv-assistant);
+}
+.tv-tok__dot--cache {
+  background: var(--tv-success);
 }
 
 .tv-cost-badge {
@@ -756,7 +796,7 @@ mark {
   :root {
     --tv-nav-width: 188px;
   }
-  .tv-main {
+  .tv-main__inner {
     padding: var(--tv-space-4);
   }
 }

--- a/packages/web/src/styles/global.css
+++ b/packages/web/src/styles/global.css
@@ -318,10 +318,35 @@ button {
 .tv-chip--cache {
   border-color: #3fb95055;
 }
-/* Overflow chip ("+N") for capped lists like <ModelChips>; the rest are in its title. */
+/* Overflow chip ("+N") for capped lists like <ModelChips> — a button that opens
+   a popover listing the remaining items. */
 .tv-chip--more {
-  cursor: default;
+  cursor: pointer;
   color: var(--tv-fg-muted);
+  font-family: inherit;
+}
+.tv-chip--more:hover {
+  color: var(--tv-fg);
+  border-color: var(--tv-border-strong);
+}
+.tv-modelchips__more-wrap {
+  position: relative;
+  display: inline-flex;
+}
+.tv-modelchips__pop {
+  position: absolute;
+  top: calc(100% + 4px);
+  left: 0;
+  z-index: 30;
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--tv-space-1);
+  max-width: 260px;
+  padding: var(--tv-space-2);
+  background: var(--tv-bg-elevated);
+  border: 1px solid var(--tv-border-strong);
+  border-radius: var(--tv-radius);
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.4);
 }
 
 /* Per-turn token chips — compact dots (input/output) + grouped cache, matching

--- a/packages/web/src/styles/global.css
+++ b/packages/web/src/styles/global.css
@@ -27,6 +27,11 @@
 
   --tv-accent: #58a6ff;
   --tv-accent-muted: #1f6feb33;
+  /* Filled action buttons use a deeper, more saturated blue than the (lighter)
+     link accent, so white text stays legible. */
+  --tv-btn-primary: #1f6feb;
+  --tv-btn-primary-hover: #388bfd;
+  --tv-on-accent: #ffffff;
   --tv-success: #3fb950;
   --tv-warning: #d29922;
   --tv-danger: #f85149;
@@ -90,6 +95,9 @@
 
   --tv-accent: #0969da;
   --tv-accent-muted: #0969da1a;
+  --tv-btn-primary: #0969da;
+  --tv-btn-primary-hover: #0860ca;
+  --tv-on-accent: #ffffff;
   --tv-success: #1a7f37;
   --tv-warning: #9a6700;
   --tv-danger: #cf222e;
@@ -746,6 +754,99 @@ mark {
   border: 1px solid var(--tv-border);
   border-radius: var(--tv-radius);
   padding: var(--tv-space-4);
+}
+
+/* Buttons — one shared vocabulary. Primary = filled deep blue with readable
+   text; secondary = bordered; sm = compact (inline, e.g. a Copy next to code). */
+.tv-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: var(--tv-space-1);
+  padding: var(--tv-space-2) var(--tv-space-4);
+  border: 1px solid transparent;
+  border-radius: var(--tv-radius);
+  font-family: inherit;
+  font-size: var(--tv-fs-md);
+  font-weight: 600;
+  line-height: 1.2;
+  cursor: pointer;
+  white-space: nowrap;
+  transition: background 0.12s ease, border-color 0.12s ease, color 0.12s ease;
+}
+.tv-btn--primary {
+  background: var(--tv-btn-primary);
+  color: var(--tv-on-accent);
+}
+.tv-btn--primary:hover {
+  background: var(--tv-btn-primary-hover);
+  text-decoration: none;
+}
+.tv-btn--secondary {
+  background: transparent;
+  border-color: var(--tv-border-strong);
+  color: var(--tv-fg);
+}
+.tv-btn--secondary:hover {
+  background: var(--tv-bg-hover);
+  text-decoration: none;
+}
+.tv-btn--sm {
+  padding: var(--tv-space-1) var(--tv-space-2);
+  font-size: var(--tv-fs-sm);
+  font-weight: 500;
+}
+
+/* Search/filter field — one shared control (magnifier in-field + clear ×). */
+.tv-field {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--tv-space-2);
+  min-width: 220px;
+  padding: 0 var(--tv-space-2) 0 var(--tv-space-3);
+  background: var(--tv-bg-inset);
+  border: 1px solid var(--tv-border);
+  border-radius: var(--tv-radius);
+}
+.tv-field--grow {
+  flex: 1 1 280px;
+}
+.tv-field:focus-within {
+  border-color: var(--tv-accent);
+  box-shadow: 0 0 0 2px var(--tv-accent-muted);
+}
+.tv-field__icon {
+  flex: 0 0 auto;
+  color: var(--tv-fg-muted);
+}
+.tv-field__input {
+  flex: 1 1 auto;
+  min-width: 0;
+  padding: var(--tv-space-2) 0;
+  background: transparent;
+  border: 0;
+  outline: none;
+  color: var(--tv-fg);
+  font-family: inherit;
+  font-size: var(--tv-fs-md);
+}
+.tv-field__input::placeholder {
+  color: var(--tv-fg-faint);
+}
+.tv-field__clear {
+  flex: 0 0 auto;
+  display: inline-flex;
+  align-items: center;
+  padding: 2px;
+  background: transparent;
+  border: 0;
+  border-radius: var(--tv-radius-sm);
+  color: var(--tv-fg-muted);
+  cursor: pointer;
+}
+.tv-field__clear:hover {
+  color: var(--tv-fg);
+  background: var(--tv-bg-hover);
 }
 
 .tv-muted {

--- a/packages/web/src/styles/global.css
+++ b/packages/web/src/styles/global.css
@@ -467,6 +467,22 @@ button {
   border-color: var(--tv-danger);
 }
 
+/* Quiet variant — tool calls demote to one subtle line with a "details" hint,
+   expanding to the full body. (Rule order: this beats `--tool`'s gold icon.) */
+.tv-collapsible--quiet {
+  background: transparent;
+}
+.tv-collapsible--quiet .tv-collapsible__title {
+  font-weight: 500;
+}
+.tv-collapsible--quiet .tv-collapsible__icon {
+  color: var(--tv-fg-faint);
+}
+.tv-collapsible__details {
+  font-size: var(--tv-fs-sm);
+  color: var(--tv-fg-faint);
+}
+
 .tv-tool__section-label {
   font-size: var(--tv-fs-sm);
   color: var(--tv-fg-faint);


### PR DESCRIPTION
Batch 2 of the UI/UX review (plan [`docs/plans/0026`](docs/plans/0026-ui-ux-review-batches.md)) — grouping, previews, privacy, and thread polish.

## What's in this batch

- **⑤ Search — grouping + relevance bar.** Matches nest under one card per session ("N matches across M sessions") with a "Show N more" expander, instead of N near-identical flat rows. The raw BM25 number is replaced by a quiet relevance bar normalized against the strongest hit in the result set (green ≥ 50%, amber below). Client-side only.
- **⑧ Memory — previews + "no memory store".** Each agent card previews real content (latest fact + category, or an instruction-doc excerpt) rather than bare counts, and agents that keep no store (pi, opencode) are shown explicitly as *no memory store* (dimmed, non-clickable) instead of being hidden. Backed by a new `connectors` array on `GET /api/memory` (server reuses the already-loaded sources, so no extra disk reads; `supported` is derived from whether a connector exposes a memory provider).
- **⑩ Export — redaction made legible.** A proper panel: a toggle switch, the redaction explained with a **truthful** example (`/Users/you/… → ~/…  ·  sk-… → «redacted-key»`) and honest *best-effort* wording (an unrecognized secret can slip through), Download primary / Copy secondary.
- **② Session thread polish.** A token legend above the conversation (input / output / cache colors), and tool calls demoted to one quiet "details" line — per-tool icon + file/`call · id` descriptor — that expands to the **existing** rich diff/code body (unchanged).

## Verification
- `npm run typecheck` ✓, `npm test` ✓ (230; +5 new memory-overview tests), `npm run build` ✓.
- Visually verified Search, Memory, the Export popover, and the session thread (legend + demoted tools) against the mockups in light + dark (isolated synthetic data; no real agent data touched).
- No new dependencies, so no flake hash change.

Batch 3 (files-changed jump rail + diffstat + viewed) follows in a separate PR.