### PR TITLE
feat: Analyze — activity heatmap + streaks, tool-usage breakdown

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,5 +18,9 @@ perf-result.json
 .junie/
 .demo/
 
+# Agent working scratch — never committed; only docs/plans/NNNN is the committed record.
+.superpowers/
+docs/superpowers/
+
 # Nix build output symlink
 /result

--- a/docs/plans/0030-analyze-activity-heatmap-tool-usage.md
+++ b/docs/plans/0030-analyze-activity-heatmap-tool-usage.md
@@ -1,0 +1,167 @@
+# 0030 — Analyze tab: activity heatmap + tool-usage breakdown
+
+- **Status:** done <!-- proposed | in-progress | done | superseded | abandoned -->
+- **Date:** 2026-06-29
+- **PR:** https://github.com/vladar107/claudescope/pull/41
+
+## Context
+
+A comparison with [Code Insights](https://github.com/melagiri/code-insights) — a
+local-first, multi-agent session analyzer — surfaced two analytical angles
+Claudescope lacks. Code Insights' headline features (decision/learning
+extraction, prompt-quality scoring, weekly synthesis, generated rules) all depend
+on an LLM and cross Claudescope's identity: **deterministic, read-only, nothing
+leaves the machine**. But two of its lighter ideas are a clean fit and need no
+LLM:
+
+- **"When do I work?"** — Code Insights' *activity charts*. Claudescope's `events.ts`
+  is indexed but never bucketed by hour/day-of-week, and there is no streak notion.
+- **"What do I do?"** — Code Insights' *multi-tool usage metrics*. Claudescope only
+  stores a per-event `tool_use_count`; the tool *names* are discarded, so we can't
+  break usage down by tool.
+
+Claudescope's existing Session-Efficiency table (#0027) already covers the
+deterministic equivalent of Code Insights' per-session metrics (turns, tool
+calls, cost-per-response), so the only real gaps are these two.
+
+Everything here is pure aggregation over the existing DuckDB index — no new
+runtime dependency, no network, no LLM.
+
+## Goal
+
+Add two cards to the existing **Analyze** tab (`AnalyticsPage`): a GitHub-punchcard
+**activity heatmap** (with current/longest streak), and a **tool-usage breakdown**
+by normalized category. Both honor the page's existing date-range filter.
+
+## Decisions
+
+- **Activity unit = user prompts** (`events.type = 'user'`) — the best proxy for
+  "when I'm actively driving an agent." Rejected: sessions-started (too coarse) and
+  all-events (dominated by assistant/tool chatter, not *my* engagement).
+- **Tool names stored as a list column on `events`, not a side `tool_calls` table.**
+  Add `tool_names VARCHAR[]` to `events`, populated where `tool_use_count` is already
+  computed. Keeps the one-row-per-event model, needs no join, and is fully
+  rebuildable. A side table only pays off for per-tool tokens/latency — out of scope
+  (YAGNI).
+- **Normalized categories, mapping in code; raw names stored in the index.** The
+  index keeps the (already-canonicalized) raw tool name; a pure
+  `toolCategory(name)` in `packages/shared` maps to a fixed taxonomy
+  (**Edit, Read, Search, Shell, Web, Subagent, Other**). The taxonomy can evolve
+  without re-indexing, and raw names survive for tooltips ("Search = Grep + Glob").
+- **Migration is a version bump.** Bump `SCHEMA_VERSION` 7 → 8 so the derived-cache
+  rebuild path discards and re-indexes automatically. No in-place migration code.
+- **Streaks are all-time** (current + longest, relative to today) and ignore the
+  date filter — a "current streak" is only meaningful relative to now. The heatmap
+  and tool bars *do* respect the filter.
+- **Local-timezone bucketing.** An hour-of-day heatmap is meaningless in UTC. The
+  client sends its IANA zone; the server buckets in local time. See Risks for the
+  ICU detail.
+- **Heatmap is a CSS-grid component, not Recharts.** Recharts has no native heatmap;
+  a 7×24 grid of intensity-shaded cells is simpler and adds no dependency. The
+  tool-usage bars reuse the existing `chart-common.tsx` styling.
+- **Placement:** both cards land in `AnalyticsPage`'s existing vertical stack,
+  after the token/cost time-series and before the project/model breakdown and the
+  Session-Efficiency table — so the page reads *how much* → *when & what* → *where
+  it goes*. No new tab.
+
+## Approach
+
+1. **Shared taxonomy** — add `ToolCategory` type + pure `toolCategory(name)` to
+   `packages/shared`. Default → `Other`. Cover the canonical names Claudescope
+   already normalizes (`Edit`/`Write`/`MultiEdit` → Edit, `Read` → Read, `Bash` →
+   Shell) plus the common agent-specific ones (`Grep`/`Glob`/`Search` → Search,
+   `WebFetch`/`WebSearch` → Web, `Task` → Subagent, …).
+2. **Index schema** — add `tool_names VARCHAR[]` to the `events` DDL in
+   `db/schema.ts`; bump `SCHEMA_VERSION` to 8.
+3. **Connector extraction (×6)** — populate `tool_names` alongside `tool_use_count`:
+   - Claude Code: a `list` aggregate over `$.name` of `tool_use` blocks (mirror
+     `TOOL_USE_COUNT_EXPR`).
+   - Codex / Copilot / pi / opencode / Junie: `blocks.filter(t==='tool_use').map(b => b.name)`
+     in each normalize step; add the column to each connector's `read_ndjson` column-type map.
+   - Register `tool_names` in `connectors/types.ts` projected columns.
+4. **Activity API** — `GET /api/analytics/activity?from&to&tz` →
+   `{ heatmap: [{ dow, hour, count }], streak: { current, longest, lastActiveDay } }`.
+   Counts `type='user'` events bucketed by local day-of-week × hour (heatmap honors
+   `from`/`to`); streak computed all-time from the per-local-day series.
+5. **Tools API** — `GET /api/analytics/tools?from&to` → raw `[{ toolName, count }]`
+   (UNNEST `tool_names`); honors `from`/`to`.
+6. **Web — activity card** — a `ActivityHeatmap` CSS-grid component (7 rows Mon–Sun
+   × 24 hour cols, theme-aware intensity, tooltip with count + local hour) plus a
+   compact streak stat. Send `Intl.DateTimeFormat().resolvedOptions().timeZone` to
+   the API.
+7. **Web — tool-usage card** — a `ToolUsageChart` (horizontal category bars,
+   descending, raw-tool tooltip), mapping raw counts → categories via the shared fn.
+8. **Wire into `AnalyticsPage`** in the agreed order; reuse existing `from`/`to`
+   state.
+9. **Tests** — see Testing.
+
+## Files affected
+
+- `packages/shared/src/…` — new `ToolCategory` type + `toolCategory()` mapping.
+- `packages/server/src/db/schema.ts` — `tool_names` column; `SCHEMA_VERSION` → 8.
+- `packages/server/src/connectors/types.ts` — register `tool_names`.
+- `packages/server/src/connectors/{claude-code,codex,copilot,pi,opencode,junie}/…` —
+  extract tool names next to `tool_use_count`.
+- `packages/server/src/routes/analytics-activity.ts` *(new)* — activity endpoint.
+- `packages/server/src/routes/analytics-tools.ts` *(new)* — tool-usage endpoint.
+  (Or fold both into `routes/analytics.ts` if that fits the existing route layout.)
+- `packages/web/src/pages/analytics/ActivityHeatmap.tsx` *(new)*, `ToolUsageChart.tsx` *(new)*.
+- `packages/web/src/pages/analytics/AnalyticsPage.tsx` — mount the two cards.
+- Tests under the existing integration + unit suites.
+
+## Testing
+
+`npm test` + `npm run typecheck`. Focus on the bug-prone edges (per CLAUDE.md), not
+happy-path glue:
+
+- **Tool-name extraction across all six connectors** — canonical names, multiple
+  tools per event, zero-tool events.
+- **Taxonomy mapping** — unknown tool → `Other`; agent-specific names land in the
+  right bucket.
+- **Streaks** — gaps, a single active day, today-inclusive boundary, longest ≠
+  current.
+- **Timezone bucketing** — an event near local midnight lands on the correct local
+  day/hour for a non-UTC zone.
+- Extend the synthetic-fixture integration suite (real DuckDB index in a temp dir)
+  to assert activity buckets + tool counts. Never touches a real agent source.
+
+## Risks / open questions
+
+- **Timezone / ICU (primary risk).** Local-time bucketing needs DuckDB's
+  `AT TIME ZONE` (ICU). Confirm ICU is loadable in `@duckdb/node-api`; if not,
+  fall back to a client-sent UTC-offset shift (DST-imperfect). Resolve in the
+  implementation plan before writing the activity query.
+- **Connector coverage.** Six connectors must each populate `tool_names`; a missed
+  one silently yields empty tool data for that agent. The cross-connector test guards
+  this.
+- **`events.ts` storage semantics.** Verify whether `ts` is stored UTC-naive so the
+  `UTC → local` conversion is correct; adjust the query accordingly.
+- **Out of scope (YAGNI):** message-length distribution, separate day-of-week /
+  hour-of-day bars (the heatmap encodes both), and anything LLM-derived.
+
+## Implementation notes (deltas from the plan above)
+
+What shipped differs from the original sketch in a few places, all driven by
+review findings and UX feedback:
+
+- **Activity unit excludes subagent + fork rows.** The plan said "user prompts =
+  `events.type = 'user'`". The whole-branch review found this counts sidechain
+  (subagent-internal) turns and fork/resume copies — a ~2.6× over-count on a real
+  index. The activity heatmap and streak queries add `AND NOT e.is_sidechain AND
+  e.forked_from_session_id IS NULL`, so they count genuine human prompts only.
+  (User rows carry a NULL `message_id`, so the `usage_canonical` election does not
+  dedup them — the explicit filter is required.)
+- **Dedicated "Activity" view.** Rather than mounting the two cards inside
+  *Overview* (whose group-by/time controls don't affect them), they live in a new
+  third segment beside *Overview* / *Session efficiency*.
+- **Tool usage is attributed by agent.** `GET /api/analytics/tools` groups by tool
+  **and** `sessions.connector_id`; the tooltip shows `tool · agent` (e.g.
+  `apply_patch · opencode`). `ToolUsageRow` gained an `agent` field. (This reverses
+  the original "per-agent tool split = out of scope" line, on user request.)
+- **Timezone: offset-shift, no ICU.** No existing ICU usage in the repo, so the
+  client sends `tzOffsetMinutes` and the server buckets with `to_minutes()` (DST-
+  imperfect but dependency-free). `events.ts` confirmed UTC-naive.
+- **Compact heatmap.** Fixed ~14px GitHub-punchcard cells (`width: fit-content`)
+  instead of cells stretched to full width.
+- **`tool_names` stored only on `events`** (comma-joined VARCHAR, like
+  `sessions.models`); `sessions` was not touched.

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -54,3 +54,4 @@ decision, or a change worth explaining before doing. Skip it for one-line fixes.
 | 0027 | [Session-efficiency analytics (per-session ratios table)](./0027-session-efficiency-analytics.md) | done |
 | 0028 | [CI/CD segmentation & reusable workflows](./0028-ci-segmentation-and-reuse.md) | done |
 | 0029 | [Localhost host guard (anti DNS-rebinding)](./0029-localhost-host-guard.md) | done |
+| 0030 | [Analyze tab: activity heatmap + tool-usage breakdown](./0030-analyze-activity-heatmap-tool-usage.md) | done |

--- a/packages/server/src/connectors/claude-code/claude-code.ts
+++ b/packages/server/src/connectors/claude-code/claude-code.ts
@@ -62,6 +62,18 @@ const TOOL_USE_COUNT_EXPR = `
     )
   END`;
 
+/** Comma-joined `$.name` of `tool_use` blocks in a message's content array. */
+const TOOL_NAMES_EXPR = `
+  CASE
+    WHEN message IS NULL OR json_type(message -> '$.content') = 'VARCHAR' THEN ''
+    ELSE COALESCE((
+      SELECT string_agg(json_extract_string(b.value, '$.name'), ',')
+      FROM json_each(message, '$.content') AS b
+      WHERE json_extract_string(b.value, '$.type') = 'tool_use'
+        AND json_extract_string(b.value, '$.name') IS NOT NULL
+    ), '')
+  END`;
+
 /**
  * Recursively collect every `*.jsonl` file under the projects directory. The
  * top level holds `<encoded-cwd>/<session>.jsonl`; sidechain events live in a
@@ -124,6 +136,7 @@ function eventsProjectionSql(filePath: string): string {
       json_extract_string(message, '$.usage.service_tier') AS service_tier,
       COALESCE(isSidechain, FALSE) AS is_sidechain,
       ${TOOL_USE_COUNT_EXPR} AS tool_use_count,
+      ${TOOL_NAMES_EXPR} AS tool_names,
       ${TEXT_CONTENT_EXPR} AS text_content,
       json_extract_string(message, '$.id') AS message_id,
       json_extract_string(forkedFrom, '$.sessionId') AS forked_from_session_id

--- a/packages/server/src/connectors/codex/codex.ts
+++ b/packages/server/src/connectors/codex/codex.ts
@@ -70,14 +70,14 @@ function eventsProjectionSql(filePath: string): string {
     SELECT
       file_path, session_id, uuid, parent_uuid, role, type, ts, cwd, git_branch,
       model, input_tokens, output_tokens, cache_read_tokens, cache_write_tokens,
-      service_tier, is_sidechain, tool_use_count, text_content,
+      service_tier, is_sidechain, tool_use_count, tool_names, text_content,
       CAST(NULL AS VARCHAR) AS message_id, CAST(NULL AS VARCHAR) AS forked_from_session_id
     FROM read_ndjson(${path}, format='newline_delimited', maximum_object_size=268435456, ignore_errors=true, columns={
       file_path:'VARCHAR', session_id:'VARCHAR', uuid:'VARCHAR', parent_uuid:'VARCHAR',
       role:'VARCHAR', type:'VARCHAR', ts:'TIMESTAMP', cwd:'VARCHAR', git_branch:'VARCHAR',
       model:'VARCHAR', input_tokens:'BIGINT', output_tokens:'BIGINT', cache_read_tokens:'BIGINT',
       cache_write_tokens:'BIGINT', service_tier:'VARCHAR', is_sidechain:'BOOLEAN',
-      tool_use_count:'INTEGER', text_content:'VARCHAR'
+      tool_use_count:'INTEGER', tool_names:'VARCHAR', text_content:'VARCHAR'
     })`;
 }
 

--- a/packages/server/src/connectors/codex/normalize.ts
+++ b/packages/server/src/connectors/codex/normalize.ts
@@ -24,6 +24,7 @@ import type {
   ToolUseBlock,
   UserEvent,
 } from '@claudescope/shared';
+import { toolNamesCsv } from '../tool-names.js';
 
 interface CodexLine {
   type?: string;
@@ -295,6 +296,7 @@ export interface CanonicalRow {
   service_tier: string | null;
   is_sidechain: boolean;
   tool_use_count: number;
+  tool_names: string;
   text_content: string;
 }
 
@@ -329,6 +331,7 @@ export function toCanonicalRows(session: CodexSession, filePath: string): Canoni
       service_tier: null,
       is_sidechain: false,
       tool_use_count: arr.filter((b) => b.type === 'tool_use').length,
+      tool_names: toolNamesCsv(arr),
       text_content: text,
     };
   });

--- a/packages/server/src/connectors/copilot/copilot.ts
+++ b/packages/server/src/connectors/copilot/copilot.ts
@@ -68,14 +68,14 @@ function eventsProjectionSql(filePath: string): string {
     SELECT
       file_path, session_id, uuid, parent_uuid, role, type, ts, cwd, git_branch,
       model, input_tokens, output_tokens, cache_read_tokens, cache_write_tokens,
-      service_tier, is_sidechain, tool_use_count, text_content,
+      service_tier, is_sidechain, tool_use_count, tool_names, text_content,
       CAST(NULL AS VARCHAR) AS message_id, CAST(NULL AS VARCHAR) AS forked_from_session_id
     FROM read_ndjson(${path}, format='newline_delimited', maximum_object_size=268435456, ignore_errors=true, columns={
       file_path:'VARCHAR', session_id:'VARCHAR', uuid:'VARCHAR', parent_uuid:'VARCHAR',
       role:'VARCHAR', type:'VARCHAR', ts:'TIMESTAMP', cwd:'VARCHAR', git_branch:'VARCHAR',
       model:'VARCHAR', input_tokens:'BIGINT', output_tokens:'BIGINT', cache_read_tokens:'BIGINT',
       cache_write_tokens:'BIGINT', service_tier:'VARCHAR', is_sidechain:'BOOLEAN',
-      tool_use_count:'INTEGER', text_content:'VARCHAR'
+      tool_use_count:'INTEGER', tool_names:'VARCHAR', text_content:'VARCHAR'
     })`;
 }
 

--- a/packages/server/src/connectors/copilot/normalize.ts
+++ b/packages/server/src/connectors/copilot/normalize.ts
@@ -41,6 +41,7 @@ import type {
   ToolResultBlock,
   UserEvent,
 } from '@claudescope/shared';
+import { toolNamesCsv } from '../tool-names.js';
 
 export interface CopilotSession {
   sessionId: string;
@@ -383,6 +384,7 @@ export interface CanonicalRow {
   service_tier: string | null;
   is_sidechain: boolean;
   tool_use_count: number;
+  tool_names: string;
   text_content: string;
   /** Session title (read by auxProjections; ignored by the events projection). */
   title: string;
@@ -416,6 +418,7 @@ export function toCanonicalRows(session: CopilotSession, filePath: string): Cano
       service_tier: null,
       is_sidechain: false,
       tool_use_count: content.filter((b) => b.type === 'tool_use').length,
+      tool_names: toolNamesCsv(content),
       text_content: text,
       title: session.title,
     };

