### PR TITLE
feat(server): reject non-loopback Host headers (anti DNS-rebinding)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0 # push events diff against the branch's prior tip
-      - uses: dorny/paths-filter@v3
+      - uses: dorny/paths-filter@v4
         id: f
         with:
           # PRs diff against the base via the API (no history needed). On push,
@@ -134,7 +134,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - name: Markdown lint
-        uses: DavidAnson/markdownlint-cli2-action@v20
+        uses: DavidAnson/markdownlint-cli2-action@v23
         with:
           globs: '**/*.md'
       - name: Link check

--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -33,7 +33,7 @@ jobs:
       perf: ${{ steps.f.outputs.perf }}
     steps:
       - uses: actions/checkout@v6
-      - uses: dorny/paths-filter@v3
+      - uses: dorny/paths-filter@v4
         id: f
         with:
           filters: |

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -48,6 +48,11 @@ None of these are misused; they're listed here so you can verify that.
 
 - **Binds to `127.0.0.1` only** (`packages/server/src/index.ts`) — the server is
   never exposed to your LAN or the internet.
+- **Rejects non-loopback `Host` headers** (`packages/server/src/security.ts`) —
+  a request whose `Host` isn't `localhost`/`127.0.0.1`/`[::1]` gets a `403`. This
+  blocks DNS-rebinding attacks, where a malicious site you visit rebinds its own
+  hostname to `127.0.0.1` to read your transcripts past the loopback bind. Override
+  the allowlist with `CLAUDESCOPE_ALLOWED_HOSTS` for custom local hostnames.
 - Shipped code makes exactly **two kinds of outbound request**, both to
   hardcoded trusted endpoints:
   - a version check against `https://registry.npmjs.org` (cached for 24h) to

