### PR TITLE
fix: symlink-safe image resolution via shared safe-image resolver

### DIFF
--- a/docs/plans/0033-symlink-safe-image-resolution.md
+++ b/docs/plans/0033-symlink-safe-image-resolution.md
@@ -1,0 +1,76 @@
+# 0033 — Symlink-safe image resolution
+
+- **Status:** done
+- **Date:** 2026-07-02
+- **PR:** https://github.com/vladar107/claudescope/pull/44
+
+## Context
+
+A Codex security scan of the repo (2026-07-02, rev 5306b37) validated two
+medium-severity findings with runtime PoCs through the real Fastify routes:
+the Copilot saved-attachment resolver (`connectors/copilot/normalize.ts`) and
+the Antigravity uploaded-media resolver (`connectors/antigravity/normalize.ts`)
+contain paths with `basename()` only, but `statSync`/`readFileSync` follow
+symlinks — a symlink planted inside a session/conversation dir exfiltrates
+arbitrary readable local files into the session-detail API response as base64.
+
+For the localhost single-user threat model the marginal risk is low (an
+attacker who can write to `~/.copilot`/`~/.gemini` already has the user's
+account), but the primitive is real, the fix is small, and the Junie connector
+already implements the correct realpath-containment pattern — this is an
+inconsistency, not a new policy. The scan's third, deferred item (large-input
+DoS) is dismissed per the threat model: single-user localhost.
+
+## Goal
+
+No image resolver in any connector follows a symlink outside its trusted root.
+One shared helper owns the containment logic; Junie/Copilot/Antigravity all use
+it.
+
+## Decisions
+
+- **Shared helper `connectors/safe-image.ts`** (sibling of `tool-names.ts`) —
+  the three per-connector resolvers duplicate the mime map and size cap and
+  disagree on containment; one implementation combines all three properties
+  (ext/mime gate, realpath containment, 20 MB cap). Rejected: patching each
+  resolver in place (leaves the next connector to re-introduce the bug).
+- **Realpath containment, not symlink rejection** — resolve the real path of
+  root and candidate and require the candidate to stay inside the root
+  (Junie's `real === root || real.startsWith(root + sep)` idiom). A symlink
+  that stays inside the root is harmless; rejecting all symlinks would be
+  stricter than needed and diverge from the existing Junie behavior.
+- **Copilot migrates in the subagent-embedding PR** — its normalize.ts is
+  heavily edited there; migrating it here would entangle the two PRs.
+  Antigravity and Junie migrate here.
+
+## Approach
+
+1. Add `packages/server/src/connectors/safe-image.ts`: shared `IMAGE_MIME`,
+   `MAX_IMAGE_BYTES`, and a resolver that realpath-contains a candidate path
+   inside a trusted root before reading.
+2. Migrate `junie/normalize.ts` `imageBlockFromPath` (gains the size cap) and
+   `antigravity/normalize.ts` `resolveImage` (gains containment).
+3. Symlink fixture tests: an uploaded-media / attachment name that is a symlink
+   pointing outside the trusted dir must produce no image block; in-root
+   regular files (and in-root symlinks) still resolve.
+
+## Files affected
+
+- `packages/server/src/connectors/safe-image.ts` — new shared resolver.
+- `packages/server/src/connectors/junie/normalize.ts` — use the helper.
+- `packages/server/src/connectors/antigravity/normalize.ts` — use the helper.
+- `packages/server/test/antigravity.integration.test.ts` — symlink fixture.
+- `packages/server/test/safe-image.test.ts` / junie test — containment cases.
+
+## Testing
+
+`npm test` and `npm run typecheck`. New tests assert: symlink escaping the
+root → no image block; regular in-root file → image block (existing happy-path
+tests stay green).
+
+## Risks / open questions
+
+- Behavior change: Junie attachments larger than 20 MB no longer render
+  (previously uncapped) — acceptable, matches the other connectors.
+- Sharing untrusted transcript bundles remains out of scope; this closes the
+  read primitive if it ever happens.

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -56,3 +56,4 @@ decision, or a change worth explaining before doing. Skip it for one-line fixes.
 | 0029 | [Localhost host guard (anti DNS-rebinding)](./0029-localhost-host-guard.md) | done |
 | 0030 | [Analyze tab: activity heatmap + tool-usage breakdown](./0030-analyze-activity-heatmap-tool-usage.md) | done |
 | 0031 | [Google Antigravity connector](./0031-antigravity-connector.md) | done |
+| 0033 | [Symlink-safe image resolution](./0033-symlink-safe-image-resolution.md) | done |

--- a/packages/server/src/connectors/antigravity/normalize.ts
+++ b/packages/server/src/connectors/antigravity/normalize.ts
@@ -30,7 +30,7 @@
  */
 
 import { readFileSync, readdirSync, statSync } from 'node:fs';
-import { basename, dirname, extname, join } from 'node:path';
+import { basename, dirname, join } from 'node:path';
 import type {
   AssistantEvent,
   ContentBlock,
@@ -38,6 +38,7 @@ import type {
   ToolUseBlock,
   UserEvent,
 } from '@claudescope/shared';
+import { resolveImageWithin } from '../safe-image.js';
 import { toolNamesCsv } from '../tool-names.js';
 
 const str = (v: unknown): string => (typeof v === 'string' ? v : '');
@@ -317,15 +318,6 @@ export function subagentLabel(prompt: string): string {
 
 // --- images -----------------------------------------------------------------
 
-const MAX_IMAGE_BYTES = 20 * 1024 * 1024;
-const IMAGE_MIME: Record<string, string> = {
-  '.png': 'image/png',
-  '.jpg': 'image/jpeg',
-  '.jpeg': 'image/jpeg',
-  '.gif': 'image/gif',
-  '.webp': 'image/webp',
-};
-
 /** Absolute `uploaded_media_*.png` paths listed in a USER_INPUT metadata blob.
  *  Accepts POSIX (`/…`) and Windows (`C:\…`) paths, including spaces — only the
  *  basename is used downstream, so the leading form doesn't matter. */
@@ -339,21 +331,15 @@ function extractImagePaths(content: string): string[] {
 
 /**
  * Resolve an uploaded image to a base64 `ImageBlock`. Contained to the
- * conversation dir: only ever reads `<convDir>/<basename>`, so a traversal path
- * can never escape it. Returns null for a non-image or a missing/oversized file.
+ * conversation dir: only `<convDir>/<basename>` is considered, and the shared
+ * resolver refuses it unless its real path stays inside `convDir` (so neither
+ * traversal nor a planted symlink can escape). Returns null for a non-image or
+ * a missing/oversized file.
  */
 function resolveImage(convDir: string, absPath: string): ContentBlock | null {
   const name = basename(absPath);
-  const mime = IMAGE_MIME[extname(name).toLowerCase()];
-  if (!name || !mime) return null;
-  try {
-    const full = join(convDir, name);
-    if (statSync(full).size > MAX_IMAGE_BYTES) return null;
-    const data = readFileSync(full).toString('base64');
-    return { type: 'image', source: { type: 'base64', media_type: mime, data } };
-  } catch {
-    return null;
-  }
+  if (!name) return null;
+  return resolveImageWithin(convDir, join(convDir, name));
 }
 
 // --- tool mapping -----------------------------------------------------------

--- a/packages/server/src/connectors/junie/normalize.ts
+++ b/packages/server/src/connectors/junie/normalize.ts
@@ -24,8 +24,8 @@
  * STRICTLY READ-ONLY with respect to ~/.junie — files are only ever read.
  */
 
-import { readFileSync, realpathSync } from 'node:fs';
-import { basename, dirname, isAbsolute, join, sep } from 'node:path';
+import { readFileSync } from 'node:fs';
+import { basename, dirname, isAbsolute, join } from 'node:path';
 import type {
   AssistantEvent,
   ContentBlock,
@@ -34,6 +34,7 @@ import type {
   UserEvent,
 } from '@claudescope/shared';
 import { JUNIE_HOME } from '../../config.js';
+import { resolveImageWithin } from '../safe-image.js';
 import { toolNamesCsv } from '../tool-names.js';
 
 export interface JunieSession {
@@ -80,56 +81,16 @@ interface StepAgg {
   status?: string;
 }
 
-/** Image extensions we will inline (anything else is refused, not read). */
-const IMAGE_EXTS = new Set(['png', 'jpg', 'jpeg', 'gif', 'webp']);
-
-/** Real path of Junie's home dir, resolved once; attachment reads are confined here. */
-let junieRootReal: string | null = null;
-function junieRoot(): string {
-  if (junieRootReal === null) {
-    try {
-      junieRootReal = realpathSync(JUNIE_HOME);
-    } catch {
-      junieRootReal = JUNIE_HOME; // home absent — containment check below just won't match
-    }
-  }
-  return junieRootReal;
-}
-
 /**
  * Map an absolute image path to an inlined base64 ImageBlock, or null.
  *
  * The path comes from transcript content (`customAttachments` / `@`-mentions),
  * so it is UNTRUSTED: a poisoned session could name `/Users/you/.ssh/id_rsa` or
- * `../../etc/passwd`. We therefore (1) require an image extension and (2) resolve
- * the real path and refuse anything that escapes Junie's own home dir — the only
- * tree this connector is ever allowed to read.
+ * `../../etc/passwd`. The shared resolver confines reads to Junie's own home
+ * dir — the only tree this connector is ever allowed to read.
  */
 function imageBlockFromPath(path: string): ImageBlock | null {
-  const ext = path.toLowerCase().split('.').pop() ?? '';
-  if (!IMAGE_EXTS.has(ext)) return null; // not an image we inline
-  let real: string;
-  try {
-    real = realpathSync(path);
-  } catch {
-    return null; // image vanished, unreadable, or a broken symlink — skip it
-  }
-  const root = junieRoot();
-  if (real !== root && !real.startsWith(root + sep)) return null; // outside ~/.junie — refuse
-  try {
-    const data = readFileSync(real).toString('base64');
-    const mediaType =
-      ext === 'jpg' || ext === 'jpeg'
-        ? 'image/jpeg'
-        : ext === 'gif'
-          ? 'image/gif'
-          : ext === 'webp'
-            ? 'image/webp'
-            : 'image/png';
-    return { type: 'image', source: { type: 'base64', media_type: mediaType, data } };
-  } catch {
-    return null; // unreadable after resolution — skip it
-  }
+  return resolveImageWithin(JUNIE_HOME, path);
 }
 
 /** Image blocks for a UserPromptEvent's string-path attachments (objects skipped). */

--- a/packages/server/src/connectors/safe-image.ts
+++ b/packages/server/src/connectors/safe-image.ts
@@ -1,0 +1,56 @@
+/**
+ * Shared symlink-safe image inlining for connectors.
+ *
+ * Several connectors inline transcript-referenced images as base64 blocks. The
+ * referenced path/name comes from transcript content, so it is UNTRUSTED: a
+ * poisoned session dir could use `../../` traversal or — subtler — plant a
+ * symlink whose textual path sits inside the allowed directory but whose target
+ * is anywhere on disk (`statSync`/`readFileSync` follow symlinks). This helper
+ * closes both holes with one rule, generalized from the Junie connector's
+ * containment pattern: resolve the REAL path of both the trusted root and the
+ * candidate, and refuse to read anything that does not resolve to inside the
+ * root. A symlink is fine only while its target stays within the root.
+ */
+
+import { readFileSync, realpathSync, statSync } from 'node:fs';
+import { extname, sep } from 'node:path';
+import type { ImageBlock } from '@claudescope/shared';
+
+/** Refuse to inline anything bigger than this (keeps API payloads sane). */
+export const MAX_IMAGE_BYTES = 20 * 1024 * 1024;
+
+/** Media types we will inline, keyed by lowercase extension (with dot). */
+export const IMAGE_MIME: Record<string, string> = {
+  '.png': 'image/png',
+  '.jpg': 'image/jpeg',
+  '.jpeg': 'image/jpeg',
+  '.gif': 'image/gif',
+  '.webp': 'image/webp',
+};
+
+/**
+ * Read `candidatePath` as a base64 `ImageBlock`, but only if its REAL path
+ * stays inside `rootDir` (real paths compared, so neither traversal nor a
+ * symlink escaping the root can leak a file). Returns null for a non-image
+ * extension, a missing/unreadable/oversized file, or a containment violation.
+ */
+export function resolveImageWithin(rootDir: string, candidatePath: string): ImageBlock | null {
+  const mime = IMAGE_MIME[extname(candidatePath).toLowerCase()];
+  if (!mime) return null; // not an image we inline
+  let root: string;
+  let real: string;
+  try {
+    root = realpathSync(rootDir);
+    real = realpathSync(candidatePath);
+  } catch {
+    return null; // root or image missing, unreadable, or a broken symlink — skip
+  }
+  if (real !== root && !real.startsWith(root + sep)) return null; // escapes the root — refuse
+  try {
+    if (statSync(real).size > MAX_IMAGE_BYTES) return null;
+    const data = readFileSync(real).toString('base64');
+    return { type: 'image', source: { type: 'base64', media_type: mime, data } };
+  } catch {
+    return null; // unreadable after resolution — skip
+  }
+}

--- a/packages/server/test/antigravity.integration.test.ts
+++ b/packages/server/test/antigravity.integration.test.ts
@@ -14,14 +14,15 @@
  *   - tool results are separate typed records correlated by order, and a result
  *     with no preceding call (implicit read) synthesizes a `Read`;
  *   - `write_to_file` → canonical `Write` (feeds Files-changed);
- *   - an uploaded `uploaded_media_*.png` → base64 ImageBlock;
+ *   - an uploaded `uploaded_media_*.png` → base64 ImageBlock, while a symlink
+ *     escaping the conversation dir is refused (symlink-safe containment);
  *   - the `SYSTEM_MESSAGE` subagent summary renders; CHECKPOINT/CONVERSATION_HISTORY
  *     are dropped; cost/tokens are zero (no token data exists);
  *   - global memory read from `~/.gemini/config/agents/AGENTS.md`.
  */
 
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import type { FastifyInstance } from 'fastify';
@@ -49,6 +50,11 @@ const CHILD = '22222222-2222-2222-2222-222222222222';
 const ORPHAN = '33333333-3333-3333-3333-333333333333';
 const IMG_NAME = 'uploaded_media_0_1782909688549.png';
 const IMG_ABS = join(cliDir, 'brain', PARENT, IMG_NAME);
+// A poisoned upload: textually inside the conversation dir, but a symlink whose
+// target lives outside it (the connector must refuse to inline it).
+const EVIL_NAME = 'uploaded_media_1_1782909688550.png';
+const EVIL_ABS = join(cliDir, 'brain', PARENT, EVIL_NAME);
+const SECRET_ABS = join(work, 'outside-secret.png');
 
 const PNG_B64 =
   'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYPhfDwAChwGA60e6kgAAAABJRU5ErkJggg==';
@@ -86,7 +92,7 @@ function writeFixtures(): void {
       content:
         '<USER_REQUEST>\nAnalyze my projects\n</USER_REQUEST>\n' +
         '<ADDITIONAL_METADATA>\nThe current local time is: 2026-07-01T14:00:00+02:00.\n\n' +
-        `The user has uploaded 1 image(s):\n- ${IMG_ABS}\n</ADDITIONAL_METADATA>\n` +
+        `The user has uploaded 2 image(s):\n- ${IMG_ABS}\n- ${EVIL_ABS}\n</ADDITIONAL_METADATA>\n` +
         '<USER_SETTINGS_CHANGE>\nThe user changed setting `Model Selection` from None to ' +
         'Gemini 3.5 Flash (Medium). No need to comment on this change.\n</USER_SETTINGS_CHANGE>',
     }),
@@ -187,8 +193,11 @@ function writeFixtures(): void {
     step(2, 'MODEL', 'CODE_ACTION', { content: 'Created file file:///tmp/orphan.md with requested content.' }),
   ]);
 
-  // The uploaded image bytes referenced by the parent's USER_INPUT metadata.
+  // The uploaded image bytes referenced by the parent's USER_INPUT metadata,
+  // plus the poisoned one: a symlink escaping the conversation dir.
   writeFileSync(IMG_ABS, Buffer.from(PNG_B64, 'base64'));
+  writeFileSync(SECRET_ABS, 'secret bytes that must never be inlined');
+  symlinkSync(SECRET_ABS, EVIL_ABS);
 
   // history.jsonl maps the PARENT (and only it) to a workspace. A leading
   // slash-command line without a conversationId is present (as in real data).
@@ -336,11 +345,17 @@ describe('antigravity session detail', () => {
     expect(JSON.stringify(read.result.content)).toContain('README.md');
 
     // Uploaded screenshot → base64 ImageBlock (carried as an attachment block).
-    const att = flat.find((b: Record<string, unknown>) => b.kind === 'attachment');
-    expect(att.attachment).toMatchObject({
+    // Only the legit upload is inlined — the symlinked one escaping the
+    // conversation dir is refused, so exactly one image comes back.
+    const atts = flat.filter((b: Record<string, unknown>) => b.kind === 'attachment');
+    expect(atts).toHaveLength(1);
+    expect(atts[0].attachment).toMatchObject({
       type: 'image',
       source: { type: 'base64', media_type: 'image/png', data: PNG_B64 },
     });
+    expect(JSON.stringify(detail)).not.toContain(
+      Buffer.from('secret bytes that must never be inlined').toString('base64'),
+    );
   });
 
   it('does not synthesize a blank Write for an orphan write result', async () => {

--- a/packages/server/test/junie.integration.test.ts
+++ b/packages/server/test/junie.integration.test.ts
@@ -11,7 +11,7 @@
  */
 
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import type { FastifyInstance } from 'fastify';
@@ -65,13 +65,16 @@ function writeSession(): void {
   writeFileSync(pngPath, Buffer.from(PNG_BASE64, 'base64'));
   writeFileSync(mentionPath, Buffer.from(PNG_BASE64, 'base64'));
 
-  // Two POISONED attachments the connector must refuse (F4): a real PNG OUTSIDE
-  // ~/.junie (arbitrary-file read / traversal), and a non-image file INSIDE the
-  // tree (extension gate). Both hold "secret" bytes that must never be inlined.
+  // Three POISONED attachments the connector must refuse (F4): a real PNG OUTSIDE
+  // ~/.junie (arbitrary-file read / traversal), a non-image file INSIDE the tree
+  // (extension gate), and a symlink INSIDE the tree whose target escapes it
+  // (realpath containment). All hold "secret" bytes that must never be inlined.
   const secretImg = join(outside, 'secret.png');
   const secretTxt = join(imgDir, 'secret.txt');
+  const secretLink = join(imgDir, 'link.png');
   writeFileSync(secretImg, Buffer.from(PNG_BASE64, 'base64'));
   writeFileSync(secretTxt, 'TOP SECRET');
+  symlinkSync(secretImg, secretLink);
 
   writeFileSync(
     join(junieDir, 'index.jsonl'),
@@ -95,7 +98,13 @@ function writeSession(): void {
       {
         kind: 'UserPromptEvent',
         prompt: `look at this screenshot @${mentionPath} and the old one @${missingPath}`,
-        customAttachments: [pngPath, secretImg, secretTxt, { kind: 'OnboardingMigrationAttachment' }],
+        customAttachments: [
+          pngPath,
+          secretImg,
+          secretTxt,
+          secretLink,
+          { kind: 'OnboardingMigrationAttachment' },
+        ],
       },
       { kind: 'SendToAgentEvent' },
       // Token usage for the assistant turn (haiku family → priced via substring).
@@ -267,8 +276,9 @@ describe('Junie session detail', () => {
         b.kind === 'attachment' && (b.attachment as { type?: string })?.type === 'image',
     );
     // Exactly two: the `@mention` one + the in-tree customAttachments PNG. The
-    // poisoned attachments (a PNG outside ~/.junie and an in-tree .txt) are refused
-    // by the F4 containment + extension gate, and the purged mention embeds nothing.
+    // poisoned attachments (a PNG outside ~/.junie, an in-tree .txt, and an
+    // in-tree symlink escaping ~/.junie) are refused by the F4 containment +
+    // extension gate, and the purged mention embeds nothing.
     expect(images).toHaveLength(2);
     for (const img of images) {
       const source = (img.attachment as { source: { type: string; media_type: string; data: string } })

--- a/packages/server/test/safe-image.test.ts
+++ b/packages/server/test/safe-image.test.ts
@@ -1,0 +1,67 @@
+/**
+ * Unit tests for the shared symlink-safe image resolver — the containment
+ * semantics every connector relies on: real-path escape refusal (traversal and
+ * symlinks), within-root symlinks allowed, extension gate, size cap.
+ */
+
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { MAX_IMAGE_BYTES, resolveImageWithin } from '../src/connectors/safe-image.js';
+
+const work = mkdtempSync(join(tmpdir(), 'claudescope-safeimg-'));
+const root = join(work, 'root');
+const outside = join(work, 'outside');
+
+const PNG = Buffer.from(
+  'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==',
+  'base64',
+);
+
+beforeAll(() => {
+  mkdirSync(root, { recursive: true });
+  mkdirSync(outside, { recursive: true });
+  writeFileSync(join(root, 'ok.png'), PNG);
+  writeFileSync(join(root, 'target.png'), PNG);
+  writeFileSync(join(outside, 'secret.png'), PNG);
+  writeFileSync(join(root, 'notes.txt'), 'not an image');
+  symlinkSync(join(outside, 'secret.png'), join(root, 'escape.png')); // escapes root
+  symlinkSync(join(root, 'target.png'), join(root, 'alias.png')); // stays inside root
+});
+
+afterAll(() => {
+  rmSync(work, { recursive: true, force: true });
+});
+
+describe('resolveImageWithin', () => {
+  it('inlines a regular image inside the root', () => {
+    const block = resolveImageWithin(root, join(root, 'ok.png'));
+    expect(block).toMatchObject({
+      type: 'image',
+      source: { type: 'base64', media_type: 'image/png', data: PNG.toString('base64') },
+    });
+  });
+
+  it('refuses a symlink whose target escapes the root', () => {
+    expect(resolveImageWithin(root, join(root, 'escape.png'))).toBeNull();
+  });
+
+  it('refuses a traversal path resolving outside the root', () => {
+    expect(resolveImageWithin(root, join(root, '..', 'outside', 'secret.png'))).toBeNull();
+  });
+
+  it('allows a symlink whose target stays inside the root', () => {
+    expect(resolveImageWithin(root, join(root, 'alias.png'))).not.toBeNull();
+  });
+
+  it('refuses a non-image extension and a missing file', () => {
+    expect(resolveImageWithin(root, join(root, 'notes.txt'))).toBeNull();
+    expect(resolveImageWithin(root, join(root, 'gone.png'))).toBeNull();
+  });
+
+  it('refuses an oversized image', () => {
+    writeFileSync(join(root, 'big.png'), Buffer.alloc(MAX_IMAGE_BYTES + 1));
+    expect(resolveImageWithin(root, join(root, 'big.png'))).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

An external security scan (2026-07-02, rev 5306b37) validated two medium-severity findings with runtime PoCs: the **Copilot** saved-attachment and **Antigravity** uploaded-media image resolvers contain paths with `basename()` only, but `statSync`/`readFileSync` follow symlinks — a symlink planted inside a session/conversation dir exfiltrates arbitrary readable local files into the session-detail API response as base64. Junie already implements the correct realpath-containment pattern, so this was an inconsistency between connectors.

## Changes

- New shared `connectors/safe-image.ts`: `resolveImageWithin(rootDir, candidatePath)` combining the ext/mime gate, **realpath containment** inside a trusted root (Junie's idiom), and the 20 MB size cap; shared `IMAGE_MIME` / `MAX_IMAGE_BYTES`.
- **Junie** `imageBlockFromPath` → helper (gains the size cap; local containment machinery removed).
- **Antigravity** `resolveImage` → helper (gains realpath containment).
- **Copilot** migrates in the follow-up subagent-embedding PR — its `normalize.ts` is heavily rewritten there; migrating it here would entangle the two.

## Tests

- Antigravity integration: poisoned-upload fixture — `uploaded_media_*.png` symlinked outside the conversation dir returns no image block and the target bytes never appear in the response; happy path retained.
- Junie integration: escaping in-tree symlink refused.
- New `safe-image.test.ts`: within-root symlink allowed, escaping symlink refused, traversal refused, ext gate, missing file, size cap.

Plan: [docs/plans/0033-symlink-safe-image-resolution.md](./docs/plans/0033-symlink-safe-image-resolution.md)