--- a/packages/server/src/connectors/junie/junie.ts
+++ b/packages/server/src/connectors/junie/junie.ts
@@ -82,14 +82,14 @@ function eventsProjectionSql(filePath: string): string {
     SELECT
       file_path, session_id, uuid, parent_uuid, role, type, ts, cwd, git_branch,
       model, input_tokens, output_tokens, cache_read_tokens, cache_write_tokens,
-      service_tier, is_sidechain, tool_use_count, text_content,
+      service_tier, is_sidechain, tool_use_count, tool_names, text_content,
       CAST(NULL AS VARCHAR) AS message_id, CAST(NULL AS VARCHAR) AS forked_from_session_id
     FROM read_ndjson(${path}, format='newline_delimited', maximum_object_size=268435456, ignore_errors=true, columns={
       file_path:'VARCHAR', session_id:'VARCHAR', uuid:'VARCHAR', parent_uuid:'VARCHAR',
       role:'VARCHAR', type:'VARCHAR', ts:'TIMESTAMP', cwd:'VARCHAR', git_branch:'VARCHAR',
       model:'VARCHAR', input_tokens:'BIGINT', output_tokens:'BIGINT', cache_read_tokens:'BIGINT',
       cache_write_tokens:'BIGINT', service_tier:'VARCHAR', is_sidechain:'BOOLEAN',
-      tool_use_count:'INTEGER', text_content:'VARCHAR'
+      tool_use_count:'INTEGER', tool_names:'VARCHAR', text_content:'VARCHAR'
     })`;
 }
 

--- a/packages/server/src/connectors/junie/normalize.ts
+++ b/packages/server/src/connectors/junie/normalize.ts
@@ -34,6 +34,7 @@ import type {
   UserEvent,
 } from '@claudescope/shared';
 import { JUNIE_HOME } from '../../config.js';
+import { toolNamesCsv } from '../tool-names.js';
 
 export interface JunieSession {
   sessionId: string;
@@ -472,6 +473,7 @@ export interface CanonicalRow {
   service_tier: string | null;
   is_sidechain: boolean;
   tool_use_count: number;
+  tool_names: string;
   text_content: string;
   /** Not a canonical column — read separately by the title aux projection. */
   title: string;
@@ -512,6 +514,7 @@ export function toCanonicalRows(session: JunieSession, filePath: string): Canoni
       service_tier: null,
       is_sidechain: false,
       tool_use_count: arr.filter((b) => b.type === 'tool_use').length,
+      tool_names: toolNamesCsv(arr),
       text_content: text,
       title: session.title,
     };

--- a/packages/server/src/connectors/opencode/normalize.ts
+++ b/packages/server/src/connectors/opencode/normalize.ts
@@ -29,6 +29,7 @@ import type {
   UserEvent,
 } from '@claudescope/shared';
 import type { OpencodeRawSession } from './db.js';
+import { toolNamesCsv } from '../tool-names.js';
 
 const str = (v: unknown): string => (typeof v === 'string' ? v : '');
 const num = (v: unknown): number => (typeof v === 'number' && Number.isFinite(v) ? v : 0);
@@ -346,6 +347,7 @@ export interface CanonicalRow {
   service_tier: string | null;
   is_sidechain: boolean;
   tool_use_count: number;
+  tool_names: string;
   text_content: string;
   /** Session title (read by auxProjections; ignored by the events projection). */
   title: string;
@@ -379,6 +381,7 @@ export function toCanonicalRows(session: OpencodeRawSession, filePath: string): 
       service_tier: null,
       is_sidechain: false,
       tool_use_count: content.filter((b) => b.type === 'tool_use').length,
+      tool_names: toolNamesCsv(content),
       text_content: text,
       title: session.title,
     };

--- a/packages/server/src/connectors/opencode/opencode.ts
+++ b/packages/server/src/connectors/opencode/opencode.ts
@@ -73,14 +73,14 @@ function eventsProjectionSql(filePath: string): string {
     SELECT
       file_path, session_id, uuid, parent_uuid, role, type, ts, cwd, git_branch,
       model, input_tokens, output_tokens, cache_read_tokens, cache_write_tokens,
-      service_tier, is_sidechain, tool_use_count, text_content,
+      service_tier, is_sidechain, tool_use_count, tool_names, text_content,
       CAST(NULL AS VARCHAR) AS message_id, CAST(NULL AS VARCHAR) AS forked_from_session_id
     FROM read_ndjson(${path}, format='newline_delimited', maximum_object_size=268435456, ignore_errors=true, columns={
       file_path:'VARCHAR', session_id:'VARCHAR', uuid:'VARCHAR', parent_uuid:'VARCHAR',
       role:'VARCHAR', type:'VARCHAR', ts:'TIMESTAMP', cwd:'VARCHAR', git_branch:'VARCHAR',
       model:'VARCHAR', input_tokens:'BIGINT', output_tokens:'BIGINT', cache_read_tokens:'BIGINT',
       cache_write_tokens:'BIGINT', service_tier:'VARCHAR', is_sidechain:'BOOLEAN',
-      tool_use_count:'INTEGER', text_content:'VARCHAR'
+      tool_use_count:'INTEGER', tool_names:'VARCHAR', text_content:'VARCHAR'
     })`;
 }
 

