### PR TITLE
feat: embed subagents for Codex, pi, opencode, and Copilot

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -125,6 +125,13 @@ The CLI `update` command (`cli.ts`) detects the install method and defers to
   also keeps an opaque `thinkingSignature`), so their reasoning renders in full.
 - **Codex sessions have no stored title** — the session title falls back to the
   first user message (see `first_user` in `data/index.ts`). Same for **pi**.
+- **Codex subagents & apply_patch** — subagent rollouts are separate files whose
+  `session_meta` carries `thread_source: "subagent"` + the parent thread id; they
+  re-key under their ROOT thread (`is_sidechain`) and nest via a canonical `Task`
+  synthesized from the parent's `spawn_agent` call. File edits arrive as
+  `custom_tool_call` records (NOT `function_call`) named `apply_patch` → parsed
+  V4A envelopes fan out to canonical `Write`/`MultiEdit` per file so the
+  Files-changed tab works.
 - **pi connector** (`connectors/pi/`) — JSONL like Claude/Codex but `cwd` is on
   the `session` line and tool results are separate `toolResult` records, so a
   `prepare()` pass normalizes to canonical NDJSON (Codex pattern). `model` comes
@@ -132,6 +139,9 @@ The CLI `update` command (`cli.ts`) detects the install method and defers to
   attribution); the `uuid`/`parentUuid` chain is synthesized over message rows
   because pi's native chain threads through `model_change`/`thinking_level_change`
   records. pi has no home-dir memory, so the connector implements no memory.
+  Subagent runs live at `<sessionBase>/<runId>/run-N/session.jsonl` (linkage:
+  the `subagent` toolResult's `details.runId`); they re-key to the parent by
+  path shape and nest via a canonical `Task` (management calls stay passthrough).
 - **opencode connector** (`connectors/opencode/`) — the only **SQLite-backed**
   source: one `opencode.db` (`session`/`message`/`part`), read read-only via
   `node:sqlite` (built into Node 24 — no dep). Each session is a synthetic
@@ -142,7 +152,10 @@ The CLI `update` command (`cli.ts`) detects the install method and defers to
   pasted screenshot is a `file` part (data-URL) → `ImageBlock`. Reasoning is
   plaintext. Tokens are per-message (reasoning folded into output). `discover()`
   throws on a present-but-unreadable DB (the indexer isolates a throwing connector
-  and preserves its sessions — it never wipes them). No memory.
+  and preserves its sessions — it never wipes them). No memory. Task-spawned
+  child sessions carry `session.parent_id` → re-keyed to the root ancestor
+  (`is_sidechain`, cycle-guarded) and nested via the parent's `task` tool part
+  (its `state.metadata.sessionId` names the child).
 - **GitHub Copilot CLI connector** (`connectors/copilot/`) — event-sourced
   `~/.copilot/session-state/<uuid>/events.jsonl` (Junie/pi-shaped lines of
   `{type, data, id, timestamp, parentId}`); `prepare()` normalizes to canonical
@@ -158,6 +171,10 @@ The CLI `update` command (`cli.ts`) detects the install method and defers to
   `ImageBlock`, else the inline `[📷 …]` marker remains. Global memory is
   `~/.copilot/copilot-instructions.md`; "session-level memory" is session-scoped
   (per-session `session.db` + `files/`), not cross-session, so no project memory.
+  Subagents are INLINE in the parent's `events.jsonl`: inner events carry an
+  event-level `agentId` (= the spawning `task` toolCallId) and are segmented into
+  per-agent streams (`is_sidechain`), nested via a canonical `Task`; the
+  `subagent.started` record supplies agent name/model.
 - **Google Antigravity connector** (`connectors/antigravity/`) — an event stream
   but **with** assistant prose and plaintext thinking (unlike Junie). Read
   `~/.gemini/antigravity-cli/brain/**/transcript_full.jsonl` (also scans the
@@ -176,6 +193,11 @@ The CLI `update` command (`cli.ts`) detects the install method and defers to
   a session renders as tool/terminal/file blocks plus a final result. Expected,
   not a bug. Older Junie sessions also lack a recorded `cwd` (no `projectDir` in
   `index.jsonl`) and group under the `(unknown — Junie)` project bucket.
+- **Junie "subagents" are NOT embeddable by design** — Junie delegates by running
+  `junie …` as a plain terminal command, so children are independent sessions
+  with zero ID linkage to the spawner (only the coincidental prompt text).
+  Matching command text to session prompts would be heuristic and fragile, so
+  they intentionally list as separate top-level sessions.
 - **Cost is a local estimate** from token usage × rates; not real billing.
   Computed once at index time and stored. Rates auto-refresh daily from LiteLLM
   at runtime (`pricing.fetched.json`); `pricing.json` is the fallback/override

--- a/docs/plans/0032-subagent-embedding-connectors.md
+++ b/docs/plans/0032-subagent-embedding-connectors.md
@@ -1,0 +1,113 @@
+# 0032 — Subagent embedding for Codex, pi, opencode, Copilot
+
+- **Status:** done
+- **Date:** 2026-07-02
+- **PR:** https://github.com/vladar107/claudescope/pull/45
+
+## Context
+
+Only Claude Code and Antigravity nest subagent runs under their parent session.
+The other connectors either double-list children as independent top-level
+sessions (Codex separate rollouts, pi nested run transcripts, opencode child
+session rows) or flatten them into the main thread (Copilot inline events).
+Codex additionally drops `custom_tool_call` records entirely, so `apply_patch`
+edits are invisible in the transcript and the Files-changed tab.
+
+Inspection of real session data (2026-07-02) established every source records
+enough linkage to embed:
+
+- **Codex**: child rollouts carry `session_meta.thread_source: "subagent"` +
+  `source.subagent.thread_spawn.{parent_thread_id, agent_nickname, agent_role}`;
+  the parent records `spawn_agent` (output: `{agent_id}`) / `wait_agent` /
+  `close_agent` calls. `apply_patch` arrives as `custom_tool_call` (not
+  `function_call`).
+- **pi**: a `subagent` toolCall `{agent, task}`; the toolResult carries
+  `details.{mode, runId, results[]}`; the child transcript lives at
+  `<sessionBasename>/<runId>/run-N/session.jsonl`.
+- **opencode**: child sessions have `session.parent_id`; the parent's `task`
+  tool part has `input.{description, prompt, subagent_type}` and
+  `state.metadata.sessionId` = the child id.
+- **Copilot**: the subagent's whole event stream is inline in the parent's
+  `events.jsonl` between `subagent.started`/`subagent.completed`, every inner
+  event tagged with `agentId` (= the spawning `task` toolCallId).
+- **Junie**: no linkage exists — its "subagents" are plain `junie` CLI
+  subprocesses launched from terminal commands; children are independent
+  sessions by design. Documented, not embedded.
+
+## Goal
+
+Codex/pi/opencode subagent transcripts fold into their parent session (list,
+search, tokens) and render nested at their spawn point; Copilot subagent turns
+are segmented out of the main thread and nested; Codex `apply_patch` edits
+render as canonical `Write`/`Edit` blocks and populate the Files-changed tab.
+
+## Decisions
+
+- **Antigravity pattern everywhere** — child canonical rows are re-keyed to the
+  root session id with `is_sidechain = true`; the indexer, parser, API, and web
+  UI need no changes (session grouping is purely `files.session_id`; nesting
+  correlates a `SubagentSource.description` to a canonical `Task` block's
+  `input.description`). Rejected: teaching the indexer about parent links —
+  the connector seam already carries everything.
+- **Synthesize canonical `Task` blocks in each normalizer** (`spawn_agent`,
+  pi `subagent`, opencode `task`, Copilot `task`), `description` derived
+  identically on both the Task-block side and the `SubagentSource` side so
+  `buildSubagentRuns` anchors runs deterministically.
+- **Codex `apply_patch` → per-file `Write`/`Edit`/`MultiEdit`**, mirroring the
+  opencode connector's existing mapping, so `changeset.ts` keys off it.
+- **One `SCHEMA_VERSION` bump** (8 → 9) forces existing indexes to rebuild so
+  already-indexed child sessions re-key under their parents.
+- **Junie: docs only** — matching terminal-command text to session prompts
+  would be heuristic and fragile; not worth it.
+
+## Approach
+
+1. Codex: parse `custom_tool_call`/`custom_tool_call_output` (+ tool/web
+   search records), map `apply_patch`; re-key subagent rollouts via a cached
+   id→parent map from `session_meta` scans; `spawn_agent` → `Task`;
+   `loadSession` splits parent/children.
+2. pi: re-key nested `run-N/session.jsonl` by path shape; `subagent` toolCall →
+   `Task` (management calls stay passthrough); capture `toolResult.details`;
+   `loadSession` attaches per-result run transcripts.
+3. opencode: expose `parent_id`; re-key children to the root ancestor
+   (cycle-guarded); `task` part → `Task`; `loadSession` reads children via
+   `readSession`, correlated by `state.metadata.sessionId`.
+4. Copilot: segment events by `agentId` into per-subagent buffers
+   (`is_sidechain = true` in canonical rows); `task` toolRequest → `Task`;
+   metadata from `subagent.started`; migrate its image resolver to the shared
+   `safe-image.ts` helper (plan 0033).
+5. Bump `SCHEMA_VERSION`; update CLAUDE.md gotchas (incl. Junie's by-design
+   non-linkage).
+
+## Files affected
+
+- `packages/server/src/connectors/codex/{normalize,codex}.ts` — custom tool
+  records, apply_patch, subagent re-keying and loading.
+- `packages/server/src/connectors/pi/{normalize,pi}.ts` — child re-keying,
+  Task mapping, run attachment.
+- `packages/server/src/connectors/opencode/{normalize,opencode,db}.ts` —
+  parent_id plumbing, Task mapping, child loading.
+- `packages/server/src/connectors/copilot/{normalize,copilot}.ts` — agentId
+  segmentation, Task mapping, safe-image migration.
+- `packages/server/src/db/schema.ts` — SCHEMA_VERSION 9.
+- `packages/server/test/{codex,pi,opencode,copilot}.integration.test.ts` —
+  embedding fixtures and assertions.
+- `CLAUDE.md` — per-connector gotcha updates.
+
+## Testing
+
+`npm test` and `npm run typecheck`. Per connector: child folds into the parent
+session (never listed top-level), `hasSidechain` set, `detail.subagents`
+anchored to the `Task` block via `toolUseId`, child text searchable under the
+parent, orphan/missing-parent fallbacks don't crash indexing. Codex:
+`apply_patch` produces canonical blocks with `file_path`; result envelopes
+stripped. Copilot: main thread free of subagent turns.
+
+## Risks / open questions
+
+- Codex/pi child token usage now counts toward the parent session (matches
+  Claude Code semantics; Copilot unchanged — tokens are session-level).
+- pi parallel subagent runs (`run-1+`) are inferred from `details.results`
+  order; only single-run fixtures exist today.
+- Copilot nested (subagent-spawned) subagents: no real-world sample; segmenter
+  should tolerate unknown `agentId`s rather than crash.

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -56,4 +56,5 @@ decision, or a change worth explaining before doing. Skip it for one-line fixes.
 | 0029 | [Localhost host guard (anti DNS-rebinding)](./0029-localhost-host-guard.md) | done |
 | 0030 | [Analyze tab: activity heatmap + tool-usage breakdown](./0030-analyze-activity-heatmap-tool-usage.md) | done |
 | 0031 | [Google Antigravity connector](./0031-antigravity-connector.md) | done |
+| 0032 | [Subagent embedding for Codex, pi, opencode, Copilot](./0032-subagent-embedding-connectors.md) | done |
 | 0033 | [Symlink-safe image resolution](./0033-symlink-safe-image-resolution.md) | done |

--- a/packages/server/src/connectors/codex/codex.ts
+++ b/packages/server/src/connectors/codex/codex.ts
@@ -7,18 +7,23 @@
  * {@link parseRollout}/{@link toCanonicalRows}) and `eventsProjectionSql` reads
  * that 1:1 — the indexer/FTS/cost stay native and Claude's path is untouched.
  *
+ * Subagents are separate rollouts (`thread_source: "subagent"`) re-keyed under
+ * their root session at prepare time, so `loadSession` splits the resolved files
+ * into the main transcript and one {@link SubagentSource} per child, which the
+ * thread assembler nests at the parent's `spawn_agent` (→ `Task`) call.
+ *
  * STRICTLY READ-ONLY with respect to ~/.codex — files are only ever read.
  */
 
 import { createHash } from 'node:crypto';
