### PR TITLE
feat(web): UI hierarchy pass — batch 3 (files changed)

### DIFF
--- a/docs/plans/0026-ui-ux-review-batches.md
+++ b/docs/plans/0026-ui-ux-review-batches.md
@@ -1,8 +1,8 @@
 # 0026 — UI/UX review: hierarchy pass across all screens
 
-- **Status:** in-progress <!-- proposed | in-progress | done | superseded | abandoned -->
+- **Status:** done <!-- proposed | in-progress | done | superseded | abandoned -->
 - **Date:** 2026-06-17
-- **PR:** Batch 1 — [#32](https://github.com/vladar107/claudescope/pull/32) · Batch 2 — [#33](https://github.com/vladar107/claudescope/pull/33)
+- **PR:** Batch 1 — [#32](https://github.com/vladar107/claudescope/pull/32) · Batch 2 — [#33](https://github.com/vladar107/claudescope/pull/33) · Batch 3 — [#34](https://github.com/vladar107/claudescope/pull/34)
 
 ## Context
 

--- a/docs/plans/0026-ui-ux-review-batches.md
+++ b/docs/plans/0026-ui-ux-review-batches.md
@@ -62,9 +62,10 @@ hierarchy and an app-wide icon set.
 - **Clean the fallback title in the shared path, not a Codex special-case.** pi has
   the identical no-stored-title behavior, so fixing `first_user` covers both
   (and is deterministic, so titles stay stable across re-index).
-- **Viewed-state for Files-changed is client-only (localStorage).** It is ephemeral
-  review UI state; persisting it server-side would add an index/state surface for
-  no benefit and the read-only-sources rule stays untouched.
+- **Files-changed has no "viewed" review state.** The mockup's per-file "viewed"
+  checkbox and "N of M viewed" progress bar were dropped on review; the tab is a
+  jump rail + diffstat only, so no client/server state is needed. Instead the rail
+  shows a per-file **edit count** (how many change operations touched each file).
 - **Cap model chips at three, `+N` reveals the rest on hover.** Sessions/projects
   can surface 1–5+ models; a shared `ModelChips` component owns the cap so the
   session header, session rows, and any card stay consistent.
@@ -131,10 +132,11 @@ hierarchy and an app-wide icon set.
 
 ### Batch 3 — biggest build (scope carefully)
 
-13. **④ Files-changed jump rail + diffstat + viewed** (`ChangesetPanel.tsx`,
-    `LineDiff`) — two-pane layout (file rail left, diff right), session-level
-    diffstat (`+412 −86`) up top, per-file +/− in the rail, and a "viewed" checkbox
-    per file (localStorage) with an "N of M viewed" progress indicator.
+13. **④ Files-changed jump rail + diffstat** (`ChangesetPanel.tsx`, `LineDiff`) —
+    two-pane layout (file rail left, diff right), session-level diffstat
+    (`+412 −86`) up top, per-file edit count + +/− in the rail. (The mockup's
+    per-file "viewed" checkbox + "N of M viewed" progress bar were dropped on
+    review.)
 
 ## Files affected
 

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -50,4 +50,4 @@ decision, or a change worth explaining before doing. Skip it for one-line fixes.
 | 0023 | [Structured rendering for command turns (slash/bash tags)](./0023-command-turn-rendering.md) | done |
 | 0024 | [Continue session from transcript (terminal auto-open)](./0024-continue-session.md) | abandoned |
 | 0025 | [Continue session: copy the command](./0025-continue-session-copy-command.md) | done |
-| 0026 | [UI/UX review: hierarchy pass across all screens](./0026-ui-ux-review-batches.md) | in-progress |
+| 0026 | [UI/UX review: hierarchy pass across all screens](./0026-ui-ux-review-batches.md) | done |

--- a/packages/web/src/pages/session/ChangesetPanel.tsx
+++ b/packages/web/src/pages/session/ChangesetPanel.tsx
@@ -1,28 +1,8 @@
 import { useEffect, useMemo, useState } from 'react';
+import { Pencil } from 'lucide-react';
 import { LineDiff } from '../../components';
 import type { FileChange } from './changeset.js';
 import { fileStats } from './changeset.js';
-
-const VIEWED_PREFIX = 'cs.viewed.';
-
-/** Load the set of file paths marked "viewed" for a session (client-only state). */
-function loadViewed(sessionId: string): Set<string> {
-  try {
-    const raw = localStorage.getItem(VIEWED_PREFIX + sessionId);
-    if (raw) return new Set(JSON.parse(raw) as string[]);
-  } catch {
-    /* ignore unavailable/garbage storage */
-  }
-  return new Set();
-}
-
-function saveViewed(sessionId: string, viewed: Set<string>): void {
-  try {
-    localStorage.setItem(VIEWED_PREFIX + sessionId, JSON.stringify([...viewed]));
-  } catch {
-    /* ignore */
-  }
-}
 
 /** Abbreviate a path to its last two segments (e.g. "…/session/ThreadView.tsx"). */
 function shortPath(path: string): string {
@@ -42,22 +22,12 @@ function baseOf(path: string): string {
 }
 
 /**
- * "Files changed" view — a master/detail review surface: a session diffstat and
- * a "viewed" progress bar on top, a left rail of changed files (each with a
- * viewed checkbox and per-file +/− counts), and the selected file's diff on the
- * right. Per-file line stats run `lineDiff`, so they're computed only once the
- * tab has actually been opened (`active`). "Viewed" state persists in
- * localStorage per session — a lightweight, code-review-style pass.
+ * "Files changed" view — master/detail: a session diffstat on top, a left rail
+ * of changed files (each with per-file +/− counts), and the selected file's diff
+ * on the right. Per-file line stats run `lineDiff`, so they're computed only once
+ * the tab has actually been opened (`active`).
  */
-export function ChangesetPanel({
-  changes,
-  sessionId,
-  active,
-}: {
-  changes: FileChange[];
-  sessionId: string;
-  active: boolean;
-}) {
+export function ChangesetPanel({ changes, active }: { changes: FileChange[]; active: boolean }) {
   // Defer the (potentially heavy) all-files stat computation until the tab is
   // first opened, so loading a session never pays for a view it may not see.
   const [everActive, setEverActive] = useState(active);
@@ -71,26 +41,12 @@ export function ChangesetPanel({
   );
 
   const [selected, setSelected] = useState(0);
-  const [viewed, setViewed] = useState<Set<string>>(() => loadViewed(sessionId));
-
-  // A soft refresh swaps the session id → reset selection and reload viewed.
-  useEffect(() => {
-    setSelected(0);
-    setViewed(loadViewed(sessionId));
-  }, [sessionId]);
+  // Reset the selection when the changeset swaps (new session / soft refresh).
+  useEffect(() => setSelected(0), [changes]);
 
   if (changes.length === 0) {
     return <p className="tv-muted">This session changed no files.</p>;
   }
-
-  const toggleViewed = (path: string) =>
-    setViewed((prev) => {
-      const next = new Set(prev);
-      if (next.has(path)) next.delete(path);
-      else next.add(path);
-      saveViewed(sessionId, next);
-      return next;
-    });
 
   const totals = stats
     ? stats.reduce(
@@ -98,7 +54,6 @@ export function ChangesetPanel({
         { additions: 0, deletions: 0 },
       )
     : null;
-  const viewedCount = changes.reduce((n, c) => n + (viewed.has(c.path) ? 1 : 0), 0);
   const idx = Math.min(selected, changes.length - 1);
   const current = changes[idx];
   if (!current) return null;
@@ -118,17 +73,6 @@ export function ChangesetPanel({
             </>
           ) : null}
         </div>
-        <div className="tv-changeset__progress">
-          <span className="tv-changeset__progress-bar" aria-hidden="true">
-            <span
-              className="tv-changeset__progress-fill"
-              style={{ width: `${(viewedCount / changes.length) * 100}%` }}
-            />
-          </span>
-          <span className="tv-muted">
-            {viewedCount} of {changes.length} viewed
-          </span>
-        </div>
       </div>
 
       <div className="tv-changeset__panes">
@@ -136,26 +80,29 @@ export function ChangesetPanel({
           {changes.map((c, i) => {
             const s = stats?.[i];
             return (
-              <li
-                key={c.path}
-                className={i === idx ? 'tv-changeset__railrow is-active' : 'tv-changeset__railrow'}
-              >
-                <input
-                  type="checkbox"
-                  className="tv-changeset__viewed"
-                  checked={viewed.has(c.path)}
-                  onChange={() => toggleViewed(c.path)}
-                  aria-label={`Mark ${c.path} viewed`}
-                  title="Viewed"
-                />
-                <button type="button" className="tv-changeset__railbtn" onClick={() => setSelected(i)} title={c.path}>
+              <li key={c.path}>
+                <button
+                  type="button"
+                  className={i === idx ? 'tv-changeset__railbtn is-active' : 'tv-changeset__railbtn'}
+                  onClick={() => setSelected(i)}
+                  title={c.path}
+                >
                   <span className="tv-mono tv-changeset__railpath">{shortPath(c.path)}</span>
-                  {s ? (
-                    <span className="tv-changeset__railstat">
-                      {s.additions > 0 ? <span className="tv-diff-add">+{s.additions}</span> : null}
-                      {s.deletions > 0 ? <span className="tv-diff-del">−{s.deletions}</span> : null}
+                  <span className="tv-changeset__railstat">
+                    <span
+                      className="tv-changeset__edits"
+                      title={`${c.edits.length} edit${c.edits.length === 1 ? '' : 's'}`}
+                    >
+                      <Pencil size={11} aria-hidden="true" />
+                      {c.edits.length}
                     </span>
-                  ) : null}
+                    {s ? (
+                      <>
+                        {s.additions > 0 ? <span className="tv-diff-add">+{s.additions}</span> : null}
+                        {s.deletions > 0 ? <span className="tv-diff-del">−{s.deletions}</span> : null}
+                      </>
+                    ) : null}
+                  </span>
                 </button>
               </li>
             );
@@ -168,12 +115,17 @@ export function ChangesetPanel({
               {dirOf(current.path)}
               <strong>{baseOf(current.path)}</strong>
             </span>
-            {currentStat ? (
-              <span className="tv-changeset__railstat">
-                <span className="tv-diff-add">+{currentStat.additions}</span>
-                <span className="tv-diff-del">−{currentStat.deletions}</span>
+            <span className="tv-changeset__railstat">
+              <span className="tv-changeset__edits">
+                {current.edits.length} edit{current.edits.length === 1 ? '' : 's'}
               </span>
-            ) : null}
+              {currentStat ? (
+                <>
+                  <span className="tv-diff-add">+{currentStat.additions}</span>
+                  <span className="tv-diff-del">−{currentStat.deletions}</span>
+                </>
+              ) : null}
+            </span>
           </div>
           <div className="tv-changeset__diffs">
             {current.edits.map((e, i) => (

--- a/packages/web/src/pages/session/ChangesetPanel.tsx
+++ b/packages/web/src/pages/session/ChangesetPanel.tsx
@@ -1,63 +1,187 @@
-import { useMemo, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { LineDiff } from '../../components';
 import type { FileChange } from './changeset.js';
 import { fileStats } from './changeset.js';
 
+const VIEWED_PREFIX = 'cs.viewed.';
+
+/** Load the set of file paths marked "viewed" for a session (client-only state). */
+function loadViewed(sessionId: string): Set<string> {
+  try {
+    const raw = localStorage.getItem(VIEWED_PREFIX + sessionId);
+    if (raw) return new Set(JSON.parse(raw) as string[]);
+  } catch {
+    /* ignore unavailable/garbage storage */
+  }
+  return new Set();
+}
+
+function saveViewed(sessionId: string, viewed: Set<string>): void {
+  try {
+    localStorage.setItem(VIEWED_PREFIX + sessionId, JSON.stringify([...viewed]));
+  } catch {
+    /* ignore */
+  }
+}
+
+/** Abbreviate a path to its last two segments (e.g. "…/session/ThreadView.tsx"). */
+function shortPath(path: string): string {
+  const parts = path.split('/').filter(Boolean);
+  if (parts.length <= 2) return path;
+  return `…/${parts.slice(-2).join('/')}`;
+}
+
+/** Directory portion (with trailing slash) of a path, for the muted prefix. */
+function dirOf(path: string): string {
+  const i = path.lastIndexOf('/');
+  return i >= 0 ? path.slice(0, i + 1) : '';
+}
+function baseOf(path: string): string {
+  const i = path.lastIndexOf('/');
+  return i >= 0 ? path.slice(i + 1) : path;
+}
+
 /**
- * "Files changed" view (rendered only when its tab is active). Each file is
- * collapsed by default; its line stats and syntax-highlighted diffs are computed
- * only when expanded — so opening the tab is instant even for big sessions.
+ * "Files changed" view — a master/detail review surface: a session diffstat and
+ * a "viewed" progress bar on top, a left rail of changed files (each with a
+ * viewed checkbox and per-file +/− counts), and the selected file's diff on the
+ * right. Per-file line stats run `lineDiff`, so they're computed only once the
+ * tab has actually been opened (`active`). "Viewed" state persists in
+ * localStorage per session — a lightweight, code-review-style pass.
  */
-export function ChangesetPanel({ changes }: { changes: FileChange[] }) {
+export function ChangesetPanel({
+  changes,
+  sessionId,
+  active,
+}: {
+  changes: FileChange[];
+  sessionId: string;
+  active: boolean;
+}) {
+  // Defer the (potentially heavy) all-files stat computation until the tab is
+  // first opened, so loading a session never pays for a view it may not see.
+  const [everActive, setEverActive] = useState(active);
+  useEffect(() => {
+    if (active && !everActive) setEverActive(true);
+  }, [active, everActive]);
+
+  const stats = useMemo(
+    () => (everActive ? changes.map((c) => fileStats(c.edits)) : null),
+    [everActive, changes],
+  );
+
+  const [selected, setSelected] = useState(0);
+  const [viewed, setViewed] = useState<Set<string>>(() => loadViewed(sessionId));
+
+  // A soft refresh swaps the session id → reset selection and reload viewed.
+  useEffect(() => {
+    setSelected(0);
+    setViewed(loadViewed(sessionId));
+  }, [sessionId]);
+
   if (changes.length === 0) {
     return <p className="tv-muted">This session changed no files.</p>;
   }
-  return (
-    <ul className="tv-changeset__list">
-      {changes.map((c) => (
-        <FileRow key={c.path} change={c} />
-      ))}
-    </ul>
-  );
-}
 
-function FileRow({ change }: { change: FileChange }) {
-  const [open, setOpen] = useState(false);
-  // Stats run lineDiff — compute only once the file is expanded.
-  const stats = useMemo(() => (open ? fileStats(change.edits) : null), [open, change.edits]);
+  const toggleViewed = (path: string) =>
+    setViewed((prev) => {
+      const next = new Set(prev);
+      if (next.has(path)) next.delete(path);
+      else next.add(path);
+      saveViewed(sessionId, next);
+      return next;
+    });
+
+  const totals = stats
+    ? stats.reduce(
+        (acc, s) => ({ additions: acc.additions + s.additions, deletions: acc.deletions + s.deletions }),
+        { additions: 0, deletions: 0 },
+      )
+    : null;
+  const viewedCount = changes.reduce((n, c) => n + (viewed.has(c.path) ? 1 : 0), 0);
+  const idx = Math.min(selected, changes.length - 1);
+  const current = changes[idx];
+  if (!current) return null;
+  const currentStat = stats?.[idx] ?? null;
 
   return (
-    <li className="tv-changeset__file">
-      <button
-        type="button"
-        className="tv-changeset__summary"
-        aria-expanded={open}
-        onClick={() => setOpen((o) => !o)}
-      >
-        <span className="tv-changeset__chevron" aria-hidden="true">
-          {open ? '▾' : '▸'}
-        </span>
-        <span className="tv-mono tv-changeset__path">{change.path}</span>
-        <span className="tv-changeset__stat">
-          {stats ? (
+    <div className="tv-changeset">
+      <div className="tv-changeset__bar">
+        <div className="tv-changeset__diffstat">
+          <span>
+            {changes.length} file{changes.length === 1 ? '' : 's'}
+          </span>
+          {totals ? (
             <>
-              <span className="tv-diff-add">+{stats.additions}</span>{' '}
-              <span className="tv-diff-del">−{stats.deletions}</span>
+              <span className="tv-diff-add">+{totals.additions}</span>
+              <span className="tv-diff-del">−{totals.deletions}</span>
             </>
-          ) : (
-            <span className="tv-muted">
-              {change.edits.length} edit{change.edits.length === 1 ? '' : 's'}
-            </span>
-          )}
-        </span>
-      </button>
-      {open ? (
-        <div className="tv-changeset__diffs">
-          {change.edits.map((e, i) => (
-            <LineDiff key={i} oldText={e.oldText} newText={e.newText} lang={change.lang} />
-          ))}
+          ) : null}
         </div>
-      ) : null}
-    </li>
+        <div className="tv-changeset__progress">
+          <span className="tv-changeset__progress-bar" aria-hidden="true">
+            <span
+              className="tv-changeset__progress-fill"
+              style={{ width: `${(viewedCount / changes.length) * 100}%` }}
+            />
+          </span>
+          <span className="tv-muted">
+            {viewedCount} of {changes.length} viewed
+          </span>
+        </div>
+      </div>
+
+      <div className="tv-changeset__panes">
+        <ul className="tv-changeset__rail">
+          {changes.map((c, i) => {
+            const s = stats?.[i];
+            return (
+              <li
+                key={c.path}
+                className={i === idx ? 'tv-changeset__railrow is-active' : 'tv-changeset__railrow'}
+              >
+                <input
+                  type="checkbox"
+                  className="tv-changeset__viewed"
+                  checked={viewed.has(c.path)}
+                  onChange={() => toggleViewed(c.path)}
+                  aria-label={`Mark ${c.path} viewed`}
+                  title="Viewed"
+                />
+                <button type="button" className="tv-changeset__railbtn" onClick={() => setSelected(i)} title={c.path}>
+                  <span className="tv-mono tv-changeset__railpath">{shortPath(c.path)}</span>
+                  {s ? (
+                    <span className="tv-changeset__railstat">
+                      {s.additions > 0 ? <span className="tv-diff-add">+{s.additions}</span> : null}
+                      {s.deletions > 0 ? <span className="tv-diff-del">−{s.deletions}</span> : null}
+                    </span>
+                  ) : null}
+                </button>
+              </li>
+            );
+          })}
+        </ul>
+
+        <div className="tv-changeset__detail">
+          <div className="tv-changeset__detail-head">
+            <span className="tv-mono tv-changeset__detail-path" title={current.path}>
+              {dirOf(current.path)}
+              <strong>{baseOf(current.path)}</strong>
+            </span>
+            {currentStat ? (
+              <span className="tv-changeset__railstat">
+                <span className="tv-diff-add">+{currentStat.additions}</span>
+                <span className="tv-diff-del">−{currentStat.deletions}</span>
+              </span>
+            ) : null}
+          </div>
+          <div className="tv-changeset__diffs">
+            {current.edits.map((e, i) => (
+              <LineDiff key={i} oldText={e.oldText} newText={e.newText} lang={current.lang} />
+            ))}
+          </div>
+        </div>
+      </div>
+    </div>
   );
 }

--- a/packages/web/src/pages/session/SessionPage.tsx
+++ b/packages/web/src/pages/session/SessionPage.tsx
@@ -512,7 +512,7 @@ function SessionView({
           className="tv-session__changes"
           style={tab === 'changes' ? undefined : { display: 'none' }}
         >
-          <ChangesetPanel changes={changes} />
+          <ChangesetPanel changes={changes} sessionId={meta.id} active={tab === 'changes'} />
         </div>
       ) : null}
     </div>

--- a/packages/web/src/pages/session/SessionPage.tsx
+++ b/packages/web/src/pages/session/SessionPage.tsx
@@ -512,7 +512,7 @@ function SessionView({
           className="tv-session__changes"
           style={tab === 'changes' ? undefined : { display: 'none' }}
         >
-          <ChangesetPanel changes={changes} sessionId={meta.id} active={tab === 'changes'} />
+          <ChangesetPanel changes={changes} active={tab === 'changes'} />
         </div>
       ) : null}
     </div>

--- a/packages/web/src/pages/session/session.css
+++ b/packages/web/src/pages/session/session.css
@@ -488,48 +488,127 @@
 .tv-diff-del {
   color: var(--tv-danger);
 }
-.tv-changeset__list {
+/* Top bar: session diffstat (left) + "N of M viewed" progress (right). */
+.tv-changeset__bar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  gap: var(--tv-space-3);
+  margin-bottom: var(--tv-space-3);
+}
+.tv-changeset__diffstat {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--tv-space-2);
+  font-size: var(--tv-fs-md);
+  font-variant-numeric: tabular-nums;
+}
+.tv-changeset__progress {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--tv-space-2);
+  font-size: var(--tv-fs-sm);
+}
+.tv-changeset__progress-bar {
+  display: inline-block;
+  width: 120px;
+  height: 6px;
+  border-radius: 999px;
+  background: var(--tv-bg-inset);
+  overflow: hidden;
+}
+.tv-changeset__progress-fill {
+  display: block;
+  height: 100%;
+  border-radius: 999px;
+  background: var(--tv-success);
+  transition: width 0.15s ease;
+}
+
+/* Master/detail: file rail on the left, the selected file's diff on the right. */
+.tv-changeset__panes {
+  display: grid;
+  grid-template-columns: 270px minmax(0, 1fr);
+  gap: var(--tv-space-4);
+  align-items: start;
+  padding-bottom: var(--tv-space-6);
+}
+.tv-changeset__rail {
   list-style: none;
   margin: 0;
-  padding: 0 0 var(--tv-space-6);
+  padding: 0;
   display: flex;
   flex-direction: column;
-  gap: var(--tv-space-2);
+  gap: 1px;
 }
-.tv-changeset__summary {
-  width: 100%;
-  cursor: pointer;
+.tv-changeset__railrow {
   display: flex;
   align-items: center;
   gap: var(--tv-space-2);
-  padding: var(--tv-space-2);
-  border: 1px solid var(--tv-border);
+  padding: var(--tv-space-1) var(--tv-space-2);
   border-radius: var(--tv-radius-sm);
+}
+.tv-changeset__railrow.is-active {
   background: var(--tv-bg-inset);
-  color: inherit;
-  text-align: left;
 }
-.tv-changeset__summary:hover {
-  background: var(--tv-bg-elevated);
-}
-.tv-changeset__chevron {
+.tv-changeset__viewed {
   flex: 0 0 auto;
+  accent-color: var(--tv-success);
+  cursor: pointer;
+}
+.tv-changeset__railbtn {
+  flex: 1 1 auto;
+  min-width: 0;
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: var(--tv-space-2);
+  padding: 0;
+  background: transparent;
+  border: 0;
+  color: var(--tv-fg);
+  font-family: inherit;
+  text-align: left;
+  cursor: pointer;
+}
+.tv-changeset__railpath {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: var(--tv-fs-sm);
+}
+.tv-changeset__railstat {
+  flex: 0 0 auto;
+  display: inline-flex;
+  gap: 5px;
+  font-size: var(--tv-fs-sm);
+  font-variant-numeric: tabular-nums;
+}
+.tv-changeset__detail {
+  min-width: 0;
+}
+.tv-changeset__detail-head {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: var(--tv-space-3);
+  margin-bottom: var(--tv-space-2);
+  padding-bottom: var(--tv-space-2);
+  border-bottom: 1px solid var(--tv-border);
+}
+.tv-changeset__detail-path {
+  font-size: var(--tv-fs-sm);
+  word-break: break-all;
   color: var(--tv-fg-muted);
 }
-.tv-changeset__path {
-  flex: 1 1 auto;
-  word-break: break-all;
-}
-.tv-changeset__stat {
-  flex: 0 0 auto;
-  font-family: var(--tv-font-mono, monospace);
-  font-size: var(--tv-fs-sm);
+.tv-changeset__detail-path strong {
+  color: var(--tv-fg);
 }
 .tv-changeset__diffs {
   display: flex;
   flex-direction: column;
   gap: var(--tv-space-2);
-  padding: var(--tv-space-2) 0 var(--tv-space-2) var(--tv-space-3);
 }
 
 /* ── Export menu ──────────────────────────────────────────────────────── */

--- a/packages/web/src/pages/session/session.css
+++ b/packages/web/src/pages/session/session.css
@@ -488,11 +488,10 @@
 .tv-diff-del {
   color: var(--tv-danger);
 }
-/* Top bar: session diffstat (left) + "N of M viewed" progress (right). */
+/* Top bar: the session diffstat. */
 .tv-changeset__bar {
   display: flex;
   align-items: center;
-  justify-content: space-between;
   flex-wrap: wrap;
   gap: var(--tv-space-3);
   margin-bottom: var(--tv-space-3);
@@ -503,27 +502,6 @@
   gap: var(--tv-space-2);
   font-size: var(--tv-fs-md);
   font-variant-numeric: tabular-nums;
-}
-.tv-changeset__progress {
-  display: inline-flex;
-  align-items: center;
-  gap: var(--tv-space-2);
-  font-size: var(--tv-fs-sm);
-}
-.tv-changeset__progress-bar {
-  display: inline-block;
-  width: 120px;
-  height: 6px;
-  border-radius: 999px;
-  background: var(--tv-bg-inset);
-  overflow: hidden;
-}
-.tv-changeset__progress-fill {
-  display: block;
-  height: 100%;
-  border-radius: 999px;
-  background: var(--tv-success);
-  transition: width 0.15s ease;
 }
 
 /* Master/detail: file rail on the left, the selected file's diff on the right. */
@@ -542,35 +520,27 @@
   flex-direction: column;
   gap: 1px;
 }
-.tv-changeset__railrow {
-  display: flex;
-  align-items: center;
-  gap: var(--tv-space-2);
-  padding: var(--tv-space-1) var(--tv-space-2);
-  border-radius: var(--tv-radius-sm);
-}
-.tv-changeset__railrow.is-active {
-  background: var(--tv-bg-inset);
-}
-.tv-changeset__viewed {
-  flex: 0 0 auto;
-  accent-color: var(--tv-success);
-  cursor: pointer;
-}
 .tv-changeset__railbtn {
-  flex: 1 1 auto;
+  width: 100%;
   min-width: 0;
   display: flex;
   align-items: baseline;
   justify-content: space-between;
   gap: var(--tv-space-2);
-  padding: 0;
+  padding: var(--tv-space-1) var(--tv-space-2);
   background: transparent;
   border: 0;
+  border-radius: var(--tv-radius-sm);
   color: var(--tv-fg);
   font-family: inherit;
   text-align: left;
   cursor: pointer;
+}
+.tv-changeset__railbtn:hover {
+  background: var(--tv-bg-hover);
+}
+.tv-changeset__railbtn.is-active {
+  background: var(--tv-bg-inset);
 }
 .tv-changeset__railpath {
   overflow: hidden;
@@ -581,9 +551,17 @@
 .tv-changeset__railstat {
   flex: 0 0 auto;
   display: inline-flex;
-  gap: 5px;
+  align-items: center;
+  gap: var(--tv-space-2);
   font-size: var(--tv-fs-sm);
   font-variant-numeric: tabular-nums;
+}
+/* Per-file count of edit operations (pencil + N). */
+.tv-changeset__edits {
+  display: inline-flex;
+  align-items: center;
+  gap: 3px;
+  color: var(--tv-fg-muted);
 }
 .tv-changeset__detail {
   min-width: 0;

--- a/packages/web/src/styles/global.css
+++ b/packages/web/src/styles/global.css
@@ -264,11 +264,13 @@ button {
 .tv-main {
   overflow-y: auto;
 }
-/* Cap + left-align the content so it doesn't stretch edge-to-edge on wide
-   screens (which left titles/meta far apart). The padding lives here, so the
-   session header's negative-margin full-bleed resolves to this box's edges. */
+/* Cap + center the content so it doesn't stretch edge-to-edge on wide screens
+   (which left titles/meta far apart) and the leftover space splits evenly
+   instead of piling up on the right. The padding lives here, so the session
+   header's negative-margin full-bleed resolves to this box's edges. */
 .tv-main__inner {
   max-width: 1200px;
+  margin: 0 auto;
   padding: var(--tv-space-5);
 }
 


### PR DESCRIPTION
Batch 3 of the UI/UX review (plan [`docs/plans/0026`](docs/plans/0026-ui-ux-review-batches.md)) — the Files-changed rebuild, plus a wide-screen layout fix.

## ④ Files changed — jump rail + diffstat + viewed
Rebuilds the Files-changed tab as a code-review-style master/detail:
- **Session diffstat** (`N files +X −Y`) and an **"N of M viewed" progress bar** up top.
- A **left rail** of changed files — each with a **"viewed" checkbox** and per-file **+/−** counts; clicking a file shows its diff in the right pane (filename bold in the path header).
- **"Viewed" state persists per session in `localStorage`** (client-only — agent sources stay read-only), turning the tab into a review pass.
- Per-file line stats (which run `lineDiff`) are computed **only once the tab is opened**, so loading a session never pays for a view it may not show.

## Also: wide-screen content centering (review fix)
My Batch 2 width cap left the content **left-aligned**, so on a wide monitor all the leftover space piled up on the right. Centering the capped box (`margin: 0 auto`) splits the space evenly and moves the content toward the middle.

## Verification
- `npm run typecheck` ✓, `npm test` ✓ (230), `npm run build` ✓.
- Verified the Files-changed two-pane (diffstat, rail + checkbox + per-file stats, diff pane) and the centering at 2000px (isolated demo data; no real agent data touched). Demo sessions cap at one changed file, so the multi-file rail is exercised by the same row map on real sessions.
- No new dependencies.

This completes the three-batch UI/UX review (Batches 1 #32, 2 #33, 3 here).