--- a/packages/server/src/connectors/pi/normalize.ts
+++ b/packages/server/src/connectors/pi/normalize.ts
@@ -25,6 +25,7 @@
 
 import { readFileSync } from 'node:fs';
 import type { AssistantEvent, ContentBlock, MessageUsage, UserEvent } from '@claudescope/shared';
+import { toolNamesCsv } from '../tool-names.js';
 
 export interface PiSession {
   sessionId: string;
@@ -307,6 +308,7 @@ export interface CanonicalRow {
   service_tier: string | null;
   is_sidechain: boolean;
   tool_use_count: number;
+  tool_names: string;
   text_content: string;
 }
 
@@ -338,6 +340,7 @@ export function toCanonicalRows(session: PiSession, filePath: string): Canonical
       service_tier: null,
       is_sidechain: false,
       tool_use_count: content.filter((b) => b.type === 'tool_use').length,
+      tool_names: toolNamesCsv(content),
       text_content: text,
     };
   });

--- a/packages/server/src/connectors/pi/pi.ts
+++ b/packages/server/src/connectors/pi/pi.ts
@@ -73,14 +73,14 @@ function eventsProjectionSql(filePath: string): string {
     SELECT
       file_path, session_id, uuid, parent_uuid, role, type, ts, cwd, git_branch,
       model, input_tokens, output_tokens, cache_read_tokens, cache_write_tokens,
-      service_tier, is_sidechain, tool_use_count, text_content,
+      service_tier, is_sidechain, tool_use_count, tool_names, text_content,
       CAST(NULL AS VARCHAR) AS message_id, CAST(NULL AS VARCHAR) AS forked_from_session_id
     FROM read_ndjson(${path}, format='newline_delimited', maximum_object_size=268435456, ignore_errors=true, columns={
       file_path:'VARCHAR', session_id:'VARCHAR', uuid:'VARCHAR', parent_uuid:'VARCHAR',
       role:'VARCHAR', type:'VARCHAR', ts:'TIMESTAMP', cwd:'VARCHAR', git_branch:'VARCHAR',
       model:'VARCHAR', input_tokens:'BIGINT', output_tokens:'BIGINT', cache_read_tokens:'BIGINT',
       cache_write_tokens:'BIGINT', service_tier:'VARCHAR', is_sidechain:'BOOLEAN',
-      tool_use_count:'INTEGER', text_content:'VARCHAR'
+      tool_use_count:'INTEGER', tool_names:'VARCHAR', text_content:'VARCHAR'
     })`;
 }
 

--- a/packages/server/src/connectors/tool-names.ts
+++ b/packages/server/src/connectors/tool-names.ts
@@ -1,0 +1,15 @@
+/**
+ * Comma-joined canonical tool names of a message's `tool_use` blocks, in order
+ * (empty string when there are none). Stored in the `events.tool_names` column
+ * to power the tool-usage breakdown — mirrors how `sessions.models` joins a list
+ * into a VARCHAR. Tool names never contain commas, so the join is unambiguous.
+ */
+export function toolNamesCsv(
+  blocks: ReadonlyArray<{ type: string; name?: string }>,
+): string {
+  return blocks
+    .filter((b) => b.type === 'tool_use')
+    .map((b) => b.name ?? '')
+    .filter((n) => n !== '')
+    .join(',');
+}

--- a/packages/server/src/connectors/types.ts
+++ b/packages/server/src/connectors/types.ts
@@ -45,6 +45,7 @@ export const CANONICAL_EVENT_COLUMNS = [
   'service_tier',
   'is_sidechain',
   'tool_use_count',
+  'tool_names',
   'text_content',
 ] as const;
 

--- a/packages/server/src/data/index.ts
+++ b/packages/server/src/data/index.ts
@@ -148,7 +148,7 @@ async function loadFile(
     SELECT
       ev.file_path, ev.session_id, ev.uuid, ev.parent_uuid, ev.role, ev.type, ev.ts, ev.cwd, ev.git_branch,
       ev.model, ev.input_tokens, ev.output_tokens, ev.cache_read_tokens, ev.cache_write_tokens,
-      ev.service_tier, ev.is_sidechain, ev.tool_use_count,
+      ev.service_tier, ev.is_sidechain, ev.tool_use_count, ev.tool_names,
       ${costExpr} AS cost_usd,
       ev.text_content,
       ev.message_id, ev.forked_from_session_id, TRUE AS usage_canonical

--- a/packages/server/src/db/schema.ts
+++ b/packages/server/src/db/schema.ts
@@ -24,7 +24,8 @@
 // v5: Codex title fallback (first user message) + `<image …>` placeholder strip.
 // v6: usage dedup by billed API call (message_id / forked_from_session_id / usage_canonical).
 // v7: fallback title cleaning (strip markup/wrapper blobs) + `title_derived` flag.
-export const SCHEMA_VERSION = 7;
+// v8: per-event tool_names (comma-joined canonical tool names) for the tool-usage breakdown.
+export const SCHEMA_VERSION = 8;
 
 /** All DDL statements, executed in order at startup. Idempotent. */
 export const SCHEMA_DDL: readonly string[] = [
@@ -60,6 +61,7 @@ export const SCHEMA_DDL: readonly string[] = [
      service_tier VARCHAR,
      is_sidechain BOOLEAN DEFAULT FALSE,
      tool_use_count INTEGER DEFAULT 0,
+     tool_names   VARCHAR DEFAULT '',
      cost_usd     DOUBLE DEFAULT 0,
      text_content VARCHAR,
      message_id   VARCHAR,

--- a/packages/server/src/routes/analytics-activity.ts
+++ b/packages/server/src/routes/analytics-activity.ts
@@ -62,7 +62,10 @@ export async function registerActivityRoute(app: FastifyInstance): Promise<void>
     const localTs = `(e.ts + to_minutes(${offset}))`;
 
     // Heatmap: honors the date filter (matches the rest of the page).
-    const filters: string[] = ["e.type = 'user'"];
+    // Exclude sidechain rows (subagent-internal user turns) and fork-copy rows
+    // (copied when a session is forked/resumed) so only genuine human prompts
+    // are counted — sidechain + fork copies would otherwise inflate by ~2.6×.
+    const filters: string[] = ["e.type = 'user'", 'NOT e.is_sidechain', 'e.forked_from_session_id IS NULL'];
     if (req.query.from) filters.push(`e.ts >= ${sqlString(req.query.from)}::TIMESTAMP`);
     if (req.query.to) filters.push(`e.ts <= ${sqlString(req.query.to)}::TIMESTAMP`);
     const heatmapRows = await queryRows(
@@ -80,12 +83,14 @@ export async function registerActivityRoute(app: FastifyInstance): Promise<void>
       return { dow: rd.num('dow'), hour: rd.num('hour'), count: rd.num('count') };
     });
 
-    // Streak: all-time (ignores the date filter).
+    // Streak: all-time (ignores the date filter). Same exclusions apply.
     const dayRows = await queryRows(
       conn,
       `SELECT DISTINCT strftime(${localTs}, '%Y-%m-%d') AS day
        FROM events e
-       WHERE e.type = 'user'`,
+       WHERE e.type = 'user'
+         AND NOT e.is_sidechain
+         AND e.forked_from_session_id IS NULL`,
     );
     const activeDays = dayRows
       .map((r) => readRow(r, 'activity-days').str('day'))

--- a/packages/server/src/routes/analytics-activity.ts
+++ b/packages/server/src/routes/analytics-activity.ts
@@ -1,0 +1,97 @@
+/**
+ * GET /api/analytics/activity — a punchcard of user prompts by local
+ * day-of-week × hour, plus an all-time prompt streak.
+ *
+ * Local time: `events.ts` is stored UTC-naive, so the client sends its current
+ * UTC offset in minutes and the server shifts with `to_minutes()`. This avoids a
+ * DuckDB ICU dependency; the (DST-imperfect) fixed offset is fine for a
+ * "when do I usually work" view. The heatmap honors the `from`/`to` filter; the
+ * streak is always all-time (a current streak only means anything vs. today).
+ */
+import type { FastifyInstance } from 'fastify';
+import type { ActivityCell, ActivityResponse, StreakInfo } from '@claudescope/shared';
+import { getConnection, queryRows, sqlString } from '../db/duckdb.js';
+import { readRow } from '../db/row.js';
+
+const DAY_MS = 86_400_000;
+const dayNum = (s: string): number => Math.floor(Date.parse(`${s}T00:00:00Z`) / DAY_MS);
+
+/** All-time prompt streak from the set of active local days and the local today. */
+export function computeStreaks(activeDays: string[], today: string): StreakInfo {
+  const uniq = [...new Set(activeDays)].filter(Boolean).sort();
+  if (uniq.length === 0) return { current: 0, longest: 0, lastActiveDay: null };
+
+  // longest consecutive run
+  let longest = 1;
+  let run = 1;
+  for (let i = 1; i < uniq.length; i++) {
+    run = dayNum(uniq[i]!) - dayNum(uniq[i - 1]!) === 1 ? run + 1 : 1;
+    if (run > longest) longest = run;
+  }
+
+  // current run ending at the last active day, only "alive" if that day is
+  // today or yesterday relative to `today`.
+  const lastActiveDay = uniq[uniq.length - 1]!;
+  const gap = dayNum(today) - dayNum(lastActiveDay);
+  let current = 0;
+  if (gap <= 1 && gap >= 0) {
+    current = 1;
+    for (let i = uniq.length - 1; i > 0; i--) {
+      if (dayNum(uniq[i]!) - dayNum(uniq[i - 1]!) === 1) current++;
+      else break;
+    }
+  }
+  return { current, longest, lastActiveDay };
+}
+
+function clampOffset(raw: string | undefined): number {
+  const n = Number.parseInt(raw ?? '0', 10);
+  if (!Number.isFinite(n)) return 0;
+  return Math.max(-840, Math.min(840, n));
+}
+
+const ISO_DAY = /^\d{4}-\d{2}-\d{2}$/;
+
+export async function registerActivityRoute(app: FastifyInstance): Promise<void> {
+  app.get<{
+    Querystring: { from?: string; to?: string; tzOffsetMinutes?: string; today?: string };
+  }>('/api/analytics/activity', async (req): Promise<ActivityResponse> => {
+    const conn = await getConnection();
+    const offset = clampOffset(req.query.tzOffsetMinutes);
+    const today = ISO_DAY.test(req.query.today ?? '') ? (req.query.today as string) : '';
+    const localTs = `(e.ts + to_minutes(${offset}))`;
+
+    // Heatmap: honors the date filter (matches the rest of the page).
+    const filters: string[] = ["e.type = 'user'"];
+    if (req.query.from) filters.push(`e.ts >= ${sqlString(req.query.from)}::TIMESTAMP`);
+    if (req.query.to) filters.push(`e.ts <= ${sqlString(req.query.to)}::TIMESTAMP`);
+    const heatmapRows = await queryRows(
+      conn,
+      `SELECT
+         CAST(extract('isodow' FROM ${localTs}) AS INTEGER) AS dow,
+         CAST(extract('hour'   FROM ${localTs}) AS INTEGER) AS hour,
+         count(*) AS count
+       FROM events e
+       WHERE ${filters.join(' AND ')}
+       GROUP BY dow, hour`,
+    );
+    const heatmap: ActivityCell[] = heatmapRows.map((r) => {
+      const rd = readRow(r, 'activity-heatmap');
+      return { dow: rd.num('dow'), hour: rd.num('hour'), count: rd.num('count') };
+    });
+
+    // Streak: all-time (ignores the date filter).
+    const dayRows = await queryRows(
+      conn,
+      `SELECT DISTINCT strftime(${localTs}, '%Y-%m-%d') AS day
+       FROM events e
+       WHERE e.type = 'user'`,
+    );
+    const activeDays = dayRows
+      .map((r) => readRow(r, 'activity-days').str('day'))
+      .filter(Boolean);
+    const streak = computeStreaks(activeDays, today);
+
+    return { heatmap, streak };
+  });
+}