-import { mkdirSync, readdirSync, statSync, writeFileSync } from 'node:fs';
+import { mkdirSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { CLAUDESCOPE_HOME, CODEX_SESSIONS_DIR } from '../../config.js';
 import { sqlString } from '../../db/duckdb.js';
-import type { SessionData } from '../../data/session-loader.js';
+import type { SessionData, SubagentSource } from '../../data/session-loader.js';
 import type { AgentConnector, AuxProjections, DiscoveredFile } from '../types.js';
 import { codexGlobalMemory } from './memory.js';
-import { parseRollout, toCanonicalRows } from './normalize.js';
+import { listRollouts, parseRollout, toCanonicalRows, type CodexSession } from './normalize.js';
 
 const CACHE_DIR = join(CLAUDESCOPE_HOME, 'cache', 'codex');
 
@@ -28,32 +33,14 @@ function cachePath(filePath: string): string {
   return join(CACHE_DIR, `${hash}.ndjson`);
 }
 
-/** Recursively collect every `rollout-*.jsonl` under the Codex sessions dir. */
+/**
+ * Every `rollout-*.jsonl` under the Codex sessions dir. Subagent rollouts are
+ * included as ordinary files — they re-key to their root session at prepare time.
+ * Unlike antigravity, no mtime folding is needed: a child's parent link lives in
+ * its OWN `session_meta` from creation, so it never changes after the fact.
+ */
 function discover(): DiscoveredFile[] {
-  const out: DiscoveredFile[] = [];
-  const walk = (dir: string): void => {
-    let entries: import('node:fs').Dirent[];
-    try {
-      entries = readdirSync(dir, { withFileTypes: true });
-    } catch {
-      return;
-    }
-    for (const entry of entries) {
-      const full = join(dir, entry.name);
-      if (entry.isDirectory()) {
-        walk(full);
-      } else if (entry.isFile() && /^rollout-.*\.jsonl$/.test(entry.name)) {
-        try {
-          const st = statSync(full);
-          out.push({ path: full, mtimeMs: Math.floor(st.mtimeMs), size: st.size });
-        } catch {
-          /* file vanished between readdir and stat; ignore */
-        }
-      }
-    }
-  };
-  walk(CODEX_SESSIONS_DIR);
-  return out;
+  return listRollouts();
 }
 
 /** Normalize a rollout to canonical NDJSON the projection will read. */
@@ -85,9 +72,36 @@ function auxProjections(_filePath: string): AuxProjections {
   return {}; // Codex has no ai-title / pr-link records
 }
 
-async function loadSession(_sessionId: string, paths: string[]): Promise<SessionData> {
-  const mainEvents = paths.flatMap((p) => parseRollout(p)?.events ?? []);
-  return { mainEvents, subagents: [] };
+/**
+ * Load a session's events, splitting the resolved rollouts into the main thread
+ * (its own thread id equals the session id) and one subagent per re-keyed child
+ * rollout. A child's `description`/`agentType` come from the parent's matching
+ * `spawn_agent` call (correlated via the spawn output's `agent_id`), so the run
+ * anchors to the canonical `Task` block.
+ */
+async function loadSession(sessionId: string, paths: string[]): Promise<SessionData> {
+  const sessions = paths
+    .map((p) => parseRollout(p))
+    .filter((s): s is CodexSession => s !== null);
+  const main = sessions.find((s) => s.sessionId === sessionId);
+  const subagents: SubagentSource[] = [];
+  for (const s of sessions) {
+    if (s === main) continue;
+    const meta = main?.spawnedAgents.get(s.sessionId);
+    subagents.push({
+      agentId: s.sessionId,
+      agentType: meta?.agentType ?? s.agentRole ?? '',
+      description: meta?.description ?? '',
+      events: s.events,
+    });
+  }
+  const mainEvents = main?.events ?? [];
+  // Fallback: a session whose parent rollout is missing (deleted, or never
+  // existed) would render an empty main thread — promote the children instead.
+  if (mainEvents.length === 0 && subagents.length > 0) {
+    return { mainEvents: subagents.flatMap((s) => s.events), subagents: [] };
+  }
+  return { mainEvents, subagents };
 }
 
 export const codexConnector: AgentConnector = {

--- a/packages/server/src/connectors/codex/normalize.ts
+++ b/packages/server/src/connectors/codex/normalize.ts
@@ -9,14 +9,20 @@
  * the existing thread assembler and the canonical index row builder both reuse it.
  *
  * Grouping: consecutive assistant-side items (assistant message, reasoning,
- * function_call) coalesce into one assistant turn; user-side items (user message,
- * function_call_output) coalesce into one user turn. `developer` messages (the
- * system prompt) are dropped. Tokens from `token_count` are attributed to the
- * most recent assistant turn.
+ * function_call, custom_tool_call, *_search_call) coalesce into one assistant
+ * turn; user-side items (user message, *_call_output) coalesce into one user
+ * turn. `developer` messages (the system prompt) are dropped. Tokens from
+ * `token_count` are attributed to the most recent assistant turn.
+ *
+ * Subagents: a `thread_source: "subagent"` rollout is a separate file linked to
+ * its parent via `source.subagent.thread_spawn.parent_thread_id`; it is re-keyed
+ * to the ROOT thread id (`is_sidechain: true`) so it folds into the parent
+ * session, and the parent's `spawn_agent` call becomes a canonical `Task` block
+ * the nested run anchors to.
  */
 
-import { readFileSync } from 'node:fs';
-import { basename } from 'node:path';
+import { closeSync, openSync, readFileSync, readSync, readdirSync, statSync } from 'node:fs';
+import { basename, join } from 'node:path';
 import type {
   AssistantEvent,
   ContentBlock,
@@ -24,6 +30,7 @@ import type {
   ToolUseBlock,
   UserEvent,
 } from '@claudescope/shared';
+import { CODEX_SESSIONS_DIR } from '../../config.js';
 import { toolNamesCsv } from '../tool-names.js';
 
 interface CodexLine {
@@ -33,10 +40,20 @@ interface CodexLine {
 }
 
 export interface CodexSession {
+  /** Own thread id — the correlation key `loadSession` splits files by. */
   sessionId: string;
+  /** Indexing key: the ROOT thread id (the top-level ancestor, for a subagent). */
+  indexSessionId: string;
+  /** True for a `thread_source: "subagent"` rollout (re-parented under the root). */
+  isSidechain: boolean;
+  /** `thread_spawn.agent_role` for a subagent rollout (fallback agentType). */
+  agentRole?: string;
   cwd: string;
   gitBranch?: string;
   events: (UserEvent | AssistantEvent)[];
+  /** Spawned child thread id → Task correlation meta, from this rollout's
+   *  `spawn_agent` calls (description must equal the Task block's). */
+  spawnedAgents: Map<string, { description: string; agentType: string }>;
 }
 
 /** Mutable per-turn token accumulator (assignable to {@link MessageUsage}). */
@@ -54,6 +71,142 @@ const zeroUsage = (): CodexUsage => ({
 
 const str = (v: unknown): string => (typeof v === 'string' ? v : '');
 const num = (v: unknown): number => (typeof v === 'number' && Number.isFinite(v) ? v : 0);
+
+/** Coerce to a record, else `{}` (arrays are not records). */
+const rec = (v: unknown): Record<string, unknown> =>
+  v && typeof v === 'object' && !Array.isArray(v) ? (v as Record<string, unknown>) : {};
+
+// --- rollout discovery + subagent linkage -------------------------------------
+
+/** A discovered rollout file with change-detection stats. */
+export interface RolloutFile {
+  path: string;
+  mtimeMs: number;
+  size: number;
+}
+
+/** Recursively collect every `rollout-*.jsonl` under the Codex sessions dir. */
+export function listRollouts(): RolloutFile[] {
+  const out: RolloutFile[] = [];
+  const walk = (dir: string): void => {
+    let entries: import('node:fs').Dirent[];
+    try {
+      entries = readdirSync(dir, { withFileTypes: true });
+    } catch {
+      return;
+    }
+    for (const entry of entries) {
+      const full = join(dir, entry.name);
+      if (entry.isDirectory()) {
+        walk(full);
+      } else if (entry.isFile() && /^rollout-.*\.jsonl$/.test(entry.name)) {
+        try {
+          const st = statSync(full);
+          out.push({ path: full, mtimeMs: Math.floor(st.mtimeMs), size: st.size });
+        } catch {
+          /* file vanished between readdir and stat; ignore */
+        }
+      }
+    }
+  };
+  walk(CODEX_SESSIONS_DIR);
+  return out;
+}
+
+/** Read a file's first line (the `session_meta` record) without loading the whole
+ *  rollout — the line can be tens of KB (it embeds the base instructions), so read
+ *  in chunks up to a 1 MiB cap. */
+function firstLine(path: string): string {
+  const CHUNK = 64 * 1024;
+  const CAP = 1024 * 1024;
+  let fd: number;
+  try {
+    fd = openSync(path, 'r');
+  } catch {
+    return '';
+  }
+  try {
+    const buf = Buffer.alloc(CHUNK);
+    let acc = '';
+    let pos = 0;
+    while (pos < CAP) {
+      const n = readSync(fd, buf, 0, CHUNK, pos);
+      if (n <= 0) break;
+      acc += buf.toString('utf8', 0, n);
+      const nl = acc.indexOf('\n');
+      if (nl >= 0) return acc.slice(0, nl);
+      pos += n;
+    }
+    return acc;
+  } catch {
+    return '';
+  } finally {
+    closeSync(fd);
+  }
+}
+
+/** Cross-file subagent linkage: subagent thread id → parent thread id. */
+interface CodexContext {
+  parents: Map<string, string>;
+}
+
+let ctxCache: { fp: string; ctx: CodexContext } | null = null;
+
+/** Cheap fingerprint: every rollout's (path, mtime, size). */
+function fingerprint(files: RolloutFile[]): string {
+  return files
+    .map((f) => `${f.path}:${f.mtimeMs}:${f.size}`)
+    .sort()
+    .join('|');
+}
+
+/**
+ * The memoized subagent parent-map for the sessions dir, built by reading only
+ * each rollout's first line (`session_meta` carries `thread_source` and
+ * `source.subagent.thread_spawn.parent_thread_id`). Rebuilt only when a rollout
+ * changes, so per-file `prepare`/`loadSession` calls in one reindex reuse one scan.
+ */
+export function getCodexContext(): CodexContext {
+  const files = listRollouts();
+  const fp = fingerprint(files);
+  if (ctxCache && ctxCache.fp === fp) return ctxCache.ctx;
+  const parents = new Map<string, string>();
+  for (const f of files) {
+    let meta: Record<string, unknown>;
+    try {
+      meta = rec(rec(JSON.parse(firstLine(f.path))).payload);
+    } catch {
+      continue;
+    }
+    if (str(meta.thread_source) !== 'subagent') continue;
+    const spawn = rec(rec(rec(meta.source).subagent).thread_spawn);
+    const id = str(meta.id) || str(meta.session_id);
+    const parent = str(spawn.parent_thread_id);
+    if (id && parent) parents.set(id, parent);
+  }
+  const ctx = { parents };
+  ctxCache = { fp, ctx };
+  return ctx;
+}
+
+/** Follow the parent chain to the top-level (non-subagent) thread. Mirrors the
+ *  antigravity connector's `rootConvId` (cycle-guarded, multi-level nesting). */
+export function rootThreadId(id: string, parents: Map<string, string>): string {
+  let cur = id;
+  const guard = new Set<string>();
+  while (parents.has(cur) && !guard.has(cur)) {
+    guard.add(cur);
+    cur = parents.get(cur)!;
+  }
+  return cur;
+}
+
+/** First line of a subagent prompt, truncated — used as the correlation key AND
+ *  label (mirrors the antigravity connector's `subagentLabel`). */
+export function subagentLabel(prompt: string): string {
+  const line = prompt.trim().split('\n')[0]?.trim() ?? '';
+  return line.length > 80 ? `${line.slice(0, 80)}…` : line;
+}
 
 /** Strip Codex's redundant `<image …>` / `</image>` placeholder tags. */
 function stripImagePlaceholders(text: string): string {
@@ -107,10 +260,12 @@ const SHELL_TOOLS = new Set(['exec_command', 'shell', 'local_shell', 'container.
  * Files-changed extractor key off the Claude tool names (`Bash`/`Read`/`Edit`/…),
  * so without this every Codex tool renders as raw JSON with no syntax
  * highlighting. Canonicalize the shell tool to `Bash` (mirrors the
- * pi/copilot/opencode connectors); other tools (`update_plan`, `write_stdin`,
- * `apply_patch`, MCP tools, …) — and any shell call whose command we can't
- * recover (e.g. unparseable `arguments`) — pass through under their raw name so
- * the payload stays visible rather than collapsing to an empty Bash block.
+ * pi/copilot/opencode connectors) and `spawn_agent` to `Task` (its
+ * `description`/`subagent_type` anchor the child rollout's nested run — see
+ * `buildSubagentRuns`); other tools (`update_plan`, `write_stdin`, `wait_agent`,
+ * MCP tools, …) — and any shell/spawn call whose payload we can't recover (e.g.
+ * unparseable `arguments`) — pass through under their raw name so the payload
+ * stays visible rather than collapsing to an empty block.
  */
 function codexToolUse(name: string, input: unknown, id: string): ToolUseBlock {
   if (SHELL_TOOLS.has(name)) {
@@ -120,6 +275,22 @@ function codexToolUse(name: string, input: unknown, id: string): ToolUseBlock {
     const raw = args.cmd || args.command || action.command;
     const command = Array.isArray(raw) ? raw.map(quoteArg).join(' ') : str(raw);
     if (command) return { type: 'tool_use', id, name: 'Bash', input: { command } };
+  }
+  if (name === 'spawn_agent') {
+    const args = argsRecord(input);
+    const message = str(args.message);
+    if (message) {
+      return {
+        type: 'tool_use',
+        id,
+        name: 'Task',
+        input: {
+          description: subagentLabel(message),
+          subagent_type: str(args.agent_type),
+          prompt: message,
+        },
+      };
+    }
   }
   return { type: 'tool_use', id, name, input };
 }
@@ -137,6 +308,138 @@ function stripExecEnvelope(output: string): string {
   );
   if (!m) return output;
   return Number(m[1]) === 0 ? m[2]! : output;
+}
+
+/** The `apply_patch`-style custom-tool output envelope (`Exit code: N / Wall
+ *  time: … / Output:`) — group 1 is the exit code, group 2 the captured output. */
+const CUSTOM_ENVELOPE_RE = /^Exit code: (-?\d+)\nWall time: [^\n]*\n(?:[^\n]*\n)*?Output:\n?([\s\S]*)$/;
+
+/**
+ * Strip the custom-tool output envelope down to the captured output on success —
+ * the same rationale as {@link stripExecEnvelope}, which handles the different
+ * `Chunk ID:` envelope of the shell tool. A non-zero exit keeps the full envelope.
+ */
+function stripCustomEnvelope(output: string): string {
+  const m = output.match(CUSTOM_ENVELOPE_RE);
+  if (!m) return output;
+  return Number(m[1]) === 0 ? m[2]! : output;
+}
+
+// --- apply_patch → canonical edit blocks -------------------------------------
+
+interface Hunk {
+  oldText: string;
+  newText: string;
+}
+
+interface PatchFile {
+  op: 'add' | 'update' | 'delete';
+  path: string;
+  hunks: Hunk[];
+}
+
+/**
+ * Parse Codex's V4A `apply_patch` envelope (`*** Begin Patch` / `*** Add File:` /
+ * `*** Update File:` (+ optional `*** Move to:`) / `*** Delete File:` /
+ * `*** End Patch`) into per-file sections. Within a section, `@@` starts a hunk
+ * (content may also start one implicitly), ` ` = context, `-` = removed,
+ * `+` = added — the same hunk semantics as the opencode connector's unified-diff
+ * parser. Returns `[]` when the text isn't a patch (the caller then falls back to
+ * a raw passthrough block).
+ */
+function parseApplyPatch(patch: string): PatchFile[] {
+  const lines = patch.replace(/\r\n/g, '\n').split('\n');
+  if (!lines.some((l) => l.startsWith('*** Begin Patch'))) return [];
+  const files: PatchFile[] = [];
+  // Holders (not bare `let`s) so reads aren't reset by closure mutation in CFA.
+  const fileRef: { cur: PatchFile | null } = { cur: null };
+  const hunkRef: { cur: { old: string[]; neu: string[] } | null } = { cur: null };
+  const flushHunk = (): void => {
+    if (fileRef.cur && hunkRef.cur) {
+      fileRef.cur.hunks.push({
+        oldText: hunkRef.cur.old.join('\n'),
+        newText: hunkRef.cur.neu.join('\n'),
+      });
+    }
+    hunkRef.cur = null;
+  };
+  const openFile = (op: PatchFile['op'], path: string): void => {
+    flushHunk();
+    fileRef.cur = { op, path: path.trim(), hunks: [] };
+    files.push(fileRef.cur);
+  };
+  for (const line of lines) {
+    if (line.startsWith('*** Begin Patch') || line.startsWith('*** End Patch')) {
+      flushHunk();
+      fileRef.cur = null;
+      continue;
+    }
+    let m: RegExpMatchArray | null;
+    if ((m = line.match(/^\*\*\* Add File: (.+)$/))) {
+      openFile('add', m[1]!);
+      continue;
+    }
+    if ((m = line.match(/^\*\*\* Update File: (.+)$/))) {
+      openFile('update', m[1]!);
+      continue;
+    }
+    if ((m = line.match(/^\*\*\* Delete File: (.+)$/))) {
+      openFile('delete', m[1]!);
+      continue;
+    }
+    if ((m = line.match(/^\*\*\* Move to: (.+)$/))) {
+      // A rename: the Files-changed tab should show the resulting path.
+      if (fileRef.cur) fileRef.cur.path = m[1]!.trim();
+      continue;
+    }
+    if (line.startsWith('*** ')) continue; // e.g. `*** End of File`
+    if (!fileRef.cur || fileRef.cur.op === 'delete') continue;
+    if (line.startsWith('@@')) {
+      flushHunk();
+      hunkRef.cur = { old: [], neu: [] };
+      continue;
+    }
+    const tag = line[0];
+    if (tag !== ' ' && tag !== '-' && tag !== '+') continue;
+    if (!hunkRef.cur) hunkRef.cur = { old: [], neu: [] }; // implicit hunk (V4A allows no `@@`)
+    const body = line.slice(1);
+    if (tag === ' ') {
+      hunkRef.cur.old.push(body);
+      hunkRef.cur.neu.push(body);
+    } else if (tag === '-') {
+      hunkRef.cur.old.push(body);
+    } else {
+      hunkRef.cur.neu.push(body);
+    }
+  }
+  flushHunk();
+  return files.filter((f) => f.path);
+}
+
+/** A concise per-file status for a fanned-out apply_patch result (mirrors the
+ *  opencode connector — avoids repeating the multi-file summary on every block). */
+function patchFileStatus(f: PatchFile): string {
+  const verb = f.op === 'add' ? 'Created' : f.op === 'delete' ? 'Deleted' : 'Updated';
+  return `${verb} ${f.path}`;
+}
+
+/** One parsed patch file → a canonical Write/Edit/MultiEdit tool_use block
+ *  (the names + `file_path` input the Files-changed tab keys off). */
+function patchFileToolUse(f: PatchFile, id: string): ToolUseBlock {
+  if (f.op === 'add') {
+    const content = f.hunks
+      .map((h) => h.newText)
+      .filter((t) => t.length > 0)
+      .join('\n');
+    return { type: 'tool_use', id, name: 'Write', input: { file_path: f.path, content } };
+  }
+  if (f.op === 'delete') {
+    // V4A deletions carry no body, so there is no old content to show — an empty
+    // Edit still registers the file in the Files-changed tab.
+    return { type: 'tool_use', id, name: 'Edit', input: { file_path: f.path, old_string: '', new_string: '' } };
+  }
+  const edits = f.hunks.map((h) => ({ old_string: h.oldText, new_string: h.newText }));
+  return { type: 'tool_use', id, name: 'MultiEdit', input: { file_path: f.path, edits } };
 }
 
 /** Session id from the filename: `rollout-<ts>-<uuid>.jsonl`. */
@@ -170,10 +473,37 @@ export function parseRollout(path: string): CodexSession | null {
   const git = meta.git as Record<string, unknown> | undefined;
   const gitBranch = git ? str(git.branch) || str(git.ref) || undefined : undefined;
 
+  // A `thread_source: "subagent"` rollout is re-parented under its ROOT thread
+  // (multi-level: walk the cross-file parent map), so it folds into the parent
+  // session in the index instead of surfacing as its own top-level session.
+  let indexSessionId = sessionId;
+  let isSidechain = false;
+  let agentRole: string | undefined;
+  if (str(meta.thread_source) === 'subagent') {
+    const spawn = rec(rec(rec(meta.source).subagent).thread_spawn);
+    const parentId = str(spawn.parent_thread_id);
+    agentRole = str(spawn.agent_role) || undefined;
+    if (parentId) {
+      isSidechain = true;
+      indexSessionId = rootThreadId(parentId, getCodexContext().parents);
+    }
+  }
+
   const events: (UserEvent | AssistantEvent)[] = [];
   let seq = 0;
+  let wsSeq = 0;
   let prevUuid: string | null = null;
   let model = '';
+
+  // spawn_agent correlation: call_id → Task meta (set at the call), promoted to
+  // spawnedAgents keyed by the child thread id when the output names it.
+  const pendingSpawns = new Map<string, { description: string; agentType: string }>();
+  const spawnedAgents = new Map<string, { description: string; agentType: string }>();
+  // apply_patch fan-out: call_id → the fanned block REFERENCES (they stay live
+  // inside the flushed event), per-file statuses, and the raw patch text — so the
+  // (single) custom_tool_call_output can pair a result to every block, or demote
+  // the blocks back to raw passthrough when the patch was rejected.
+  const patchFanout = new Map<string, { blocks: ToolUseBlock[]; statuses: string[]; raw: string }>();
 
   // Open turn buffer; flushed when the conversation side flips.
   let side: 'assistant' | 'user' | null = null;
@@ -189,7 +519,7 @@ export function parseRollout(path: string): CodexSession | null {
       return;
     }
     const uuid = `${sessionId}-${seq++}`;
-    const base = { uuid, parentUuid: prevUuid, sessionId, timestamp: turnTs, cwd, isSidechain: false };
+    const base = { uuid, parentUuid: prevUuid, sessionId, timestamp: turnTs, cwd, isSidechain };
     if (side === 'assistant') {
       const usage: MessageUsage = usageRef.current ?? zeroUsage();
       events.push({
@@ -262,19 +592,105 @@ export function parseRollout(path: string): CodexSession | null {
       } catch {
         input = { arguments: str(pl.arguments) };
       }
-      blocks.push(codexToolUse(str(pl.name), input, str(pl.call_id)));
+      const block = codexToolUse(str(pl.name), input, str(pl.call_id));
+      if (str(pl.name) === 'spawn_agent' && block.name === 'Task') {
+        const taskInput = block.input as { description: string; subagent_type: string };
+        pendingSpawns.set(block.id, {
+          description: taskInput.description,
+          agentType: taskInput.subagent_type,
+        });
+      }
+      blocks.push(block);
     } else if (kind === 'function_call_output') {
+      open('user', ts);
+      const callId = str(pl.call_id);
+      const output = str(pl.output);
+      const spawn = pendingSpawns.get(callId);
+      if (spawn) {
+        // The output names the spawned child thread: `{"agent_id": …, "nickname": …}`.
+        try {
+          const agentId = str(rec(JSON.parse(output)).agent_id);
+          if (agentId) spawnedAgents.set(agentId, spawn);
+        } catch {
+          /* unparseable spawn output — the child will render detached */
+        }
+      }
+      blocks.push({
+        type: 'tool_result',
+        tool_use_id: callId,
+        content: stripExecEnvelope(output),
+      });
+    } else if (kind === 'custom_tool_call') {
+      // Freeform tools (arguments arrive as a raw string). `apply_patch` fans out
+      // to one canonical Write/Edit/MultiEdit block per touched file (mirrors the
+      // opencode connector); other custom tools pass through under their raw name.
+      open('assistant', ts);
+      const name = str(pl.name);
+      const callId = str(pl.call_id);
+      const raw = str(pl.input);
+      const patchFiles = name === 'apply_patch' ? parseApplyPatch(raw) : [];
+      if (patchFiles.length > 0) {
+        const fanned = patchFiles.map((f, i) =>
+          patchFileToolUse(f, patchFiles.length === 1 ? callId : `${callId}#${i}`),
+        );
+        for (const b of fanned) blocks.push(b);
+        patchFanout.set(callId, {
+          blocks: fanned,
+          statuses: patchFiles.map(patchFileStatus),
+          raw,
+        });
+      } else {
+        blocks.push({ type: 'tool_use', id: callId, name, input: { input: raw } });
+      }
+    } else if (kind === 'custom_tool_call_output') {
+      open('user', ts);
+      const callId = str(pl.call_id);
+      const output = str(pl.output);
+      const fan = patchFanout.get(callId);
+      const exit = output.match(CUSTOM_ENVELOPE_RE);
+      if (fan && exit && Number(exit[1]) !== 0) {
+        // The patch was REJECTED — nothing on disk changed. Demote the fanned
+        // canonical blocks back to raw apply_patch passthrough (no `file_path`,
+        // so the Files-changed tab never lists untouched files — the same
+        // failed-edit convention as the copilot connector) and surface the full
+        // error output on each.
+        for (const b of fan.blocks) {
+          b.name = 'apply_patch';
+          b.input = { input: fan.raw };
+          blocks.push({ type: 'tool_result', tool_use_id: b.id, content: output, is_error: true });
+        }
+      } else if (fan && fan.blocks.length > 1) {
+        // Per-file status, NOT the shared multi-file summary (which would
+        // repeat identically on every fanned-out block).
+        fan.blocks.forEach((b, i) =>
+          blocks.push({ type: 'tool_result', tool_use_id: b.id, content: fan.statuses[i]! }),
+        );
+      } else {
+        blocks.push({
+          type: 'tool_result',
+          tool_use_id: callId,
+          content: stripCustomEnvelope(output),
+        });
+      }
+    } else if (kind === 'tool_search_call') {
+      open('assistant', ts);
+      blocks.push({ type: 'tool_use', id: str(pl.call_id), name: 'tool_search', input: rec(pl.arguments) });
+    } else if (kind === 'tool_search_output') {
       open('user', ts);
       blocks.push({
         type: 'tool_result',
         tool_use_id: str(pl.call_id),
-        content: stripExecEnvelope(str(pl.output)),
+        content: JSON.stringify(pl.tools ?? [], null, 1),
       });
+    } else if (kind === 'web_search_call') {
+      // No call_id and no paired output record — render the query/action alone.
+      open('assistant', ts);
+      blocks.push({ type: 'tool_use', id: `${sessionId}-ws-${wsSeq++}`, name: 'web_search', input: rec(pl.action) });
     }
   }
   flush();
 
-  return { sessionId, cwd, gitBranch, events };
+  return { sessionId, indexSessionId, isSidechain, agentRole, cwd, gitBranch, events, spawnedAgents };
 }
 
 /** A canonical index row (matches the events NDJSON the projection reads). */
@@ -315,7 +731,8 @@ export function toCanonicalRows(session: CodexSession, filePath: string): Canoni
       .join(' ');
     return {
       file_path: filePath,
-      session_id: session.sessionId,
+      // The ROOT thread id — a subagent rollout indexes under its parent session.
+      session_id: session.indexSessionId,
       uuid: e.uuid,
       parent_uuid: e.parentUuid,
       role: msg.role,
@@ -329,7 +746,7 @@ export function toCanonicalRows(session: CodexSession, filePath: string): Canoni
       cache_read_tokens: num(usage?.cache_read_input_tokens),
       cache_write_tokens: 0,
       service_tier: null,
-      is_sidechain: false,
+      is_sidechain: session.isSidechain,
       tool_use_count: arr.filter((b) => b.type === 'tool_use').length,
       tool_names: toolNamesCsv(arr),
       text_content: text,

--- a/packages/server/src/connectors/copilot/copilot.ts
+++ b/packages/server/src/connectors/copilot/copilot.ts
@@ -19,9 +19,9 @@ import { existsSync, mkdirSync, readdirSync, statSync, writeFileSync } from 'nod
 import { join } from 'node:path';
 import { CLAUDESCOPE_HOME, COPILOT_SESSIONS_DIR } from '../../config.js';
 import { sqlString } from '../../db/duckdb.js';
-import type { SessionData } from '../../data/session-loader.js';
+import type { SessionData, SubagentSource } from '../../data/session-loader.js';
 import type { AgentConnector, AuxProjections, DiscoveredFile } from '../types.js';
-import { parseCopilotSession, toCanonicalRows } from './normalize.js';
+import { parseCopilotSession, toCanonicalRows, type CopilotSession } from './normalize.js';
 import { copilotGlobalMemory } from './memory.js';
 
 const CACHE_DIR = join(CLAUDESCOPE_HOME, 'cache', 'copilot');
@@ -96,8 +96,21 @@ function auxProjections(filePath: string): AuxProjections {
 
 async function loadSession(_sessionId: string, paths: string[]): Promise<SessionData> {
   // resolveImages: pull saved-attachment bytes off disk for the detail view.
-  const mainEvents = paths.flatMap((p) => parseCopilotSession(p, { resolveImages: true })?.events ?? []);
-  return { mainEvents, subagents: [] };
+  const sessions = paths
+    .map((p) => parseCopilotSession(p, { resolveImages: true }))
+    .filter((s): s is CopilotSession => s !== null);
+  const mainEvents = sessions.flatMap((s) => s.events);
+  // Inline subagent runs, segmented out by the normalizer — each anchors to its
+  // canonical `Task` block via the shared description string.
+  const subagents: SubagentSource[] = sessions.flatMap((s) =>
+    s.subagents.map((sub) => ({
+      agentId: sub.agentId,
+      agentType: sub.agentType,
+      description: sub.description,
+      events: sub.events,
+    })),
+  );
+  return { mainEvents, subagents };
 }
 
 export const copilotConnector: AgentConnector = {

--- a/packages/server/src/connectors/copilot/normalize.ts
+++ b/packages/server/src/connectors/copilot/normalize.ts
@@ -28,12 +28,19 @@
  *    `Edit`/`Write` block ONLY when it actually succeeded (a granted, successful
  *    `tool.execution_complete`); a denied/failed attempt passes through under its raw
  *    name so it shows in-thread but never reaches the Files-changed tab.
+ *  - **Subagents are inline**: a `task` tool call spawns a subagent whose whole
+ *    event stream runs INLINE in the parent's `events.jsonl` between
+ *    `subagent.started`/`subagent.completed`, every inner event tagged with an
+ *    event-level `agentId` (= the spawning `task` toolCallId). Tagged events are
+ *    routed into per-agent buffers (never the main thread), the `task` call is
+ *    canonicalized to a `Task` block, and each buffer becomes a `SubagentSource`
+ *    nested at its spawn point (matched by description, see `buildSubagentRuns`).
  *
  * STRICTLY READ-ONLY with respect to ~/.copilot — files are only ever read.
  */
 
-import { readFileSync, statSync } from 'node:fs';
-import { basename, dirname, extname, join } from 'node:path';
+import { readFileSync } from 'node:fs';
+import { basename, dirname, join } from 'node:path';
 import type {
   AssistantEvent,
   ContentBlock,
@@ -41,7 +48,20 @@ import type {
   ToolResultBlock,
   UserEvent,
 } from '@claudescope/shared';
+import { resolveImageWithin } from '../safe-image.js';
 import { toolNamesCsv } from '../tool-names.js';
+
+/** One inline subagent run, segmented out of the parent's event stream. */
+export interface CopilotSubagent {
+  /** The spawning `task` toolCallId — the `agentId` tag on the run's events. */
+  agentId: string;
+  /** Copilot agent name from `subagent.started` (e.g. `explore`); '' if lost. */
+  agentType: string;
+  /** The `task` call's `arguments.description` — same string the canonical
+   *  `Task` block carries, so the run anchors to its spawn point. */
+  description: string;
+  events: (UserEvent | AssistantEvent)[];
+}
 
 export interface CopilotSession {
   sessionId: string;
@@ -49,6 +69,7 @@ export interface CopilotSession {
   branch: string | null;
   title: string;
   events: (UserEvent | AssistantEvent)[];
+  subagents: CopilotSubagent[];
 }
 
 const str = (v: unknown): string => (typeof v === 'string' ? v : '');
@@ -137,37 +158,19 @@ function toolUseBlock(
   return { type: 'tool_use', id, name, input: args };
 }
 
-/** Cap an inline-embedded screenshot so a stray huge file can't bloat the
- *  session-detail payload / exhaust memory when base64-encoded. */
-const MAX_IMAGE_BYTES = 20 * 1024 * 1024;
-
-const IMAGE_MIME: Record<string, string> = {
-  '.png': 'image/png',
-  '.jpg': 'image/jpeg',
-  '.jpeg': 'image/jpeg',
-  '.gif': 'image/gif',
-  '.webp': 'image/webp',
-};
-
 /**
  * Resolve a persisted attachment (`files/<displayName>`) to a base64 `ImageBlock`.
  * The `events.jsonl` attachment `path` is a deleted `$TMPDIR` copy, so we resolve by
- * `displayName` (basename only — never escape the `files/` dir). Returns null for a
- * non-image, or when the bytes weren't saved (screenshot-saving off) — the inline
- * `[📷 …]` marker in the message text already conveys the attachment in that case.
+ * `displayName` (basename, then symlink-safe containment inside `files/` via the
+ * shared resolver). Returns null for a non-image, or when the bytes weren't saved
+ * (screenshot-saving off) — the inline `[📷 …]` marker in the message text already
+ * conveys the attachment in that case.
  */
 function resolveImage(sessionDir: string, displayName: string): ContentBlock | null {
   const name = basename(displayName);
-  const mime = IMAGE_MIME[extname(name).toLowerCase()];
-  if (!name || !mime) return null;
-  try {
-    const full = join(sessionDir, 'files', name);
-    if (statSync(full).size > MAX_IMAGE_BYTES) return null; // don't inline an oversized file
-    const data = readFileSync(full).toString('base64');
-    return { type: 'image', source: { type: 'base64', media_type: mime, data } };
-  } catch {
-    return null;
-  }
+  if (!name) return null;
+  const filesDir = join(sessionDir, 'files');
+  return resolveImageWithin(filesDir, join(filesDir, name));
 }
 
 /** A `user.message` → canonical blocks: the literal text (which already carries the
@@ -199,6 +202,20 @@ interface CopilotEvent {
   id?: string;
   timestamp?: string;
   parentId?: string | null;
+  /** Present on every event belonging to an inline subagent run (= the
+   *  spawning `task` toolCallId); absent on main-thread events. */
+  agentId?: string;
+}
+
+/** Per-thread turn buffer: the main transcript and each subagent run get their
+ *  own event list, uuid chain, and running model. */
+interface TurnStream {
+  events: (UserEvent | AssistantEvent)[];
+  seq: number;
+  prevUuid: string | null;
+  uuidPrefix: string;
+  sidechain: boolean;
+  model: string;
 }
 
 /** Minimal `workspace.yaml` reader — only a few scalar keys are needed. */
@@ -248,13 +265,29 @@ export function parseCopilotSession(
   let cwd = '';
   let branch: string | null = null;
 
-  // Pass 1: session identity (session.start) + per-tool outcome (success/denied).
-  // The result/denial is needed when emitting a tool_use, which precedes its
-  // tool.execution_complete in the stream — so collect outcomes up front.
+  // Pass 1: session identity (session.start) + per-tool outcome (success/denied)
+  // + subagent identities. Outcomes and subagent metadata are needed when
+  // emitting a tool_use, which precedes both the tool.execution_complete and the
+  // subagent.started in the stream — so collect them up front.
   const resultById = new Map<string, { content: string; isError: boolean }>();
+  const agentMetaById = new Map<string, { agentType: string; model: string }>();
+  const knownAgentIds = new Set<string>();
+  // `task` toolRequest descriptions by toolCallId — the Task block and its
+  // SubagentSource must carry the SAME string (the anchor buildSubagentRuns
+  // matches on), so both sides read from this one map.
+  const taskDescById = new Map<string, string>();
   for (const ev of lines) {
     const d = rec(ev.data);
-    if (ev.type === 'session.start') {
+    if (str(ev.agentId)) knownAgentIds.add(str(ev.agentId));
+    if (ev.type === 'assistant.message') {
+      const reqs = Array.isArray(d.toolRequests) ? d.toolRequests : [];
+      for (const r of reqs) {
+        const tr = rec(r);
+        if (str(tr.name) === 'task' && str(tr.toolCallId)) {
+          taskDescById.set(str(tr.toolCallId), str(rec(tr.arguments).description));
+        }
+      }
+    } else if (ev.type === 'session.start') {
       const ctx = rec(d.context);
       if (str(d.sessionId)) sessionId = str(d.sessionId);
       if (str(ctx.cwd)) cwd = str(ctx.cwd);
@@ -270,6 +303,12 @@ export function parseCopilotSession(
       if (str(r.kind).startsWith('denied') && !resultById.has(id)) {
         resultById.set(id, { content: 'Permission denied by the user.', isError: true });
       }
+    } else if (ev.type === 'subagent.started') {
+      const id = str(d.toolCallId) || str(ev.agentId);
+      if (id) {
+        knownAgentIds.add(id);
+        agentMetaById.set(id, { agentType: str(d.agentName), model: str(d.model) });
+      }
     }
   }
   if (!cwd && ws.cwd) cwd = ws.cwd;
@@ -278,11 +317,35 @@ export function parseCopilotSession(
   const resolveImages = opts.resolveImages ?? false;
 
   // Pass 2: build the threaded events with a synthesized uuid/parent chain.
-  const events: (UserEvent | AssistantEvent)[] = [];
-  let seq = 0;
-  let prevUuid: string | null = null;
-  const nextUuid = (): string => `${sessionId}-${seq++}`;
-  const envelope = (ts: string): Pick<
+  // Events tagged with an `agentId` belong to an inline subagent run and are
+  // routed into that agent's own stream (never the main thread); untagged
+  // events build the main transcript.
+  const main: TurnStream = {
+    events: [],
+    seq: 0,
+    prevUuid: null,
+    uuidPrefix: sessionId,
+    sidechain: false,
+    model: '',
+  };
+  const subStreams = new Map<string, TurnStream>(); // insertion-ordered
+  const subStream = (agentId: string): TurnStream => {
+    let s = subStreams.get(agentId);
+    if (!s) {
+      s = {
+        events: [],
+        seq: 0,
+        prevUuid: null,
+        uuidPrefix: `${sessionId}-${agentId}`,
+        sidechain: true,
+        model: agentMetaById.get(agentId)?.model ?? '',
+      };
+      subStreams.set(agentId, s);
+    }
+    return s;
+  };
+
+  const envelope = (ts: string, sidechain: boolean): Pick<
     UserEvent,
     'sessionId' | 'timestamp' | 'cwd' | 'gitBranch' | 'isSidechain'
   > => ({
@@ -290,60 +353,83 @@ export function parseCopilotSession(
     timestamp: ts,
     cwd,
     ...(branch ? { gitBranch: branch } : {}),
-    isSidechain: false,
+    isSidechain: sidechain,
   });
-  let model = '';
-  let shutdown: MessageUsage | null = null;
 
+  const pushUser = (s: TurnStream, ts: string, content: ContentBlock[]): void => {
+    const uuid = `${s.uuidPrefix}-${s.seq++}`;
+    s.events.push({ uuid, parentUuid: s.prevUuid, ...envelope(ts, s.sidechain), type: 'user', message: { role: 'user', content } } as UserEvent);
+    s.prevUuid = uuid;
+  };
+
+  /** One `assistant.message` → an assistant turn (+ a tool-result user turn). */
+  const assistantTurn = (s: TurnStream, d: Record<string, unknown>, ts: string): void => {
+    if (str(d.model)) s.model = str(d.model);
+    const blocks: ContentBlock[] = [];
+    const reasoning = str(d.reasoningOpaque);
+    if (reasoning) blocks.push({ type: 'thinking', thinking: '', signature: reasoning });
+    const text = str(d.content);
+    if (text) blocks.push({ type: 'text', text });
+    const toolResults: ToolResultBlock[] = [];
+    const reqs = Array.isArray(d.toolRequests) ? d.toolRequests : [];
+    for (const r of reqs) {
+      const tr = rec(r);
+      const id = str(tr.toolCallId);
+      const args = rec(tr.arguments);
+      const outcome = resultById.get(id);
+      // A `task` call that actually ran a subagent → canonical `Task`: the spawn
+      // point the nested run anchors to (buildSubagentRuns matches the run by
+      // this description + subagent_type). A task with no trace of a run (never
+      // started, no tagged events) passes through under its raw name.
+      blocks.push(
+        str(tr.name) === 'task' && knownAgentIds.has(id)
+          ? {
+              type: 'tool_use',
+              id,
+              name: 'Task',
+              input: {
+                description: str(args.description),
+                subagent_type: agentMetaById.get(id)?.agentType ?? '',
+                prompt: str(args.prompt),
+              },
+            }
+          : toolUseBlock(str(tr.name), args, id, !!outcome && !outcome.isError),
+      );
+      if (outcome) {
+        toolResults.push({
+          type: 'tool_result',
+          tool_use_id: id,
+          content: outcome.content,
+          ...(outcome.isError ? { is_error: true } : {}),
+        });
+      }
+    }
+    if (blocks.length === 0) return; // empty assistant scaffolding turn — skip
+    const uuid = `${s.uuidPrefix}-${s.seq++}`;
+    s.events.push({
+      uuid,
+      parentUuid: s.prevUuid,
+      ...envelope(ts, s.sidechain),
+      type: 'assistant',
+      message: { role: 'assistant', model: s.model, content: blocks, usage: zeroUsage() },
+    } as AssistantEvent);
+    s.prevUuid = uuid;
+    // Tool results ride a following synthetic user turn (assembler pairs by id).
+    if (toolResults.length > 0) pushUser(s, ts, toolResults);
+  };
+
+  let shutdown: MessageUsage | null = null;
   for (const ev of lines) {
     const d = rec(ev.data);
     const ts = str(ev.timestamp);
+    if (ev.type === 'subagent.started' || ev.type === 'subagent.completed') continue; // metadata (pass 1)
+    const stream = str(ev.agentId) ? subStream(str(ev.agentId)) : main;
     if (ev.type === 'session.model_change') {
-      if (str(d.newModel)) model = str(d.newModel);
+      if (str(d.newModel)) stream.model = str(d.newModel);
     } else if (ev.type === 'user.message') {
-      const content = userBlocks(d, sessionDir, resolveImages);
-      const uuid = nextUuid();
-      events.push({ uuid, parentUuid: prevUuid, ...envelope(ts), type: 'user', message: { role: 'user', content } } as UserEvent);
-      prevUuid = uuid;
+      pushUser(stream, ts, userBlocks(d, sessionDir, resolveImages));
     } else if (ev.type === 'assistant.message') {
-      if (str(d.model)) model = str(d.model);
-      const blocks: ContentBlock[] = [];
-      const reasoning = str(d.reasoningOpaque);
-      if (reasoning) blocks.push({ type: 'thinking', thinking: '', signature: reasoning });
-      const text = str(d.content);
-      if (text) blocks.push({ type: 'text', text });
-      const toolResults: ToolResultBlock[] = [];
-      const reqs = Array.isArray(d.toolRequests) ? d.toolRequests : [];
-      for (const r of reqs) {
-        const tr = rec(r);
-        const id = str(tr.toolCallId);
-        const outcome = resultById.get(id);
-        blocks.push(toolUseBlock(str(tr.name), rec(tr.arguments), id, !!outcome && !outcome.isError));
-        if (outcome) {
-          toolResults.push({
-            type: 'tool_result',
-            tool_use_id: id,
-            content: outcome.content,
-            ...(outcome.isError ? { is_error: true } : {}),
-          });
-        }
-      }
-      if (blocks.length === 0) continue; // empty assistant scaffolding turn — skip
-      const uuid = nextUuid();
-      events.push({
-        uuid,
-        parentUuid: prevUuid,
-        ...envelope(ts),
-        type: 'assistant',
-        message: { role: 'assistant', model, content: blocks, usage: zeroUsage() },
-      } as AssistantEvent);
-      prevUuid = uuid;
-      // Tool results ride a following synthetic user turn (assembler pairs by id).
-      if (toolResults.length > 0) {
-        const ruid = nextUuid();
-        events.push({ uuid: ruid, parentUuid: prevUuid, ...envelope(ts), type: 'user', message: { role: 'user', content: toolResults } } as UserEvent);
-        prevUuid = ruid;
-      }
+      assistantTurn(stream, d, ts);
     } else if (ev.type === 'session.shutdown') {
       shutdown = shutdownUsage(d);
     }
@@ -351,10 +437,11 @@ export function parseCopilotSession(
     // permission.*, abort, and any unknown/new type are tolerated and skipped.
   }
 
-  // Tokens exist only at session level → attach to the last assistant turn.
+  // Tokens exist only at session level → attach to the last MAIN assistant turn
+  // (subagent turns carry no usage; Copilot reports no per-agent breakdown).
   if (shutdown) {
-    for (let i = events.length - 1; i >= 0; i--) {
-      const e = events[i];
+    for (let i = main.events.length - 1; i >= 0; i--) {
+      const e = main.events[i];
       if (e && e.type === 'assistant') {
         e.message.usage = shutdown;
         break;
@@ -362,7 +449,19 @@ export function parseCopilotSession(
     }
   }
 
-  return { sessionId, cwd, branch, title, events };
+  const subagents: CopilotSubagent[] = [];
+  for (const [agentId, s] of subStreams) {
+    if (s.events.length === 0) continue; // spawned but produced nothing — no run to show
+    subagents.push({
+      agentId,
+      agentType: agentMetaById.get(agentId)?.agentType ?? '',
+      // '' when the spawning call is lost — renders detached, never mismatched.
+      description: taskDescById.get(agentId) ?? '',
+      events: s.events,
+    });
+  }
+
+  return { sessionId, cwd, branch, title, events: main.events, subagents };
 }
 
 /** A canonical index row (matches the events NDJSON the projection reads). */
@@ -390,9 +489,12 @@ export interface CanonicalRow {
   title: string;
 }
 
-/** Flatten a parsed session into canonical index rows for one file. */
+/** Flatten a parsed session into canonical index rows for one file. Subagent
+ *  events are included (same session, `is_sidechain` true) so their text is
+ *  searchable under the session and `has_sidechain` flips on. */
 export function toCanonicalRows(session: CopilotSession, filePath: string): CanonicalRow[] {
-  return session.events.map((e) => {
+  const all = [...session.events, ...session.subagents.flatMap((s) => s.events)];
+  return all.map((e) => {
     const msg = e.message;
     const content = Array.isArray(msg.content) ? msg.content : [];
     const usage = (msg as { usage?: MessageUsage }).usage;
@@ -416,7 +518,7 @@ export function toCanonicalRows(session: CopilotSession, filePath: string): Cano
       cache_read_tokens: num(usage?.cache_read_input_tokens),
       cache_write_tokens: num(usage?.cache_creation_input_tokens),
       service_tier: null,
-      is_sidechain: false,
+      is_sidechain: e.isSidechain === true,
       tool_use_count: content.filter((b) => b.type === 'tool_use').length,
       tool_names: toolNamesCsv(content),
       text_content: text,

--- a/packages/server/src/connectors/opencode/db.ts
+++ b/packages/server/src/connectors/opencode/db.ts
@@ -25,6 +25,13 @@ export interface OpencodeRawSession {
   id: string;
   directory: string;
   title: string;
+  /** `session.parent_id` — set when this is a task-spawned child session. */
+  parentId: string | null;
+  /**
+   * Root ancestor id (own id for a top-level session) — the indexing key, so a
+   * task-spawned child folds into its parent session (the antigravity pattern).
+   */
+  rootId: string;
   /** message rows in creation order. */
   messages: { id: string; data: string }[];
   /** part `data` strings grouped by message id, each list in creation order. */
@@ -72,13 +79,40 @@ export function listSessions(dbPath: string): OpencodeSessionMeta[] {
   }
 }
 
+/**
+ * Follow `parent_id` up to the top-level ancestor. Stops at a dangling link (the
+ * parent row is gone — the walked-to session is then the root) and degrades to
+ * the session's own id on a cycle (corrupt data must not re-key anything).
+ */
+function resolveRootId(
+  db: InstanceType<typeof DatabaseSync>,
+  id: string,
+  firstParent: string | null,
+): string {
+  let rootId = id;
+  let parentId = firstParent;
+  const guard = new Set<string>([id]);
+  const parentOf = db.prepare('SELECT parent_id FROM session WHERE id = ?');
+  while (parentId) {
+    if (guard.has(parentId)) return id; // cycle — treat as standalone
+    const row = parentOf.get(parentId) as { parent_id: string | null } | undefined;
+    if (!row) break; // dangling link — current rootId is the top
+    guard.add(parentId);
+    rootId = parentId;
+    parentId = row.parent_id == null ? null : String(row.parent_id);
+  }
+  return rootId;
+}
+
 /** Read one session's metadata + messages + parts; `null` if the session is gone. */
 export function readSession(dbPath: string, sessionId: string): OpencodeRawSession | null {
   if (!existsSync(dbPath)) return null;
   const db = open(dbPath);
   try {
-    const s = db.prepare('SELECT id, directory, title FROM session WHERE id = ?').get(sessionId) as
-      | { id: string; directory: string | null; title: string | null }
+    const s = db
+      .prepare('SELECT id, directory, title, parent_id FROM session WHERE id = ?')
+      .get(sessionId) as
+      | { id: string; directory: string | null; title: string | null; parent_id: string | null }
       | undefined;
     if (!s) return null;
 
@@ -98,10 +132,14 @@ export function readSession(dbPath: string, sessionId: string): OpencodeRawSessi
       partsByMessage.set(String(p.mid), list);
     }
 
+    const id = String(s.id);
+    const parentId = s.parent_id == null ? null : String(s.parent_id);
     return {
-      id: String(s.id),
+      id,
       directory: String(s.directory ?? ''),
       title: String(s.title ?? ''),
+      parentId,
+      rootId: parentId ? resolveRootId(db, id, parentId) : id,
       messages,
       partsByMessage,
     };

--- a/packages/server/src/connectors/opencode/normalize.ts
+++ b/packages/server/src/connectors/opencode/normalize.ts
@@ -18,6 +18,10 @@
  *  - A tool part carries BOTH the call and its result, so we emit the `tool_use`
  *    on the assistant turn and the `tool_result` on a following synthetic user
  *    turn (the Claude/Codex/pi convention the assembler pairs by id).
+ *  - **Task-spawned children** (`session.parent_id`) key their rows to the ROOT
+ *    ancestor with `is_sidechain: true`, and the spawning `task` part becomes a
+ *    canonical `Task` block — so the child nests under its parent session
+ *    (the antigravity pattern).
  */
 
 import type {
@@ -195,6 +199,19 @@ function toolPartBlocks(data: Record<string, unknown>): ToolBlocks {
       name: 'Bash',
       input: { command: str(input.command), timeout: input.timeout, description: str(input.description) },
     };
+  } else if (tool === 'task') {
+    // task (subagent spawn) → canonical `Task`, so the re-parented child session
+    // nests at this call (`buildSubagentRuns` anchors by matching description).
+    use = {
+      type: 'tool_use',
+      id: callID,
+      name: 'Task',
+      input: {
+        description: str(input.description),
+        subagent_type: str(input.subagent_type),
+        prompt: str(input.prompt),
+      },
+    };
   } else {
     // grep / glob / webfetch / skill / todowrite / unknown → generic passthrough
     use = { type: 'tool_use', id: callID, name: tool, input };
@@ -230,6 +247,11 @@ function toUsage(tokens: unknown): MessageUsage {
 export function buildEvents(session: OpencodeRawSession): (UserEvent | AssistantEvent)[] {
   const events: (UserEvent | AssistantEvent)[] = [];
   const cwd = session.directory;
+  // A task-spawned child keys to its root ancestor and flags sidechain, so it
+  // folds into the parent session (claude-code/antigravity convention). Uuids
+  // stay namespaced by the child's own id — no collision with parent rows.
+  const sessionId = session.rootId;
+  const isSidechain = session.rootId !== session.id;
   let seq = 0;
   let prevUuid: string | null = null;
   const nextUuid = (): string => `${session.id}-${seq++}`;
@@ -275,10 +297,10 @@ export function buildEvents(session: OpencodeRawSession): (UserEvent | Assistant
       events.push({
         uuid,
         parentUuid,
-        sessionId: session.id,
+        sessionId,
         timestamp: ts,
         cwd,
-        isSidechain: false,
+        isSidechain,
         type: 'assistant',
         message: { role: 'assistant', model, content: blocks, usage: toUsage(data.tokens) },
       } as AssistantEvent);
@@ -315,10 +337,10 @@ export function buildEvents(session: OpencodeRawSession): (UserEvent | Assistant
       events.push({
         uuid,
         parentUuid,
-        sessionId: session.id,
+        sessionId,
         timestamp: ts,
         cwd,
-        isSidechain: false,
+        isSidechain,
         type: 'user',
         message: { role: 'user', content: blocks },
       } as UserEvent);
@@ -326,6 +348,36 @@ export function buildEvents(session: OpencodeRawSession): (UserEvent | Assistant
   }
 
   return events;
+}
+
+/**
+ * Child-session spawn metadata from a session's `task` parts:
+ * `state.metadata.sessionId` (the spawned child) → the Task block's
+ * `{subagent_type, description}`. `loadSession` uses it to label each
+ * re-parented child with the SAME description as its Task block, which is what
+ * `buildSubagentRuns` matches to anchor the run at the spawn point.
+ */
+export function taskSpawns(
+  session: OpencodeRawSession,
+): Map<string, { agentType: string; description: string }> {
+  const map = new Map<string, { agentType: string; description: string }>();
+  for (const m of session.messages) {
+    for (const raw of session.partsByMessage.get(m.id) ?? []) {
+      const p = parseJson(raw);
+      if (str(p.type) !== 'tool' || str(p.tool) !== 'task') continue;
+      const state = (p.state ?? {}) as Record<string, unknown>;
+      const input = (state.input ?? {}) as Record<string, unknown>;
+      const metadata = (state.metadata ?? {}) as Record<string, unknown>;
+      const childId = str(metadata.sessionId);
+      if (childId) {
+        map.set(childId, {
+          agentType: str(input.subagent_type),
+          description: str(input.description),
+        });
+      }
+    }
+  }
+  return map;
 }
 
 /** A canonical index row (matches the events NDJSON the projection reads). */
@@ -355,6 +407,7 @@ export interface CanonicalRow {
 
 /** Flatten a parsed session into canonical index rows for one file. */
 export function toCanonicalRows(session: OpencodeRawSession, filePath: string): CanonicalRow[] {
+  const isSidechain = session.rootId !== session.id;
   return buildEvents(session).map((e) => {
     const msg = e.message;
     const content = Array.isArray(msg.content) ? msg.content : [];
@@ -365,7 +418,7 @@ export function toCanonicalRows(session: OpencodeRawSession, filePath: string): 
       .join(' ');
     return {
       file_path: filePath,
-      session_id: session.id,
+      session_id: session.rootId,
       uuid: e.uuid,
       parent_uuid: e.parentUuid,
       role: msg.role,
@@ -379,11 +432,13 @@ export function toCanonicalRows(session: OpencodeRawSession, filePath: string): 
       cache_read_tokens: num(usage?.cache_read_input_tokens),
       cache_write_tokens: num(usage?.cache_creation_input_tokens),
       service_tier: null,
-      is_sidechain: false,
+      is_sidechain: isSidechain,
       tool_use_count: content.filter((b) => b.type === 'tool_use').length,
       tool_names: toolNamesCsv(content),
       text_content: text,
-      title: session.title,
+      // A child's title must not clobber the parent's via the titles projection
+      // (both files now share one session_id) — emit none for sidechain rows.
+      title: isSidechain ? '' : session.title,
     };
   });
 }

--- a/packages/server/src/connectors/opencode/opencode.ts
+++ b/packages/server/src/connectors/opencode/opencode.ts
@@ -18,10 +18,10 @@ import { existsSync, mkdirSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { CLAUDESCOPE_HOME, OPENCODE_DATA_DIR, OPENCODE_DB_PATH } from '../../config.js';
 import { sqlString } from '../../db/duckdb.js';
-import type { SessionData } from '../../data/session-loader.js';
+import type { SessionData, SubagentSource } from '../../data/session-loader.js';
 import type { AgentConnector, AuxProjections, DiscoveredFile } from '../types.js';
 import { listSessions, readSession } from './db.js';
-import { buildEvents, toCanonicalRows } from './normalize.js';
+import { buildEvents, taskSpawns, toCanonicalRows } from './normalize.js';
 
 const CACHE_DIR = join(CLAUDESCOPE_HOME, 'cache', 'opencode');
 
@@ -98,13 +98,42 @@ function auxProjections(filePath: string): AuxProjections {
   };
 }
 
-async function loadSession(_sessionId: string, paths: string[]): Promise<SessionData> {
-  const mainEvents = paths.flatMap((p) => {
-    const { dbPath, sessionId } = parseKey(p);
-    const session = readSession(dbPath, sessionId);
-    return session ? buildEvents(session) : [];
-  });
-  return { mainEvents, subagents: [] };
+/**
+ * Load a session's events, splitting the resolved synthetic files into the main
+ * transcript (its id equals the session id) and one subagent per re-parented
+ * task-spawned child. Children are labeled from the parent's `task` parts
+ * (matched via `state.metadata.sessionId`) so each run anchors to its Task block.
+ */
+async function loadSession(sessionId: string, paths: string[]): Promise<SessionData> {
+  const sessions = [...paths]
+    .sort()
+    .map((p) => {
+      const { dbPath, sessionId: id } = parseKey(p);
+      return readSession(dbPath, id);
+    })
+    .filter((s): s is NonNullable<typeof s> => s != null);
+
+  const main = sessions.filter((s) => s.id === sessionId);
+  const mainEvents = main.flatMap(buildEvents);
+  const spawns = new Map(main.flatMap((s) => [...taskSpawns(s)]));
+  const subagents: SubagentSource[] = sessions
+    .filter((s) => s.id !== sessionId)
+    .map((s) => ({
+      agentId: s.id,
+      agentType: spawns.get(s.id)?.agentType ?? '',
+      // No matching task part (orphan) or an empty description → the child's
+      // own title; it renders detached rather than anchored, which is the
+      // honest state, but at least carries a human-readable label.
+      description: spawns.get(s.id)?.description || s.title,
+      events: buildEvents(s),
+    }));
+
+  // Fallback: the parent session row is gone while re-parented children still
+  // resolve under its id — promote them so the thread isn't empty.
+  if (mainEvents.length === 0 && subagents.length > 0) {
+    return { mainEvents: subagents.flatMap((s) => s.events), subagents: [] };
+  }
+  return { mainEvents, subagents };
 }
 
 export const opencodeConnector: AgentConnector = {

--- a/packages/server/src/connectors/pi/normalize.ts
+++ b/packages/server/src/connectors/pi/normalize.ts
@@ -20,21 +20,49 @@
  * `parentId` graph threads *through* `model_change`/`thinking_level_change`
  * records, so copying it verbatim would dangle.
  *
+ * Subagents: a `subagent` toolCall (`{agent, task}`) spawns a child run whose
+ * transcript nests on disk under the session's sibling dir —
+ * `<sessionBase>/<runId>/run-<N>/session.jsonl` (runId from the toolResult's
+ * `details`). A child carries its own `session` record with NO parent ref, so
+ * parentage is derived purely from that path shape: child rows are re-keyed to
+ * the parent's session id with `is_sidechain: true` (antigravity pattern), which
+ * folds them into the parent session for lists/search and hands their paths to
+ * `loadSession`, where they attach as SubagentSources at their spawning `Task`.
+ *
  * STRICTLY READ-ONLY with respect to ~/.pi — files are only ever read.
  */
 
-import { readFileSync } from 'node:fs';
+import { existsSync, readFileSync, statSync } from 'node:fs';
+import { basename, dirname } from 'node:path';
 import type { AssistantEvent, ContentBlock, MessageUsage, UserEvent } from '@claudescope/shared';
 import { toolNamesCsv } from '../tool-names.js';
 
 export interface PiSession {
+  /** Indexing key: the parent's session id for a nested subagent, else the own id. */
   sessionId: string;
+  /** The file's own `session` record id (uuid prefix; `SubagentSource.agentId`). */
+  ownId: string;
+  /** True for a nested subagent transcript (re-keyed to the parent session). */
+  isSidechain: boolean;
   cwd: string;
   events: (UserEvent | AssistantEvent)[];
 }
 
 const str = (v: unknown): string => (typeof v === 'string' ? v : '');
 const num = (v: unknown): number => (typeof v === 'number' && Number.isFinite(v) ? v : 0);
+const rec = (v: unknown): Record<string, unknown> =>
+  v && typeof v === 'object' && !Array.isArray(v) ? (v as Record<string, unknown>) : {};
+
+/**
+ * First line of a subagent task, truncated — used as the correlation key AND
+ * label: the synthesized `Task` block's `input.description` and the
+ * `SubagentSource.description` must be derived identically or the thread
+ * assembler can't anchor the run (mirrors antigravity's `subagentLabel`).
+ */
+export function subagentLabel(task: string): string {
+  const line = task.trim().split('\n')[0]?.trim() ?? '';
+  return line.length > 80 ? `${line.slice(0, 80)}…` : line;
+}
 
 /** pi assistant `usage` (`{input, output, cacheRead, cacheWrite, …}`) → canonical usage. */
 function toUsage(raw: unknown): MessageUsage {
@@ -90,6 +118,24 @@ function toolUseBlock(b: Record<string, unknown>): ContentBlock {
         name: 'Bash',
         input: { command: str(args.command), timeout: args.timeout, description: str(args.description) },
       };
+    case 'subagent':
+      // pi's agent-dispatch tool: `{agent, task}` spawns a child run → canonical
+      // `Task` so the embedded subagent transcript anchors at this call.
+      // Management actions (`{action:'list'}` etc.) have no agent/task and stay
+      // passthrough — they spawn nothing.
+      if (str(args.agent) && str(args.task)) {
+        return {
+          type: 'tool_use',
+          id,
+          name: 'Task',
+          input: {
+            description: subagentLabel(str(args.task)),
+            subagent_type: str(args.agent),
+            prompt: str(args.task),
+          },
+        };
+      }
+      return { type: 'tool_use', id, name: str(b.name), input: args };
     default:
       return { type: 'tool_use', id, name: str(b.name), input: args };
   }
@@ -176,13 +222,17 @@ interface PiLine {
     model?: string;
     usage?: unknown;
     toolCallId?: string;
+    /** Set on `toolResult` records — the tool the result belongs to. */
+    toolName?: string;
+    /** `subagent` toolResult metadata: `{mode, runId, results:[{agent, task}]}`. */
+    details?: unknown;
   };
   id?: string;
   cwd?: string;
 }
 
-/** Parse a pi session JSONL into a Claude-shaped session, or null if unreadable. */
-export function parsePiSession(path: string): PiSession | null {
+/** Tolerantly read a pi JSONL file, or null if unreadable. */
+function readLines(path: string): PiLine[] | null {
   let raw: string;
   try {
     raw = readFileSync(path, 'utf8');
@@ -199,16 +249,69 @@ export function parsePiSession(path: string): PiSession | null {
       /* tolerate a corrupt/partial trailing line */
     }
   }
+  return lines;
+}
+
+/**
+ * Memo for {@link sessionIdOf}, keyed on an mtime/size fingerprint: every child
+ * parse re-resolves its parent's id, so indexing N children of one session would
+ * otherwise re-read the parent file N times (and loadSession again).
+ */
+const sessionIdMemo = new Map<string, { fp: string; id: string }>();
+
+/** A file's own session id, with the same fallback rule as {@link parsePiSession}. */
+function sessionIdOf(path: string): string {
+  let fp = '';
+  try {
+    const st = statSync(path);
+    fp = `${Math.floor(st.mtimeMs)}:${st.size}`;
+    const hit = sessionIdMemo.get(path);
+    if (hit && hit.fp === fp) return hit.id;
+  } catch {
+    /* stat failed — fall through to the uncached read (and its path fallback) */
+  }
+  const session = readLines(path)?.find((l) => l.type === 'session');
+  const id = str(session?.id) || path;
+  if (fp) sessionIdMemo.set(path, { fp, id });
+  return id;
+}
+
+/**
+ * The parent session file for a nested subagent transcript, or null for a
+ * top-level session. Children live at `<parentBase>/<runId>/run-<N>/session.jsonl`
+ * next to `<parentBase>.jsonl`; the path shape alone is the parent link (a child
+ * carries no parent ref). A missing parent file → null, so an orphaned child
+ * indexes as its own top-level session instead of keying to a dead id.
+ */
+export function parentSessionFile(path: string): string | null {
+  if (basename(path) !== 'session.jsonl') return null;
+  const runDir = dirname(path); // …/<parentBase>/<runId>/run-<N>
+  if (!/^run-\d+$/.test(basename(runDir))) return null;
+  const parentFile = `${dirname(dirname(runDir))}.jsonl`;
+  return existsSync(parentFile) ? parentFile : null;
+}
+
+/** Parse a pi session JSONL into a Claude-shaped session, or null if unreadable. */
+export function parsePiSession(path: string): PiSession | null {
+  const lines = readLines(path);
+  if (!lines) return null;
 
   // The session record carries the immutable session id + cwd for every event.
   const session = lines.find((l) => l.type === 'session');
-  const sessionId = str(session?.id) || path;
+  const ownId = str(session?.id) || path;
   const cwd = str(session?.cwd);
+
+  // A nested subagent transcript indexes under its PARENT's session id (with
+  // is_sidechain), so it folds into the parent session; the own id still
+  // prefixes the synthesized uuids to keep them unique across the merged files.
+  const parentFile = parentSessionFile(path);
+  const sessionId = parentFile ? sessionIdOf(parentFile) : ownId;
+  const isSidechain = parentFile !== null;
 
   const events: (UserEvent | AssistantEvent)[] = [];
   let seq = 0;
   let prevUuid: string | null = null;
-  const nextUuid = (): string => `${sessionId}-${seq++}`;
+  const nextUuid = (): string => `${ownId}-${seq++}`;
 
   // Consecutive `toolResult` records coalesce into one user turn.
   let toolResults: ContentBlock[] = [];
@@ -222,7 +325,7 @@ export function parsePiSession(path: string): PiSession | null {
       sessionId,
       timestamp: toolResultTs,
       cwd,
-      isSidechain: false,
+      isSidechain,
       type: 'user',
       message: { role: 'user', content: toolResults },
     } as UserEvent);
@@ -258,7 +361,7 @@ export function parsePiSession(path: string): PiSession | null {
         sessionId,
         timestamp: ts,
         cwd,
-        isSidechain: false,
+        isSidechain,
         type: 'assistant',
         message: {
           role: 'assistant',
@@ -276,7 +379,7 @@ export function parsePiSession(path: string): PiSession | null {
         sessionId,
         timestamp: ts,
         cwd,
-        isSidechain: false,
+        isSidechain,
         type: 'user',
         message: { role: 'user', content: contentBlocks(msg.content) },
       } as UserEvent);
@@ -286,7 +389,69 @@ export function parsePiSession(path: string): PiSession | null {
   }
   flushToolResults();
 
-  return { sessionId, cwd, events };
+  return { sessionId, ownId, isSidechain, cwd, events };
+}
+
+/** One spawned child run recoverable from a session's `subagent` tool records. */
+export interface PiSubagentRun {
+  /** `details.runId` — names the child dir under `<sessionBase>/`. */
+  runId: string;
+  /** Index into `details.results` — names the `run-<N>` dir. */
+  runIndex: number;
+  /** The dispatched agent's name (`results[i].agent`). */
+  agentType: string;
+  /** Correlation key — same derivation as the `Task` block's `input.description`. */
+  description: string;
+}
+
+/**
+ * Scan a (main) session file for completed `subagent` runs. The description is
+ * derived from the spawning toolCall's `args.task` (found via `toolCallId`) —
+ * NOT from `results[i].task`, which pi may suffix with an output section — so it
+ * equals the synthesized `Task` block's `input.description` and the run anchors.
+ * Management calls (no `runId`) are skipped.
+ */
+export function subagentRuns(path: string): PiSubagentRun[] {
+  const lines = readLines(path);
+  if (!lines) return [];
+
+  const taskByCallId = new Map<string, string>();
+  for (const l of lines) {
+    if (l.type !== 'message' || str(l.message?.role) !== 'assistant') continue;
+    const content = l.message?.content;
+    if (!Array.isArray(content)) continue;
+    for (const c of content) {
+      const b = rec(c);
+      const args = rec(b.arguments);
+      if (str(b.type) === 'toolCall' && str(b.name) === 'subagent' && str(args.task)) {
+        taskByCallId.set(str(b.id), str(args.task));
+      }
+    }
+  }
+
+  const runs: PiSubagentRun[] = [];
+  for (const l of lines) {
+    const msg = l.message;
+    if (l.type !== 'message' || !msg) continue;
+    if (str(msg.role) !== 'toolResult' || str(msg.toolName) !== 'subagent') continue;
+    const details = rec(msg.details);
+    const runId = str(details.runId);
+    if (!runId) continue; // management action — nothing spawned
+    const task = taskByCallId.get(str(msg.toolCallId));
+    const results = Array.isArray(details.results) ? details.results : [];
+    results.forEach((r, i) => {
+      const rr = rec(r);
+      // Fallback to results[i].task: subagentLabel keeps only the first line, so
+      // a suffixed output section can't diverge the key.
+      runs.push({
+        runId,
+        runIndex: i,
+        agentType: str(rr.agent),
+        description: subagentLabel(task ?? str(rr.task)),
+      });
+    });
+  }
+  return runs;
 }
 
 /** A canonical index row (matches the events NDJSON the projection reads). */
@@ -338,7 +503,7 @@ export function toCanonicalRows(session: PiSession, filePath: string): Canonical
       cache_read_tokens: num(usage?.cache_read_input_tokens),
       cache_write_tokens: num(usage?.cache_creation_input_tokens),
       service_tier: null,
-      is_sidechain: false,
+      is_sidechain: session.isSidechain,
       tool_use_count: content.filter((b) => b.type === 'tool_use').length,
       tool_names: toolNamesCsv(content),
       text_content: text,

--- a/packages/server/src/connectors/pi/pi.ts
+++ b/packages/server/src/connectors/pi/pi.ts
@@ -8,6 +8,10 @@
  * {@link parsePiSession}/{@link toCanonicalRows}) and `eventsProjectionSql` reads
  * that 1:1 — the indexer/FTS/cost stay native and Claude's path is untouched.
  *
+ * Subagent runs (`<sessionBase>/<runId>/run-<N>/session.jsonl`) are re-keyed to
+ * the parent session at index time and embedded as SubagentSources at their
+ * spawning `subagent` toolCall (→ canonical `Task`) in {@link loadSession}.
+ *
  * pi keeps no instruction/memory files in its home dir (only `settings.json` /
  * `auth.json`), so this connector contributes no memory.
  *
@@ -16,12 +20,12 @@
 
 import { createHash } from 'node:crypto';
 import { mkdirSync, readdirSync, statSync, writeFileSync } from 'node:fs';
-import { join } from 'node:path';
+import { basename, dirname, join } from 'node:path';
 import { CLAUDESCOPE_HOME, PI_SESSIONS_DIR } from '../../config.js';
 import { sqlString } from '../../db/duckdb.js';
-import type { SessionData } from '../../data/session-loader.js';
+import type { SessionData, SubagentSource } from '../../data/session-loader.js';
 import type { AgentConnector, AuxProjections, DiscoveredFile } from '../types.js';
-import { parsePiSession, toCanonicalRows } from './normalize.js';
+import { parentSessionFile, parsePiSession, subagentRuns, toCanonicalRows } from './normalize.js';
 
 const CACHE_DIR = join(CLAUDESCOPE_HOME, 'cache', 'pi');
 
@@ -31,7 +35,14 @@ function cachePath(filePath: string): string {
   return join(CACHE_DIR, `${hash}.ndjson`);
 }
 
-/** Recursively collect every `*.jsonl` under the pi sessions dir. */
+/**
+ * Recursively collect every `*.jsonl` under the pi sessions dir — including
+ * nested subagent transcripts (`<sessionBase>/<runId>/run-<N>/session.jsonl`),
+ * which normalize re-keys to their parent session. No parent-mtime folding is
+ * needed (unlike antigravity): a child's parentage is derived from the path
+ * shape and the parent's immutable session id, both fixed from the moment the
+ * child exists, so its re-key never changes retroactively.
+ */
 function discover(): DiscoveredFile[] {
   const out: DiscoveredFile[] = [];
   const walk = (dir: string): void => {
@@ -89,8 +100,47 @@ function auxProjections(_filePath: string): AuxProjections {
 }
 
 async function loadSession(_sessionId: string, paths: string[]): Promise<SessionData> {
-  const mainEvents = paths.flatMap((p) => parsePiSession(p)?.events ?? []);
-  return { mainEvents, subagents: [] };
+  // `paths` holds the top-level file(s) plus any nested subagent transcripts the
+  // index re-keyed to this session. Only top-level files feed the main thread;
+  // children are attached below at their spawning `Task` call. A child whose
+  // parent file has vanished no longer matches the nested shape and is promoted
+  // to a main file (mirrors antigravity's orphan fallback). If NO path is
+  // top-level (e.g. the parent indexed zero events, so only children map here),
+  // promote everything rather than serve an empty session.
+  let mainPaths = paths.filter((p) => parentSessionFile(p) === null);
+  if (mainPaths.length === 0) mainPaths = paths;
+  const mainSet = new Set(mainPaths);
+  const mainEvents = mainPaths.flatMap((p) => parsePiSession(p)?.events ?? []);
+
+  const subagents: SubagentSource[] = [];
+  const attached = new Set<string>();
+  for (const p of mainPaths) {
+    const childRoot = join(dirname(p), basename(p, '.jsonl'));
+    for (const run of subagentRuns(p)) {
+      const childPath = join(childRoot, run.runId, `run-${run.runIndex}`, 'session.jsonl');
+      const child = parsePiSession(childPath);
+      if (!child) continue; // run dir pruned since the session ran — tolerate
+      attached.add(childPath);
+      subagents.push({
+        agentId: child.ownId,
+        agentType: run.agentType,
+        description: run.description,
+        events: child.events,
+      });
+    }
+  }
+
+  // Children indexed under this session but never claimed by a subagent
+  // toolResult (crashed mid-run, an extra run-N beyond `results`, an unreadable
+  // parent): attach them detached — empty description ⇒ the thread assembler
+  // renders them unanchored — so their indexed text stays reachable in detail.
+  for (const p of paths) {
+    if (mainSet.has(p) || attached.has(p)) continue;
+    const child = parsePiSession(p);
+    if (!child) continue;
+    subagents.push({ agentId: child.ownId, agentType: '', description: '', events: child.events });
+  }
+  return { mainEvents, subagents };
 }
 
 export const piConnector: AgentConnector = {

--- a/packages/server/src/db/schema.ts
+++ b/packages/server/src/db/schema.ts
@@ -25,7 +25,9 @@
 // v6: usage dedup by billed API call (message_id / forked_from_session_id / usage_canonical).
 // v7: fallback title cleaning (strip markup/wrapper blobs) + `title_derived` flag.
 // v8: per-event tool_names (comma-joined canonical tool names) for the tool-usage breakdown.
-export const SCHEMA_VERSION = 8;
+// v9: subagent embedding for codex/pi/opencode/copilot — child transcripts re-key
+//     to their root session (is_sidechain), so stale child-as-session rows must go.
+export const SCHEMA_VERSION = 9;
 
 /** All DDL statements, executed in order at startup. Idempotent. */
 export const SCHEMA_DDL: readonly string[] = [

--- a/packages/server/test/codex.integration.test.ts
+++ b/packages/server/test/codex.integration.test.ts
@@ -70,6 +70,68 @@ function writeRollout(): string {
       { type: 'response_item', timestamp: ts(11), payload: { type: 'function_call_output', call_id: 'call_4', output: 'oops\n' } },
       { type: 'response_item', timestamp: ts(12), payload: { type: 'message', role: 'assistant', content: [{ type: 'output_text', text: 'found it' }] } },
       { type: 'event_msg', timestamp: ts(13), payload: { type: 'token_count', info: { last_token_usage: { input_tokens: 1000, cached_input_tokens: 200, output_tokens: 300, reasoning_output_tokens: 50, total_tokens: 1300 } }, rate_limits: {} } },
+      // ToolSearch-style deferred-tool discovery: call + output pair by call_id.
+      { type: 'response_item', timestamp: ts(14), payload: { type: 'tool_search_call', call_id: 'call_ts1', status: 'completed', arguments: { query: 'spawn subagent', limit: 8 } } },
+      { type: 'response_item', timestamp: ts(15), payload: { type: 'tool_search_output', call_id: 'call_ts1', status: 'completed', tools: [{ type: 'namespace', name: 'multi_agent_v1' }] } },
+      // spawn_agent → canonical Task; the output names the child thread id that the
+      // child rollout's session_meta carries as its own id.
+      { type: 'response_item', timestamp: ts(16), payload: { type: 'function_call', name: 'spawn_agent', arguments: '{"agent_type":"explorer","message":"Scan the repo for issues.\\nReport back concisely."}', call_id: 'call_spawn1' } },
+      { type: 'response_item', timestamp: ts(17), payload: { type: 'function_call_output', call_id: 'call_spawn1', output: '{"agent_id":"019f2222-aaaa-7bbb-8ccc-000000000001","nickname":"Linnaeus"}' } },
+      // wait_agent stays under its raw name (payload visible, no Task synthesized).
+      { type: 'response_item', timestamp: ts(18), payload: { type: 'function_call', name: 'wait_agent', arguments: '{"targets":["019f2222-aaaa-7bbb-8ccc-000000000001"]}', call_id: 'call_wait1' } },
+      { type: 'response_item', timestamp: ts(19), payload: { type: 'function_call_output', call_id: 'call_wait1', output: '{"status":{"019f2222-aaaa-7bbb-8ccc-000000000001":{"completed":"done"}}}' } },
+      // apply_patch (custom_tool_call: input is the raw V4A patch string) touching
+      // two files → fans out to one canonical block per file with #i suffixed ids.
+      { type: 'response_item', timestamp: ts(20), payload: { type: 'custom_tool_call', name: 'apply_patch', call_id: 'call_ap1', input: '*** Begin Patch\n*** Add File: /tmp/codexproj/notes.md\n+hello\n+world\n*** Update File: /tmp/codexproj/src/app.ts\n@@\n context line\n-old value\n+new value\n*** End Patch' } },
+      { type: 'response_item', timestamp: ts(21), payload: { type: 'custom_tool_call_output', call_id: 'call_ap1', output: 'Exit code: 0\nWall time: 0.1 seconds\nOutput:\nSuccess. Updated the following files:\nA /tmp/codexproj/notes.md\nM /tmp/codexproj/src/app.ts' } },
+      // Single-file patch: block keeps the bare call_id and the result is the
+      // envelope-stripped tool output.
+      { type: 'response_item', timestamp: ts(22), payload: { type: 'custom_tool_call', name: 'apply_patch', call_id: 'call_ap2', input: '*** Begin Patch\n*** Update File: /tmp/codexproj/single.ts\n@@\n-a\n+b\n*** End Patch' } },
+      { type: 'response_item', timestamp: ts(23), payload: { type: 'custom_tool_call_output', call_id: 'call_ap2', output: 'Exit code: 0\nWall time: 0.0 seconds\nOutput:\nSuccess. Updated the following files:\nM /tmp/codexproj/single.ts' } },
+      // web_search_call has no call_id and no paired output record.
+      { type: 'response_item', timestamp: ts(24), payload: { type: 'web_search_call', status: 'completed', action: { type: 'search', query: 'codex docs' } } },
+      // A REJECTED two-file patch (non-zero exit): nothing on disk changed, so the
+      // fanned canonical blocks must demote back to raw apply_patch (no file_path)
+      // and the real error text must survive on every result.
+      { type: 'response_item', timestamp: ts(25), payload: { type: 'custom_tool_call', name: 'apply_patch', call_id: 'call_ap3', input: '*** Begin Patch\n*** Update File: /tmp/codexproj/missing.ts\n@@\n-x\n+y\n*** Update File: /tmp/codexproj/other.ts\n@@\n-p\n+q\n*** End Patch' } },
+      { type: 'response_item', timestamp: ts(26), payload: { type: 'custom_tool_call_output', call_id: 'call_ap3', output: 'Exit code: 1\nWall time: 0.0 seconds\nOutput:\napply_patch: /tmp/codexproj/missing.ts: No such file or directory' } },
+    ]),
+  );
+  return file;
+}
+
+/** A subagent rollout: separate file, re-keyed under the parent via thread_spawn. */
+function writeChildRollout(): string {
+  const dir = join(codexDir, '2026', '01', '01');
+  mkdirSync(dir, { recursive: true });
+  const file = join(dir, 'rollout-2026-01-01T10-01-00-019f2222-aaaa-7bbb-8ccc-000000000001.jsonl');
+  writeFileSync(
+    file,
+    jsonl([
+      { type: 'session_meta', timestamp: ts(30), payload: { id: '019f2222-aaaa-7bbb-8ccc-000000000001', cwd: '/tmp/codexproj', thread_source: 'subagent', source: { subagent: { thread_spawn: { parent_thread_id: 'codex-sess-1', depth: 1, agent_nickname: 'Linnaeus', agent_role: 'explorer' } } }, git: { branch: 'main' } } },
+      { type: 'turn_context', timestamp: ts(31), payload: { model: 'gpt-5.4' } },
+      { type: 'response_item', timestamp: ts(32), payload: { type: 'message', role: 'user', content: [{ type: 'input_text', text: 'Scan the repo for issues.' }] } },
+      { type: 'response_item', timestamp: ts(33), payload: { type: 'message', role: 'assistant', content: [{ type: 'output_text', text: 'zebranugget report from the child' }] } },
+      // Child usage folds into the parent session's totals (claude-code precedent).
+      { type: 'event_msg', timestamp: ts(34), payload: { type: 'token_count', info: { last_token_usage: { input_tokens: 100, cached_input_tokens: 0, output_tokens: 50 } }, rate_limits: {} } },
+    ]),
+  );
+  return file;
+}
+
+/** A subagent rollout whose parent rollout does not exist: it indexes under the
+ *  (absent) root id and `loadSession` promotes its events to the main thread. */
+function writeOrphanRollout(): string {
+  const dir = join(codexDir, '2026', '01', '02');
+  mkdirSync(dir, { recursive: true });
+  const file = join(dir, 'rollout-2026-01-02T09-00-00-019f3333-aaaa-7bbb-8ccc-000000000002.jsonl');
+  writeFileSync(
+    file,
+    jsonl([
+      { type: 'session_meta', timestamp: ts(40), payload: { id: '019f3333-aaaa-7bbb-8ccc-000000000002', cwd: '/tmp/codexproj', thread_source: 'subagent', source: { subagent: { thread_spawn: { parent_thread_id: 'codex-gone', depth: 1, agent_nickname: 'Orphan', agent_role: 'explorer' } } } } },
+      { type: 'turn_context', timestamp: ts(41), payload: { model: 'gpt-5.4' } },
+      { type: 'response_item', timestamp: ts(42), payload: { type: 'message', role: 'user', content: [{ type: 'input_text', text: 'orphan probe text' }] } },
+      { type: 'response_item', timestamp: ts(43), payload: { type: 'message', role: 'assistant', content: [{ type: 'output_text', text: 'orphan done' }] } },
     ]),
   );
   return file;
@@ -81,6 +143,8 @@ let closeConnection: () => Promise<void>;
 beforeAll(async () => {
   mkdirSync(claudeDir, { recursive: true });
   writeRollout();
+  writeChildRollout();
+  writeOrphanRollout();
 
   const Fastify = (await import('fastify')).default;
   const { registerRoutes } = await import('../src/routes/index.js');
@@ -104,13 +168,18 @@ const get = (url: string) => app.inject({ method: 'GET', url });
 describe('Codex session indexing', () => {
   it('lists the Codex session with model from turn_context and a codex agent tag', async () => {
     const sessions = (await get('/api/sessions')).json();
-    expect(sessions.map((s: { id: string }) => s.id)).toEqual(['codex-sess-1']);
-    expect(sessions[0].models).toContain('gpt-5.4');
-    expect(sessions[0].connectorId).toBe('codex');
+    // The child rollout folds into its parent (never its own session); the orphan
+    // child indexes under its absent root id `codex-gone`.
+    expect(sessions.map((s: { id: string }) => s.id).sort()).toEqual(['codex-gone', 'codex-sess-1']);
+    const main = sessions.find((s: { id: string }) => s.id === 'codex-sess-1');
+    expect(main.models).toContain('gpt-5.4');
+    expect(main.connectorId).toBe('codex');
     // Codex has no ai-title, so the title falls back to the (cleaned) first user
     // message and is flagged derived so the UI can mark it "from first message".
-    expect(sessions[0].title).toBe('find the needle in this codex haystack');
-    expect(sessions[0].titleDerived).toBe(true);
+    expect(main.title).toBe('find the needle in this codex haystack');
+    expect(main.titleDerived).toBe(true);
+    // The re-keyed subagent rollout flips the parent's sidechain flag.
+    expect(main.hasSidechain).toBe(true);
   });
 
   it('tags the project with its agent and groups analytics by agent', async () => {
@@ -126,12 +195,15 @@ describe('Codex session indexing', () => {
     expect(sources.some((s: { id: string }) => s.id === 'codex')).toBe(true);
   });
 
-  it('attributes token_count usage and computes a gpt-5.4 cost', async () => {
-    const s = (await get('/api/sessions')).json()[0];
-    // input 1000 - cached 200 = 800 input; 200 cache_read; 300 output → 1300 total.
-    expect(s.totalTokens).toBe(1300);
+  it('attributes token_count usage (incl. the subagent) and computes a gpt-5.4 cost', async () => {
+    const sessions = (await get('/api/sessions')).json();
+    const s = sessions.find((x: { id: string }) => x.id === 'codex-sess-1');
+    // Parent: input 1000 - cached 200 = 800 input; 200 cache_read; 300 output = 1300.
+    // Child rollout usage counts toward the parent session: +100 input +50 output.
+    expect(s.totalTokens).toBe(1450);
     // gpt-5.4 @ official cached 0.25: (800*2.5 + 300*15 + 200*0.25) / 1e6 = 0.00655
-    expect(s.totalCostUsd).toBeCloseTo(0.00655, 5);
+    // plus the child's (100*2.5 + 50*15) / 1e6 = 0.001 → 0.00755
+    expect(s.totalCostUsd).toBeCloseTo(0.00755, 5);
   });
 
   it('groups analytics by the OpenAI model', async () => {
@@ -143,12 +215,18 @@ describe('Codex session indexing', () => {
     const { sessions: results } = (await get('/api/search?q=needle')).json();
     expect(results.some((r: { sessionId: string }) => r.sessionId === 'codex-sess-1')).toBe(true);
   });
+
+  it('surfaces subagent text under the PARENT session in search', async () => {
+    const { sessions: results } = (await get('/api/search?q=zebranugget')).json();
+    const ids = results.map((r: { sessionId: string }) => r.sessionId);
+    expect(ids).toContain('codex-sess-1');
+    expect(ids).not.toContain('019f2222-aaaa-7bbb-8ccc-000000000001');
+  });
 });
 
 describe('Codex session detail', () => {
   it('normalizes response_items into a thread with paired tool call/result', async () => {
     const detail = (await get('/api/sessions/codex-sess-1')).json();
-    expect(detail.subagents).toEqual([]);
 
     // assembleThread pairs tool_use+tool_result into a `kind:'tool'` block and
     // folds the result-only user turn away.
@@ -199,5 +277,109 @@ describe('Codex session detail', () => {
     expect(img).toBeTruthy();
     expect((img.attachment as { source: { url: string } }).source.url).toMatch(/^data:image\/png;base64,/);
     expect(allText).not.toContain('codex-clipboard'); // placeholder path dropped
+  });
+
+  it('nests the subagent rollout at the spawn_agent → Task call', async () => {
+    const detail = (await get('/api/sessions/codex-sess-1')).json();
+    const flat = detail.thread.flatMap(
+      (t: { blocks: Record<string, unknown>[] }) => t.blocks,
+    );
+
+    // spawn_agent is canonicalized to a Task block whose description is the first
+    // line of the prompt — the correlation key the nested run anchors to.
+    const task = flat.find((b: Record<string, unknown>) => b.name === 'Task');
+    expect(task).toMatchObject({ id: 'call_spawn1' });
+    expect(task.input).toMatchObject({
+      description: 'Scan the repo for issues.',
+      subagent_type: 'explorer',
+    });
+
+    expect(detail.subagents).toHaveLength(1);
+    const run = detail.subagents[0];
+    expect(run).toMatchObject({
+      agentId: '019f2222-aaaa-7bbb-8ccc-000000000001',
+      agentType: 'explorer',
+      description: 'Scan the repo for issues.',
+      toolUseId: 'call_spawn1', // anchored to the Task block
+    });
+    expect(JSON.stringify(run.thread)).toContain('zebranugget');
+    // The subagent's turns must NOT be inlined into the main thread.
+    expect(JSON.stringify(detail.thread)).not.toContain('zebranugget');
+
+    // wait_agent is not a spawn — it stays under its raw name.
+    const wait = flat.find((b: Record<string, unknown>) => b.id === 'call_wait1');
+    expect(wait.name).toBe('wait_agent');
+  });
+
+  it('fans apply_patch out to canonical Write/Edit blocks the changeset keys off', async () => {
+    const detail = (await get('/api/sessions/codex-sess-1')).json();
+    const flat = detail.thread.flatMap(
+      (t: { blocks: Record<string, unknown>[] }) => t.blocks,
+    );
+
+    // Two-file patch → one canonical block per file, ids suffixed with #i.
+    const write = flat.find((b: Record<string, unknown>) => b.id === 'call_ap1#0');
+    expect(write).toMatchObject({ name: 'Write' });
+    expect(write.input).toEqual({ file_path: '/tmp/codexproj/notes.md', content: 'hello\nworld' });
+    expect(write.result.content[0].text).toBe('Created /tmp/codexproj/notes.md');
+
+    const edit = flat.find((b: Record<string, unknown>) => b.id === 'call_ap1#1');
+    expect(edit).toMatchObject({ name: 'MultiEdit' });
+    expect(edit.input).toEqual({
+      file_path: '/tmp/codexproj/src/app.ts',
+      edits: [{ old_string: 'context line\nold value', new_string: 'context line\nnew value' }],
+    });
+
+    // Single-file patch keeps the bare call_id and the envelope-stripped output.
+    const single = flat.find((b: Record<string, unknown>) => b.id === 'call_ap2');
+    expect(single).toMatchObject({ name: 'MultiEdit' });
+    const out = single.result.content[0].text as string;
+    expect(out).toContain('Success. Updated');
+    expect(out).not.toContain('Exit code');
+
+    // tool_search / web_search render as tool blocks instead of vanishing.
+    const search = flat.find((b: Record<string, unknown>) => b.id === 'call_ts1');
+    expect(search).toMatchObject({ name: 'tool_search' });
+    expect(search.result).toBeTruthy();
+    const web = flat.find((b: Record<string, unknown>) => b.name === 'web_search');
+    expect((web.input as { query: string }).query).toBe('codex docs');
+  });
+
+  it('demotes a REJECTED apply_patch to raw blocks so Files-changed never sees it', async () => {
+    const detail = (await get('/api/sessions/codex-sess-1')).json();
+    const flat = detail.thread.flatMap(
+      (t: { blocks: Record<string, unknown>[] }) => t.blocks,
+    );
+
+    const failed = flat.filter(
+      (b: Record<string, unknown>) => b.id === 'call_ap3#0' || b.id === 'call_ap3#1',
+    );
+    expect(failed).toHaveLength(2);
+    for (const b of failed) {
+      // Demoted: raw name and no file_path, so changeset.ts never lists the
+      // untouched files (the failed-edit convention the copilot connector set).
+      expect(b.name).toBe('apply_patch');
+      expect((b.input as { file_path?: string }).file_path).toBeUndefined();
+      // The real error output survives on every fanned result, envelope intact.
+      const out = b.result.content[0].text as string;
+      expect(out).toContain('Exit code: 1');
+      expect(out).toContain('No such file or directory');
+    }
+    // No canonical block may reference the rejected patch's files.
+    const canonical = flat.filter((b: Record<string, unknown>) =>
+      ['Write', 'Edit', 'MultiEdit'].includes(b.name as string),
+    );
+    for (const b of canonical) {
+      expect((b.input as { file_path: string }).file_path).not.toContain('missing.ts');
+      expect((b.input as { file_path: string }).file_path).not.toContain('other.ts');
+    }
+  });
+
+  it('promotes an orphaned subagent (missing parent rollout) to the main thread', async () => {
+    const detail = (await get('/api/sessions/codex-gone')).json();
+    expect(detail.subagents).toEqual([]);
+    const allText = JSON.stringify(detail.thread);
+    expect(allText).toContain('orphan probe text');
+    expect(allText).toContain('orphan done');
   });
 });

--- a/packages/server/test/copilot.integration.test.ts
+++ b/packages/server/test/copilot.integration.test.ts
@@ -14,11 +14,16 @@
  *   - a SUCCESSFUL `edit` → canonical `Edit` (feeds Files-changed), while a DENIED
  *     edit passes through under its raw name (excluded from Files-changed);
  *   - an unknown event type (`session.context_changed`) tolerated;
+ *   - an inline subagent (`subagent.started` + `agentId`-tagged events) segmented
+ *     out of the main thread and nested under a canonical `Task` block, with a
+ *     stray `agentId` (no started record) tolerated as a detached run;
+ *   - a symlinked saved attachment escaping `files/` refused (symlink-safe
+ *     containment);
  *   - global memory read from `~/.copilot/copilot-instructions.md`.
  */
 
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import type { FastifyInstance } from 'fastify';
@@ -44,6 +49,11 @@ const ts = (s: number) => `2026-06-16T10:00:${String(s).padStart(2, '0')}.000Z`;
 let evtId = 0;
 /** Wrap a `{type, data}` pair into a Copilot event envelope. */
 const ev = (type: string, data: unknown) => ({ type, data, id: `e${evtId++}`, timestamp: ts(evtId), parentId: null });
+/** Tag an event as belonging to an inline subagent run. */
+const sub = (e: Record<string, unknown>, agentId: string) => ({ ...e, agentId });
+
+// Bytes a poisoned symlink points at — must never surface in an API response.
+const SECRET_B64 = Buffer.from('copilot-secret-bytes').toString('base64');
 
 // 1x1 transparent PNG — stands in for a saved screenshot.
 const PNG_B64 =
@@ -139,12 +149,56 @@ function writeSession2(): void {
   ]);
 }
 
+/** Session 3: an inline `task` subagent (started + tagged events + completed),
+ *  a stray tagged turn with no `subagent.started`, and a POISONED saved
+ *  attachment — `files/evil.png` is a symlink escaping the session dir. */
+function writeSession3(): void {
+  writeSession('sc', 'Explore with subagent', [
+    ev('session.start', {
+      sessionId: 'copilot-sess-3',
+      context: { cwd: '/tmp/cproj', branch: 'main', repository: 'me/cproj', hostType: 'github' },
+    }),
+    ev('session.model_change', { newModel: 'gpt-5-mini' }),
+    ev('user.message', {
+      content: 'inspect the entry point [📷 evil.png]',
+      attachments: [{ type: 'file', path: '/var/folders/T/evil.png', displayName: 'evil.png' }],
+    }),
+    ev('assistant.message', {
+      messageId: 'm3',
+      model: 'gpt-5-mini',
+      content: 'Delegating to the explore agent.',
+      toolRequests: [
+        { toolCallId: 'call-task', name: 'task', arguments: { description: 'Inspect entry point', prompt: 'Find the entry point of this repo.' } },
+      ],
+    }),
+    sub(ev('subagent.started', { toolCallId: 'call-task', agentName: 'explore', agentDisplayName: 'Explore Agent', model: 'gpt-5-mini' }), 'call-task'),
+    sub(ev('assistant.message', {
+      model: 'gpt-5-mini',
+      content: 'Scanning for the zebrafinder entry.',
+      toolRequests: [{ toolCallId: 'call-sub-view', name: 'view', arguments: { path: '/tmp/cproj/package.json' } }],
+    }), 'call-task'),
+    sub(ev('tool.execution_start', { toolCallId: 'call-sub-view', toolName: 'view' }), 'call-task'),
+    sub(ev('tool.execution_complete', { toolCallId: 'call-sub-view', success: true, result: { content: '{"main":"src/index.ts"}' } }), 'call-task'),
+    sub(ev('subagent.completed', { toolCallId: 'call-task', agentName: 'explore' }), 'call-task'),
+    ev('tool.execution_complete', { toolCallId: 'call-task', success: true, result: { content: 'Entry point is src/index.ts.' } }),
+    // A tagged turn with no subagent.started — tolerated as a detached run.
+    sub(ev('assistant.message', { model: 'gpt-5-mini', content: 'ghost turn from a lost agent' }), 'call-ghost'),
+    ev('assistant.message', { messageId: 'm4', model: 'gpt-5-mini', content: 'The entry point is src/index.ts.' }),
+  ]);
+  // The poisoned attachment: textually inside files/, target outside the session.
+  const secret = join(work, 'secret-outside.png');
+  writeFileSync(secret, Buffer.from(SECRET_B64, 'base64'));
+  mkdirSync(join(sessionsDir, 'sc', 'files'), { recursive: true });
+  symlinkSync(secret, join(sessionsDir, 'sc', 'files', 'evil.png'));
+}
+
 let app: FastifyInstance;
 let closeConnection: () => Promise<void>;
 
 beforeAll(async () => {
   writeSession1();
   writeSession2();
+  writeSession3();
   // Global memory file in the Copilot home (parent of session-state).
   writeFileSync(join(copilotHome, 'copilot-instructions.md'), '# User profile\nuser.name: Vlad\n');
 
@@ -166,20 +220,23 @@ afterAll(async () => {
 });
 
 const get = (url: string) => app.inject({ method: 'GET', url });
-type Session = { id: string; connectorId: string; title: string; models: string[]; totalTokens: number; totalCostUsd: number };
+type Session = { id: string; connectorId: string; title: string; models: string[]; totalTokens: number; totalCostUsd: number; hasSidechain: boolean };
 const sessionById = async (id: string): Promise<Session> =>
   (await get('/api/sessions')).json().find((s: Session) => s.id === id);
 
 describe('copilot session indexing', () => {
-  it('lists both sessions tagged copilot, with model and workspace.yaml title', async () => {
+  it('lists the sessions tagged copilot, with model and workspace.yaml title', async () => {
     const sessions: Session[] = (await get('/api/sessions')).json();
-    expect(sessions.map((s) => s.id).sort()).toEqual(['copilot-sess-1', 'copilot-sess-2']);
+    expect(sessions.map((s) => s.id).sort()).toEqual(['copilot-sess-1', 'copilot-sess-2', 'copilot-sess-3']);
     for (const s of sessions) {
       expect(s.connectorId).toBe('copilot');
       expect(s.models).toContain('gpt-5-mini');
     }
     expect((await sessionById('copilot-sess-1')).title).toBe('Fix the bug');
     expect((await sessionById('copilot-sess-2')).title).toBe('Audit the project');
+    // The inline subagent flips has_sidechain on (and only there).
+    expect((await sessionById('copilot-sess-3')).hasSidechain).toBe(true);
+    expect((await sessionById('copilot-sess-1')).hasSidechain).toBe(false);
   });
 
   it('prices the shutdown session from tokenDetails and charges the no-shutdown session nothing', async () => {
@@ -261,5 +318,65 @@ describe('copilot session detail', () => {
     // Unsaved screenshot: no attachment block, but the inline marker remains.
     expect(flat.some((b: Record<string, unknown>) => b.kind === 'attachment')).toBe(false);
     expect(JSON.stringify(detail.thread)).toContain('[📷 missing.png]');
+  });
+});
+
+describe('copilot subagent embedding', () => {
+  type Block = Record<string, any>;
+  type Run = Record<string, any>;
+
+  it('segments the tagged run out of the main thread and nests it under a canonical Task block', async () => {
+    const detail = (await get('/api/sessions/copilot-sess-3')).json();
+    const flat: Block[] = detail.thread.flatMap((t: { blocks: Block[] }) => t.blocks);
+
+    // Main thread: no subagent turns leaked (its text and tools live in the run).
+    expect(JSON.stringify(detail.thread)).not.toContain('zebrafinder');
+    expect(detail.thread.every((t: { isSidechain?: boolean }) => !t.isSidechain)).toBe(true);
+
+    // The spawning `task` call is canonicalized to Task, its result (the final
+    // report) intact.
+    const task = flat.find((b) => b.kind === 'tool' && b.name === 'Task');
+    expect(task.input).toEqual({
+      description: 'Inspect entry point',
+      subagent_type: 'explore',
+      prompt: 'Find the entry point of this repo.',
+    });
+    expect(JSON.stringify(task.result.content)).toContain('Entry point is src/index.ts');
+
+    // The run is anchored to that Task block and carries the subagent's turns.
+    const runs: Run[] = detail.subagents;
+    expect(runs).toHaveLength(2);
+    const run = runs.find((r) => r.agentType === 'explore');
+    expect(run).toMatchObject({ description: 'Inspect entry point', toolUseId: task.id });
+    expect(run.spawnUuid).toBeTruthy();
+    expect(JSON.stringify(run.thread)).toContain('zebrafinder');
+    const runBlocks: Block[] = run.thread.flatMap((t: { blocks: Block[] }) => t.blocks);
+    const view = runBlocks.find((b) => b.kind === 'tool' && b.name === 'Read');
+    expect(view.input.file_path).toBe('/tmp/cproj/package.json');
+    expect(JSON.stringify(view.result.content)).toContain('src/index.ts');
+  });
+
+  it('tolerates a tagged turn with no subagent.started as a detached run', async () => {
+    const detail = (await get('/api/sessions/copilot-sess-3')).json();
+    const ghost = detail.subagents.find((r: Run) => r.agentId === 'call-ghost');
+    expect(ghost).toBeTruthy();
+    expect(JSON.stringify(ghost.thread)).toContain('ghost turn');
+    // No started record → no description → never matched to a spawn point.
+    expect(ghost.toolUseId).toBeUndefined();
+  });
+
+  it('finds subagent text via full-text search under the parent session', async () => {
+    const { sessions: results } = (await get('/api/search?q=zebrafinder')).json();
+    expect(results.some((r: { sessionId: string }) => r.sessionId === 'copilot-sess-3')).toBe(true);
+  });
+
+  it('refuses a saved attachment whose symlink escapes files/', async () => {
+    const detail = (await get('/api/sessions/copilot-sess-3')).json();
+    const flat: Block[] = detail.thread.flatMap((t: { blocks: Block[] }) => t.blocks);
+    // No attachment block for the poisoned name — only the inline marker survives —
+    // and the symlink target's bytes never appear anywhere in the response.
+    expect(flat.some((b) => b.kind === 'attachment')).toBe(false);
+    expect(JSON.stringify(detail.thread)).toContain('[📷 evil.png]');
+    expect(JSON.stringify(detail)).not.toContain(SECRET_B64);
   });
 });

--- a/packages/server/test/opencode.integration.test.ts
+++ b/packages/server/test/opencode.integration.test.ts
@@ -6,7 +6,10 @@
  * session becomes one synthetic file, per-message tokens (reasoning folded into
  * output) cost as `gpt-5.4-mini-fast`, plaintext reasoning renders, `apply_patch`
  * fans out to canonical `MultiEdit`/`Write` (Files-changed tab), `read`→`Read`,
- * and a pasted screenshot (`file` part, data URL) embeds.
+ * and a pasted screenshot (`file` part, data URL) embeds. Task-spawned child
+ * sessions (`parent_id`) fold into the parent as embedded subagents anchored to
+ * their canonical `Task` block; dangling and cyclic parent links degrade to
+ * standalone sessions instead of hanging or crashing.
  *
  * Never touches the real `~/.local/share/opencode`.
  */
@@ -63,13 +66,19 @@ function writeDb(): void {
   mkdirSync(ocDataDir, { recursive: true });
   const db = new DatabaseSync(join(ocDataDir, 'opencode.db'));
   db.exec(`
-    CREATE TABLE session (id TEXT PRIMARY KEY, directory TEXT, title TEXT, time_created INTEGER, time_updated INTEGER);
+    CREATE TABLE session (id TEXT PRIMARY KEY, directory TEXT, title TEXT, parent_id TEXT, time_created INTEGER, time_updated INTEGER);
     CREATE TABLE message (id TEXT PRIMARY KEY, session_id TEXT, time_created INTEGER, time_updated INTEGER, data TEXT);
     CREATE TABLE part (id TEXT PRIMARY KEY, message_id TEXT, session_id TEXT, time_created INTEGER, time_updated INTEGER, data TEXT);
   `);
-  db.prepare('INSERT INTO session VALUES (?,?,?,?,?)').run(
-    'ses_test1', '/tmp/ocproj', 'Test session', 1000, 3000,
-  );
+  const ses = db.prepare('INSERT INTO session VALUES (?,?,?,?,?,?)');
+  ses.run('ses_test1', '/tmp/ocproj', 'Test session', null, 1000, 3000);
+  // task-spawned child — must fold into ses_test1, its title must NOT clobber the parent's.
+  ses.run('ses_child1', '/tmp/ocproj', 'Inspect entry point (@explore subagent)', 'ses_test1', 2500, 2900);
+  // degraded parent links: a dangling parent_id and a two-session cycle. All three
+  // must index as standalone sessions — no re-keying, no hang, no crash.
+  ses.run('ses_dangling', '/tmp/ocproj', 'Dangling child', 'ses_ghost', 4000, 4100);
+  ses.run('ses_cyc1', '/tmp/ocproj', 'Cycle one', 'ses_cyc2', 5000, 5100);
+  ses.run('ses_cyc2', '/tmp/ocproj', 'Cycle two', 'ses_cyc1', 5000, 5100);
 
   const msg = db.prepare('INSERT INTO message VALUES (?,?,?,?,?)');
   msg.run('u1', 'ses_test1', 1000, 1000, JSON.stringify({ role: 'user', time: { created: 1000 } }));
@@ -110,6 +119,48 @@ function writeDb(): void {
   part.run('p7', 'a1', 'ses_test1', 2005, 2005, JSON.stringify({
     type: 'step-finish', tokens: { total: 1550, input: 1000, output: 50, reasoning: 200, cache: { write: 0, read: 300 } }, cost: 0,
   }));
+
+  // Parent turn that spawns the subagent: a `task` part whose metadata.sessionId
+  // names the child — the connector maps it to a canonical `Task` block.
+  msg.run('a2', 'ses_test1', 2500, 2500, JSON.stringify({
+    role: 'assistant', modelID: 'gpt-5.4-mini-fast', providerID: 'openai', time: { created: 2500 },
+    tokens: { total: 0, input: 0, output: 0, reasoning: 0, cache: { write: 0, read: 0 } },
+  }));
+  part.run('p8', 'a2', 'ses_test1', 2501, 2501, JSON.stringify({
+    type: 'tool', tool: 'task', callID: 'call_t',
+    state: {
+      status: 'completed',
+      input: {
+        description: 'Inspect entry point',
+        prompt: 'Find the app entry point and report it.',
+        subagent_type: 'explore', task_id: '', command: 'inspect the codebase entry point',
+      },
+      output: 'Entry point is packages/server/src/index.ts',
+      metadata: {
+        sessionId: 'ses_child1', parentSessionId: 'ses_test1',
+        model: { modelID: 'gpt-5.4-mini-fast', providerID: 'openai' },
+      },
+    },
+  }));
+
+  // Child transcript — tokens must fold into the parent's totals.
+  msg.run('cu1', 'ses_child1', 2600, 2600, JSON.stringify({ role: 'user', time: { created: 2600 } }));
+  part.run('cp1', 'cu1', 'ses_child1', 2601, 2601, JSON.stringify({ type: 'text', text: 'Find the app entry point and report it.' }));
+  msg.run('ca1', 'ses_child1', 2700, 2700, JSON.stringify({
+    role: 'assistant', modelID: 'gpt-5.4-mini-fast', providerID: 'openai', time: { created: 2700 },
+    tokens: { total: 110, input: 100, output: 10, reasoning: 0, cache: { write: 0, read: 0 } },
+  }));
+  part.run('cp2', 'ca1', 'ses_child1', 2701, 2701, JSON.stringify({
+    type: 'text', text: 'The xylophone entry point is packages/server/src/index.ts',
+  }));
+
+  // Degraded sessions need at least one event row to materialize in the index.
+  msg.run('du1', 'ses_dangling', 4000, 4000, JSON.stringify({ role: 'user', time: { created: 4000 } }));
+  part.run('dp1', 'du1', 'ses_dangling', 4001, 4001, JSON.stringify({ type: 'text', text: 'orphaned child prompt' }));
+  msg.run('y1u', 'ses_cyc1', 5000, 5000, JSON.stringify({ role: 'user', time: { created: 5000 } }));
+  part.run('y1p', 'y1u', 'ses_cyc1', 5001, 5001, JSON.stringify({ type: 'text', text: 'cycle one prompt' }));
+  msg.run('y2u', 'ses_cyc2', 5000, 5000, JSON.stringify({ role: 'user', time: { created: 5000 } }));
+  part.run('y2p', 'y2u', 'ses_cyc2', 5001, 5001, JSON.stringify({ type: 'text', text: 'cycle two prompt' }));
   db.close();
 }
 
@@ -140,12 +191,20 @@ afterAll(async () => {
 const get = (url: string) => app.inject({ method: 'GET', url });
 
 describe('opencode session indexing', () => {
-  it('lists the SQLite-sourced session with its stored title and an opencode tag', async () => {
+  it('lists the SQLite-sourced sessions; task children fold, degraded links stay standalone', async () => {
     const sessions = (await get('/api/sessions')).json();
-    expect(sessions.map((s: { id: string }) => s.id)).toEqual(['ses_test1']);
-    expect(sessions[0].connectorId).toBe('opencode');
-    expect(sessions[0].models).toContain('gpt-5.4-mini-fast');
-    expect(sessions[0].title).toBe('Test session'); // stored title, not first-message fallback
+    // ses_child1 must NOT be listed (re-keyed under ses_test1); the dangling and
+    // cyclic parent links must degrade to standalone sessions, not hang or vanish.
+    expect(sessions.map((s: { id: string }) => s.id).sort()).toEqual([
+      'ses_cyc1', 'ses_cyc2', 'ses_dangling', 'ses_test1',
+    ]);
+    const parent = sessions.find((s: { id: string }) => s.id === 'ses_test1');
+    expect(parent.connectorId).toBe('opencode');
+    expect(parent.models).toContain('gpt-5.4-mini-fast');
+    // stored title, not first-message fallback — and not the CHILD's title, which
+    // shares the parent's session_id in the titles projection.
+    expect(parent.title).toBe('Test session');
+    expect(parent.hasSidechain).toBe(true);
   });
 
   it('tags the project, exposes the source, and groups analytics by agent/model', async () => {
@@ -157,24 +216,29 @@ describe('opencode session indexing', () => {
     expect(byModel).toContain('gpt-5.4-mini-fast');
   });
 
-  it('folds reasoning into output and prices gpt-5.4-mini-fast', async () => {
-    const s = (await get('/api/sessions')).json()[0];
-    // input 1000 + output(50)+reasoning(200)=250 + cacheRead 300 + cacheWrite 0 = 1550.
-    expect(s.totalTokens).toBe(1550);
-    // (1000*0.75 + 250*4.5 + 300*0.075) / 1e6 = 0.0018975.
-    expect(s.totalCostUsd).toBeCloseTo(0.0018975, 6);
+  it('folds reasoning into output, prices gpt-5.4-mini-fast, and counts child tokens', async () => {
+    const sessions = (await get('/api/sessions')).json();
+    const s = sessions.find((x: { id: string }) => x.id === 'ses_test1');
+    // main: input 1000 + output(50)+reasoning(200)=250 + cacheRead 300 = 1550;
+    // child (folded in): input 100 + output 10 = 110. Total 1660.
+    expect(s.totalTokens).toBe(1660);
+    // (1000*0.75 + 250*4.5 + 300*0.075 + 100*0.75 + 10*4.5) / 1e6 = 0.0020175.
+    expect(s.totalCostUsd).toBeCloseTo(0.0020175, 6);
   });
 
-  it('finds the session via full-text search', async () => {
+  it('finds the session via full-text search, including subagent text under the parent', async () => {
     const { sessions: results } = (await get('/api/search?q=patched')).json();
     expect(results.some((r: { sessionId: string }) => r.sessionId === 'ses_test1')).toBe(true);
+    // text from the child transcript surfaces under the PARENT session id.
+    const { sessions: sub } = (await get('/api/search?q=xylophone')).json();
+    expect(sub.some((r: { sessionId: string }) => r.sessionId === 'ses_test1')).toBe(true);
+    expect(sub.every((r: { sessionId: string }) => r.sessionId !== 'ses_child1')).toBe(true);
   });
 });
 
 describe('opencode session detail', () => {
   it('renders reasoning, apply_patch→canonical edits, read, and the screenshot', async () => {
     const detail = (await get('/api/sessions/ses_test1')).json();
-    expect(detail.subagents).toEqual([]);
     const flat = detail.thread.flatMap((t: { blocks: Record<string, unknown>[] }) => t.blocks);
 
     // plaintext reasoning survives.
@@ -212,5 +276,33 @@ describe('opencode session detail', () => {
         b.kind === 'attachment' && (b.attachment as { type?: string })?.type === 'image',
     );
     expect((img.attachment as { source: { url: string } }).source.url).toBe(PNG_URL);
+  });
+
+  it('embeds the task-spawned child as a subagent anchored to its Task block', async () => {
+    const detail = (await get('/api/sessions/ses_test1')).json();
+    const flat = detail.thread.flatMap((t: { blocks: Record<string, unknown>[] }) => t.blocks);
+
+    // the `task` part becomes a canonical Task block in the parent thread.
+    const task = flat.find((b: Record<string, unknown>) => b.kind === 'tool' && b.name === 'Task');
+    expect(task.input).toMatchObject({ description: 'Inspect entry point', subagent_type: 'explore' });
+
+    // the child session rides in as a SubagentRun anchored to that block.
+    expect(detail.subagents).toHaveLength(1);
+    const run = detail.subagents[0];
+    expect(run).toMatchObject({
+      agentId: 'ses_child1',
+      agentType: 'explore',
+      description: 'Inspect entry point',
+    });
+    expect(run.toolUseId).toBe(task.id);
+    // the child's own turns render inside the run, not in the main thread.
+    expect(JSON.stringify(run.thread)).toContain('xylophone');
+    expect(JSON.stringify(detail.thread)).not.toContain('xylophone');
+  });
+
+  it('serves a degraded (dangling-parent) child as its own session', async () => {
+    const detail = (await get('/api/sessions/ses_dangling')).json();
+    expect(detail.subagents).toEqual([]);
+    expect(JSON.stringify(detail.thread)).toContain('orphaned child prompt');
   });
 });

--- a/packages/server/test/pi.integration.test.ts
+++ b/packages/server/test/pi.integration.test.ts
@@ -1,13 +1,18 @@
 /**
  * pi connector integration test.
  *
- * Builds the index from a synthetic pi session JSONL (in an isolated temp
+ * Builds the index from synthetic pi session JSONL (in an isolated temp
  * PI_SESSIONS_DIR, with the other agents empty) and exercises the routes,
  * verifying the pi-specific normalization: cwd/session id from the `session`
  * line, model from the assistant message, plaintext thinking (NOT blanked),
  * composite-id tool_use ↔ tool_result pairing, the synthesized thread chain that
- * sidesteps pi's `model_change`/`thinking_level_change` records, and correct
- * `gpt-5.4-mini` cost (not the `gpt`-family overcharge).
+ * sidesteps pi's `model_change`/`thinking_level_change` records, correct
+ * `gpt-5.4-mini` cost (not the `gpt`-family overcharge), and subagent embedding:
+ * a nested `<sessionBase>/<runId>/run-<N>/session.jsonl` child folds into the
+ * parent session (searchable, tokens counted, never a top-level session) and
+ * nests at its `subagent` toolCall → canonical `Task`, while a management-mode
+ * `subagent` call stays passthrough and an orphaned child (no parent file)
+ * indexes standalone instead of crashing.
  */
 
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
@@ -34,12 +39,17 @@ process.env.REINDEX_INTERVAL_MS = '0';
 
 const jsonl = (events: unknown[]): string => events.map((e) => JSON.stringify(e)).join('\n') + '\n';
 const ts = (s: number) => `2026-06-15T10:00:${String(s).padStart(2, '0')}.000Z`;
+const ts2 = (s: number) => `2026-06-15T11:00:${String(s).padStart(2, '0')}.000Z`;
 
 // Composite tool ids as pi writes them (`call_…|fc_…`) — must survive verbatim
 // on both the tool_use and its tool_result, or the pairing breaks.
 const CALL_A = 'call_AAA|fc_aaa';
 const CALL_B = 'call_BBB|fc_bbb';
 const CALL_C = 'call_CCC|fc_ccc';
+const CALL_M = 'call_MMM|fc_mmm'; // management-mode subagent call
+const CALL_S = 'call_SSS|fc_sss'; // spawning subagent call
+// The dispatched task; the run must anchor on its FIRST LINE (subagentLabel).
+const SCOUT_TASK = 'Map the cave system\nCover every passage.';
 // 1x1 transparent PNG (base64) — stands in for a pasted screenshot pi read back.
 const PNG_B64 =
   'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYPhfDwAChwGA60e6kgAAAABJRU5ErkJggg==';
@@ -84,12 +94,116 @@ function writeSession(): string {
   return file;
 }
 
+/**
+ * Write a second session that dispatches a subagent: a management `subagent`
+ * call (stays passthrough), a spawning call (→ canonical `Task`), the nested
+ * child transcript at `<sessionBase>/<runId>/run-0/session.jsonl`, an ORPHANED
+ * child with no parent `.jsonl` sibling (must index standalone), and an
+ * UNMATCHED child run no toolResult claims (must attach detached).
+ */
+function writeSubagentSession(): void {
+  const dir = join(piDir, '--tmp-piproj--');
+  const base = '2026-06-15T11-00-00-000Z_02aaaaaa-1111-7222-8333-444455556666';
+  writeFileSync(
+    join(dir, `${base}.jsonl`),
+    jsonl([
+      { type: 'session', version: 3, id: 'pi-sess-2', timestamp: ts2(0), cwd: '/tmp/piproj' },
+      { type: 'message', id: 'u1', parentId: null, timestamp: ts2(1), message: { role: 'user', content: [{ type: 'text', text: 'dispatch a scout to map the caves' }] } },
+      { type: 'message', id: 'a1', parentId: 'u1', timestamp: ts2(2), message: {
+        role: 'assistant', model: 'gpt-5.4-mini', provider: 'openai-codex',
+        content: [{ type: 'toolCall', id: CALL_M, name: 'subagent', arguments: { action: 'list' } }],
+      } },
+      // Management action: mode 'management', no runId → no child, stays `subagent`.
+      { type: 'message', id: 'tr1', parentId: 'a1', timestamp: ts2(3), message: { role: 'toolResult', toolCallId: CALL_M, toolName: 'subagent', content: [{ type: 'text', text: 'Executable agents:\n- scout' }], details: { mode: 'management', results: [] } } },
+      { type: 'message', id: 'a2', parentId: 'tr1', timestamp: ts2(4), message: {
+        role: 'assistant', model: 'gpt-5.4-mini', provider: 'openai-codex',
+        content: [{ type: 'toolCall', id: CALL_S, name: 'subagent', arguments: { agent: 'scout', task: SCOUT_TASK } }],
+      } },
+      // The result echoes the task WITH a suffixed output section — the correlation
+      // key must come from the toolCall args (first line), not this string.
+      { type: 'message', id: 'tr2', parentId: 'a2', timestamp: ts2(20), message: { role: 'toolResult', toolCallId: CALL_S, toolName: 'subagent', content: [{ type: 'text', text: '# Cave map\nAll passages covered.' }], details: { mode: 'single', runId: 'run1abc', results: [{ agent: 'scout', task: `${SCOUT_TASK}\n\n---\n**Output requirements**\nreport back` }] } } },
+      { type: 'message', id: 'a3', parentId: 'tr2', timestamp: ts2(21), message: {
+        role: 'assistant', model: 'gpt-5.4-mini', provider: 'openai-codex',
+        content: [{ type: 'text', text: 'The scout mapped the caves.' }],
+      } },
+    ]),
+  );
+
+  // The child run transcript — nested under the parent's basename dir. Only the
+  // child carries usage, so the parent's totalTokens proves sidechain folding.
+  const childDir = join(dir, base, 'run1abc', 'run-0');
+  mkdirSync(childDir, { recursive: true });
+  writeFileSync(
+    join(childDir, 'session.jsonl'),
+    jsonl([
+      { type: 'session', version: 3, id: 'pi-child-1', timestamp: ts2(10), cwd: '/tmp/piproj' },
+      { type: 'message', id: 'cu1', parentId: null, timestamp: ts2(11), message: { role: 'user', content: [{ type: 'text', text: 'Map the cave system' }] } },
+      { type: 'message', id: 'ca1', parentId: 'cu1', timestamp: ts2(12), message: {
+        role: 'assistant', model: 'gpt-5.4-mini', provider: 'openai-codex',
+        content: [{ type: 'text', text: 'Stalactite chamber found in the glowworm grotto.' }],
+        usage: { input: 100, output: 20, cacheRead: 0, cacheWrite: 0, totalTokens: 120 },
+      } },
+    ]),
+  );
+
+  // Orphan: shaped like a child (`run-0/session.jsonl`) but `no-parent-here.jsonl`
+  // does not exist — must index as its own session, not crash or key to a dead id.
+  const orphanDir = join(dir, 'no-parent-here', 'runX', 'run-0');
+  mkdirSync(orphanDir, { recursive: true });
+  writeFileSync(
+    join(orphanDir, 'session.jsonl'),
+    jsonl([
+      { type: 'session', version: 3, id: 'pi-orphan-1', timestamp: ts2(30), cwd: '/tmp/piproj' },
+      { type: 'message', id: 'ou1', parentId: null, timestamp: ts2(31), message: { role: 'user', content: [{ type: 'text', text: 'orphan child with no parent' }] } },
+    ]),
+  );
+
+  // UNMATCHED child: a run dir no subagent toolResult ever claimed (crashed
+  // mid-run). Indexed under the parent (path shape is content-independent), so
+  // it must surface in detail as a DETACHED run — not vanish behind a search hit.
+  const unmatchedDir = join(dir, base, 'run-crashed', 'run-0');
+  mkdirSync(unmatchedDir, { recursive: true });
+  writeFileSync(
+    join(unmatchedDir, 'session.jsonl'),
+    jsonl([
+      { type: 'session', version: 3, id: 'pi-child-crashed', timestamp: ts2(25), cwd: '/tmp/piproj' },
+      { type: 'message', id: 'xu1', parentId: null, timestamp: ts2(26), message: { role: 'user', content: [{ type: 'text', text: 'abandoned expedition notes' }] } },
+    ]),
+  );
+}
+
+/**
+ * A parent whose file holds ONLY the `session` line (zero indexable events) plus
+ * a nested child: the session's `files` rows are the child's alone, so
+ * loadSession sees no top-level path and must promote the child to the main
+ * thread instead of serving an empty detail.
+ */
+function writeEmptyParentSession(): void {
+  const dir = join(piDir, '--tmp-piproj--');
+  const base = '2026-06-15T12-00-00-000Z_03bbbbbb-1111-7222-8333-444455556666';
+  writeFileSync(
+    join(dir, `${base}.jsonl`),
+    jsonl([{ type: 'session', version: 3, id: 'pi-empty-parent', timestamp: ts2(40), cwd: '/tmp/piproj' }]),
+  );
+  const childDir = join(dir, base, 'runZ', 'run-0');
+  mkdirSync(childDir, { recursive: true });
+  writeFileSync(
+    join(childDir, 'session.jsonl'),
+    jsonl([
+      { type: 'session', version: 3, id: 'pi-child-2', timestamp: ts2(41), cwd: '/tmp/piproj' },
+      { type: 'message', id: 'zu1', parentId: null, timestamp: ts2(42), message: { role: 'user', content: [{ type: 'text', text: 'promoted child speaks for the parent' }] } },
+    ]),
+  );
+}
+
 let app: FastifyInstance;
 let closeConnection: () => Promise<void>;
 
 beforeAll(async () => {
   mkdirSync(claudeDir, { recursive: true });
   writeSession();
+  writeSubagentSession();
+  writeEmptyParentSession();
 
   const Fastify = (await import('fastify')).default;
   const { registerRoutes } = await import('../src/routes/index.js');
@@ -111,13 +225,22 @@ afterAll(async () => {
 const get = (url: string) => app.inject({ method: 'GET', url });
 
 describe('pi session indexing', () => {
-  it('lists the pi session with model from the assistant message and a pi agent tag', async () => {
+  it('lists the pi sessions with model from the assistant message and a pi agent tag', async () => {
     const sessions = (await get('/api/sessions')).json();
-    expect(sessions.map((s: { id: string }) => s.id)).toEqual(['pi-sess-1']);
-    expect(sessions[0].models).toContain('gpt-5.4-mini');
-    expect(sessions[0].connectorId).toBe('pi');
+    // The nested children (`pi-child-*`) fold into their parents — never
+    // top-level sessions; the orphan (parent file missing) stays standalone, and
+    // the empty parent is listed via its child's re-keyed rows.
+    expect(sessions.map((s: { id: string }) => s.id).sort()).toEqual([
+      'pi-empty-parent',
+      'pi-orphan-1',
+      'pi-sess-1',
+      'pi-sess-2',
+    ]);
+    const s1 = sessions.find((s: { id: string }) => s.id === 'pi-sess-1');
+    expect(s1.models).toContain('gpt-5.4-mini');
+    expect(s1.connectorId).toBe('pi');
     // pi has no ai-title, so the title falls back to the first user message.
-    expect(sessions[0].title).toBe('find the needle in this pi haystack');
+    expect(s1.title).toBe('find the needle in this pi haystack');
   });
 
   it('tags the project with its agent and groups analytics by agent', async () => {
@@ -134,7 +257,7 @@ describe('pi session indexing', () => {
   });
 
   it('maps usage directly (input excl. cache) and prices gpt-5.4-mini correctly', async () => {
-    const s = (await get('/api/sessions')).json()[0];
+    const s = (await get('/api/sessions')).json().find((x: { id: string }) => x.id === 'pi-sess-1');
     // input is cache-exclusive in pi → totalTokens = Σ(input+output+cacheRead+cacheWrite)
     // = (1000+300+200+0) + (500+50+1000+0) = 3050.
     expect(s.totalTokens).toBe(3050);
@@ -197,5 +320,82 @@ describe('pi session detail', () => {
     expect(img.source).toEqual({ type: 'base64', media_type: 'image/png', data: PNG_B64 });
 
     expect(JSON.stringify(detail.thread)).toContain('Found the needle.');
+  });
+});
+
+describe('pi subagent embedding', () => {
+  it('marks the parent session as having a sidechain and folds child tokens into it', async () => {
+    const sessions = (await get('/api/sessions')).json();
+    const s2 = sessions.find((s: { id: string }) => s.id === 'pi-sess-2');
+    expect(s2.hasSidechain).toBe(true);
+    // Only the CHILD carries usage (100 in + 20 out) — the parent total proves
+    // the re-keyed sidechain rows are counted under the parent session.
+    expect(s2.totalTokens).toBe(120);
+    // Fallback title comes from the parent's (earliest) user turn, not the child's.
+    expect(s2.title).toBe('dispatch a scout to map the caves');
+  });
+
+  it('nests the child run at its spawning toolCall via the canonical Task block', async () => {
+    const detail = (await get('/api/sessions/pi-sess-2')).json();
+    const flat = detail.thread.flatMap((t: { blocks: Record<string, unknown>[] }) => t.blocks);
+
+    // The spawning `subagent` toolCall → canonical `Task`; the description is the
+    // task's FIRST LINE, shared with the SubagentSource so the run anchors here.
+    const task = flat.find((b: { name?: string }) => b.name === 'Task');
+    expect(task.id).toBe(CALL_S);
+    expect(task.input).toMatchObject({ description: 'Map the cave system', subagent_type: 'scout' });
+    expect(task.input.prompt).toBe(SCOUT_TASK);
+
+    // Two runs: the anchored scout + the detached crashed run (asserted below).
+    expect(detail.subagents).toHaveLength(2);
+    const run = detail.subagents.find((r: { agentType: string }) => r.agentType === 'scout');
+    expect(run).toMatchObject({ agentType: 'scout', description: 'Map the cave system' });
+    expect(run.toolUseId).toBe(CALL_S);
+    // The child transcript rides the run — not the main thread.
+    expect(JSON.stringify(run)).toContain('glowworm grotto');
+    expect(JSON.stringify(detail.thread)).not.toContain('glowworm');
+  });
+
+  it('attaches an unmatched child run as a detached (unanchored) subagent', async () => {
+    const detail = (await get('/api/sessions/pi-sess-2')).json();
+    // The crashed run has no claiming toolResult → no description to anchor on,
+    // but its events must still be reachable in the detail response.
+    const detached = detail.subagents.find((r: { toolUseId?: string }) => !r.toolUseId);
+    expect(detached).toMatchObject({ agentType: '', description: '' });
+    expect(JSON.stringify(detached)).toContain('abandoned expedition notes');
+  });
+
+  it('keeps a management-mode subagent call passthrough (no Task, no run)', async () => {
+    const detail = (await get('/api/sessions/pi-sess-2')).json();
+    const flat = detail.thread.flatMap((t: { blocks: Record<string, unknown>[] }) => t.blocks);
+    const mgmt = flat.find((b: { id?: string }) => b.id === CALL_M);
+    expect(mgmt.name).toBe('subagent'); // NOT canonicalized — nothing was spawned
+    // No run anchors to the management call.
+    expect(detail.subagents.some((r: { toolUseId?: string }) => r.toolUseId === CALL_M)).toBe(false);
+  });
+
+  it('promotes children to the main thread when the parent contributes no events', async () => {
+    // `pi-empty-parent` indexed only its child's rows: loadSession finds no
+    // top-level path and must promote the child instead of serving nothing.
+    const detail = (await get('/api/sessions/pi-empty-parent')).json();
+    expect(JSON.stringify(detail.thread)).toContain('promoted child speaks for the parent');
+    expect(detail.subagents).toEqual([]);
+  });
+
+  it('finds child-transcript text under the PARENT session via search', async () => {
+    const { sessions: results } = (await get('/api/search?q=glowworm')).json();
+    expect(results.some((r: { sessionId: string }) => r.sessionId === 'pi-sess-2')).toBe(true);
+    expect(results.every((r: { sessionId: string }) => r.sessionId !== 'pi-child-1')).toBe(true);
+
+    // The unmatched child's text hits the parent too — and the detached run in
+    // detail (asserted above) is what makes that hit followable.
+    const { sessions: crashed } = (await get('/api/search?q=expedition')).json();
+    expect(crashed.some((r: { sessionId: string }) => r.sessionId === 'pi-sess-2')).toBe(true);
+  });
+
+  it('indexes an orphaned child (missing parent file) as its own session', async () => {
+    const detail = (await get('/api/sessions/pi-orphan-1')).json();
+    expect(JSON.stringify(detail.thread)).toContain('orphan child with no parent');
+    expect(detail.subagents).toEqual([]);
   });
 });


### PR DESCRIPTION
## Summary

Only Claude Code and Antigravity nested subagent runs under their parent session. The other connectors either **double-listed** children as independent top-level sessions (Codex separate rollouts, pi nested run transcripts, opencode child session rows) or **flattened** them into the main thread (Copilot inline events). Codex additionally dropped `custom_tool_call` records entirely, so **apply_patch edits were invisible** in the transcript and the Files-changed tab.

All four now follow the Antigravity pattern: child canonical rows re-key to the root session id with `is_sidechain`, a canonical `Task` tool_use is synthesized at the spawn point, and `loadSession` splits children into `SubagentSource` runs anchored by description equality. The indexer, parser, API, and web UI are untouched — the connector seam carries everything.

## Per connector

- **Codex** — parse `custom_tool_call`/`custom_tool_call_output`: `apply_patch` V4A envelopes fan out to canonical `Write`/`MultiEdit` per file (a **rejected** patch demotes back to raw passthrough so Files-changed never lists untouched files, with the full error preserved); `tool_search`/`web_search` render instead of vanishing. `spawn_agent` → `Task`; subagent rollouts (`thread_source: "subagent"`) re-key to their root thread via a cached, cycle-guarded parent map; orphaned children promote to the main thread.
- **pi** — children (`<base>/<runId>/run-N/session.jsonl`) re-key purely by path shape; `subagent` toolCall → `Task` (management calls stay passthrough); runs attach via the toolResult's `details.runId`/`results`; unmatched/crashed runs surface as detached runs so indexed text is always reachable.
- **opencode** — `session.parent_id` resolved to the root ancestor (cycle-guarded, dangling-safe); `task` tool part → `Task`; children correlate via `state.metadata.sessionId`; child rows emit empty titles so the shared titles projection can't clobber the parent's.
- **Copilot** — inline events segment into per-agent streams by the event-level `agentId` (main-thread uuid chain unchanged for sessions without subagents); `task` toolRequest → `Task` with `subagent.started` metadata; image resolver migrated to the shared `safe-image` helper (#44).
- **Junie** — intentionally unchanged: its "subagents" are plain `junie` CLI subprocesses with zero ID linkage; documented in CLAUDE.md.
- `SCHEMA_VERSION` 8 → 9 so existing indexes rebuild and stale child-as-session rows re-key under their parents.

## Review & verification

Four adversarial review passes (one per connector) ran against the diff; all confirmed findings are fixed and tested (failed apply_patch demotion, pi orphan reachability, opencode label/statement tidy-ups). Verified end-to-end against real local data: an opencode task-spawned child folds under its parent with `hasSidechain`, and the run anchors to its `Task` block with the child thread intact. Full suite: 304 tests / 35 files, typecheck clean.

Plan: [docs/plans/0032-subagent-embedding-connectors.md](./docs/plans/0032-subagent-embedding-connectors.md)