### PR TITLE
chore: segment CI by change area and share build/test + nix via reusable workflows

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -1,0 +1,35 @@
+name: Setup Node + install
+description: setup-node with npm cache, then npm ci. Checkout stays in the caller.
+
+inputs:
+  node-version:
+    description: Node major version to set up
+    required: true
+  registry-url:
+    description: npm registry URL (set only for the publish job; empty is a no-op)
+    required: false
+    default: ''
+  cache-dependency-path:
+    description: Path to package-lock.json for the npm cache key (default = root lockfile)
+    required: false
+    default: ''
+  working-directory:
+    description: Directory to run `npm ci` in (for multi-checkout layouts like perf)
+    required: false
+    default: '.'
+
+runs:
+  using: composite
+  steps:
+    - name: Set up Node.js ${{ inputs.node-version }}
+      uses: actions/setup-node@v6
+      with:
+        node-version: ${{ inputs.node-version }}
+        cache: npm
+        registry-url: ${{ inputs.registry-url }}
+        cache-dependency-path: ${{ inputs.cache-dependency-path }}
+
+    - name: Install dependencies
+      shell: bash
+      working-directory: ${{ inputs.working-directory }}
+      run: npm ci

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -1,0 +1,41 @@
+name: build-test
+
+# Reusable: typecheck + build + test for one os/node combination. Called by ci.yml
+# (across the os×node matrix) and by release.yml's validate (single ubuntu/node 24),
+# so CI and Release share ONE definition of what "validated" means.
+on:
+  workflow_call:
+    inputs:
+      os:
+        description: Runner OS (e.g. ubuntu-latest)
+        required: true
+        type: string
+      node:
+        description: Node major version as a string (e.g. "22")
+        required: true
+        type: string
+
+# Reusable workflows do not inherit caller permissions — declare our own.
+permissions:
+  contents: read
+
+jobs:
+  build-test:
+    runs-on: ${{ inputs.os }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Node + install
+        uses: ./.github/actions/setup
+        with:
+          node-version: ${{ inputs.node }}
+
+      - name: Typecheck
+        run: npm run typecheck
+
+      - name: Build
+        run: npm run build
+
+      - name: Test
+        run: npm test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,9 @@
 name: CI
 
-# Sanity check before merge (pull requests into main) and after merge
-# (pushes to main): typecheck, build, and test.
+# Sanity check before merge (pull requests into main) and after merge (pushes to
+# main): typecheck, build, and test — but only for the areas a change touches. A
+# `changes` job (path filter) and a `guard` job (release-bump detector) gate the
+# heavy jobs, and the single `CI success` job is the only required status check.
 on:
   push:
     branches: [main]
@@ -17,52 +19,149 @@ permissions:
   contents: read
 
 jobs:
-  test:
-    runs-on: ${{ matrix.os }}
+  # Which areas changed? `infra` (deps/config/CI) forces the full build/test; `code`
+  # is any package or infra change; `docs` is prose + the docs-lint config. Perf is
+  # gated in perf.yml, not here.
+  changes:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read # paths-filter reads the PR file list via the API
+    outputs:
+      code: ${{ steps.f.outputs.code }}
+      docs: ${{ steps.f.outputs.docs }}
+      infra: ${{ steps.f.outputs.infra }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0 # push events diff against the branch's prior tip
+      - uses: dorny/paths-filter@v3
+        id: f
+        with:
+          # PRs diff against the base via the API (no history needed). On push,
+          # passing the SHORT branch name makes paths-filter diff against the
+          # branch's pre-push tip (full refs/heads/... is not recognized as the
+          # "same branch"). Empty on PR → auto-detect the PR base.
+          base: ${{ github.event_name == 'push' && github.ref_name || '' }}
+          filters: |
+            infra: &infra
+              - 'package.json'
+              - 'package-lock.json'
+              - 'tsconfig*.json'
+              - 'vitest.config.ts'
+              - 'flake.nix'
+              - 'flake.lock'
+              - 'scripts/**'
+              - '.github/workflows/**'
+              - '.github/actions/**'
+            code:
+              - *infra
+              - 'packages/**'
+            docs:
+              - '**/*.md'
+              - 'docs/**'
+              - 'LICENSE'
+              - '.markdownlint-cli2.jsonc'
+              - '.lycheeignore'
+
+  # Is the pushed HEAD a release bump? `npm version` pushes the bump commit and its
+  # tag together (--follow-tags); release.yml already validates that exact commit,
+  # so skip the redundant CI here. PRs are never bumps; tag pushes don't trigger
+  # this workflow (no push.tags), so only the bump branch push needs suppressing.
+  guard:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      is_release: ${{ steps.g.outputs.is_release }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0 # full history + tags to see a v* tag on HEAD
+      - id: g
+        shell: bash
+        run: |
+          if [ "${{ github.event_name }}" != "push" ]; then
+            echo "is_release=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          git fetch --tags --force --quiet || true
+          if git tag --points-at HEAD | grep -qE '^v[0-9]'; then
+            echo "HEAD is release-tagged → skipping CI (release.yml validates this commit)"
+            echo "is_release=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "is_release=false" >> "$GITHUB_OUTPUT"
+          fi
+
+  # Typecheck + build + test across both supported LTS lines and OSes. Shared with
+  # release.yml via the reusable workflow.
+  build-test:
+    needs: [changes, guard]
+    if: needs.guard.outputs.is_release != 'true' && needs.changes.outputs.code == 'true'
     strategy:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest]
-        node: [22, 24] # both supported LTS lines (22 = engines floor, 24 = latest)
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v6
+        node: ['22', '24'] # 22 = engines floor, 24 = latest
+    uses: ./.github/workflows/build-test.yml
+    with:
+      os: ${{ matrix.os }}
+      node: ${{ matrix.node }}
 
-      - name: Set up Node.js ${{ matrix.node }}
-        uses: actions/setup-node@v6
-        with:
-          node-version: ${{ matrix.node }}
-          cache: npm
-
-      - name: Install dependencies
-        run: npm ci
-
-      - name: Typecheck
-        run: npm run typecheck
-
-      - name: Build
-        run: npm run build
-
-      - name: Test
-        run: npm test
-
-  # Build the Nix flake so a broken flake or a stale deps hash is caught on PRs,
-  # not first at release time. The hash is version-independent (see flake.nix), so
-  # it only needs updating on real dependency changes — which this job catches.
-  # Matrix covers the platforms users install on: Linux x64 and macOS arm64
-  # (macos-14). Intel macOS (macos-13) is omitted — GitHub is deprecating Intel
-  # runners (they queue indefinitely), and the darwin-x64 build path is identical
-  # to arm64 bar the binding dir. npmDepsHash is OS-independent, shared by both.
+  # Build the Nix flake so a broken flake or stale deps hash is caught on PRs, not
+  # first at release time. Gated on `infra` (deps/flake/build-tooling) — a pure
+  # source change is already covered by build-test's `npm run build`. Matrix covers
+  # Linux x64 and macOS arm64 (the platforms users install on). Shared with
+  # release.yml.
   nix:
+    needs: [changes, guard]
+    if: needs.guard.outputs.is_release != 'true' && needs.changes.outputs.infra == 'true'
     strategy:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-14]
-    runs-on: ${{ matrix.os }}
+    uses: ./.github/workflows/nix-build.yml
+    with:
+      os: ${{ matrix.os }}
+
+  # Light docs check (markdown lint + link check) on docs/prose changes only.
+  docs-lint:
+    needs: [changes, guard]
+    if: needs.guard.outputs.is_release != 'true' && needs.changes.outputs.docs == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-      - name: Install Nix
-        uses: DeterminateSystems/nix-installer-action@main
-      - name: Build the flake
-        run: nix build .#claudescope -L
+      - uses: actions/checkout@v6
+      - name: Markdown lint
+        uses: DavidAnson/markdownlint-cli2-action@v20
+        with:
+          globs: '**/*.md'
+      - name: Link check
+        uses: lycheeverse/lychee-action@v2
+        with:
+          args: "--no-progress --cache --max-retries 2 --accept 200,206,403,429 '**/*.md'"
+          fail: true
+
+  # The ONLY required status check. Branch protection must require this job, not the
+  # individual matrix legs: their reported names change under the reusable workflows,
+  # and gated legs report "skipped". Skipped = pass (intentional gating); failure or
+  # cancelled = fail.
+  ci-success:
+    name: CI success
+    if: always()
+    needs: [changes, guard, build-test, nix, docs-lint]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify no required job failed
+        shell: bash
+        run: |
+          results='${{ needs.changes.result }} ${{ needs.guard.result }} ${{ needs.build-test.result }} ${{ needs.nix.result }} ${{ needs.docs-lint.result }}'
+          echo "Upstream results: $results"
+          for r in $results; do
+            case "$r" in
+              success|skipped) ;;
+              *) echo "::error::A required job did not succeed (got '$r')"; exit 1 ;;
+            esac
+          done
+          echo "All required jobs succeeded or were intentionally skipped."