--- a/packages/server/src/routes/analytics-tools.ts
+++ b/packages/server/src/routes/analytics-tools.ts
@@ -1,9 +1,10 @@
 /**
- * GET /api/analytics/tools — count of tool calls by raw (canonical) tool name,
- * descending. Unnests the `events.tool_names` CSV. Filters on `usage_canonical`
- * to match the "tool calls" semantics of the session-efficiency table (a fork
- * copy / multi-block split must not multiply-count a call). The web maps raw
- * names → categories via `toolCategory()`.
+ * GET /api/analytics/tools — count of tool calls by raw (canonical) tool name
+ * AND the agent that emitted it (joined from `sessions.connector_id`), descending.
+ * Unnests the `events.tool_names` CSV. Filters on `usage_canonical` to match the
+ * "tool calls" semantics of the session-efficiency table (a fork copy / multi-block
+ * split must not multiply-count a call). The web maps raw names → categories via
+ * `toolCategory()` and surfaces the per-agent attribution in the tooltip.
  */
 import type { FastifyInstance } from 'fastify';
 import type { ToolUsageResponse, ToolUsageRow } from '@claudescope/shared';
@@ -21,19 +22,20 @@ export async function registerToolsRoute(app: FastifyInstance): Promise<void> {
 
     const rows = await queryRows(
       conn,
-      `SELECT tool, count(*) AS count
+      `SELECT tool, agent, count(*) AS count
        FROM (
-         SELECT unnest(string_split(e.tool_names, ',')) AS tool
+         SELECT unnest(string_split(e.tool_names, ',')) AS tool, s.connector_id AS agent
          FROM events e
+         JOIN sessions s ON e.session_id = s.id
          WHERE ${filters.join(' AND ')}
        ) t
        WHERE tool <> ''
-       GROUP BY tool
-       ORDER BY count DESC, tool`,
+       GROUP BY tool, agent
+       ORDER BY count DESC, tool, agent`,
     );
     const result: ToolUsageRow[] = rows.map((r) => {
       const rd = readRow(r, 'analytics-tools');
-      return { tool: rd.str('tool'), count: rd.num('count') };
+      return { tool: rd.str('tool'), agent: rd.str('agent'), count: rd.num('count') };
     });
     return { rows: result };
   });

--- a/packages/server/src/routes/analytics-tools.ts
+++ b/packages/server/src/routes/analytics-tools.ts
@@ -1,0 +1,40 @@
+/**
+ * GET /api/analytics/tools — count of tool calls by raw (canonical) tool name,
+ * descending. Unnests the `events.tool_names` CSV. Filters on `usage_canonical`
+ * to match the "tool calls" semantics of the session-efficiency table (a fork
+ * copy / multi-block split must not multiply-count a call). The web maps raw
+ * names → categories via `toolCategory()`.
+ */
+import type { FastifyInstance } from 'fastify';
+import type { ToolUsageResponse, ToolUsageRow } from '@claudescope/shared';
+import { getConnection, queryRows, sqlString } from '../db/duckdb.js';
+import { readRow } from '../db/row.js';
+
+export async function registerToolsRoute(app: FastifyInstance): Promise<void> {
+  app.get<{
+    Querystring: { from?: string; to?: string };
+  }>('/api/analytics/tools', async (req): Promise<ToolUsageResponse> => {
+    const conn = await getConnection();
+    const filters: string[] = ["e.type = 'assistant'", 'e.usage_canonical', "e.tool_names <> ''"];
+    if (req.query.from) filters.push(`e.ts >= ${sqlString(req.query.from)}::TIMESTAMP`);
+    if (req.query.to) filters.push(`e.ts <= ${sqlString(req.query.to)}::TIMESTAMP`);
+
+    const rows = await queryRows(
+      conn,
+      `SELECT tool, count(*) AS count
+       FROM (
+         SELECT unnest(string_split(e.tool_names, ',')) AS tool
+         FROM events e
+         WHERE ${filters.join(' AND ')}
+       ) t
+       WHERE tool <> ''
+       GROUP BY tool
+       ORDER BY count DESC, tool`,
+    );
+    const result: ToolUsageRow[] = rows.map((r) => {
+      const rd = readRow(r, 'analytics-tools');
+      return { tool: rd.str('tool'), count: rd.num('count') };
+    });
+    return { rows: result };
+  });
+}

--- a/packages/server/src/routes/index.ts
+++ b/packages/server/src/routes/index.ts
@@ -14,6 +14,7 @@ import { registerSearchRoute } from './search.js';
 import { registerAnalyticsRoute } from './analytics.js';
 import { registerSessionEfficiencyRoute } from './analytics-sessions.js';
 import { registerActivityRoute } from './analytics-activity.js';
+import { registerToolsRoute } from './analytics-tools.js';
 import { registerSourcesRoute } from './sources.js';
 import { registerMemoryRoute } from './memory.js';
 
