### PR TITLE
fix(web): restore reader's place after a full reload (Safari ⌘R)

### DIFF
--- a/docs/plans/0034-safari-reload-scroll-restore.md
+++ b/docs/plans/0034-safari-reload-scroll-restore.md
@@ -1,0 +1,122 @@
+# 0034 — Restore reader's place after a full reload (Safari ⌘R)
+
+- **Status:** in-progress <!-- proposed | in-progress | done | superseded | abandoned -->
+- **Date:** 2026-07-02
+- **PR:** <link, once opened>
+
+## Context
+
+The session page intercepts ⌘R/Ctrl+R (`SessionPage.tsx`) to do an in-place soft
+refresh instead of a full browser reload, so the reader keeps their place in the
+transcript. **Safari ignores `preventDefault()` on ⌘R** — it's a protected
+navigation shortcut there (unlike Chrome/Firefox) — so Safari users get a full
+reload and lose their scroll position. The interception cannot be made to work
+in Safari; no page is allowed to block that shortcut.
+
+Constraints that shape the fix:
+
+- The scroll container is not the window — it's the `<main class="tv-main">`
+  pane (`overflow-y: auto`), so native browser scroll restoration doesn't apply.
+- Turns mount progressively (`useProgressiveMount`, first ~80 turns): after a
+  reload most of the transcript has no height yet, so a raw `scrollTop` restore
+  would land wrong. Restoration must anchor to a turn and ride the existing
+  `ensureMounted` retry loop the `#<uuid>` hash deep-link effect uses.
+- A soft refresh swaps `data` without unmounting — restoration must never fire
+  there (same guard pattern as `hashScrolledForId`).
+
+## Goal
+
+A full reload of a session page — Safari ⌘R, hard reloads anywhere — lands the
+reader back at the same turn at the same on-screen offset. Chrome/Firefox ⌘R
+soft refresh is unchanged. Expanded blocks / finder state are out of scope; only
+the scroll position ("your place").
+
+## Decisions
+
+- **Restore the place after reload, instead of an alternate Safari shortcut** —
+  user-confirmed. Works in every browser and also fixes accidental reloads; a
+  new keybinding would fix nothing for muscle-memory ⌘R.
+- **Anchor = topmost visible turn uuid + pixel delta, not raw scrollTop** —
+  progressive mounting makes absolute offsets meaningless after reload; a uuid
+  can be force-mounted via the existing `ensureMounted` machinery.
+- **`sessionStorage`, key `claudescope-scroll:<sessionId>`** — per-tab (two tabs
+  on one session don't clobber each other), naturally expires with the browsing
+  session. All access `try/catch`-wrapped (private mode ⇒ feature no-ops),
+  following the `ThemeProvider` precedent.
+- **Save on throttled scroll + `pagehide` flush** — `pagehide`, not
+  `beforeunload`: it fires reliably in Safari (the browser that matters here)
+  and doesn't break BFCache eligibility.
+- **Restore only when the document loaded on this session** (module-scope
+  capture of the initial `/sessions/:id` pathname) — SPA navigation to a
+  session is an intentional "open this session" and still lands at the top.
+  BFCache back-nav needs nothing: DOM and scroll are restored intact.
+- **`#<uuid>` deep links win over a saved place** — the hash effect owns the
+  scroll; restoration bows out.
+- **Uuid gone after reload → nearest turn by saved index, centered** — cheap
+  and lands close; empty session → no-op.
+- **Post-restore "anchor hold" (~1.2 s), not a one-shot scroll** — added after
+  end-to-end verification: async syntax highlighting settles within ~500 ms of
+  the restore and reflows the transcript above the anchor by hundreds of px
+  (~820 px observed). Chrome's native scroll anchoring compensates, but Safari
+  — the browser this feature exists for — has none. The hold re-aligns the
+  anchor every frame until layout settles, and cancels itself the moment any scroll
+  it didn't make happens (user wheel/touch, a hash navigation, finder jumps,
+  Chrome's scroll anchoring), so it never fights the reader.
+- **Read the anchor uuid from `article.id`, resolve its index via a uuid→index
+  map** — some turn variants render `null`, so DOM position ≠ `items` index.
+
+## Approach
+
+1. New hook `packages/web/src/pages/session/useScrollRestore.ts`:
+   - Save path: throttled (300 ms trailing) `scroll` listener on `.tv-main`
+     (scroll doesn't bubble — attached directly) + `pagehide` flush. Topmost
+     visible turn found by binary search over `:scope > article.tv-turn`
+     (articles are vertically ordered). At-top ⇒ `removeItem` (reload = plain
+     load). Saves skipped while the thread is hidden (Files-changed tab shares
+     the scroller and must not corrupt the saved place).
+   - Restore path: effect modeled on the hash deep-link effect — once per
+     session id (ref guard), bails on SPA nav or a hash, `ensureMounted` +
+     retry-on-`mounted`-growth until the anchor exists, then holds the anchor
+     at the saved delta (exact match) or centered (index fallback) for ~1.2 s
+     while late content settles. No highlight.
+   - Pure helpers `parseSavedPlace` / `resolveAnchor` exported for tests.
+2. Wire into `SessionView` (`SessionPage.tsx`): one hook call, passing
+   `meta.id`, `items`, and the `useProgressiveMount` outputs. The ⌘R
+   interception and the Refresh button/tooltip stay byte-for-byte unchanged —
+   "without losing your place (⌘R)" becomes true in every browser.
+3. Tests (`packages/web/test/scrollRestore.test.ts`): pure-logic only —
+   malformed/wrong-shape stored JSON, uuid-gone index fallback + clamping,
+   empty session. No jsdom scroll simulation; DOM behavior verified manually.
+
+## Files affected
+
+- `packages/web/src/pages/session/useScrollRestore.ts` — new; the hook and
+  pure helpers.
+- `packages/web/src/pages/session/SessionPage.tsx` — import + one hook call in
+  `SessionView`.
+- `packages/web/test/scrollRestore.test.ts` — new; helper edge cases.
+
+## Testing
+
+- `npm test`, `npm run typecheck`.
+- Safari (motivating case): open a long session (>80 turns), scroll deep, ⌘R →
+  full reload returns to the same turn at the same offset, no highlight; repeat
+  from the very bottom (exercises the `ensureMounted` walk).
+- Chrome: ⌘R still soft-refreshes in place; ⌘⇧R hard-reloads and also restores
+  the place (acceptable — the escape hatch is about fresh data, not losing your
+  spot).
+- Hash deep link with a saved place present → hash wins. Browse → session SPA
+  nav → lands at top. Scrolling the Files-changed tab then reloading leaves the
+  conversation place untouched. Safari private window → feature silently inert.
+
+## Risks / open questions
+
+- If the session shrank server-side, the index fallback lands near, not at, the
+  old place — acceptable for a rebuilt transcript.
+- Layout shift that finishes after the 1.2 s hold window would still nudge the
+  position; not observed locally (settle completed in ~500 ms), and the hash
+  deep-link accepts the same limitation.
+- Verified end-to-end in headless Chrome (exact restore byte-stable across two
+  reloads; fallback, SPA-nav, hash-precedence, corrupt-storage, tab-guard, and
+  Ctrl+R soft-refresh probes all pass). Real-Safari WebDriver run blocked on
+  the "Allow remote automation" Safari setting — worth one manual ⌘R check.

--- a/docs/plans/0034-safari-reload-scroll-restore.md
+++ b/docs/plans/0034-safari-reload-scroll-restore.md
@@ -1,8 +1,8 @@
 # 0034 — Restore reader's place after a full reload (Safari ⌘R)
 
-- **Status:** in-progress <!-- proposed | in-progress | done | superseded | abandoned -->
+- **Status:** done <!-- proposed | in-progress | done | superseded | abandoned -->
 - **Date:** 2026-07-02
-- **PR:** <link, once opened>
+- **PR:** https://github.com/vladar107/claudescope/pull/46
 
 ## Context
 

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -58,3 +58,4 @@ decision, or a change worth explaining before doing. Skip it for one-line fixes.
 | 0031 | [Google Antigravity connector](./0031-antigravity-connector.md) | done |
 | 0032 | [Subagent embedding for Codex, pi, opencode, Copilot](./0032-subagent-embedding-connectors.md) | done |
 | 0033 | [Symlink-safe image resolution](./0033-symlink-safe-image-resolution.md) | done |
+| 0034 | [Restore reader's place after a full reload (Safari ⌘R)](./0034-safari-reload-scroll-restore.md) | in-progress |

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -58,4 +58,4 @@ decision, or a change worth explaining before doing. Skip it for one-line fixes.
 | 0031 | [Google Antigravity connector](./0031-antigravity-connector.md) | done |
 | 0032 | [Subagent embedding for Codex, pi, opencode, Copilot](./0032-subagent-embedding-connectors.md) | done |
 | 0033 | [Symlink-safe image resolution](./0033-symlink-safe-image-resolution.md) | done |
-| 0034 | [Restore reader's place after a full reload (Safari ⌘R)](./0034-safari-reload-scroll-restore.md) | in-progress |
+| 0034 | [Restore reader's place after a full reload (Safari ⌘R)](./0034-safari-reload-scroll-restore.md) | done |

--- a/packages/web/src/pages/session/SessionPage.tsx
+++ b/packages/web/src/pages/session/SessionPage.tsx
@@ -8,6 +8,7 @@ import { formatBytes, formatDateTime, formatDuration } from '../browse/format.js
 import { hasRenderableContent } from './blocks.js';
 import { SubagentBlock, SubagentJumpMenu, ThreadList, useHashTarget } from './ThreadView.js';
 import { useProgressiveMount } from './useProgressiveMount.js';
+import { useScrollRestore } from './useScrollRestore.js';
 import { ChangesetPanel } from './ChangesetPanel.js';
 import { buildChangeset } from './changeset.js';
 import { ExportMenu } from './ExportMenu.js';
@@ -226,6 +227,10 @@ function SessionView({
   const [activeIndex, setActiveIndex] = useState(0);
   const threadRef = useRef<HTMLDivElement>(null);
   const inputRef = useRef<HTMLInputElement>(null);
+
+  // Safari can't intercept ⌘R (see the keydown handler above), so a full
+  // reload there — or a hard reload anywhere — restores the reader's place.
+  useScrollRestore({ sessionId: meta.id, items, mounted, allMounted, ensureMounted, threadRef });
 
   // Debounce the query and require >= 2 chars, so rapid typing (or a 1-char
   // query that matches everything) never triggers heavy work on every keystroke.

--- a/packages/web/src/pages/session/useScrollRestore.ts
+++ b/packages/web/src/pages/session/useScrollRestore.ts
@@ -1,0 +1,266 @@
+import { useEffect, useRef, type RefObject } from 'react';
+import type { ThreadItem } from '@claudescope/shared';
+
+/**
+ * Persist and restore the reader's place across full page reloads.
+ *
+ * The ⌘R interception in SessionPage keeps a refresh in-place on Chrome and
+ * Firefox, but Safari treats ⌘R as a protected navigation shortcut and ignores
+ * preventDefault — the page fully reloads. This hook makes that reload (and any
+ * other hard reload) non-destructive: it continuously saves the topmost visible
+ * turn + its pixel offset to sessionStorage, and on a fresh document load of
+ * the same session scrolls back to it once the turn is mounted.
+ *
+ * A raw scrollTop is useless here: turns mount progressively (see
+ * useProgressiveMount), so after a reload most of the transcript has no height
+ * yet. Anchoring to a turn uuid lets the restore ride the existing
+ * `ensureMounted` retry loop the hash deep-link effect uses.
+ */
+
+/** sessionStorage key prefix — per-session, per-tab. */
+const STORAGE_PREFIX = 'claudescope-scroll:';
+const SAVE_THROTTLE_MS = 300;
+
+interface SavedPlace {
+  /** Topmost visible turn's uuid (= its article element id). */
+  uuid: string;
+  /** Its index in `items` at save time — fallback if the uuid disappears. */
+  index: number;
+  /** anchor top − scroller top at save time (px), so restore is exact. */
+  delta: number;
+}
+
+/** Parse + validate a stored place; null for anything malformed. */
+export function parseSavedPlace(raw: string | null): SavedPlace | null {
+  if (!raw) return null;
+  try {
+    const v: unknown = JSON.parse(raw);
+    if (typeof v !== 'object' || v === null) return null;
+    const { uuid, index, delta } = v as Record<string, unknown>;
+    if (typeof uuid !== 'string' || uuid === '') return null;
+    if (typeof index !== 'number' || !Number.isFinite(index) || index < 0) return null;
+    if (typeof delta !== 'number' || !Number.isFinite(delta)) return null;
+    return { uuid, index, delta };
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Resolve the saved place against the current turn list: the exact uuid when
+ * it still exists (scroll restores to the exact offset), otherwise the nearest
+ * turn by saved index (restore centers it instead — `exact: false`).
+ */
+export function resolveAnchor(
+  saved: SavedPlace,
+  indexByUuid: Map<string, number>,
+  items: readonly { uuid: string }[],
+): { uuid: string; exact: boolean } | null {
+  if (indexByUuid.has(saved.uuid)) return { uuid: saved.uuid, exact: true };
+  const nearest = items[Math.min(saved.index, items.length - 1)];
+  return nearest ? { uuid: nearest.uuid, exact: false } : null;
+}
+
+/**
+ * Topmost visible turn: first `article.tv-turn` child whose bottom edge is
+ * below the scroller's top. Articles are vertically ordered, so binary search
+ * keeps a save cheap even in a several-thousand-turn session.
+ */
+function pickAnchor(
+  thread: HTMLElement,
+  scrollerTop: number,
+): { el: HTMLElement; delta: number } | null {
+  const articles = thread.querySelectorAll<HTMLElement>(':scope > article.tv-turn');
+  if (articles.length === 0) return null;
+  let lo = 0;
+  let hi = articles.length - 1;
+  while (lo < hi) {
+    const mid = (lo + hi) >> 1;
+    if (articles[mid]!.getBoundingClientRect().bottom > scrollerTop) hi = mid;
+    else lo = mid + 1;
+  }
+  const el = articles[lo]!;
+  const rect = el.getBoundingClientRect();
+  if (rect.bottom <= scrollerTop) return null; // everything is above the viewport
+  return { el, delta: rect.top - scrollerTop };
+}
+
+/**
+ * How long to hold the restored anchor in place. Late-arriving content (async
+ * syntax highlighting swapping in above the anchor) reflows the transcript by
+ * hundreds of px within ~500 ms of the restore scroll. Chrome's scroll
+ * anchoring compensates; Safari — the browser this feature exists for — has
+ * none, so the anchor is re-aligned every frame for a beat instead.
+ */
+const HOLD_MS = 1200;
+
+/**
+ * Keep `el` at `targetDelta()` px below the scroller top until layout settles.
+ * Any scroll the hold didn't make itself — user wheel/touch, a hash
+ * navigation, finder jumps, Chrome's own scroll anchoring — cancels it
+ * immediately, so it only ever counteracts silent layout shift.
+ */
+function holdAnchor(
+  scroller: HTMLElement,
+  el: HTMLElement,
+  targetDelta: () => number,
+  isCancelled: () => boolean,
+): void {
+  const start = performance.now();
+  let expected: number | null = null;
+  const step = () => {
+    if (isCancelled() || !el.isConnected) return;
+    if (expected !== null && Math.abs(scroller.scrollTop - expected) > 1) return;
+    const offset = el.getBoundingClientRect().top - scroller.getBoundingClientRect().top;
+    const diff = offset - targetDelta();
+    if (Math.abs(diff) > 1) scroller.scrollTop += diff;
+    expected = scroller.scrollTop;
+    if (performance.now() - start < HOLD_MS) requestAnimationFrame(step);
+  };
+  step();
+}
+
+/**
+ * The session id the document itself was loaded on. Restoration only fires
+ * when the current session matches — SPA navigation to a session is an
+ * intentional "open this session" and lands at the top as before. Captured
+ * once at module load, before the router can rewrite the URL.
+ */
+const initialLoadSessionId: string | null = (() => {
+  if (typeof window === 'undefined') return null; // node (tests import the helpers)
+  const id = /^\/sessions\/([^/]+)/.exec(window.location.pathname)?.[1];
+  if (!id) return null;
+  try {
+    return decodeURIComponent(id);
+  } catch {
+    return id;
+  }
+})();
+
+export function useScrollRestore({
+  sessionId,
+  items,
+  mounted,
+  allMounted,
+  ensureMounted,
+  threadRef,
+}: {
+  sessionId: string;
+  items: ThreadItem[];
+  mounted: number;
+  allMounted: boolean;
+  ensureMounted: (uuid: string) => void;
+  threadRef: RefObject<HTMLDivElement | null>;
+}): void {
+  const indexByUuid = useRef(new Map<string, number>());
+  indexByUuid.current = new Map(items.map((it, i) => [it.uuid, i]));
+
+  // ── Save: throttled on scroll, flushed on pagehide ────────────────────────
+  // `pagehide` (not `beforeunload`) is what catches Safari's uninterceptable
+  // ⌘R — it fires reliably there and doesn't break BFCache eligibility.
+  useEffect(() => {
+    const key = STORAGE_PREFIX + sessionId;
+    const scroller = threadRef.current?.closest('main.tv-main');
+    if (!(scroller instanceof HTMLElement)) return;
+
+    const save = () => {
+      const thread = threadRef.current;
+      // Hidden thread (Files-changed tab shares the same scroller): its
+      // scrolling must not clobber the conversation's saved place.
+      if (!thread || thread.getClientRects().length === 0) return;
+      try {
+        if (scroller.scrollTop <= 4) {
+          // Effectively at the top — a reload should just be a plain load.
+          sessionStorage.removeItem(key);
+          return;
+        }
+        const anchor = pickAnchor(thread, scroller.getBoundingClientRect().top);
+        if (!anchor) return;
+        const index = indexByUuid.current.get(anchor.el.id);
+        if (index === undefined) return;
+        const place: SavedPlace = { uuid: anchor.el.id, index, delta: anchor.delta };
+        sessionStorage.setItem(key, JSON.stringify(place));
+      } catch {
+        /* sessionStorage may be unavailable (private mode) — feature no-ops */
+      }
+    };
+
+    let timer: number | null = null;
+    const onScroll = () => {
+      if (timer !== null) return;
+      timer = window.setTimeout(() => {
+        timer = null;
+        save();
+      }, SAVE_THROTTLE_MS);
+    };
+    const flush = () => {
+      if (timer !== null) {
+        window.clearTimeout(timer);
+        timer = null;
+      }
+      save();
+    };
+
+    scroller.addEventListener('scroll', onScroll, { passive: true });
+    window.addEventListener('pagehide', flush);
+    return () => {
+      scroller.removeEventListener('scroll', onScroll);
+      window.removeEventListener('pagehide', flush);
+      if (timer !== null) window.clearTimeout(timer);
+    };
+  }, [sessionId, threadRef]);
+
+  // ── Restore: once per fresh document load of this session ────────────────
+  // Modeled on the hash deep-link effect: re-runs as `mounted` grows until the
+  // anchor's turn exists, then scrolls. The ref guard keeps a soft refresh
+  // (which swaps `items` without unmounting) from ever re-scrolling.
+  const restoredForId = useRef<string | null>(null);
+  const holdCancelled = useRef(false);
+  // Leaving the session (or unmounting) must stop an in-flight anchor hold —
+  // the `.tv-main` scroller outlives this page and must not keep being pinned.
+  useEffect(() => {
+    holdCancelled.current = false;
+    return () => {
+      holdCancelled.current = true;
+    };
+  }, [sessionId]);
+  useEffect(() => {
+    if (restoredForId.current === sessionId) return;
+    if (sessionId !== initialLoadSessionId || window.location.hash) {
+      // SPA navigation, or a `#<uuid>` deep-link that owns the scroll.
+      restoredForId.current = sessionId;
+      return;
+    }
+    let saved: SavedPlace | null = null;
+    try {
+      saved = parseSavedPlace(sessionStorage.getItem(STORAGE_PREFIX + sessionId));
+    } catch {
+      /* storage unavailable */
+    }
+    if (!saved) {
+      restoredForId.current = sessionId;
+      return;
+    }
+    const place = saved;
+    const anchor = resolveAnchor(place, indexByUuid.current, items);
+    if (!anchor) {
+      restoredForId.current = sessionId;
+      return;
+    }
+    const el = document.getElementById(anchor.uuid);
+    if (!el) {
+      if (allMounted) restoredForId.current = sessionId; // never going to appear
+      else ensureMounted(anchor.uuid); // retry as turns mount
+      return;
+    }
+    restoredForId.current = sessionId;
+    const scroller = el.closest('main.tv-main');
+    if (!(scroller instanceof HTMLElement)) return;
+    const targetDelta = anchor.exact
+      ? () => place.delta
+      : // Nearest-turn fallback (the exact turn disappeared): center it, but
+        // keep the top of a taller-than-viewport turn in view.
+        () => Math.max(24, (scroller.clientHeight - el.getBoundingClientRect().height) / 2);
+    holdAnchor(scroller, el, targetDelta, () => holdCancelled.current);
+  }, [sessionId, items, mounted, allMounted, ensureMounted]);
+}

--- a/packages/web/test/scrollRestore.test.ts
+++ b/packages/web/test/scrollRestore.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest';
+import { parseSavedPlace, resolveAnchor } from '../src/pages/session/useScrollRestore.js';
+
+describe('parseSavedPlace', () => {
+  it('accepts a well-formed place', () => {
+    expect(parseSavedPlace('{"uuid":"u1","index":3,"delta":-42.5}')).toEqual({
+      uuid: 'u1',
+      index: 3,
+      delta: -42.5,
+    });
+  });
+
+  it('rejects null and malformed JSON', () => {
+    expect(parseSavedPlace(null)).toBeNull();
+    expect(parseSavedPlace('')).toBeNull();
+    expect(parseSavedPlace('{"uuid":')).toBeNull();
+  });
+
+  it('rejects wrong shapes and non-finite numbers', () => {
+    expect(parseSavedPlace('"u1"')).toBeNull();
+    expect(parseSavedPlace('{"uuid":"","index":0,"delta":0}')).toBeNull();
+    expect(parseSavedPlace('{"uuid":"u1","index":"3","delta":0}')).toBeNull();
+    expect(parseSavedPlace('{"uuid":"u1","index":-1,"delta":0}')).toBeNull();
+    expect(parseSavedPlace('{"uuid":"u1","index":0,"delta":null}')).toBeNull();
+    expect(parseSavedPlace('{"uuid":"u1","index":0}')).toBeNull();
+  });
+});
+
+describe('resolveAnchor', () => {
+  const items = [{ uuid: 'a' }, { uuid: 'b' }, { uuid: 'c' }];
+  const indexByUuid = new Map(items.map((it, i) => [it.uuid, i]));
+
+  it('resolves an existing uuid exactly', () => {
+    expect(resolveAnchor({ uuid: 'b', index: 1, delta: 0 }, indexByUuid, items)).toEqual({
+      uuid: 'b',
+      exact: true,
+    });
+  });
+
+  it('falls back to the saved index when the uuid is gone', () => {
+    expect(resolveAnchor({ uuid: 'gone', index: 1, delta: 0 }, indexByUuid, items)).toEqual({
+      uuid: 'b',
+      exact: false,
+    });
+  });
+
+  it('clamps an out-of-range index to the last turn', () => {
+    expect(resolveAnchor({ uuid: 'gone', index: 99, delta: 0 }, indexByUuid, items)).toEqual({
+      uuid: 'c',
+      exact: false,
+    });
+  });
+
+  it('returns null for an empty session', () => {
+    expect(resolveAnchor({ uuid: 'gone', index: 0, delta: 0 }, new Map(), [])).toBeNull();
+  });
+});


### PR DESCRIPTION
## Problem

The session page intercepts ⌘R/Ctrl+R to soft-refresh in place, but **Safari ignores `preventDefault()` on ⌘R** (protected navigation shortcut) — Safari users get a full reload and lose their place in the transcript. The interception cannot be made to work there.

## Fix

Keep the interception (it works in Chrome/Firefox) and make a full reload non-destructive:

- **Save** — a throttled scroll listener on the `.tv-main` pane persists the topmost visible turn (uuid + pixel offset + index fallback) to `sessionStorage`, keyed per session; flushed on `pagehide` (reliable in Safari, BFCache-safe). At-top removes the entry; Files-changed-tab scrolling is guarded out; storage failures no-op.
- **Restore** — on a fresh document load of the same session only (module-scope pathname capture ⇒ SPA navigation still lands at top; `#uuid` deep links win), the saved turn is mounted via the existing `ensureMounted` retry loop and **held** at the saved offset for ~1.2 s.

The hold exists because verification showed async Shiki highlighting reflows the transcript by ~820 px within ~500 ms of the restore scroll. Chrome's native scroll anchoring compensates; **Safari has none** — so a one-shot scroll lands a full viewport off exactly in the browser this fixes. The hold re-aligns per frame and cancels on any scroll it didn't make itself (wheel/touch, hash navigation, finder jumps, Chrome's anchoring).

## Verification

Driven end-to-end in headless Chrome against the built app (see `docs/plans/0030`): exact restore is byte-stable across two consecutive reloads (saved delta −420.08 → restored −419.4); stale-uuid → nearest-index fallback; hash-precedence; SPA-nav-no-restore; at-top key removal; corrupt-storage; hidden-tab guard; Ctrl+R soft refresh regression — all pass. `npm test` (257) and `npm run typecheck` clean. Real-Safari WebDriver was blocked on the "Allow remote automation" setting — worth one manual ⌘R sanity check.

Plan: [docs/plans/0034-safari-reload-scroll-restore.md](docs/plans/0034-safari-reload-scroll-restore.md)