--- a/.github/workflows/nix-build.yml
+++ b/.github/workflows/nix-build.yml
@@ -1,0 +1,29 @@
+name: nix-build
+
+# Reusable: build the Nix flake on one OS. Called by ci.yml (matrix: linux + macos)
+# and by release.yml's nix channel (linux). Catches a broken flake or a stale deps
+# hash. The deps hash is version-independent (see flake.nix), so releases need no
+# hash step — this job is what flags a real dependency change.
+on:
+  workflow_call:
+    inputs:
+      os:
+        description: Runner OS (e.g. ubuntu-latest, macos-14)
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  nix:
+    runs-on: ${{ inputs.os }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Install Nix
+        uses: DeterminateSystems/nix-installer-action@main
+
+      - name: Build the flake
+        run: nix build .#claudescope -L

--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -20,7 +20,34 @@ permissions:
   contents: read
 
 jobs:
+  # The bench is `tsx packages/server/perf/run.ts` — server/data-layer only. Gate it
+  # on server/shared/root-deps changes; NEVER on packages/web/** (frontend can't move
+  # the backend bench). The workspace-wide lockfile is included on purpose (a backend
+  # runtime-dep change could move the bench).
+  changes:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      perf: ${{ steps.f.outputs.perf }}
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dorny/paths-filter@v3
+        id: f
+        with:
+          filters: |
+            perf:
+              - 'package.json'
+              - 'package-lock.json'
+              - 'packages/shared/**'
+              - 'packages/server/**'
+              - '.github/workflows/perf.yml'
+              - '.github/actions/**'
+
   perf:
+    needs: changes
+    if: needs.changes.outputs.perf == 'true'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout PR head
@@ -34,17 +61,16 @@ jobs:
           ref: ${{ github.base_ref }}
           path: base
 
-      - name: Set up Node.js
-        uses: actions/setup-node@v6
+      - name: Setup Node + install (PR head)
+        uses: ./pr/.github/actions/setup
         with:
           node-version: 24
-          cache: npm
           cache-dependency-path: pr/package-lock.json
+          working-directory: pr
 
-      - name: Install deps (PR head)
-        working-directory: pr
-        run: npm ci
-
+      # Base side stays a bare `npm ci` (node is already set up above): base must run
+      # main's harness, not PR-introduced tooling. Do not route this through the
+      # composite action — the base checkout may predate it.
       - name: Install deps (base)
         working-directory: base
         run: npm ci
@@ -82,3 +108,21 @@ jobs:
             cand-*.json
             base-*.json
           if-no-files-found: ignore
+
+  # Single status check for perf, safe whether or not it's a required check: a
+  # skipped `perf` (frontend/docs-only PR) still reports success here.
+  perf-success:
+    name: Perf success
+    if: always()
+    needs: [changes, perf]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify perf did not fail
+        shell: bash
+        run: |
+          for r in '${{ needs.changes.result }}' '${{ needs.perf.result }}'; do
+            case "$r" in
+              success|skipped) ;;
+              *) echo "::error::perf gate did not succeed (got '$r')"; exit 1 ;;
+            esac
+          done

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,10 +5,10 @@ name: Release
 #   npm version patch   # bumps package.json + creates the vX.Y.Z tag
 #   git push --follow-tags
 #