--- a/docs/plans/0029-localhost-host-guard.md
+++ b/docs/plans/0029-localhost-host-guard.md
@@ -1,0 +1,80 @@
+# 0029 — Localhost host guard (anti DNS-rebinding)
+
+- **Status:** done <!-- proposed | in-progress | done | superseded | abandoned -->
+- **Date:** 2026-06-21
+- **PR:** https://github.com/vladar107/claudescope/pull/40
+
+## Context
+
+Claudescope is a local, read-only viewer whose API returns **high-value data** —
+full transcripts (source code, prompts, memory files, paths, possibly secrets). The
+server binds to `127.0.0.1` only and the security posture has been *"loopback bind =
+safe"* (stated in README and SECURITY.md).
+
+That bind stops the LAN/internet, but **not a malicious website the user visits**.
+Via **DNS rebinding**, a page on `evil.com` lowers its DNS TTL, then re-resolves
+`evil.com` to `127.0.0.1`. It fetches `http://evil.com:4317/api/sessions/...`; the
+browser now treats this as *same-origin* (page origin `evil.com` == request host
+`evil.com`), connects to the loopback server, and reads the response. CORS doesn't
+help (no cross-origin from the browser's view) and the existing CSP doesn't apply
+(CSP guards *our* origin's content from phoning out — it can't stop a *different*
+origin reading the API).
+
+Evaluated full FE↔BE auth and rejected it: the SPA and API are one app, one origin,
+one local user — there's no second party to authenticate, and a login/token layer
+would add friction for no real-world gain. The fitting, standard defense (Jupyter,
+Vite, webpack-dev-server all do it) is **Host-header validation**.
+
+## Goal
+
+Reject any request whose `Host` header isn't a loopback host, closing the
+DNS-rebinding hole with zero UX cost and no auth. A rebinding request arrives as
+`Host: evil.com:4317` → `403`.
+
+## Decisions
+
+- **Host allowlist, not auth** — validate the `Host` *hostname* against
+  `{localhost, 127.0.0.1, ::1}`. Rejected FE↔BE auth (no second party) and a
+  per-session token (only warranted if a non-loopback `--host` is ever added —
+  noted as the future guardrail).
+- **Ignore the port** — the dev proxy (Vite on `:5317`) and a custom `PORT` both
+  forward a loopback *hostname*; the port never changes the security property.
+  Checking hostname-only avoids breaking dev/proxied/custom-port setups.
+- **Env escape hatch** — `CLAUDESCOPE_ALLOWED_HOSTS` (comma-separated) for
+  non-standard local setups (e.g. a custom `/etc/hosts` alias).
+- **`onRequest` hook, before routing** — a rebinding page never reaches a route.
+
+## Approach
+
+1. `packages/server/src/security.ts` — add `ALLOWED_HOSTNAMES` (env-overridable),
+   `hostnameFromHeader()` (strips port + IPv6 brackets, lowercases),
+   `isAllowedHost()`, and `registerHostGuard(app)` (an `onRequest` hook → `403` on a
+   non-loopback Host).
+2. `packages/server/src/index.ts` — call `registerHostGuard(app)` alongside
+   `registerSecurityHeaders(app)`.
+3. `packages/server/test/security.test.ts` — allow loopback hosts incl. the Vite
+   `:5317` proxy and `[::1]`; reject `evil.com`, the `localhost.evil.com` prefix
+   trick, etc.; unit-test the parser/predicate for missing/bracketed/cased values.
+4. `SECURITY.md` — document the guard and the `CLAUDESCOPE_ALLOWED_HOSTS` override.
+
+## Files affected
+
+- `packages/server/src/security.ts` — host guard + helpers (new exports).
+- `packages/server/src/index.ts` — wire the guard.
+- `packages/server/test/security.test.ts` — coverage.
+- `SECURITY.md` — Network section wording.
+
+## Testing
+
+`npm run typecheck` (clean) and `npm test` (250/250). The security suite covers
+loopback-allow, rebinding-reject, the prefix trick, and parser edges. Manual: the
+daemon health check hits `127.0.0.1:<port>` and still passes; the Vite dev proxy
+(`localhost:5317`) passes.
+
+## Risks / open questions
+
+- A user fronting claudescope with a custom local hostname (reverse proxy,
+  `/etc/hosts` alias) must set `CLAUDESCOPE_ALLOWED_HOSTS` — documented.
+- If a remote/shared/`--host` mode is ever added, the host allowlist is **not**
+  sufficient on its own — a per-session token (or real auth) becomes mandatory.
+  This plan deliberately scopes to the localhost threat model only.

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -53,3 +53,4 @@ decision, or a change worth explaining before doing. Skip it for one-line fixes.
 | 0026 | [UI/UX review: hierarchy pass across all screens](./0026-ui-ux-review-batches.md) | done |
 | 0027 | [Session-efficiency analytics (per-session ratios table)](./0027-session-efficiency-analytics.md) | done |
 | 0028 | [CI/CD segmentation & reusable workflows](./0028-ci-segmentation-and-reuse.md) | done |
+| 0029 | [Localhost host guard (anti DNS-rebinding)](./0029-localhost-host-guard.md) | done |

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -19,7 +19,7 @@ import {
   ensureStateDir,
 } from './config.js';
 import { registerRoutes } from './routes/index.js';
-import { registerSecurityHeaders } from './security.js';
+import { registerHostGuard, registerSecurityHeaders } from './security.js';
 import { reindex } from './data/index.js';
 import { refreshPricing } from './data/pricing-refresh.js';
 import { openBrowser } from './util/open-browser.js';
@@ -49,8 +49,9 @@ async function main(): Promise<void> {
 
   const app = Fastify({ logger: true });
 
-  // Lock down what the served SPA may load — notably block remote image fetches
-  // from transcript content (see security.ts).
+  // Reject non-loopback Host headers (anti DNS-rebinding) before anything routes,
+  // and lock down what the served SPA may load (CSP). See security.ts.
+  registerHostGuard(app);
   registerSecurityHeaders(app);
 
   await registerRoutes(app);

--- a/packages/server/src/security.ts
+++ b/packages/server/src/security.ts
@@ -48,3 +48,59 @@ export function registerSecurityHeaders(app: FastifyInstance): void {
     return payload;
   });
 }