@@ -28,6 +29,7 @@ export async function registerRoutes(app: FastifyInstance): Promise<void> {
   await registerAnalyticsRoute(app);
   await registerSessionEfficiencyRoute(app);
   await registerActivityRoute(app);
+  await registerToolsRoute(app);
   await registerSourcesRoute(app);
   await registerMemoryRoute(app);
 

--- a/packages/server/src/routes/index.ts
+++ b/packages/server/src/routes/index.ts
@@ -13,6 +13,7 @@ import { registerSessionsRoutes } from './sessions.js';
 import { registerSearchRoute } from './search.js';
 import { registerAnalyticsRoute } from './analytics.js';
 import { registerSessionEfficiencyRoute } from './analytics-sessions.js';
+import { registerActivityRoute } from './analytics-activity.js';
 import { registerSourcesRoute } from './sources.js';
 import { registerMemoryRoute } from './memory.js';
 
@@ -26,6 +27,7 @@ export async function registerRoutes(app: FastifyInstance): Promise<void> {
   await registerSearchRoute(app);
   await registerAnalyticsRoute(app);
   await registerSessionEfficiencyRoute(app);
+  await registerActivityRoute(app);
   await registerSourcesRoute(app);
   await registerMemoryRoute(app);
 

--- a/packages/server/test/analytics-activity.integration.test.ts
+++ b/packages/server/test/analytics-activity.integration.test.ts
@@ -1,0 +1,70 @@
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+const work = mkdtempSync(join(tmpdir(), 'claudescope-act-'));
+const projectsDir = join(work, 'projects');
+const codexDir = join(work, 'codex');
+process.env.CLAUDE_PROJECTS_DIR = projectsDir;
+process.env.CODEX_SESSIONS_DIR = codexDir;
+process.env.JUNIE_SESSIONS_DIR = join(work, 'junie-empty');
+process.env.PI_SESSIONS_DIR = join(work, 'pi-empty');
+process.env.OPENCODE_DATA_DIR = join(work, 'opencode-empty');
+process.env.COPILOT_SESSIONS_DIR = join(work, 'copilot-empty');
+process.env.DUCKDB_PATH = join(work, 'index.duckdb');
+process.env.CLAUDESCOPE_HOME = join(work, 'home');
+process.env.REINDEX_INTERVAL_MS = '0';
+
+const jsonl = (events: unknown[]): string => events.map((e) => JSON.stringify(e)).join('\n') + '\n';
+
+let app: import('fastify').FastifyInstance;
+let closeConnection: typeof import('../src/db/duckdb.js').closeConnection;
+
+beforeAll(async () => {
+  const projA = join(projectsDir, 'enc-act');
+  mkdirSync(projA, { recursive: true });
+  const base = { sessionId: 'sA', cwd: '/tmp/act', gitBranch: 'main', version: '2.1.0' };
+  // Two user prompts at 23:30 UTC on consecutive days. With offset +60 (CET-ish),
+  // local time is 00:30 the NEXT day → isodow shifts and hour = 0.
+  writeFileSync(
+    join(projA, 'sA.jsonl'),
+    jsonl([
+      { ...base, type: 'user', uuid: 'u1', parentUuid: null, timestamp: '2026-06-01T23:30:00.000Z', isSidechain: false, message: { role: 'user', content: 'one' } },
+      { ...base, type: 'user', uuid: 'u2', parentUuid: 'u1', timestamp: '2026-06-02T23:30:00.000Z', isSidechain: false, message: { role: 'user', content: 'two' } },
+    ]),
+  );
+  const Fastify = (await import('fastify')).default;
+  const { registerRoutes } = await import('../src/routes/index.js');
+  const { reindex } = await import('../src/data/index.js');
+  ({ closeConnection } = await import('../src/db/duckdb.js'));
+  app = Fastify();
+  await registerRoutes(app);
+  await reindex();
+  await app.ready();
+});
+
+afterAll(async () => {
+  await app?.close();
+  await closeConnection?.();
+  rmSync(work, { recursive: true, force: true });
+});
+
+describe('GET /api/analytics/activity', () => {
+  it('buckets user prompts by LOCAL hour using the offset', async () => {
+    const res = await app.inject({ method: 'GET', url: '/api/analytics/activity?tzOffsetMinutes=60&today=2026-06-03' });
+    const body = res.json() as { heatmap: { dow: number; hour: number; count: number }[]; streak: { current: number; longest: number } };
+    // 23:30Z + 60min = 00:30 local → hour 0, two prompts on (local) June 2 and 3.
+    const atHour0 = body.heatmap.filter((c) => c.hour === 0).reduce((n, c) => n + c.count, 0);
+    expect(atHour0).toBe(2);
+    expect(body.heatmap.every((c) => c.dow >= 1 && c.dow <= 7)).toBe(true);
+  });
+  it('reports an all-time streak relative to the supplied today', async () => {
+    const res = await app.inject({ method: 'GET', url: '/api/analytics/activity?tzOffsetMinutes=60&today=2026-06-03' });
+    const body = res.json() as { streak: { current: number; longest: number; lastActiveDay: string } };
+    // local active days: 2026-06-02, 2026-06-03 → longest 2; today 06-03 → current 2.
+    expect(body.streak.longest).toBe(2);
+    expect(body.streak.current).toBe(2);
+    expect(body.streak.lastActiveDay).toBe('2026-06-03');
+  });
+});

--- a/packages/server/test/analytics-activity.integration.test.ts
+++ b/packages/server/test/analytics-activity.integration.test.ts
@@ -32,6 +32,11 @@ beforeAll(async () => {
     jsonl([
       { ...base, type: 'user', uuid: 'u1', parentUuid: null, timestamp: '2026-06-01T23:30:00.000Z', isSidechain: false, message: { role: 'user', content: 'one' } },
       { ...base, type: 'user', uuid: 'u2', parentUuid: 'u1', timestamp: '2026-06-02T23:30:00.000Z', isSidechain: false, message: { role: 'user', content: 'two' } },
+      // sidechain + fork-copy prompts must not count toward heatmap/streak.
+      // Sidechain: a subagent-internal user turn at the same hour — must be excluded.
+      { ...base, type: 'user', uuid: 'u3', parentUuid: 'u2', timestamp: '2026-06-02T23:30:00.000Z', isSidechain: true, message: { role: 'user', content: 'subagent turn' } },
+      // Fork-copy: a user row in a forked session carrying forkedFrom — must be excluded.
+      { ...base, sessionId: 'sB', type: 'user', uuid: 'u1', parentUuid: null, timestamp: '2026-06-01T23:30:00.000Z', isSidechain: false, forkedFrom: { sessionId: 'sA', messageUuid: 'u1' }, message: { role: 'user', content: 'one (fork copy)' } },
     ]),
   );
   const Fastify = (await import('fastify')).default;
@@ -55,6 +60,7 @@ describe('GET /api/analytics/activity', () => {
     const res = await app.inject({ method: 'GET', url: '/api/analytics/activity?tzOffsetMinutes=60&today=2026-06-03' });
     const body = res.json() as { heatmap: { dow: number; hour: number; count: number }[]; streak: { current: number; longest: number } };
     // 23:30Z + 60min = 00:30 local → hour 0, two prompts on (local) June 2 and 3.
+    // sidechain + fork-copy prompts must not count — count must remain 2, not 3 or 4.
     const atHour0 = body.heatmap.filter((c) => c.hour === 0).reduce((n, c) => n + c.count, 0);
     expect(atHour0).toBe(2);
     expect(body.heatmap.every((c) => c.dow >= 1 && c.dow <= 7)).toBe(true);
@@ -63,6 +69,7 @@ describe('GET /api/analytics/activity', () => {
     const res = await app.inject({ method: 'GET', url: '/api/analytics/activity?tzOffsetMinutes=60&today=2026-06-03' });
     const body = res.json() as { streak: { current: number; longest: number; lastActiveDay: string } };
     // local active days: 2026-06-02, 2026-06-03 → longest 2; today 06-03 → current 2.
+    // sidechain + fork-copy prompts must not inflate or alter the streak.
     expect(body.streak.longest).toBe(2);
     expect(body.streak.current).toBe(2);
     expect(body.streak.lastActiveDay).toBe('2026-06-03');

--- a/packages/server/test/analytics-tools.integration.test.ts
+++ b/packages/server/test/analytics-tools.integration.test.ts
@@ -36,6 +36,22 @@ beforeAll(async () => {
       ], usage: { input_tokens: 1, output_tokens: 1 } } },
     ]),
   );
+  // Fork-copy session: same message.id 'm1', same tool_use blocks, carrying forkedFrom.
+  // The canonical-usage election prefers the original (forked_from_session_id IS NULL)
+  // and marks this copy non-canonical — proving usage_canonical is load-bearing.
+  const forkBase = { sessionId: 'sTF', cwd: '/tmp/tools', gitBranch: 'main', version: '2.1.0' };
+  const forkFrom = { sessionId: 'sT', messageUuid: 'a1' };
+  writeFileSync(
+    join(projA, 'sTF.jsonl'),
+    jsonl([
+      { ...forkBase, type: 'user', uuid: 'u1', parentUuid: null, timestamp: '2026-06-01T10:00:00.000Z', isSidechain: false, forkedFrom: forkFrom, message: { role: 'user', content: 'go' } },
+      { ...forkBase, type: 'assistant', uuid: 'a1', parentUuid: 'u1', timestamp: '2026-06-01T10:00:01.000Z', isSidechain: false, forkedFrom: forkFrom, message: { role: 'assistant', model: 'claude-opus-4-8', id: 'm1', content: [
+        { type: 'tool_use', id: 't1', name: 'Edit', input: {} },
+        { type: 'tool_use', id: 't2', name: 'Edit', input: {} },
+        { type: 'tool_use', id: 't3', name: 'Bash', input: {} },
+      ], usage: { input_tokens: 1, output_tokens: 1 } } },
+    ]),
+  );
   const Fastify = (await import('fastify')).default;
   const { registerRoutes } = await import('../src/routes/index.js');
   const { reindex } = await import('../src/data/index.js');
@@ -57,6 +73,9 @@ describe('GET /api/analytics/tools', () => {
     const res = await app.inject({ method: 'GET', url: '/api/analytics/tools' });
     const body = res.json() as { rows: { tool: string; count: number }[] };
     const byTool = Object.fromEntries(body.rows.map((r) => [r.tool, r.count]));
+    // The fork-copy row shares message.id 'm1' and carries the same [Edit, Edit, Bash]
+    // blocks, but is marked non-canonical by usage_canonical election. Counts must
+    // remain Edit=2 and Bash=1, not 4 and 2 — proving usage_canonical is load-bearing.
     expect(byTool.Edit).toBe(2);
     expect(byTool.Bash).toBe(1);
     // descending

--- a/packages/server/test/analytics-tools.integration.test.ts
+++ b/packages/server/test/analytics-tools.integration.test.ts
@@ -71,13 +71,15 @@ afterAll(async () => {
 describe('GET /api/analytics/tools', () => {
   it('counts each tool occurrence (unnested), descending', async () => {
     const res = await app.inject({ method: 'GET', url: '/api/analytics/tools' });
-    const body = res.json() as { rows: { tool: string; count: number }[] };
-    const byTool = Object.fromEntries(body.rows.map((r) => [r.tool, r.count]));
+    const body = res.json() as { rows: { tool: string; agent: string; count: number }[] };
+    const sumTool = (t: string) => body.rows.filter((r) => r.tool === t).reduce((n, r) => n + r.count, 0);
     // The fork-copy row shares message.id 'm1' and carries the same [Edit, Edit, Bash]
     // blocks, but is marked non-canonical by usage_canonical election. Counts must
     // remain Edit=2 and Bash=1, not 4 and 2 — proving usage_canonical is load-bearing.
-    expect(byTool.Edit).toBe(2);
-    expect(byTool.Bash).toBe(1);
+    expect(sumTool('Edit')).toBe(2);
+    expect(sumTool('Bash')).toBe(1);
+    // Each row is attributed to the agent that emitted it (here, all Claude Code).
+    expect(body.rows.every((r) => r.agent === 'claude-code')).toBe(true);
     // descending
     expect(body.rows[0]?.count).toBeGreaterThanOrEqual(body.rows[body.rows.length - 1]?.count ?? 0);
   });

--- a/packages/server/test/analytics-tools.integration.test.ts
+++ b/packages/server/test/analytics-tools.integration.test.ts
@@ -1,0 +1,65 @@
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+const work = mkdtempSync(join(tmpdir(), 'claudescope-tools-'));
+const projectsDir = join(work, 'projects');
+const codexDir = join(work, 'codex');
+process.env.CLAUDE_PROJECTS_DIR = projectsDir;
+process.env.CODEX_SESSIONS_DIR = codexDir;
+process.env.JUNIE_SESSIONS_DIR = join(work, 'junie-empty');
+process.env.PI_SESSIONS_DIR = join(work, 'pi-empty');
+process.env.OPENCODE_DATA_DIR = join(work, 'opencode-empty');
+process.env.COPILOT_SESSIONS_DIR = join(work, 'copilot-empty');
+process.env.DUCKDB_PATH = join(work, 'index.duckdb');
+process.env.CLAUDESCOPE_HOME = join(work, 'home');
+process.env.REINDEX_INTERVAL_MS = '0';
+
+const jsonl = (events: unknown[]): string => events.map((e) => JSON.stringify(e)).join('\n') + '\n';
+
+let app: import('fastify').FastifyInstance;
+let closeConnection: typeof import('../src/db/duckdb.js').closeConnection;
+
+beforeAll(async () => {
+  const projA = join(projectsDir, 'enc-tools');
+  mkdirSync(projA, { recursive: true });
+  const base = { sessionId: 'sT', cwd: '/tmp/tools', gitBranch: 'main', version: '2.1.0' };
+  writeFileSync(
+    join(projA, 'sT.jsonl'),
+    jsonl([
+      { ...base, type: 'user', uuid: 'u1', parentUuid: null, timestamp: '2026-06-01T10:00:00.000Z', isSidechain: false, message: { role: 'user', content: 'go' } },
+      { ...base, type: 'assistant', uuid: 'a1', parentUuid: 'u1', timestamp: '2026-06-01T10:00:01.000Z', isSidechain: false, message: { role: 'assistant', model: 'claude-opus-4-8', id: 'm1', content: [
+        { type: 'tool_use', id: 't1', name: 'Edit', input: {} },
+        { type: 'tool_use', id: 't2', name: 'Edit', input: {} },
+        { type: 'tool_use', id: 't3', name: 'Bash', input: {} },
+      ], usage: { input_tokens: 1, output_tokens: 1 } } },
+    ]),
+  );
+  const Fastify = (await import('fastify')).default;
+  const { registerRoutes } = await import('../src/routes/index.js');
+  const { reindex } = await import('../src/data/index.js');
+  ({ closeConnection } = await import('../src/db/duckdb.js'));
+  app = Fastify();
+  await registerRoutes(app);
+  await reindex();
+  await app.ready();
+});
+
+afterAll(async () => {
+  await app?.close();
+  await closeConnection?.();
+  rmSync(work, { recursive: true, force: true });
+});
+
+describe('GET /api/analytics/tools', () => {
+  it('counts each tool occurrence (unnested), descending', async () => {
+    const res = await app.inject({ method: 'GET', url: '/api/analytics/tools' });
+    const body = res.json() as { rows: { tool: string; count: number }[] };
+    const byTool = Object.fromEntries(body.rows.map((r) => [r.tool, r.count]));
+    expect(byTool.Edit).toBe(2);
+    expect(byTool.Bash).toBe(1);
+    // descending
+    expect(body.rows[0]?.count).toBeGreaterThanOrEqual(body.rows[body.rows.length - 1]?.count ?? 0);
+  });
+});

--- a/packages/server/test/streaks.test.ts
+++ b/packages/server/test/streaks.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest';
+import { computeStreaks } from '../src/routes/analytics-activity.js';
+
+describe('computeStreaks', () => {
+  it('counts a run ending today', () => {
+    const s = computeStreaks(['2026-06-27', '2026-06-28', '2026-06-29'], '2026-06-29');
+    expect(s).toEqual({ current: 3, longest: 3, lastActiveDay: '2026-06-29' });
+  });
+  it('keeps current alive when the last active day is yesterday', () => {
+    const s = computeStreaks(['2026-06-27', '2026-06-28'], '2026-06-29');
+    expect(s.current).toBe(2);
+  });
+  it('breaks current when the gap to today is >1 day', () => {
+    const s = computeStreaks(['2026-06-20', '2026-06-21'], '2026-06-29');
+    expect(s.current).toBe(0);
+    expect(s.longest).toBe(2);
+  });
+  it('finds the longest run across gaps', () => {
+    const s = computeStreaks(['2026-06-01', '2026-06-02', '2026-06-03', '2026-06-10'], '2026-06-29');
+    expect(s.longest).toBe(3);
+    expect(s.current).toBe(0);
+  });
+  it('handles a single day and unsorted/duplicate input', () => {
+    expect(computeStreaks(['2026-06-29', '2026-06-29'], '2026-06-29')).toEqual({ current: 1, longest: 1, lastActiveDay: '2026-06-29' });
+  });
+  it('handles no activity', () => {
+    expect(computeStreaks([], '2026-06-29')).toEqual({ current: 0, longest: 0, lastActiveDay: null });
+  });
+});

--- a/packages/server/test/tool-names.integration.test.ts
+++ b/packages/server/test/tool-names.integration.test.ts
@@ -1,0 +1,84 @@
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+const work = mkdtempSync(join(tmpdir(), 'claudescope-tn-'));
+const projectsDir = join(work, 'projects');
+const codexDir = join(work, 'codex');
+process.env.CLAUDE_PROJECTS_DIR = projectsDir;
+process.env.CODEX_SESSIONS_DIR = codexDir;
+process.env.JUNIE_SESSIONS_DIR = join(work, 'junie-empty');
+process.env.PI_SESSIONS_DIR = join(work, 'pi-empty');
+process.env.OPENCODE_DATA_DIR = join(work, 'opencode-empty');
+process.env.COPILOT_SESSIONS_DIR = join(work, 'copilot-empty');
+process.env.DUCKDB_PATH = join(work, 'index.duckdb');
+process.env.CLAUDESCOPE_HOME = join(work, 'home');
+process.env.REINDEX_INTERVAL_MS = '0';
+
+const jsonl = (events: unknown[]): string => events.map((e) => JSON.stringify(e)).join('\n') + '\n';
+
+let getConnection: typeof import('../src/db/duckdb.js').getConnection;
+let queryRows: typeof import('../src/db/duckdb.js').queryRows;
+let closeConnection: typeof import('../src/db/duckdb.js').closeConnection;
+
+beforeAll(async () => {
+  // Claude Code: one assistant message with two tool_use blocks (Edit, Bash).
+  const projA = join(projectsDir, 'enc-projA');
+  mkdirSync(projA, { recursive: true });
+  const base = { sessionId: 'sessA', cwd: '/tmp/projA', gitBranch: 'main', version: '2.1.0' };
+  writeFileSync(
+    join(projA, 'sessA.jsonl'),
+    jsonl([
+      { ...base, type: 'user', uuid: 'u1', parentUuid: null, timestamp: '2026-01-01T10:00:00.000Z', isSidechain: false, message: { role: 'user', content: 'go' } },
+      { ...base, type: 'assistant', uuid: 'a1', parentUuid: 'u1', timestamp: '2026-01-01T10:00:05.000Z', isSidechain: false, message: { role: 'assistant', model: 'claude-opus-4-8', id: 'm1', content: [{ type: 'tool_use', id: 't1', name: 'Edit', input: {} }, { type: 'tool_use', id: 't2', name: 'Bash', input: {} }], usage: { input_tokens: 10, output_tokens: 5 } } },
+    ]),
+  );
+
+  // Codex: a function_call that canonicalizes to Bash (shell), to prove cross-connector flow.
+  mkdirSync(codexDir, { recursive: true });
+  writeFileSync(
+    join(codexDir, 'rollout-2026-01-01T10-00-00-019db3da-f840-7142-a548-5bd30f5fe572.jsonl'),
+    jsonl([
+      { type: 'session_meta', timestamp: '2026-01-01T10:00:00.000Z', payload: { id: 'codex-sess-1', cwd: '/tmp/codexproj', cli_version: '0.122.0', model_provider: 'openai', git: { branch: 'main' } } },
+      { type: 'turn_context', timestamp: '2026-01-01T10:00:01.000Z', payload: { model: 'gpt-5.4', cwd: '/tmp/codexproj' } },
+      { type: 'response_item', timestamp: '2026-01-01T10:00:02.000Z', payload: { type: 'message', role: 'user', content: [{ type: 'input_text', text: 'go' }] } },
+      { type: 'response_item', timestamp: '2026-01-01T10:00:03.000Z', payload: { type: 'function_call', name: 'shell', arguments: '{"command":["ls"]}', call_id: 'c1' } },
+      { type: 'response_item', timestamp: '2026-01-01T10:00:04.000Z', payload: { type: 'function_call_output', call_id: 'c1', output: 'x' } },
+      { type: 'event_msg', timestamp: '2026-01-01T10:00:05.000Z', payload: { type: 'token_count', info: { last_token_usage: { input_tokens: 10, cached_input_tokens: 0, output_tokens: 5, reasoning_output_tokens: 0, total_tokens: 15 } }, rate_limits: {} } },
+    ]),
+  );
+
+  ({ getConnection, queryRows, closeConnection } = await import('../src/db/duckdb.js'));
+  const { reindex } = await import('../src/data/index.js');
+  await reindex();
+});
+
+afterAll(async () => {
+  await closeConnection?.();
+  rmSync(work, { recursive: true, force: true });
+});
+
+describe('tool_names indexing', () => {
+  it('captures multiple canonical tool names per Claude Code event', async () => {
+    const conn = await getConnection();
+    const rows = await queryRows(conn, "SELECT tool_names FROM events WHERE uuid = 'a1'");
+    expect(rows[0]?.tool_names).toBe('Edit,Bash');
+  });
+
+  it('captures canonicalized tool names from the Codex connector', async () => {
+    const conn = await getConnection();
+    // Codex `shell` function_call canonicalizes to Bash.
+    const rows = await queryRows(
+      conn,
+      "SELECT tool_names FROM events WHERE type='assistant' AND tool_names <> '' AND session_id LIKE 'codex-%'",
+    );
+    expect(rows.map((r) => r.tool_names)).toContain('Bash');
+  });
+
+  it('leaves tool_names empty for non-tool events', async () => {
+    const conn = await getConnection();
+    const rows = await queryRows(conn, "SELECT tool_names FROM events WHERE uuid = 'u1'");
+    expect(rows[0]?.tool_names).toBe('');
+  });
+});

--- a/packages/server/test/tool-names.test.ts
+++ b/packages/server/test/tool-names.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest';
+import { toolNamesCsv } from '../src/connectors/tool-names.js';
+
+describe('toolNamesCsv', () => {
+  it('joins tool_use names in order', () => {
+    const blocks = [
+      { type: 'text', text: 'hi' },
+      { type: 'tool_use', name: 'Edit' },
+      { type: 'tool_use', name: 'Bash' },
+    ];
+    expect(toolNamesCsv(blocks)).toBe('Edit,Bash');
+  });
+  it('returns empty string when there are no tool_use blocks', () => {
+    expect(toolNamesCsv([{ type: 'text' }])).toBe('');
+    expect(toolNamesCsv([])).toBe('');
+  });
+  it('skips tool_use blocks with a missing/empty name', () => {
+    const blocks = [{ type: 'tool_use', name: '' }, { type: 'tool_use' }, { type: 'tool_use', name: 'Read' }];
+    expect(toolNamesCsv(blocks)).toBe('Read');
+  });
+});

--- a/packages/shared/src/api.ts
+++ b/packages/shared/src/api.ts
@@ -454,3 +454,40 @@ export interface MemoryResponse {
 
 /** GET /api/projects/:projectId/memory */
 export type ProjectMemoryResponse = ProjectMemory;
+
+// ---------------------------------------------------------------------------
+// Analytics — activity heatmap and tool usage
+// ---------------------------------------------------------------------------
+
+/** One cell of the activity punchcard: prompts in (local) day-of-week × hour. */
+export interface ActivityCell {
+  /** ISO day of week: 1 = Monday … 7 = Sunday. */
+  dow: number;
+  /** Local hour, 0–23. */
+  hour: number;
+  count: number;
+}
+
+/** All-time prompt streak (consecutive local calendar days with ≥1 user prompt). */
+export interface StreakInfo {
+  current: number;
+  longest: number;
+  lastActiveDay: string | null;
+}
+
+/** GET /api/analytics/activity */
+export interface ActivityResponse {
+  heatmap: ActivityCell[];
+  streak: StreakInfo;
+}
+
+/** One bar of the tool-usage breakdown (raw, pre-categorization, name). */
+export interface ToolUsageRow {
+  tool: string;
+  count: number;
+}
+
+/** GET /api/analytics/tools */
+export interface ToolUsageResponse {
+  rows: ToolUsageRow[];
+}

--- a/packages/shared/src/api.ts
+++ b/packages/shared/src/api.ts
@@ -481,9 +481,12 @@ export interface ActivityResponse {
   streak: StreakInfo;
 }
 
-/** One bar of the tool-usage breakdown (raw, pre-categorization, name). */
+/** One bar of the tool-usage breakdown: a raw (pre-categorization) tool name,
+ *  attributed to the agent that emitted it. */
 export interface ToolUsageRow {
   tool: string;
+  /** Connector id of the agent that made the calls (e.g. 'claude-code', 'codex'). */
+  agent: string;
   count: number;
 }
 

--- a/packages/shared/src/categories.ts
+++ b/packages/shared/src/categories.ts
@@ -1,0 +1,30 @@
+/** A normalized tool category for cross-agent comparison. Mapping is maintained
+ *  here (not in the index), so the taxonomy can evolve without re-indexing. */
+export type ToolCategory =
+  | 'Edit'
+  | 'Read'
+  | 'Search'
+  | 'Shell'
+  | 'Web'
+  | 'Subagent'
+  | 'Other';
+
+const EDIT = new Set(['edit', 'write', 'multiedit', 'notebookedit', 'apply_patch', 'str_replace', 'str_replace_editor', 'create_file']);
+const READ = new Set(['read', 'view', 'read_file']);
+const SEARCH = new Set(['grep', 'glob', 'search', 'codebase_search', 'file_search', 'find', 'list_dir', 'ls']);
+const SHELL = new Set(['bash', 'shell', 'exec_command', 'run_terminal_cmd', 'terminal', 'execute_command']);
+const WEB = new Set(['webfetch', 'websearch', 'web_search', 'fetch', 'browser']);
+const SUBAGENT = new Set(['task', 'agent', 'subagent', 'dispatch_agent']);
+
+/** Map a raw (already connector-canonicalized) tool name to a category. */
+export function toolCategory(name: string): ToolCategory {
+  const n = name.trim().toLowerCase();
+  if (n === '') return 'Other';
+  if (EDIT.has(n)) return 'Edit';
+  if (READ.has(n)) return 'Read';
+  if (SEARCH.has(n)) return 'Search';
+  if (SHELL.has(n)) return 'Shell';
+  if (WEB.has(n)) return 'Web';
+  if (SUBAGENT.has(n)) return 'Subagent';
+  return 'Other';
+}

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -4,3 +4,4 @@ export * from './events.js';
 export * from './thread.js';
 export * from './api.js';
 export * from './pricing.js';
+export * from './categories.js';

--- a/packages/shared/test/categories.test.ts
+++ b/packages/shared/test/categories.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest';
+import { toolCategory } from '../src/categories.js';
+
+describe('toolCategory', () => {
+  it('maps canonical file ops to Edit', () => {
+    for (const n of ['Edit', 'Write', 'MultiEdit', 'apply_patch']) {
+      expect(toolCategory(n)).toBe('Edit');
+    }
+  });
+  it('maps reads, searches, shells, web, subagents', () => {
+    expect(toolCategory('Read')).toBe('Read');
+    expect(toolCategory('Grep')).toBe('Search');
+    expect(toolCategory('Glob')).toBe('Search');
+    expect(toolCategory('Bash')).toBe('Shell');
+    expect(toolCategory('shell')).toBe('Shell'); // codex raw name
+    expect(toolCategory('WebFetch')).toBe('Web');
+    expect(toolCategory('Task')).toBe('Subagent');
+  });
+  it('is case-insensitive and trims', () => {
+    expect(toolCategory('  bash ')).toBe('Shell');
+  });
+  it('falls back to Other for unknown / empty / mcp names', () => {
+    expect(toolCategory('TodoWrite')).toBe('Other');
+    expect(toolCategory('mcp__foo__bar')).toBe('Other');
+    expect(toolCategory('')).toBe('Other');
+  });
+});

--- a/packages/web/src/api/client.ts
+++ b/packages/web/src/api/client.ts
@@ -5,6 +5,7 @@
  */
 
 import type {
+  ActivityResponse,
   AnalyticsGroupBy,
   AnalyticsResponse,
   HealthResponse,
@@ -22,6 +23,7 @@ import type {
   SessionSort,
   SessionsResponse,
   SourcesResponse,
+  ToolUsageResponse,
 } from '@claudescope/shared';
 
 /** Thrown when an `/api/*` response is not 2xx. Carries the HTTP status. */
@@ -148,6 +150,22 @@ export const api = {
       `/analytics${qs({ groupBy: params.groupBy, from: params.from, to: params.to })}`,
       { signal },
     );
+  },
+
+  /** GET /api/analytics/activity?from=&to=&tzOffsetMinutes=&today= */
+  analyticsActivity(
+    params: { from?: string; to?: string; tzOffsetMinutes: number; today: string },
+    signal?: AbortSignal,
+  ): Promise<ActivityResponse> {
+    return request<ActivityResponse>(
+      `/analytics/activity${qs({ from: params.from, to: params.to, tzOffsetMinutes: params.tzOffsetMinutes, today: params.today })}`,
+      { signal },
+    );
+  },
+
+  /** GET /api/analytics/tools?from=&to= */
+  analyticsTools(params: { from?: string; to?: string }, signal?: AbortSignal): Promise<ToolUsageResponse> {
+    return request<ToolUsageResponse>(`/analytics/tools${qs({ from: params.from, to: params.to })}`, { signal });
   },
 
   /** GET /api/analytics/sessions?from=&to=&sort=&dir=&limit=&minResponses= */

--- a/packages/web/src/pages/analytics/ActivityHeatmap.tsx
+++ b/packages/web/src/pages/analytics/ActivityHeatmap.tsx
@@ -1,0 +1,60 @@
+import type { ActivityResponse } from '@claudescope/shared';
+
+const DOW_LABELS = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun']; // isodow 1..7
+const HOURS = Array.from({ length: 24 }, (_, h) => h);
+
+/** GitHub-punchcard heatmap of user prompts by local day-of-week × hour, plus
+ *  a current/longest streak readout. Intensity uses the accent color mixed with
+ *  the surface, so it tracks the active theme. */
+export function ActivityHeatmap({ data }: { data: ActivityResponse }) {
+  // index: dow(1..7) -> hour(0..23) -> count
+  const counts = new Map<string, number>();
+  let max = 0;
+  for (const c of data.heatmap) {
+    counts.set(`${c.dow}:${c.hour}`, c.count);
+    if (c.count > max) max = c.count;
+  }
+  const cellBg = (count: number): string => {
+    if (count <= 0) return 'var(--tv-bg-inset)';
+    const pct = Math.round(15 + 85 * (max > 0 ? count / max : 0));
+    return `color-mix(in srgb, var(--tv-accent) ${pct}%, transparent)`;
+  };
+
+  return (
+    <div className="tv-heatmap">
+      <div className="tv-heatmap__streaks">
+        <span className="tv-heatmap__streak">🔥 {data.streak.current}-day streak</span>
+        <span className="tv-heatmap__streak-sub">longest {data.streak.longest}</span>
+      </div>
+      <div className="tv-heatmap__grid" role="img" aria-label="Activity by day and hour">
+        {DOW_LABELS.map((label, i) => {
+          const dow = i + 1;
+          return (
+            <div className="tv-heatmap__row" key={dow}>
+              <span className="tv-heatmap__rowlabel">{label}</span>
+              {HOURS.map((hour) => {
+                const count = counts.get(`${dow}:${hour}`) ?? 0;
+                return (
+                  <span
+                    key={hour}
+                    className="tv-heatmap__cell"
+                    style={{ backgroundColor: cellBg(count) }}
+                    title={`${label} ${String(hour).padStart(2, '0')}:00 — ${count} prompt${count === 1 ? '' : 's'}`}
+                  />
+                );
+              })}
+            </div>
+          );
+        })}
+        <div className="tv-heatmap__hours">
+          <span className="tv-heatmap__rowlabel" />
+          {HOURS.map((h) => (
+            <span className="tv-heatmap__hourlabel" key={h}>
+              {h % 6 === 0 ? h : ''}
+            </span>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/packages/web/src/pages/analytics/AnalyticsPage.tsx
+++ b/packages/web/src/pages/analytics/AnalyticsPage.tsx
@@ -24,11 +24,13 @@ import type {
   SessionEfficiencyResponse,
   SessionEfficiencySort,
   SortDir,
+  ToolUsageResponse,
 } from '@claudescope/shared';
 import { api } from '../../api/client.js';
 import { ErrorBox, Spinner } from '../../components/index.js';
 import { ActivityHeatmap } from './ActivityHeatmap.js';
 import { BreakdownChart } from './BreakdownChart.js';
+import { ToolUsageChart } from './ToolUsageChart.js';
 import type { BreakdownMetric, BreakdownSort } from './BreakdownChart.js';
 import { TimeSeriesChart } from './TimeSeriesChart.js';
 import { formatCount, formatCost, formatPct } from './format.js';
@@ -91,6 +93,7 @@ export function AnalyticsPage() {
   // trend chart is available regardless of the selected breakdown dimension.
   const [series, setSeries] = useState<QueryState>(INITIAL);
   const [activity, setActivity] = useState<{ data: ActivityResponse | null; loading: boolean; error: unknown }>({ data: null, loading: true, error: null });
+  const [tools, setTools] = useState<{ data: ToolUsageResponse | null; loading: boolean; error: unknown }>({ data: null, loading: true, error: null });
 
   // Convert the date inputs (YYYY-MM-DD, local) into inclusive ISO bounds.
   const range = useMemo(() => {
@@ -156,6 +159,19 @@ export function AnalyticsPage() {
       .catch((error) => {
         if (ctrl.signal.aborted) return;
         setActivity({ data: null, loading: false, error });
+      });
+    return () => ctrl.abort();
+  }, [range.from, range.to]);
+
+  useEffect(() => {
+    const ctrl = new AbortController();
+    setTools((s) => ({ ...s, loading: true }));
+    api
+      .analyticsTools({ from: range.from, to: range.to }, ctrl.signal)
+      .then((data) => setTools({ data, loading: false, error: null }))
+      .catch((error) => {
+        if (ctrl.signal.aborted) return;
+        setTools({ data: null, loading: false, error });
       });
     return () => ctrl.abort();
   }, [range.from, range.to]);
@@ -331,6 +347,15 @@ export function AnalyticsPage() {
               empty={!activity.data || activity.data.heatmap.length === 0}
             >
               {activity.data && <ActivityHeatmap data={activity.data} />}
+            </ChartCard>
+
+            <ChartCard
+              title="Tool usage"
+              hint="calls by category"
+              loading={tools.loading}
+              empty={!tools.data || tools.data.rows.length === 0}
+            >
+              {tools.data && <ToolUsageChart rows={tools.data.rows} />}
             </ChartCard>
 
             <ChartCard

--- a/packages/web/src/pages/analytics/AnalyticsPage.tsx
+++ b/packages/web/src/pages/analytics/AnalyticsPage.tsx
@@ -68,7 +68,7 @@ export function AnalyticsPage() {
   const [to, setTo] = useState('');
   // Cache tokens dwarf input/output and clutter the charts — hidden by default.
   const [showCache, setShowCache] = useState(false);
-  const [view, setView] = useState<'overview' | 'sessions'>('overview');
+  const [view, setView] = useState<'overview' | 'sessions' | 'activity'>('overview');
   const [effSort, setEffSort] = useState<SessionEfficiencySort>('cost');
   const [effDir, setEffDir] = useState<SortDir>('desc');
   const [eff, setEff] = useState<{
@@ -227,6 +227,14 @@ export function AnalyticsPage() {
             >
               Session efficiency
             </button>
+            <button
+              type="button"
+              className={view === 'activity' ? 'tv-segmented__btn is-active' : 'tv-segmented__btn'}
+              aria-pressed={view === 'activity'}
+              onClick={() => setView('activity')}
+            >
+              Activity
+            </button>
           </div>
         </div>
 
@@ -290,16 +298,18 @@ export function AnalyticsPage() {
           </button>
         )}
 
-        <label className="tv-analytics__toggle">
-          <input
-            type="checkbox"
-            className="tv-switch__input"
-            checked={showCache}
-            onChange={(e) => setShowCache(e.target.checked)}
-          />
-          <span className="tv-switch" aria-hidden="true" />
-          Show cache
-        </label>
+        {view !== 'activity' && (
+          <label className="tv-analytics__toggle">
+            <input
+              type="checkbox"
+              className="tv-switch__input"
+              checked={showCache}
+              onChange={(e) => setShowCache(e.target.checked)}
+            />
+            <span className="tv-switch" aria-hidden="true" />
+            Show cache
+          </label>
+        )}
       </div>
 
       {view === 'sessions' ? (
@@ -324,6 +334,26 @@ export function AnalyticsPage() {
             showCache={showCache}
           />
         )
+      ) : view === 'activity' ? (
+        <div className="tv-analytics__charts">
+          <ChartCard
+            title="Activity"
+            hint="user prompts, your local time"
+            loading={activity.loading}
+            empty={!activity.data || activity.data.heatmap.length === 0}
+          >
+            {activity.data && <ActivityHeatmap data={activity.data} />}
+          </ChartCard>
+
+          <ChartCard
+            title="Tool usage"
+            hint="calls by category"
+            loading={tools.loading}
+            empty={!tools.data || tools.data.rows.length === 0}
+          >
+            {tools.data && <ToolUsageChart rows={tools.data.rows} />}
+          </ChartCard>
+        </div>
       ) : error ? (
         <ErrorBox error={error} title="Failed to load analytics" onRetry={load} />
       ) : (
@@ -338,24 +368,6 @@ export function AnalyticsPage() {
               empty={!series.data || series.data.rows.length === 0}
             >
               {series.data && <TimeSeriesChart rows={series.data.rows} showCache={showCache} />}
-            </ChartCard>
-
-            <ChartCard
-              title="Activity"
-              hint="user prompts, your local time"
-              loading={activity.loading}
-              empty={!activity.data || activity.data.heatmap.length === 0}
-            >
-              {activity.data && <ActivityHeatmap data={activity.data} />}
-            </ChartCard>
-
-            <ChartCard
-              title="Tool usage"
-              hint="calls by category"
-              loading={tools.loading}
-              empty={!tools.data || tools.data.rows.length === 0}
-            >
-              {tools.data && <ToolUsageChart rows={tools.data.rows} />}
             </ChartCard>
 
             <ChartCard

--- a/packages/web/src/pages/analytics/AnalyticsPage.tsx
+++ b/packages/web/src/pages/analytics/AnalyticsPage.tsx
@@ -16,6 +16,7 @@
 import type { ReactNode } from 'react';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import type {
+  ActivityResponse,
   AnalyticsGroupBy,
   AnalyticsResponse,
   AnalyticsTotals,
@@ -26,6 +27,7 @@ import type {
 } from '@claudescope/shared';
 import { api } from '../../api/client.js';
 import { ErrorBox, Spinner } from '../../components/index.js';
+import { ActivityHeatmap } from './ActivityHeatmap.js';
 import { BreakdownChart } from './BreakdownChart.js';
 import type { BreakdownMetric, BreakdownSort } from './BreakdownChart.js';
 import { TimeSeriesChart } from './TimeSeriesChart.js';
@@ -88,6 +90,7 @@ export function AnalyticsPage() {
   // The time series is always grouped by day (independent of the toggle) so the
   // trend chart is available regardless of the selected breakdown dimension.
   const [series, setSeries] = useState<QueryState>(INITIAL);
+  const [activity, setActivity] = useState<{ data: ActivityResponse | null; loading: boolean; error: unknown }>({ data: null, loading: true, error: null });
 
   // Convert the date inputs (YYYY-MM-DD, local) into inclusive ISO bounds.
   const range = useMemo(() => {
@@ -138,6 +141,24 @@ export function AnalyticsPage() {
       });
     return () => ctrl.abort();
   }, [view, range.from, range.to, effSort, effDir, effRetry]);
+
+  useEffect(() => {
+    const ctrl = new AbortController();
+    const tzOffsetMinutes = -new Date().getTimezoneOffset(); // east-of-UTC positive
+    const today = (() => {
+      const d = new Date();
+      return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`;
+    })();
+    setActivity((s) => ({ ...s, loading: true }));
+    api
+      .analyticsActivity({ from: range.from, to: range.to, tzOffsetMinutes, today }, ctrl.signal)
+      .then((data) => setActivity({ data, loading: false, error: null }))
+      .catch((error) => {
+        if (ctrl.signal.aborted) return;
+        setActivity({ data: null, loading: false, error });
+      });
+    return () => ctrl.abort();
+  }, [range.from, range.to]);
 
   // Header click: re-clicking the active column flips direction; a new column
   // starts at descending (largest first).
@@ -301,6 +322,15 @@ export function AnalyticsPage() {
               empty={!series.data || series.data.rows.length === 0}
             >
               {series.data && <TimeSeriesChart rows={series.data.rows} showCache={showCache} />}
+            </ChartCard>
+
+            <ChartCard
+              title="Activity"
+              hint="user prompts, your local time"
+              loading={activity.loading}
+              empty={!activity.data || activity.data.heatmap.length === 0}
+            >
+              {activity.data && <ActivityHeatmap data={activity.data} />}
             </ChartCard>
 
             <ChartCard

--- a/packages/web/src/pages/analytics/ToolUsageChart.tsx
+++ b/packages/web/src/pages/analytics/ToolUsageChart.tsx
@@ -1,0 +1,73 @@
+import { Bar, BarChart, CartesianGrid, Cell, ResponsiveContainer, Tooltip, XAxis, YAxis } from 'recharts';
+import type { ToolUsageRow } from '@claudescope/shared';
+import { type ToolCategory, toolCategory } from '@claudescope/shared';
+import { useTheme } from '../../theme/ThemeProvider.js';
+import { axisTick, type ChartColors, getChartColors, TooltipCard } from './chart-common.js';
+import { formatCount } from './format.js';
+
+interface Bucket {
+  key: ToolCategory;
+  count: number;
+  /** Raw tools (name + count) that fell into this category, for the tooltip. */
+  tools: { tool: string; count: number }[];
+}
+
+const CATEGORY_COLOR = (c: ChartColors): Record<ToolCategory, string> => ({
+  Edit: c.output,
+  Read: c.input,
+  Search: c.cacheRead,
+  Shell: c.cost,
+  Web: c.cacheWrite,
+  Subagent: c.output,
+  Other: c.axis,
+});
+
+function bucketize(rows: ToolUsageRow[]): Bucket[] {
+  const map = new Map<ToolCategory, Bucket>();
+  for (const r of rows) {
+    const key = toolCategory(r.tool);
+    const b = map.get(key) ?? { key, count: 0, tools: [] };
+    b.count += r.count;
+    b.tools.push({ tool: r.tool, count: r.count });
+    map.set(key, b);
+  }
+  return [...map.values()].sort((a, b) => b.count - a.count);
+}
+
+export function ToolUsageChart({ rows }: { rows: ToolUsageRow[] }) {
+  const { resolvedTheme } = useTheme();
+  const colors = getChartColors(resolvedTheme);
+  const palette = CATEGORY_COLOR(colors);
+  const data = bucketize(rows);
+  const tick = axisTick(colors);
+  const height = Math.max(140, data.length * 34 + 24);
+
+  return (
+    <ResponsiveContainer width="100%" height={height}>
+      <BarChart layout="vertical" data={data} margin={{ top: 8, right: 24, left: 8, bottom: 8 }}>
+        <CartesianGrid stroke={colors.grid} horizontal={false} />
+        <XAxis type="number" tick={tick} tickLine={false} axisLine={{ stroke: colors.grid }} tickFormatter={(v: number) => formatCount(v)} />
+        <YAxis type="category" dataKey="key" tick={tick} tickLine={false} axisLine={{ stroke: colors.grid }} width={84} interval={0} />
+        <Tooltip cursor={{ fill: colors.cursor }} content={<ToolTip palette={palette} />} />
+        <Bar dataKey="count" name="Calls" radius={[0, 2, 2, 0]} isAnimationActive={false}>
+          {data.map((b) => (
+            <Cell key={b.key} fill={palette[b.key]} />
+          ))}
+        </Bar>
+      </BarChart>
+    </ResponsiveContainer>
+  );
+}
+
+function ToolTip(props: { active?: boolean; payload?: ReadonlyArray<{ payload?: Bucket }>; palette: Record<ToolCategory, string> }) {
+  if (!props.active || !props.payload?.length) return null;
+  const b = props.payload[0]?.payload;
+  if (!b) return null;
+  const top = [...b.tools].sort((a, z) => z.count - a.count).slice(0, 6);
+  return (
+    <TooltipCard
+      title={`${b.key} — ${formatCount(b.count)} calls`}
+      rows={top.map((t) => ({ label: t.tool, value: formatCount(t.count), color: props.palette[b.key] }))}
+    />
+  );
+}

--- a/packages/web/src/pages/analytics/ToolUsageChart.tsx
+++ b/packages/web/src/pages/analytics/ToolUsageChart.tsx
@@ -4,12 +4,13 @@ import { type ToolCategory, toolCategory } from '@claudescope/shared';
 import { useTheme } from '../../theme/ThemeProvider.js';
 import { axisTick, type ChartColors, getChartColors, TooltipCard } from './chart-common.js';
 import { formatCount } from './format.js';
+import { agentLabel } from '../../components/index.js';
 
 interface Bucket {
   key: ToolCategory;
   count: number;
-  /** Raw tools (name + count) that fell into this category, for the tooltip. */
-  tools: { tool: string; count: number }[];
+  /** Raw tools (name + agent + count) that fell into this category, for the tooltip. */
+  tools: { tool: string; agent: string; count: number }[];
 }
 
 const CATEGORY_COLOR = (c: ChartColors): Record<ToolCategory, string> => ({
@@ -28,7 +29,7 @@ function bucketize(rows: ToolUsageRow[]): Bucket[] {
     const key = toolCategory(r.tool);
     const b = map.get(key) ?? { key, count: 0, tools: [] };
     b.count += r.count;
-    b.tools.push({ tool: r.tool, count: r.count });
+    b.tools.push({ tool: r.tool, agent: r.agent, count: r.count });
     map.set(key, b);
   }
   return [...map.values()].sort((a, b) => b.count - a.count);
@@ -67,7 +68,7 @@ function ToolTip(props: { active?: boolean; payload?: ReadonlyArray<{ payload?: 
   return (
     <TooltipCard
       title={`${b.key} — ${formatCount(b.count)} calls`}
-      rows={top.map((t) => ({ label: t.tool, value: formatCount(t.count), color: props.palette[b.key] }))}
+      rows={top.map((t) => ({ label: `${t.tool} · ${agentLabel(t.agent)}`, value: formatCount(t.count), color: props.palette[b.key] }))}
     />
   );
 }

--- a/packages/web/src/pages/analytics/analytics.css
+++ b/packages/web/src/pages/analytics/analytics.css
@@ -257,10 +257,10 @@
 .tv-heatmap__streaks { display: flex; align-items: baseline; gap: var(--tv-space-2); margin-bottom: var(--tv-space-3); }
 .tv-heatmap__streak { font-weight: 600; }
 .tv-heatmap__streak-sub { color: var(--tv-fg-muted); font-size: 0.85em; }
-.tv-heatmap__grid { display: flex; flex-direction: column; gap: 2px; overflow-x: auto; }
-.tv-heatmap__row, .tv-heatmap__hours { display: grid; grid-template-columns: 2.5rem repeat(24, 1fr); gap: 2px; align-items: center; }
+.tv-heatmap__grid { display: flex; flex-direction: column; gap: 3px; overflow-x: auto; width: fit-content; max-width: 100%; }
+.tv-heatmap__row, .tv-heatmap__hours { display: grid; grid-template-columns: 2.25rem repeat(24, 14px); gap: 3px; align-items: center; }
 .tv-heatmap__rowlabel { font-size: 11px; color: var(--tv-fg-muted); }
-.tv-heatmap__cell { aspect-ratio: 1 / 1; min-width: 10px; border-radius: 2px; }
+.tv-heatmap__cell { width: 14px; height: 14px; border-radius: 2px; }
 .tv-heatmap__hourlabel { font-size: 10px; color: var(--tv-fg-faint); text-align: left; }
 
 /* ---------------------------------------------------------------------------

--- a/packages/web/src/pages/analytics/analytics.css
+++ b/packages/web/src/pages/analytics/analytics.css
@@ -253,6 +253,16 @@
   color: var(--tv-fg);
 }
 
+/* Activity heatmap */
+.tv-heatmap__streaks { display: flex; align-items: baseline; gap: var(--tv-space-2); margin-bottom: var(--tv-space-3); }
+.tv-heatmap__streak { font-weight: 600; }
+.tv-heatmap__streak-sub { color: var(--tv-fg-muted); font-size: 0.85em; }
+.tv-heatmap__grid { display: flex; flex-direction: column; gap: 2px; overflow-x: auto; }
+.tv-heatmap__row, .tv-heatmap__hours { display: grid; grid-template-columns: 2.5rem repeat(24, 1fr); gap: 2px; align-items: center; }
+.tv-heatmap__rowlabel { font-size: 11px; color: var(--tv-fg-muted); }
+.tv-heatmap__cell { aspect-ratio: 1 / 1; min-width: 10px; border-radius: 2px; }
+.tv-heatmap__hourlabel { font-size: 10px; color: var(--tv-fg-faint); text-align: left; }
+
 /* ---------------------------------------------------------------------------
    Session efficiency view — cost + efficiency ratios table.
    Numeric alignment is set ONLY via .tv-eff__num (never a blanket td rule),


### PR DESCRIPTION
Adds two deterministic, local, read-only additions to the **Analyze** tab, plus
the index plumbing they need. Plan: `docs/plans/0030-analyze-activity-heatmap-tool-usage.md`.

## What's new

A dedicated **Activity** view (third segment beside *Overview* / *Session efficiency*) holding:

- **Activity heatmap + streaks** — a GitHub-punchcard of *user prompts* by local
  day-of-week × hour (compact fixed-size cells), plus current/longest streak.
  Counts **genuine human prompts only** — excludes sidechain (subagent) turns and
  fork-copied rows, so it isn't inflated by subagent chatter or resumed sessions.
- **Tool-usage breakdown** — tool calls bucketed into normalized categories
  (Edit / Read / Search / Shell / Web / Subagent / Other), **attributed by agent**
  in the tooltip (e.g. `Edit · Claude Code`, `apply_patch · opencode`).

## How it works

- New `events.tool_names` column (comma-joined canonical tool names), populated at
  index time across **all six connectors**. Guarded by a `SCHEMA_VERSION` 7→8 bump
  — the derived-cache index discards and rebuilds automatically.
- Two endpoints: `GET /api/analytics/activity` (local-time bucketing via a
  client-sent UTC offset — no ICU dependency) and `GET /api/analytics/tools`
  (unnests `tool_names`, grouped by tool + agent).
- Tool/usage counts dedup by billed API call (`usage_canonical`), consistent with
  the cost and session-efficiency numbers.

## Testing

`npm test` (269 passing) + `npm run typecheck` + `npm run build`, all green.
New tests cover the tool taxonomy, per-connector `tool_names` extraction, streak
math, local-time bucketing, and the `usage_canonical` dedup guard (heatmap + tools).