-# Flow: validate (gate) → create GitHub Release → publish channels.
-# npm and nix run in parallel; brew runs after npm (its formula points at the
-# published npm tarball). Each channel is an independent job, so a failure in one
-# (e.g. nix) does not block the others — re-run just that job.
+# Flow: verify-tag → validate (reuses CI's build-test) → create GitHub Release →
+# publish channels. npm and nix run in parallel; brew runs after npm (its formula
+# points at the published npm tarball). Each channel is an independent job, so a
+# failure in one (e.g. nix) does not block the others — re-run just that job.
 on:
   push:
     tags: ['v*']
@@ -18,9 +18,9 @@ permissions:
   contents: read
 
 jobs:
-  # Gate: the tag must match the package version and the suite must pass before
-  # anything ships. `npm publish` is irreversible, so this guards every channel.
-  validate:
+  # Guard against a tag that doesn't match the version in package.json, so the
+  # published version always equals the tag. Fast: no install needed.
+  verify-tag:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -30,14 +30,9 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version: 24
-          cache: npm
 
-      - name: Install dependencies
-        run: npm ci
-
-      # Guard against a tag that doesn't match the version in package.json, so the
-      # published version always equals the tag.
       - name: Verify tag matches package version
+        shell: bash
         run: |
           TAG="${GITHUB_REF_NAME#v}"
           PKG="$(node -p "require('./package.json').version")"