+
+/**
+ * Hostnames a request's `Host` header may carry. The server binds to loopback
+ * only, but that alone does NOT stop a malicious website from reaching it via
+ * DNS rebinding: the page rebinds its OWN hostname to `127.0.0.1`, so the browser
+ * treats the cross-origin read as same-origin and the loopback bind becomes moot
+ * (CORS doesn't help — there's no cross-origin from the browser's view). Refusing
+ * any non-loopback Host closes that hole, since a rebinding request arrives as
+ * `Host: attacker.com:<port>`.
+ *
+ * The PORT is intentionally ignored: the dev proxy (Vite on :5317) and a custom
+ * PORT both forward a loopback *hostname*, and the port never changes the security
+ * property. Override the set with `CLAUDESCOPE_ALLOWED_HOSTS` (comma-separated
+ * hostnames) for non-standard local setups, e.g. a custom `/etc/hosts` alias.
+ */
+export const ALLOWED_HOSTNAMES = new Set(
+  (process.env.CLAUDESCOPE_ALLOWED_HOSTS ?? 'localhost,127.0.0.1,::1')
+    .split(',')
+    .map((h) => h.trim().toLowerCase())
+    .filter(Boolean),
+);
+
+/**
+ * Extract the hostname from a `Host` header, dropping the optional port and IPv6
+ * brackets (`[::1]:4317` → `::1`, `localhost:5317` → `localhost`).
+ */
+export function hostnameFromHeader(host: string): string {
+  const h = host.trim();
+  if (h.startsWith('[')) {
+    const end = h.indexOf(']');
+    return (end >= 0 ? h.slice(1, end) : h).toLowerCase();
+  }
+  const colon = h.indexOf(':');
+  return (colon >= 0 ? h.slice(0, colon) : h).toLowerCase();
+}
+
+/** True only if the `Host` header names a permitted loopback host. */
+export function isAllowedHost(host: string | undefined): boolean {
+  if (!host) return false;
+  return ALLOWED_HOSTNAMES.has(hostnameFromHeader(host));
+}
+
+/**
+ * Reject any request whose `Host` header isn't a loopback host — the standard
+ * defense against DNS-rebinding attacks on a localhost server (see
+ * {@link ALLOWED_HOSTNAMES}). Runs at `onRequest`, before routing, so a rebinding
+ * page never reaches a route and can read nothing.
+ */
+export function registerHostGuard(app: FastifyInstance): void {
+  app.addHook('onRequest', async (req, reply) => {
+    if (!isAllowedHost(req.headers.host)) {
+      reply.code(403).send({ error: 'Forbidden: invalid Host header' });
+      return reply; // halt the request — do not route it
+    }
+  });
+}

--- a/packages/server/test/security.test.ts
+++ b/packages/server/test/security.test.ts
@@ -13,6 +13,9 @@ import Fastify from 'fastify';
 import {
   CONTENT_SECURITY_POLICY,
   THEME_BOOTSTRAP_SCRIPT_HASH,
+  hostnameFromHeader,
+  isAllowedHost,
+  registerHostGuard,
   registerSecurityHeaders,
 } from '../src/security.js';
 
