### PR TITLE
fix: address code-review findings in Antigravity connector

### DIFF
--- a/docs/plans/0031-antigravity-connector.md
+++ b/docs/plans/0031-antigravity-connector.md
@@ -113,3 +113,26 @@ New `packages/server/src/connectors/antigravity/`: `antigravity.ts`, `normalize.
   appears.
 - **Cost permanently unavailable** unless a validated token source appears (would need
   live `/usage` ground truth vs. the `gen_metadata` protobuf — a separate spike).
+
+## Post-merge review fixes (xhigh code review)
+
+A follow-up PR addresses correctness findings from the xhigh review of #42:
+
+- **Fixed** — subagent linkage now pairs prompts↔child-ids by interleaved order and
+  only reads `sender=` on `SYSTEM_MESSAGE` / "Conversation ID:" on `PLANNER_RESPONSE`
+  (a relayed summary can't inflate the pairing); re-parented children fold the root
+  transcript's mtime into their change-detection key so a parent gaining the link
+  re-indexes the child (no stale orphan session); conv-ids compared raw throughout
+  (multi-level nesting no longer breaks on case); orphan write results no longer
+  synthesize a blank canonical `Write`; `step_index` sort keeps step-less lines in
+  file order; `loadSession` promotes a lone subagent to the main thread if the parent
+  file is gone; `view_file`/`Bash` args use first-non-empty (not `??`) so a blank
+  `AbsolutePath` falls through; `/api/sources` keys on the first existing surface so a
+  desktop-only install still lists its source; pending tool-calls reset at each user
+  turn to bound the (id-less) result-correlation window.
+- **Deferred** (need a real sample or are inherent) — the model is only recorded when
+  the user changes it mid-session (no local default-model source); failed/denied
+  tool calls aren't gated to `is_error` / kept out of Files-changed (no failed-tool
+  sample yet); an edit tool (`replace_file_content`→`Edit`/`MultiEdit`) isn't mapped
+  until its shape is observed; id-less tool-result correlation stays best-effort; the
+  image helper is intentionally not shared with Copilot (avoid touching that connector).

--- a/packages/server/src/config.ts
+++ b/packages/server/src/config.ts
@@ -107,6 +107,15 @@ export const ANTIGRAVITY_DESKTOP_DIR = expandHome(
 );
 /** Every Antigravity appDataDir the connector scans (both surfaces). */
 export const ANTIGRAVITY_DIRS = [ANTIGRAVITY_CLI_DIR, ANTIGRAVITY_DESKTOP_DIR];
+/**
+ * The Antigravity source dir reported to `/api/sources` — the first surface that
+ * exists (CLI or desktop). `discover()` scans both, so keying the sources footer
+ * on the CLI dir alone would hide the source for a desktop-only install.
+ */
+export const ANTIGRAVITY_SOURCE_DIR = firstExisting(
+  [ANTIGRAVITY_CLI_DIR, ANTIGRAVITY_DESKTOP_DIR],
+  ANTIGRAVITY_CLI_DIR,
+);
 
 /**
  * READ-ONLY agent home directories — the parents of the session/project dirs

--- a/packages/server/src/connectors/antigravity/antigravity.ts
+++ b/packages/server/src/connectors/antigravity/antigravity.ts
@@ -23,13 +23,15 @@ import { createHash } from 'node:crypto';
 import { existsSync, mkdirSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import type { MemorySource, RawEvent } from '@claudescope/shared';
-import { ANTIGRAVITY_CLI_DIR, ANTIGRAVITY_DIRS, CLAUDESCOPE_HOME } from '../../config.js';
+import { ANTIGRAVITY_DIRS, ANTIGRAVITY_SOURCE_DIR, CLAUDESCOPE_HOME } from '../../config.js';
 import { sqlString } from '../../db/duckdb.js';
 import type { SessionData, SubagentSource } from '../../data/session-loader.js';
 import type { AgentConnector, AuxProjections, DiscoveredFile } from '../types.js';
 import {
+  getContext,
   listTranscripts,
   parseAntigravitySession,
+  rootConvId,
   subagentMetaFor,
   toCanonicalRows,
 } from './normalize.js';
@@ -47,8 +49,22 @@ function cachePath(filePath: string): string {
 function discover(): DiscoveredFile[] {
   const out: DiscoveredFile[] = [];
   for (const dir of ANTIGRAVITY_DIRS) {
-    for (const t of listTranscripts(dir)) {
-      out.push({ path: t.path, mtimeMs: t.mtimeMs, size: t.size });
+    const transcripts = listTranscripts(dir);
+    if (transcripts.length === 0) continue;
+    const { subagents } = getContext(dir);
+    const mtimeByConv = new Map(transcripts.map((t) => [t.convId, t.mtimeMs]));
+    for (const t of transcripts) {
+      // A subagent is re-parented under its root conversation at prepare time
+      // using the cross-file linkage map. Fold the root transcript's mtime into
+      // the child's change-detection key, so when the parent gains (or loses) the
+      // link, the indexer re-processes the child instead of leaving a stale
+      // session_id behind (the child's own bytes never change once it finishes).
+      let mtimeMs = t.mtimeMs;
+      if (subagents.has(t.convId)) {
+        const rootMtime = mtimeByConv.get(rootConvId(t.convId, subagents));
+        if (rootMtime !== undefined) mtimeMs = Math.max(mtimeMs, rootMtime);
+      }
+      out.push({ path: t.path, mtimeMs, size: t.size });
     }
   }
   return out;
@@ -106,6 +122,12 @@ async function loadSession(sessionId: string, paths: string[]): Promise<SessionD
       });
     }
   }
+  // Fallback: a session whose main transcript is missing (e.g. the parent file was
+  // deleted while a re-parented subagent still resolves under its id) would render
+  // an empty main thread. Promote the subagents to the main thread so it shows.
+  if (mainEvents.length === 0 && subagents.length > 0) {
+    return { mainEvents: subagents.flatMap((s) => s.events), subagents: [] };
+  }
   return { mainEvents, subagents };
 }
 
@@ -116,7 +138,7 @@ function globalMemory(): MemorySource[] {
 export const antigravityConnector: AgentConnector = {
   id: 'antigravity',
   label: 'Antigravity',
-  sourceDir: ANTIGRAVITY_CLI_DIR,
+  sourceDir: ANTIGRAVITY_SOURCE_DIR,
   discover,
   prepare,
   eventsProjectionSql,

--- a/packages/server/src/connectors/antigravity/normalize.ts
+++ b/packages/server/src/connectors/antigravity/normalize.ts
@@ -41,9 +41,16 @@ import type {
 import { toolNamesCsv } from '../tool-names.js';
 
 const str = (v: unknown): string => (typeof v === 'string' ? v : '');
-const num = (v: unknown): number => (typeof v === 'number' && Number.isFinite(v) ? v : 0);
 const rec = (v: unknown): Record<string, unknown> =>
   v && typeof v === 'object' ? (v as Record<string, unknown>) : {};
+/** First non-empty string among the candidates (unlike `??`, skips `''`). */
+const firstStr = (...vals: unknown[]): string => {
+  for (const v of vals) {
+    const s = str(v);
+    if (s) return s;
+  }
+  return '';
+};
 
 /** Junie-style bucket for a session whose cwd can't be resolved. */
 export const ANTIGRAVITY_UNKNOWN_CWD = '(unknown — Antigravity)';
@@ -186,48 +193,45 @@ function readHistory(appDataDir: string): Map<string, string> {
 function buildSubagentMap(appDataDir: string): Map<string, SubagentLink> {
   const map = new Map<string, SubagentLink>();
   for (const t of listTranscripts(appDataDir)) {
-    const records = readRecords(t.path);
-    const spawns: { prompt: string; typeName: string }[] = [];
-    const childIds: string[] = [];
+    // Walk records in order, pairing each spawned subagent prompt with the next
+    // child conv-id this conversation produces. Child ids come ONLY from a
+    // SYSTEM_MESSAGE `sender=` (the child messaged this parent) or a
+    // PLANNER_RESPONSE "Conversation ID: <id>" announcement — we deliberately do
+    // NOT scan a SYSTEM_MESSAGE body with the id regex, since a relayed summary
+    // may quote unrelated conversation ids and inflate the pairing.
+    const pendingPrompts: { prompt: string; typeName: string }[] = [];
     const seen = new Set<string>();
-    const addChild = (id: string): void => {
-      const cid = id.toLowerCase();
-      if (cid && cid !== t.convId.toLowerCase() && !seen.has(cid)) {
-        seen.add(cid);
-        childIds.push(cid);
-      }
-    };
-    for (const r of records) {
+    for (const r of readRecords(t.path)) {
       for (const call of r.tool_calls ?? []) {
         if (str(call.name) !== 'invoke_subagent') continue;
         const subs = rec(call.args).Subagents;
         for (const s of Array.isArray(subs) ? subs : []) {
           const sr = rec(s);
-          spawns.push({ prompt: str(sr.Prompt), typeName: str(sr.TypeName) });
+          pendingPrompts.push({ prompt: str(sr.Prompt), typeName: str(sr.TypeName) });
         }
       }
       const content = str(r.content);
-      if (r.type === 'SYSTEM_MESSAGE') {
-        const m = content.match(SENDER_RE);
-        if (m?.[1]) addChild(m[1]);
-      }
-      const cm = content.match(CONV_ID_RE);
-      if (cm?.[1]) addChild(cm[1]);
-    }
-    const n = Math.min(spawns.length, childIds.length);
-    for (let k = 0; k < n; k++) {
-      const child = childIds[k];
-      const spawn = spawns[k];
-      if (child && spawn && !map.has(child)) {
-        map.set(child, { parentConvId: t.convId, prompt: spawn.prompt, typeName: spawn.typeName });
+      const childId =
+        r.type === 'SYSTEM_MESSAGE'
+          ? content.match(SENDER_RE)?.[1]
+          : r.type === 'PLANNER_RESPONSE'
+            ? content.match(CONV_ID_RE)?.[1]
+            : undefined;
+      if (!childId || childId === t.convId || seen.has(childId)) continue;
+      seen.add(childId);
+      const spawn = pendingPrompts.shift();
+      if (spawn && !map.has(childId)) {
+        map.set(childId, { parentConvId: t.convId, prompt: spawn.prompt, typeName: spawn.typeName });
       }
     }
   }
   return map;
 }
 
-/** Follow the parent chain to the top-level (non-subagent) conversation. */
-function rootConvId(convId: string, subagents: Map<string, SubagentLink>): string {
+/** Follow the parent chain to the top-level (non-subagent) conversation. Ids are
+ *  compared as raw on-disk conv-ids throughout (map keys AND parentConvId), so the
+ *  walk stays consistent for multi-level nesting. */
+export function rootConvId(convId: string, subagents: Map<string, SubagentLink>): string {
   let cur = convId;
   const guard = new Set<string>();
   while (subagents.has(cur) && !guard.has(cur)) {
@@ -273,7 +277,7 @@ export function getContext(appDataDir: string): AntigravityContext {
 
 /** Subagent metadata (agentType, matched description) for a transcript, if it's a child. */
 export function subagentMetaFor(path: string): { agentType: string; description: string } | null {
-  const link = getContext(appDataDirFromPath(path)).subagents.get(convIdFromPath(path).toLowerCase());
+  const link = getContext(appDataDirFromPath(path)).subagents.get(convIdFromPath(path));
   if (!link) return null;
   return { agentType: link.typeName, description: subagentLabel(link.prompt) };
 }
@@ -396,7 +400,7 @@ function toolUseBlocks(name: string, args: Record<string, unknown>, id: string):
           type: 'tool_use',
           id,
           name: 'Read',
-          input: { file_path: str(args.AbsolutePath ?? args.TargetFile ?? args.Path) },
+          input: { file_path: firstStr(args.AbsolutePath, args.TargetFile, args.Path) },
         },
       ];
     case 'invoke_subagent': {
@@ -422,7 +426,7 @@ function toolUseBlocks(name: string, args: Record<string, unknown>, id: string):
             type: 'tool_use',
             id,
             name: 'Bash',
-            input: { command: str(args.Command ?? args.CommandLine ?? args.command) },
+            input: { command: firstStr(args.Command, args.CommandLine, args.command) },
           },
         ];
       }
@@ -463,13 +467,17 @@ export function parseAntigravitySession(
   const convDir = convDirFromPath(filePath);
   const ctx = getContext(appDataDirFromPath(filePath));
 
-  const key = convId.toLowerCase();
-  const isSidechain = ctx.subagents.has(key);
-  const sessionId = isSidechain ? rootConvId(key, ctx.subagents) : convId;
+  const isSidechain = ctx.subagents.has(convId);
+  const sessionId = isSidechain ? rootConvId(convId, ctx.subagents) : convId;
   const cwd = ctx.history.get(sessionId) ?? ANTIGRAVITY_UNKNOWN_CWD;
   const resolveImages = opts.resolveImages ?? false;
 
-  const records = readRecords(filePath).sort((a, b) => num(a.step_index) - num(b.step_index));
+  // Sort by step_index, falling back to file (append) order for a record missing
+  // it — so a step-less line keeps its position instead of being hoisted to 0.
+  const records = readRecords(filePath)
+    .map((r, i) => ({ r, i }))
+    .sort((a, b) => (a.r.step_index ?? a.i) - (b.r.step_index ?? b.i))
+    .map((x) => x.r);
 
   const events: (UserEvent | AssistantEvent)[] = [];
   let seq = 0;
@@ -522,6 +530,11 @@ export function parseAntigravitySession(
     if (type === 'CHECKPOINT' || type === 'CONVERSATION_HISTORY') continue;
 
     if (type === 'USER_INPUT') {
+      // A new user turn ends any prior tool loop; drop unmatched pending calls so
+      // a later same-kind result can't attach across the turn boundary.
+      pending.read.length = 0;
+      pending.write.length = 0;
+      pending.list.length = 0;
       const mm = parseModel(content);
       if (mm) model = mm;
       const blocks: ContentBlock[] = [];
@@ -557,6 +570,11 @@ export function parseAntigravitySession(
       const id = pending[rk].shift();
       if (id) {
         emitUser(ts, [{ type: 'tool_result', tool_use_id: id, content }]);
+      } else if (rk === 'write') {
+        // Orphan write result: the written content isn't in the result record, so
+        // don't synthesize a canonical Write (it would render a blank/emptied diff
+        // in the Files-changed tab). Surface the result text instead.
+        emitAssistant(ts, [{ type: 'text', text: content }]);
       } else {
         const tid = nextToolId();
         emitAssistant(ts, [synthToolUse(rk, content, tid)]);

--- a/packages/server/test/antigravity.integration.test.ts
+++ b/packages/server/test/antigravity.integration.test.ts
@@ -164,7 +164,9 @@ function writeFixtures(): void {
     step(1, 'MODEL', 'PLANNER_RESPONSE', {
       thinking: 'Exploring the tree.',
       content: 'Found 3 projects.',
-      tool_calls: [{ name: 'view_file', args: { AbsolutePath: '/tmp/proj/a/README.md' } }],
+      // AbsolutePath is an empty string; the real path is in Path → firstStr must
+      // fall through past '' (a plain ?? would not).
+      tool_calls: [{ name: 'view_file', args: { AbsolutePath: '', Path: '/tmp/proj/a/README.md' } }],
     }),
     step(2, 'MODEL', 'VIEW_FILE', { content: 'File Path: `file:///tmp/proj/a/README.md`\n# A' }),
     step(3, 'MODEL', 'PLANNER_RESPONSE', {
@@ -180,6 +182,9 @@ function writeFixtures(): void {
   writeTranscript(ORPHAN, [
     step(0, 'USER_EXPLICIT', 'USER_INPUT', { content: '<USER_REQUEST>\nHello there\n</USER_REQUEST>' }),
     step(1, 'MODEL', 'PLANNER_RESPONSE', { content: 'Hi!' }),
+    // Orphan CODE_ACTION (no preceding write_to_file): must NOT become a canonical
+    // Write with blank content (which would render an emptied-file diff).
+    step(2, 'MODEL', 'CODE_ACTION', { content: 'Created file file:///tmp/orphan.md with requested content.' }),
   ]);
 
   // The uploaded image bytes referenced by the parent's USER_INPUT metadata.
@@ -297,6 +302,12 @@ describe('antigravity session detail', () => {
     expect(run.description).toBe('Inspect all subdirectories inside /tmp/proj.');
     expect(run.thread.length).toBeGreaterThan(0);
 
+    // Empty-string coalescing: the subagent's view_file had AbsolutePath:'' with
+    // the real path in Path → the Read must use the real path, not ''.
+    const subFlat = run.thread.flatMap((t: { blocks: Record<string, unknown>[] }) => t.blocks);
+    const subRead = subFlat.find((b: Record<string, unknown>) => b.kind === 'tool' && b.name === 'Read');
+    expect(subRead.input).toEqual({ file_path: '/tmp/proj/a/README.md' });
+
     // The run is anchored to the main-thread Task tool call spawned from invoke_subagent.
     const flat = detail.thread.flatMap((t: { blocks: Record<string, unknown>[] }) => t.blocks);
     const task = flat.find((b: Record<string, unknown>) => b.kind === 'tool' && b.name === 'Task');
@@ -330,6 +341,15 @@ describe('antigravity session detail', () => {
       type: 'image',
       source: { type: 'base64', media_type: 'image/png', data: PNG_B64 },
     });
+  });
+
+  it('does not synthesize a blank Write for an orphan write result', async () => {
+    const detail = (await get(`/api/sessions/${ORPHAN}`)).json();
+    const flat = detail.thread.flatMap((t: { blocks: Record<string, unknown>[] }) => t.blocks);
+    // The orphan CODE_ACTION must not become a canonical Write (no phantom empty diff).
+    expect(flat.some((b: Record<string, unknown>) => b.kind === 'tool' && b.name === 'Write')).toBe(false);
+    // Its content is still surfaced as text.
+    expect(JSON.stringify(detail.thread)).toContain('Created file');
   });
 
   it('renders the SYSTEM_MESSAGE subagent summary and drops truncation scaffolding', async () => {


### PR DESCRIPTION
Follow-up to #42. The xhigh code review of the Antigravity connector completed just
after #42 merged and surfaced real correctness bugs; this PR fixes the confirmed,
low-risk ones and documents what's intentionally deferred.

## Fixed
- **Subagent mis-pairing** — pair `invoke_subagent` prompts against child conv-ids by
  interleaved stream order; read child ids only from `SYSTEM_MESSAGE sender=` and
  `PLANNER_RESPONSE` "Conversation ID:" (a relayed summary quoting other ids can no
  longer inflate the pairing).
- **Stale re-parent on incremental reindex** — a re-parented subagent folds its root
  transcript's mtime into its change-detection key, so when the parent gains/loses the
  link the child is re-indexed instead of lingering as an orphan session that never
  nests.
- **Case-sensitive parent walk** — conv-ids are compared raw (map keys *and*
  `parentConvId`) so multi-level nesting doesn't break on uppercase hex.
- **Phantom blank diff** — an orphan `CODE_ACTION` (write result with no call) no longer
  synthesizes a canonical `Write` with empty content (which showed an emptied-file diff);
  its text is surfaced instead.
- **Thread reordering** — `step_index` sort falls back to file order for a step-less
  record instead of hoisting it to 0.
- **Empty main thread** — `loadSession` promotes a lone subagent to the main thread when
  the parent file is gone.
- **`??` vs empty string** — `view_file`/`Bash` args pick the first *non-empty* value, so
  a blank `AbsolutePath`/`Command` falls through to the real one.
- **Hidden desktop-only source** — `/api/sources` keys on the first existing surface
  (CLI *or* desktop), not the CLI dir alone.
- **Result-correlation window** — pending tool-calls reset at each user turn to bound the
  (id-less) FIFO correlation.

## Deferred (need a real sample, or inherent)
Default-model attribution (no local source when the user never changes model), failed/
denied-tool `is_error` gating and keeping denied writes out of Files-changed, an edit
tool (`replace_file_content`→`Edit`/`MultiEdit`) mapping, the id-less tool-result
correlation, and sharing the image helper with Copilot. See `docs/plans/0031`.

## Testing
`npm run typecheck` clean; `npm test` green (280 tests). New regression cases: orphan
write result produces no `Write`; subagent `view_file` with a blank `AbsolutePath`
resolves via `Path`.