@@ -46,8 +41,15 @@ jobs:
             exit 1
           fi
 
-      - name: Test
-        run: npm test
+  # Full validation (typecheck + build + test) — the SAME reusable workflow CI runs,
+  # so a release is gated by exactly what merges are. `npm publish` is irreversible,
+  # so this guards every channel.
+  validate:
+    needs: verify-tag
+    uses: ./.github/workflows/build-test.yml
+    with:
+      os: ubuntu-latest
+      node: '24'
 
   # Mirror the curated, human-written tag annotation (from `npm version -m`) to a
   # GitHub Release — verbatim, never auto-generated. Runs before the channels.
@@ -77,15 +79,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
-      - name: Set up Node.js
-        uses: actions/setup-node@v6
+      - name: Setup Node + install
+        uses: ./.github/actions/setup
         with:
           node-version: 24
-          cache: npm
           registry-url: https://registry.npmjs.org
-
-      - name: Install dependencies
-        run: npm ci
 
       # Trusted Publishing (OIDC) needs npm >= 11.5.1; keep npm current regardless
       # of what the Node release ships.
@@ -102,19 +100,12 @@ jobs:
   # Channel: nix. The flake builds from the tagged source, so this verifies that
   # `nix run github:vladar107/claudescope` works at this tag (nothing to push —
   # Nix pins by git commit). Independent of npm; failure here blocks no other
-  # channel. The deps hash is version-independent, so releases need no hash step.
+  # channel. Reuses the same nix-build workflow CI runs.
   nix:
     needs: release
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-
-      - name: Install Nix
-        uses: DeterminateSystems/nix-installer-action@main
-
-      - name: Build the flake
-        run: nix build .#claudescope -L
+    uses: ./.github/workflows/nix-build.yml
+    with:
+      os: ubuntu-latest
 
   # Channel: brew. Points the tap at the just-published npm tarball, so it must run
   # after npm. Pushes to the separate vladar107/homebrew-tap repo, which needs a

