### PR TITLE
fix(web): make Total tokens honor the "Show cache" toggle

### DIFF
--- a/packages/web/src/pages/analytics/AnalyticsPage.tsx
+++ b/packages/web/src/pages/analytics/AnalyticsPage.tsx
@@ -192,9 +192,11 @@ export function AnalyticsPage() {
         <label className="tv-analytics__toggle">
           <input
             type="checkbox"
+            className="tv-switch__input"
             checked={showCache}
             onChange={(e) => setShowCache(e.target.checked)}
           />
+          <span className="tv-switch" aria-hidden="true" />
           Show cache
         </label>
       </div>
@@ -289,24 +291,28 @@ function SummaryCards({
 
   // Reconcile the headline: total = input + output + cache. Cache reads usually
   // dominate, which is why the big number looks unexplained without the split.
+  // "Show cache" governs the headline too — by default the total reflects only
+  // billed input + output, and toggling cache on folds it back into the number,
+  // the reconcile bar, and the legend.
   const cacheTokens = totals.cacheReadTokens + totals.cacheCreationTokens;
+  const totalTokens = showCache ? totals.totalTokens : totals.inputTokens + totals.outputTokens;
   const cacheReadShare = totals.totalTokens > 0 ? totals.cacheReadTokens / totals.totalTokens : 0;
 
   return (
     <div className="tv-analytics__cards">
       <StatCard
         label="Total tokens"
-        value={formatCount(totals.totalTokens)}
+        value={formatCount(totalTokens)}
         sub={
           <span className="tv-stat-card__tokens">
             <TokenMiniBar
               input={totals.inputTokens}
               output={totals.outputTokens}
-              cache={cacheTokens}
+              cache={showCache ? cacheTokens : 0}
             />
             <span>
-              {formatCount(totals.inputTokens)} in · {formatCount(totals.outputTokens)} out ·{' '}
-              {formatCount(cacheTokens)} cache
+              {formatCount(totals.inputTokens)} in · {formatCount(totals.outputTokens)} out
+              {showCache && <> · {formatCount(cacheTokens)} cache</>}
             </span>
           </span>
         }

--- a/packages/web/src/pages/session/session.css
+++ b/packages/web/src/pages/session/session.css
@@ -677,45 +677,7 @@
   flex: 1 1 auto;
 }
 
-/* Toggle switch (the redact option). The real <input> is visually hidden. */
-.tv-switch__input {
-  position: absolute;
-  opacity: 0;
-  width: 0;
-  height: 0;
-}
-.tv-switch {
-  position: relative;
-  flex: 0 0 auto;
-  width: 30px;
-  height: 18px;
-  border-radius: 999px;
-  background: var(--tv-bg-inset);
-  border: 1px solid var(--tv-border-strong);
-  transition: background 0.12s ease, border-color 0.12s ease;
-}
-.tv-switch::after {
-  content: '';
-  position: absolute;
-  top: 2px;
-  left: 2px;
-  width: 12px;
-  height: 12px;
-  border-radius: 50%;
-  background: var(--tv-fg-muted);
-  transition: transform 0.12s ease, background 0.12s ease;
-}
-.tv-switch__input:checked + .tv-switch {
-  background: var(--tv-success);
-  border-color: var(--tv-success);
-}
-.tv-switch__input:checked + .tv-switch::after {
-  transform: translateX(12px);
-  background: #fff;
-}
-.tv-switch__input:focus-visible + .tv-switch {
-  box-shadow: 0 0 0 2px var(--tv-accent-muted);
-}
+/* The redact toggle uses the shared `.tv-switch` component (see global.css). */
 
 /* ── Continue (resume / fork) dropdown ────────────────────────────────── */
 

--- a/packages/web/src/styles/global.css
+++ b/packages/web/src/styles/global.css
@@ -914,6 +914,50 @@ mark {
 }
 
 /* --------------------------------------------------------------------------
+   Toggle switch — shared boolean control. The real <input> is visually hidden
+   and paired with a sibling `.tv-switch` span that renders the track + knob:
+     <label><input class="tv-switch__input" type="checkbox"> <span class="tv-switch"/> …</label>
+   -------------------------------------------------------------------------- */
+.tv-switch__input {
+  position: absolute;
+  opacity: 0;
+  width: 0;
+  height: 0;
+}
+.tv-switch {
+  position: relative;
+  flex: 0 0 auto;
+  width: 30px;
+  height: 18px;
+  border-radius: 999px;
+  background: var(--tv-bg-inset);
+  border: 1px solid var(--tv-border-strong);
+  transition: background 0.12s ease, border-color 0.12s ease;
+}
+.tv-switch::after {
+  content: '';
+  position: absolute;
+  top: 2px;
+  left: 2px;
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  background: var(--tv-fg-muted);
+  transition: transform 0.12s ease, background 0.12s ease;
+}
+.tv-switch__input:checked + .tv-switch {
+  background: var(--tv-success);
+  border-color: var(--tv-success);
+}
+.tv-switch__input:checked + .tv-switch::after {
+  transform: translateX(12px);
+  background: #fff;
+}
+.tv-switch__input:focus-visible + .tv-switch {
+  box-shadow: 0 0 0 2px var(--tv-accent-muted);
+}
+
+/* --------------------------------------------------------------------------
    Responsive — desktop-first, adapting down to small laptops. The project /
    analytics grids already reflow (auto-fill/auto-fit), so this mainly tightens
    the chrome: a narrower nav and less padding on smaller viewports, then a


### PR DESCRIPTION
## What

Two fixes to the Analytics page, both around the **Show cache** toggle:

1. **Total tokens now honors the toggle.** The headline summed cache reads/writes regardless of state, so it stayed in the billions even with "Show cache" off. Now: **off** → `input + output` only (cache segment dropped from the mini-bar and the legend); **on** → cache folded back in.
2. **Design-system toggle.** The control was a raw browser `<input type=checkbox>`; it now uses the shared `.tv-switch` toggle. That component moves from `session.css` to `global.css` (imported app-wide in `main.tsx`) so the analytics page and the session-export redact toggle share one definition.

## Verification

Drove the live UI with Playwright through both states:

| State | Total tokens | Legend |
|-------|-------------|--------|
| Show cache **off** | `32M` | 15M in · 16M out |
| Show cache **on** | `3586M` | 15M in · 16M out · 3554M cache |

`npm run typecheck` ✅ · 230 tests ✅

Left intentionally unchanged: the Total **cost** card's "% of tokens cache-read" line (cache reads are genuinely billed, so it reflects all tokens).