@@ -56,5 +59,52 @@ describe('security headers', () => {
     // If this fails after editing the inline script, update THEME_BOOTSTRAP_SCRIPT_HASH.
     expect(hash).toBe(THEME_BOOTSTRAP_SCRIPT_HASH);
     expect(CONTENT_SECURITY_POLICY).toContain(`'${THEME_BOOTSTRAP_SCRIPT_HASH}'`);
+  });
+});
+
+describe('host guard (anti DNS-rebinding)', () => {
+  function appWithGuard() {
+    const app = Fastify();
+    registerHostGuard(app);
+    app.get('/api/health', async () => ({ ok: true }));
+    return app;
+  }
+
+  // Loopback hosts the daemon and the dev proxy actually send. Port varies (4317
+  // prod, 5317 the Vite proxy, or a custom PORT) and must NOT matter.
+  it.each(['localhost', 'localhost:4317', '127.0.0.1:4317', '[::1]:4317', 'localhost:5317'])(
+    'allows loopback host %s',
+    async (host) => {
+      const app = appWithGuard();
+      const res = await app.inject({ method: 'GET', url: '/api/health', headers: { host } });
+      expect(res.statusCode).toBe(200);
+      await app.close();
+    },
+  );
+
+  // A DNS-rebinding page reaches the loopback socket but carries its own hostname
+  // in Host — including the `localhost.evil.com` prefix trick, which must NOT pass.
+  it.each(['evil.com', 'evil.com:4317', 'attacker.example:4317', 'localhost.evil.com'])(
+    'rejects non-loopback host %s with 403',
+    async (host) => {
+      const app = appWithGuard();
+      const res = await app.inject({ method: 'GET', url: '/api/health', headers: { host } });
+      expect(res.statusCode).toBe(403);
+      await app.close();
+    },
+  );
+
+  // A missing Host can't be exercised through inject (light-my-request fills in a
+  // default), so assert the defensive branch and the parser directly.
+  it('isAllowedHost/hostnameFromHeader handle missing values, ports, brackets, and casing', () => {
+    expect(isAllowedHost(undefined)).toBe(false);
+    expect(isAllowedHost('')).toBe(false);
+    expect(isAllowedHost('localhost:4317')).toBe(true);
+    expect(isAllowedHost('127.0.0.1')).toBe(true);
+    expect(isAllowedHost('[::1]:4317')).toBe(true);
+    expect(isAllowedHost('evil.com:4317')).toBe(false);
+    expect(isAllowedHost('localhost.evil.com')).toBe(false);
+    expect(hostnameFromHeader('[::1]:4317')).toBe('::1');
+    expect(hostnameFromHeader('LocalHost:5317')).toBe('localhost');
   });
 });


### PR DESCRIPTION
## Why

The API serves **high-value data** — full transcripts (source code, prompts, memory files, paths, possibly secrets). Binding to `127.0.0.1` stops the LAN/internet but **not a malicious website the user visits**: via **DNS rebinding**, a page on `evil.com` re-resolves its own hostname to `127.0.0.1`, fetches `http://evil.com:4317/api/...`, and the browser treats it as *same-origin* — reading the response straight off your loopback server. CORS doesn't apply (no cross-origin from the browser's view) and the existing CSP doesn't either (it guards *our* origin's content from phoning out, not a *different* origin reading the API).

## What

A `Host`-header guard — the standard localhost-server defense (Jupyter, Vite, webpack-dev-server all do it):

- `registerHostGuard` adds an `onRequest` hook that **403s any request whose `Host` hostname isn't `localhost` / `127.0.0.1` / `::1`**, before routing — so a rebinding page never reaches a route.
- **Port is ignored** on purpose: the Vite dev proxy (`:5317`) and a custom `PORT` both forward a loopback hostname; the port doesn't change the security property. This also avoids breaking dev/proxied setups.
- **`CLAUDESCOPE_ALLOWED_HOSTS`** (comma-separated) overrides the allowlist for custom local hostnames (e.g. an `/etc/hosts` alias).
- **No auth added.** The SPA and API are one origin for one local user — there's no second party to authenticate; a login/token layer would add friction for no real gain. (If a non-loopback `--host` mode is ever added, a per-session token becomes mandatory — noted in the plan.)

## Tests

`packages/server/test/security.test.ts` (+12): allows loopback hosts incl. the `:5317` dev proxy and `[::1]`; rejects `evil.com`, the `localhost.evil.com` prefix trick; unit-tests the parser/predicate for missing/bracketed/cased values. Full suite **250/250**, typecheck clean. The daemon health check (`127.0.0.1:<port>`) still passes.

## Plan

See [`docs/plans/0029-localhost-host-guard.md`](docs/plans/0029-localhost-host-guard.md).