--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ packages/server/data/*.duckdb.tmp
 *.tsbuildinfo
 coverage/
 perf-result.json
+.lycheecache
 .idea/
 .vscode/
 .junie/

--- a/.lycheeignore
+++ b/.lycheeignore
@@ -1,0 +1,4 @@
+# URLs the docs link-check (lychee) should skip. One regex per line.
+# Local dev-server addresses referenced in the docs (not reachable from CI).
+^https?://localhost
+^https?://127\.0\.0\.1

--- a/.markdownlint-cli2.jsonc
+++ b/.markdownlint-cli2.jsonc
@@ -1,0 +1,27 @@
+{
+  // Config for the docs-lint job (markdownlint-cli2). Lint all markdown except
+  // dependency/build output.
+  "globs": ["**/*.md"],
+  "ignores": ["**/node_modules/**", "**/dist/**"],
+
+  // Rules disabled because the EXISTING docs already trip them. Keeping the check
+  // green on day one means it only flags NEW regressions; re-enable individually
+  // after a dedicated docs cleanup. Anything not listed stays at its default
+  // (so structural breakage — bad links, empty headings, hard tabs, etc. — is
+  // still caught).
+  "config": {
+    "default": true,
+    "MD004": false, // unordered list marker style (docs mix - and *)
+    "MD012": false, // multiple consecutive blank lines
+    "MD013": false, // line length (prose and tables exceed the default)
+    "MD022": false, // headings surrounded by blank lines
+    "MD029": false, // ordered list item prefix style
+    "MD031": false, // fenced code blocks surrounded by blank lines
+    "MD032": false, // lists surrounded by blank lines
+    "MD033": false, // inline HTML (README badges, <details>, alignment)
+    "MD034": false, // bare URLs
+    "MD040": false, // fenced code language hint
+    "MD041": false, // first line should be a top-level heading
+    "MD060": false  // table-formatting rule the existing tables trip
+  }
+}

--- a/docs/plans/0028-ci-segmentation-and-reuse.md
+++ b/docs/plans/0028-ci-segmentation-and-reuse.md
@@ -1,0 +1,196 @@
+# 0028 — CI/CD segmentation & reusable workflows
+
+- **Status:** done <!-- proposed | in-progress | done | superseded | abandoned -->
+- **Date:** 2026-06-21
+- **PR:** https://github.com/vladar107/claudescope/pull/39
+
+## Context
+
+The three GitHub Actions workflows (`ci.yml`, `perf.yml`, `release.yml`) are flat
+and unsegmented, which produces two concrete problems:
+
+1. **Tag publish double-runs the world.** Releasing is `npm version patch && git
+   push --follow-tags`, which pushes the **bump commit to `main`** *and* the **tag**
+   in one push. The bump commit (a trivial version-number change to root
+   `package.json` + `package-lock.json`) triggers the full `ci.yml` matrix — **4
+   test legs + 2 nix legs ≈ 6 redundant jobs** — while the tag triggers
+   `release.yml`, which *re-validates, re-builds, and re-nixes* the same commit.
+   Per release, tests run ~5×, nix ~3×. (Tag pushes themselves do **not** trigger
+   `ci.yml` — its `branches:` filter excludes tags — so only the bump *branch*
+   push is redundant.)
+2. **No change-area segmentation.** A docs-only or frontend-only change runs the
+   entire matrix + nix (and perf on PRs). The perf bench is 100% server/data-layer
+   yet runs on every PR.
+
+The repeated `checkout + setup-node + npm ci` block and the `nix build` job are
+also duplicated across workflows with no shared definition.
+
+## Goal
+
+Make *what runs* a function of *what changed*; stop the release bump commit from
+re-running CI; and share the build/test + nix logic between CI and Release via
+reusable workflows — without weakening the release safety gate.
+
+## Decisions
+
+- **Full reuse via reusable workflows** — composite `setup` action + reusable
+  `build-test.yml` & `nix-build.yml` called by **both** `ci.yml` and `release.yml`.
+  Rejected the lighter "composite action only" option because the maintainer wants
+  CI and Release to share one definition of build/test and nix. (A one-time
+  branch-protection settings change is required either way, because path-gating
+  produces "skipped" legs.)
+- **Keep post-merge CI on `main`, skip release bumps** — a `guard` job detects a
+  `v*` tag on the pushed HEAD and skips CI's code jobs, since `release.yml` already
+  validates that exact commit. Rejected dropping post-merge CI entirely (loses the
+  safety net for direct pushes / merge skew) and rejected path-ignoring
+  `package.json` (real dep/script changes touch it too).
+- **Docs-only changes get a light docs check** — lychee link check + markdownlint
+  with a config seeded from current docs (starts green), and skip
+  build/test/nix/perf.
+- **Coarse `code` gating for build/test** — typecheck (`tsc -b`) and the
+  `shared → web → server` build are genuinely monolithic, so there is no safe
+  per-package build/test skip. The real saving is docs-only skipping build-test
+  entirely. Perf is gated separately (server/shared only); nix is gated on `infra`.
+
+## Approach
+
+### New files
+
+1. **`.github/actions/setup/action.yml`** — composite: `setup-node` (+ `cache: npm`)
+   then `npm ci`. Inputs `node-version` (required), `registry-url` (default `''`),
+   `cache-dependency-path` (default `''`), `working-directory` (default `.`).
+   Checkout stays in the caller (perf needs dual checkout). `shell: bash` on the
+   `run` step (works on Windows runners).
+2. **`.github/workflows/build-test.yml`** — reusable (`workflow_call`, inputs `os`,
+   `node` as strings): checkout → composite setup → `npm run typecheck` →
+   `npm run build` → `npm test`. Declares `permissions: contents: read`.
+3. **`.github/workflows/nix-build.yml`** — reusable (`workflow_call`, input `os`):
+   checkout → `DeterminateSystems/nix-installer-action@main` →
+   `nix build .#claudescope -L`. `permissions: contents: read`.
+4. **`.lycheeignore`** — external/auth-gated URLs to skip in the link check.
+5. **`.markdownlint-cli2.jsonc`** — lenient rules seeded by running markdownlint once
+   against current docs and disabling every rule the existing docs violate (so it
+   starts green and only catches new regressions).
+
+### `ci.yml` (push to `main` + PR)
+
+Job graph:
+
+```
+changes  (dorny/paths-filter → code, perf, docs, infra)    fetch-depth: 0
+guard    (is_release: HEAD carries a v* tag?)               fetch-depth: 0
+   ├─ build-test  uses: ./.github/workflows/build-test.yml  matrix os{ubuntu,windows}×node{22,24}
+   │                if: guard.is_release != 'true' && changes.code == 'true'
+   ├─ nix         uses: ./.github/workflows/nix-build.yml   matrix os{ubuntu,macos-14}
+   │                if: guard.is_release != 'true' && changes.infra == 'true'
+   ├─ docs-lint   if: guard.is_release != 'true' && changes.docs == 'true'   (markdownlint + lychee)
+   └─ ci-success  if: always()  needs: [changes, guard, build-test, nix, docs-lint]  ← ONLY required check
+```
+
+- **`changes`** (`dorny/paths-filter@v3`): outputs `code` / `perf` / `docs` /
+  `infra`. `infra` (root `package.json`, `package-lock.json`, `tsconfig*.json`,
+  `vitest.config.ts`, `flake.{nix,lock}`, `scripts/**`, `.github/workflows/**`,
+  `.github/actions/**`) is folded into `code` so config/dep/CI changes always run
+  the full build/test. **`perf` does NOT use the broad `infra` set** — the bench is
+  `tsx packages/server/perf/run.ts` and is unaffected by web tsconfig, the flake,
+  the bundle script, or unrelated workflow files. `perf` is its own surgical list:
+  `packages/server/**` ∪ `packages/shared/**` ∪ root `package.json` ∪
+  `package-lock.json` ∪ `.github/workflows/perf.yml` ∪ `.github/actions/**`. **No
+  `packages/web/**` path triggers perf** — frontend source changes never run the
+  bench. The only frontend-adjacent path that can still trigger perf is the
+  workspace-wide `package-lock.json` (a web-only dep bump touches it, and paths
+  alone can't distinguish a web dep from a server/shared runtime dep); triggering
+  perf there is the conservative default (a transitive backend-runtime dep change
+  *could* move the bench). `docs` = `**/*.md` ∪ `docs/**` ∪ `LICENSE`.
+  On `push` events set `base: ${{ github.ref }}` + checkout `fetch-depth: 0`; PRs
+  use the API. Add `permissions: pull-requests: read`.
+- **`guard`**: on non-push → `is_release=false`. On push → `git fetch --tags
+  --force` then `git tag --points-at HEAD | grep -qE '^v[0-9]'` →
+  `is_release=true`. `fetch-depth: 0` defeats the `--follow-tags` visibility race.
+- **Reusable callers**: matrix + `uses:` is legal; `if:` is allowed on `uses` jobs.
+  `os`/`node` pass via `with:` (they're inputs because a `uses:` job can't carry
+  `steps`/`runs-on`).
+- **`docs-lint`**: `DavidAnson/markdownlint-cli2-action@v20` (globs `**/*.md`) +
+  `lycheeverse/lychee-action@v2` (`--cache --no-progress "**/*.md"`).
+- **`ci-success`** shim: `always()`, inspects `needs.*.result`; **skipped = pass,
+  failure/cancelled = fail**. The single required status check.
+
+### `perf.yml` (PR-only)
+
+Add a `changes` job gating the `perf` job on the `perf` filter, and a `Perf
+success` shim (`always()`, skipped = pass) so it's safe whether or not perf is a
+required check. PR-head install switches to `uses: ./pr/.github/actions/setup` with
+`working-directory: pr` + `cache-dependency-path: pr/package-lock.json`. **Keep the
+base side's bare `npm ci`** — base must run main's harness, not PR-introduced
+tooling (existing invariant; do not refactor).
+
+### `release.yml` (reuse only; no behavior change)
+
+- Split `validate` → `verify-tag` (inline: checkout → composite setup → tag==
+  version check) + `validate` (`uses: ./.github/workflows/build-test.yml`,
+  `os: ubuntu-latest`, `node: '24'`, `needs: verify-tag`). This *strengthens*
+  release validation: it now typecheck+build+tests (today it only `npm test`s).
+- `nix` channel → `uses: ./.github/workflows/nix-build.yml` (`os: ubuntu-latest`,
+  `needs: release`).
+- **Leave `npm` and `brew` inline** — they need `id-token: write` (OIDC) and
+  `secrets.HOMEBREW_TAP_TOKEN`; routing those through reusables adds `secrets:`
+  ceremony for no reuse benefit. Optionally fold the npm job's setup into the
+  composite with `registry-url: https://registry.npmjs.org`.
+
+### Manual step (must accompany the merge)
+
+Moving `test`/`nix` under reusable workflows renames their reported check names, so
+the old required checks (`test (ubuntu-latest, 22)` …, `nix (…)`) would never
+report and **wedge every PR**. In **Settings → Branches → `main` protection**, in
+the same change window: **require `CI success`** (and `Perf success` if perf should
+block), and **remove** the six obsolete `test (…)` / `nix (…)` checks. Inspect
+current required checks first with `gh api
+repos/vladar107/claudescope/branches/main/protection`.
+
+## Files affected
+
+- `.github/actions/setup/action.yml` — **new** composite action.
+- `.github/workflows/build-test.yml` — **new** reusable workflow.
+- `.github/workflows/nix-build.yml` — **new** reusable workflow.
+- `.lycheeignore`, `.markdownlint-cli2.jsonc` — **new** docs-lint config.
+- `.github/workflows/ci.yml` — add `changes` + `guard` + `docs-lint` +
+  `ci-success`; replace inline `test`/`nix` with reusable callers.
+- `.github/workflows/perf.yml` — add `changes` guard + `perf-success` shim;
+  PR-head uses the composite.
+- `.github/workflows/release.yml` — `validate`/`nix` call the reusables.
+- `docs/plans/README.md` — index row for this plan.
+
+## Testing
+
+1. **Lint the YAML**: run `actionlint` over `.github/workflows/*.yml` (catches the
+   matrix+`uses:` shape, `if:` expressions, output references). No app code
+   changes, so `npm run typecheck` / `npm test` are unaffected.
+2. **Dedup guard, locally**: on a release tag commit `git tag --points-at HEAD`
+   lists `vX.Y.Z`; on a normal commit it's empty.
+3. **On a feature branch pushed to GitHub** (local `uses: ./…` only resolves
+   server-side):
+   - docs-only PR → only `changes`/`guard`/`docs-lint`/`ci-success` run;
+     `build-test`/`nix` skipped; `CI success` green.
+   - frontend-only PR (`packages/web/**`) → `build-test` runs, `nix` + perf
+     skipped.
+   - backend PR (`packages/server/**`) → `build-test` + perf run.
+   - lockfile/flake PR → `build-test` + `nix` + perf all run.
+4. **Release dry-run**: cut a throwaway prerelease tag on a branch and confirm the
+   bump-commit push to main shows `build-test`/`nix` *skipped* (`is_release=true`)
+   while `release.yml` runs validate → release → npm ∥ nix → brew.
+
+## Risks / open questions
+
+- **Required-check name drift** (highest): mitigated by the `CI success` shim + the
+  branch-protection edit done atomically with the merge.
+- **paths-filter push base**: `base: github.ref` + `fetch-depth: 0` on push; PRs
+  use the API. Without it, push events fail-open to a full run (safe, not lean).
+- **`--follow-tags` tag visibility race**: `fetch-depth: 0` + `git fetch --tags
+  --force`. Worst case the guard misses → redundant (not dangerous) CI run.
+- **markdownlint noise / lychee external flakiness**: seed `.markdownlint-cli2.jsonc`
+  from current docs; `--cache` + `.lycheeignore` for lychee; can be made advisory
+  if noisy.
+- **perf base contamination**: keep base side's bare `npm ci`; pass only flags
+  main's `run.ts` understands (existing in-file note).
+- **Tuning knob**: `nix` is gated on `infra` (deps/flake/build-tooling). Switch to
+  `code` for belt-and-suspenders at the cost of 2 nix legs on every source PR.

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -52,3 +52,4 @@ decision, or a change worth explaining before doing. Skip it for one-line fixes.
 | 0025 | [Continue session: copy the command](./0025-continue-session-copy-command.md) | done |
 | 0026 | [UI/UX review: hierarchy pass across all screens](./0026-ui-ux-review-batches.md) | done |
 | 0027 | [Session-efficiency analytics (per-session ratios table)](./0027-session-efficiency-analytics.md) | done |
+| 0028 | [CI/CD segmentation & reusable workflows](./0028-ci-segmentation-and-reuse.md) | done |


### PR DESCRIPTION
## What & why

The three workflows were flat and unsegmented, causing two concrete problems:

1. **Tag publish double-ran everything.** `npm version patch && git push --follow-tags` pushes the bump commit to `main` *and* the tag in one push. The bump commit triggered the full CI matrix (~6 redundant jobs) while the tag triggered `release.yml`, which re-validated/re-built/re-nixed the same commit.
2. **No change-area segmentation.** Docs-only and frontend-only changes ran the whole matrix + nix (and perf, which is server-only, on every PR).

This makes *what runs* a function of *what changed*, stops the release bump from re-running CI, and shares the build/test + nix logic between CI and Release via reusable workflows.

## Changes

- **`ci.yml`** — a `changes` job (`dorny/paths-filter`) and a `guard` job (skips CI when the pushed HEAD carries a `v*` tag, since `release.yml` validates it) gate `build-test` / `nix` / `docs-lint`. A single **`CI success`** job is the only required status check (skipped legs = pass, failure/cancelled = fail).
- **`build-test.yml`, `nix-build.yml`** — reusable workflows (`workflow_call`) called by both `ci.yml` (across the matrix) and `release.yml`.
- **`.github/actions/setup`** — composite `setup-node` + `npm ci`.
- **`perf.yml`** — gated to `packages/server/**` / `packages/shared/**` / root-deps changes only (never `packages/web/**`) + a `Perf success` shim.
- **`release.yml`** — `verify-tag` → `validate` (reuses `build-test`) → `release` → `npm` ∥ `nix` (reuses `nix-build`) → `brew`. Validation is now typecheck+build+test (was test-only).
- **docs-lint** — markdownlint + lychee link check, configured to start green (`.markdownlint-cli2.jsonc`, `.lycheeignore`).

## ⚠️ Required manual step (do this when merging)

Moving `test`/`nix` under reusable workflows renames their reported check names, and gated legs report "skipped" — so the old per-leg required checks would wedge every PR. In **Settings → Branches → `main` protection**:

- **Require** `CI success` (and `Perf success` if perf should block).
- **Remove** the old `test (…)` / `nix (…)` required checks.

Inspect current required checks first: `gh api repos/vladar107/claudescope/branches/main/protection`.

## Plan

See [`docs/plans/0028-ci-segmentation-and-reuse.md`](docs/plans/0028-ci-segmentation-and-reuse.md).