### PR TITLE
feat(mcp): claudescope mcp — stdio MCP server over the daemon API

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,6 +192,23 @@ payloads truncated), `get_analytics` (token/cost aggregates), and `get_memory`
 agent's context window; pass `redact: true` to mask home paths and likely
 secrets. Everything stays read-only and on localhost.
 
+### Scripting (CLI)
+
+The same lookups work from the terminal — read-only query subcommands that
+start the background server on first use and print tables (or raw JSON with
+`--json`, handy with `jq`):
+
+```bash
+claudescope search "duckdb lock" --limit 5      # where did I hit this before?
+claudescope sessions --agent codex --sort cost  # priciest Codex sessions
+claudescope session <id> --around <uuid>        # open a search hit, windowed
+claudescope analytics --group-by day --json | jq '.rows[] | [.key, .costUsd]'
+```
+
+`session` prints a pageable window of turns as Markdown (`--offset/--limit`,
+`--redact` to mask paths/secrets); `--json` returns the raw API response
+unredacted. See `claudescope help` for the full flag list.
+
 ---
 
 ## Configuration

--- a/README.md
+++ b/README.md
@@ -174,6 +174,24 @@ npm start        # builds on first run, then serves the app in the foreground
 `npm start` runs in the foreground (`Ctrl-C` to stop). For the watch-mode dev
 loop and how to contribute, see [`CONTRIBUTING.md`](./CONTRIBUTING.md).
 
+### Agent access (MCP)
+
+Claudescope doubles as an MCP server, so a coding agent can query its own
+history — "have I hit this error before?", "what did we decide last month?":
+
+```bash
+claude mcp add claudescope -- claudescope mcp
+```
+
+`claudescope mcp` speaks MCP over stdio and starts the background server on
+first use if it isn't already running. Tools: `search_transcripts` (full-text
+search with snippet hits), `list_sessions` / `list_projects` (compact listings),
+`get_session` (a windowed Markdown slice of one session — pageable, tool
+payloads truncated), `get_analytics` (token/cost aggregates), and `get_memory`
+(instruction files + distilled agent memory). Output is plain text sized for an
+agent's context window; pass `redact: true` to mask home paths and likely
+secrets. Everything stays read-only and on localhost.
+
 ---
 
 ## Configuration

--- a/docs/plans/0038-mcp-server.md
+++ b/docs/plans/0038-mcp-server.md
@@ -1,0 +1,93 @@
+# 0038 — `claudescope mcp`: agent-facing MCP server
+
+- **Status:** done
+- **Date:** 2026-07-03
+- **PR:** [#50](https://github.com/vladar107/claudescope/pull/50)
+
+## Context
+
+Roadmap [0035](./0035-agent-access-and-analytics-roadmap.md), slice 3 (Track A).
+Claudescope's transcript corpus is only reachable by humans through the web UI.
+Exposing it to agents turns it into memory infrastructure: a coding agent can
+ask "have I solved this before?" against its own history. Slice A1
+([0036](./0036-agent-api-seams.md)) landed the token-frugality seams this
+depends on: session windowing + `maxToolChars` on `/api/sessions/:id`, `limit`
+on `/api/sessions`, `format=plain` search snippets, and the shared
+`redactText`/`threadItemsToMarkdown` helpers.
+
+## Goal
+
+`claude mcp add claudescope -- claudescope mcp` works with zero preconditions
+and gives an agent six read-only tools over the corpus, with outputs compact
+enough to land in a context window.
+
+## Decisions
+
+- **Stdio subcommand proxying the daemon's HTTP API** — the DuckDB index is
+  held read-write by the daemon and DuckDB allows only one such process, so a
+  second process must never open the index file. Every tool call goes through
+  a typed localhost `ApiClient`. (Per 0035; a streamable-HTTP `/mcp` endpoint
+  on the daemon is a follow-up.)
+- **Daemon ensured lazily on first tool use, not at MCP-server start** — MCP
+  clients spawn servers eagerly at session start; deferring the spawn means
+  `claudescope mcp` costs nothing until a tool is actually called. A failed
+  ensure is retried on the next call instead of poisoning the session.
+- **Daemon lifecycle factored to `daemon.ts`** — `readDaemon`/`isAlive`/
+  `isHealthy`/`classifyExisting`/`spawnDaemon`/`ensureDaemon` are shared by
+  cli.ts and the MCP server; cli.ts re-exports them so existing importers
+  (tests) are unaffected. `ensureDaemon` writes only to stderr — stdout is the
+  MCP protocol channel. On version skew (daemon ≠ CLI version) it warns and
+  adopts; no auto-restart in this slice.
+- **Text/Markdown tool output, not JSON dumps** — results land in an agent's
+  context. `get_session` defaults to the first 20 turns with explicit paging
+  info; tool payloads are capped at 2000 chars by default; memory bodies at
+  2000 chars. Redaction is opt-in (`redact: true`), per 0035's stance for a
+  loopback-bound single-user tool.
+- **`@modelcontextprotocol/sdk` + `zod` inlined by esbuild** — only the
+  `server/mcp.js` and `server/stdio.js` subpaths are imported so the SDK's
+  HTTP stack (express/hono) stays out of the bundle. `@duckdb/node-api`
+  remains the sole runtime dependency.
+
+## Approach
+
+1. `packages/server/src/daemon.ts` — factored lifecycle primitives +
+   `spawnDaemon` + silent `ensureDaemon` (adopt / clear stale / replace wedged /
+   spawn + wait, same semantics as `start`).
+2. `packages/server/src/agent/api-client.ts` — typed fetch wrappers over the
+   existing routes (health/projects/sessions/session/search/memory/analytics),
+   reused by the CLI query subcommands in slice A3.
+3. `packages/server/src/agent/mcp.ts` — `createMcpServer(deps)` with the six
+   tools (`search_transcripts`, `list_sessions`, `get_session`, `list_projects`,
+   `get_analytics`, `get_memory`); every handler resolves the client, returns a
+   short "index is still building" note while `/api/health.ready` is false, and
+   maps errors to MCP error results. `runMcpServer()` wires stdio + the
+   memoized ensure-daemon resolver.
+4. cli.ts: `mcp` command + help text; README "Agent access (MCP)" section.
+
+## Files affected
+
+- `packages/server/src/daemon.ts` — new; lifecycle primitives moved from cli.ts.
+- `packages/server/src/cli.ts` — imports/re-exports daemon.ts, `mcp` command.
+- `packages/server/src/agent/api-client.ts`, `agent/mcp.ts` — new.
+- `packages/server/package.json` — `@modelcontextprotocol/sdk`, `zod`.
+- `packages/server/test/mcp.integration.test.ts` — new.
+- `README.md` — Agent access section.
+
+## Testing
+
+`npm test` / `npm run typecheck`. New integration suite boots the real Fastify
+app on an ephemeral port against synthetic fixtures and drives the tools through
+an SDK client over an in-memory transport: plain unescaped snippets, windowing +
+truncation flowing through `get_session`, `around` anchoring, and the not-ready
+degradation. Bundle smoke test: `npm run bundle`, then drive the bundled
+`cli.js mcp` over stdio (initialize + tools/list) with `CLAUDESCOPE_HOME` and
+all source dirs pointed at a temp sandbox.
+
+## Risks / open questions
+
+- Version skew adopt-and-warn may surprise after an upgrade (old daemon keeps
+  serving); revisit auto-restart in a follow-up.
+- The Nix flake's `npmDepsHash` changes with the new dependencies; if `nix` is
+  unavailable locally the CI `nix` job flags the new hash to paste in.
+- `get_session` defaults to the *first* 20 turns; an agent wanting "how did it
+  end" pages via the reported total. A `tail`-style anchor could follow.

--- a/docs/plans/0040-cli-query-subcommands.md
+++ b/docs/plans/0040-cli-query-subcommands.md
@@ -1,0 +1,82 @@
+# 0040 — CLI query subcommands
+
+- **Status:** done
+- **Date:** 2026-07-03
+- **PR:** [#51](https://github.com/vladar107/claudescope/pull/51)
+
+## Context
+
+Roadmap slice 4 of [0035](./0035-agent-access-and-analytics-roadmap.md). Slice
+A2 (plan [0038](./0038-mcp-server.md)) built the agent-facing plumbing — the
+typed `ApiClient` over the daemon's HTTP API, `ensureDaemon()`, and the MCP
+tools' output shaping. This slice exposes the same read-only lookups to
+terminals and scripts as CLI subcommands, so transcript history is one `grep`
+away and `--json` pipes into `jq`.
+
+## Goal
+
+`claudescope search|sessions|session|projects|analytics` — human tables /
+compact Markdown by default, raw JSON with `--json`, auto-starting the daemon,
+sharing one shaping layer with the MCP tools.
+
+## Decisions
+
+- **Shared shaping module (`agent/shape.ts`)** — the search-hit and
+  session-Markdown renderers moved out of `agent/mcp.ts` into a new pure module
+  used by both the MCP tools and the CLI, instead of duplicating them. Tables,
+  however, are CLI-only (`agent/query.ts`): MCP output stays list-shaped for
+  agent contexts, terminals get pad-aligned columns.
+- **`--json` = the raw API response** — no redaction, no clipping beyond what
+  request params ask for. Machine output should be the contract type, not a
+  shaped view; `--redact` applies to the human Markdown only (documented in
+  help/README).
+- **Flag validation before daemon spawn** — `runQuery(prepare)` runs the flag
+  parsing first, so `--limit banana` errors out without starting anything.
+- **Session windowing defaults match MCP** — no windowing flags → the first 20
+  turns with a paging line, `--max-tool-chars` default 2000. A huge session
+  never dumps whole by accident.
+- **Dependency-free tables** — code-unit `padStart`/`padEnd` alignment with a
+  60-char clip on free-text columns. Wide-glyph (emoji/CJK) alignment is
+  imperfect by design; correctness (row present, nothing crashes) over
+  typography.
+
+## Approach
+
+1. Extract `shapeSearchResults` + `shapeSessionMarkdown` (and the small fmt
+   helpers/defaults) from `agent/mcp.ts` into `agent/shape.ts`; mcp.ts
+   re-imports.
+2. New `agent/query.ts`: `querySearch` / `querySessions` / `querySession` /
+   `queryProjects` / `queryAnalytics`, each `(client, args) → Promise<string>`
+   so tests inject a fixture-app client; plus the `table()` helper.
+3. `cli.ts`: new flags in the single `parseArgs` table, `runQuery()` wrapper
+   (validate flags → `ensureDaemon()` → `ApiClient` → print; errors to stderr,
+   exit 1), five dispatch cases, help text.
+4. README: "Scripting (CLI)" subsection under Agent access with jq examples.
+
+## Files affected
+
+- `packages/server/src/agent/shape.ts` — new; shaping shared by MCP + CLI.
+- `packages/server/src/agent/query.ts` — new; the five subcommands + `table()`.
+- `packages/server/src/agent/mcp.ts` — imports the extracted shaping; behavior
+  unchanged (existing MCP tests untouched).
+- `packages/server/src/cli.ts` — flags, `runQuery`, dispatch, help.
+- `README.md` — Scripting subsection.
+- `packages/server/test/cli-query.test.ts` — new integration tests.
+
+## Testing
+
+`npm test` (344 passing, 5 new) and `npm run typecheck` clean. New tests boot
+the real app on an ephemeral port over synthetic fixtures and cover the
+CLI-specific edges: table alignment with a clipped long title and a non-ASCII
+title, `--json` passthrough (raw rows; `window` metadata; redact ignored),
+`--redact` masking home paths in Markdown output, empty-result "No matches."
+as normal output, and the analytics totals line.
+
+## Risks / open questions
+
+- Table alignment is code-unit based; emoji/CJK-heavy titles can look ragged.
+  Acceptable for a listing; revisit only if it bothers real use.
+- `--q` relies on `parseArgs` accepting single-char long option names (verified
+  on the pinned Node).
+- A `tail`-style anchor for `session` (open the END of a session) is a natural
+  follow-up, same as noted for MCP `get_session` in 0038.

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -61,3 +61,4 @@ decision, or a change worth explaining before doing. Skip it for one-line fixes.
 | 0034 | [Restore reader's place after a full reload (Safari ⌘R)](./0034-safari-reload-scroll-restore.md) | done |
 | 0035 | [Roadmap: agent-facing access (MCP + CLI) & analytics depth](./0035-agent-access-and-analytics-roadmap.md) | proposed |
 | 0036 | [API seams for agent consumers (windowing, limits, plain snippets, shared redact/markdown)](./0036-agent-api-seams.md) | done |
+| 0038 | [`claudescope mcp`: agent-facing MCP server](./0038-mcp-server.md) | done |

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -62,3 +62,4 @@ decision, or a change worth explaining before doing. Skip it for one-line fixes.
 | 0035 | [Roadmap: agent-facing access (MCP + CLI) & analytics depth](./0035-agent-access-and-analytics-roadmap.md) | proposed |
 | 0036 | [API seams for agent consumers (windowing, limits, plain snippets, shared redact/markdown)](./0036-agent-api-seams.md) | done |
 | 0038 | [`claudescope mcp`: agent-facing MCP server](./0038-mcp-server.md) | done |
+| 0040 | [CLI query subcommands (search/sessions/session/projects/analytics)](./0040-cli-query-subcommands.md) | done |

--- a/package-lock.json
+++ b/package-lock.json
@@ -817,6 +817,18 @@
         "glob": "^13.0.0"
       }
     },
+    "node_modules/@hono/node-server": {
+      "version": "1.19.14",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
+      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.14.1"
+      },
+      "peerDependencies": {
+        "hono": "^4"
+      }
+    },
     "node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.5.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
@@ -831,6 +843,46 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk": {
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
+      "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@hono/node-server": "^1.19.9",
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
+        "content-type": "^1.0.5",
+        "cors": "^2.8.5",
+        "cross-spawn": "^7.0.5",
+        "eventsource": "^3.0.2",
+        "eventsource-parser": "^3.0.0",
+        "express": "^5.2.1",
+        "express-rate-limit": "^8.2.1",
+        "hono": "^4.11.4",
+        "jose": "^6.1.3",
+        "json-schema-typed": "^8.0.2",
+        "pkce-challenge": "^5.0.0",
+        "raw-body": "^3.0.0",
+        "zod": "^3.25 || ^4.0",
+        "zod-to-json-schema": "^3.25.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@cfworker/json-schema": "^4.1.1",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "@cfworker/json-schema": {
+          "optional": true
+        },
+        "zod": {
+          "optional": false
+        }
       }
     },
     "node_modules/@napi-rs/wasm-runtime": {
@@ -997,9 +1049,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1017,9 +1066,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1037,9 +1083,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1057,9 +1100,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1077,9 +1117,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1097,9 +1134,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1597,6 +1631,19 @@
       "integrity": "sha512-2BjRTZxTPvheOvGbBslFSYOUkr+SjPtOnrLP33f+VIWLzezQpZcqVg7ja3L4dBXmzzgwT+a029jRx5PCi3JuiA==",
       "license": "MIT"
     },
+    "node_modules/accepts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/ajv": {
       "version": "8.20.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
@@ -1714,6 +1761,43 @@
         "node": "18 || 20 || >=22"
       }
     },
+    "node_modules/body-parser": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.3.0.tgz",
+      "integrity": "sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "^3.1.2",
+        "content-type": "^2.0.0",
+        "debug": "^4.4.3",
+        "http-errors": "^2.0.1",
+        "iconv-lite": "^0.7.2",
+        "on-finished": "^2.4.1",
+        "qs": "^6.15.2",
+        "raw-body": "^3.0.2",
+        "type-is": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/body-parser/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/brace-expansion": {
       "version": "5.0.6",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
@@ -1724,6 +1808,44 @@
       },
       "engines": {
         "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/ccount": {
@@ -1871,6 +1993,15 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
@@ -1889,6 +2020,46 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
+      }
+    },
+    "node_modules/cors": {
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
+      "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
       }
     },
     "node_modules/csstype": {
@@ -2094,6 +2265,26 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
     "node_modules/emoji-regex": {
       "version": "10.6.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
@@ -2101,12 +2292,51 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/es-module-lexer": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.1.0.tgz",
       "integrity": "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
     },
     "node_modules/es-toolkit": {
       "version": "1.47.0",
@@ -2208,11 +2438,41 @@
         "@types/estree": "^1.0.0"
       }
     },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/eventemitter3": {
       "version": "5.0.4",
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
       "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
       "license": "MIT"
+    },
+    "node_modules/eventsource": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
+      "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+      "license": "MIT",
+      "dependencies": {
+        "eventsource-parser": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.1.0.tgz",
+      "integrity": "sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
     },
     "node_modules/expect-type": {
       "version": "1.3.0",
@@ -2222,6 +2482,76 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=12.0.0"
+      }
+    },
+    "node_modules/express": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.1",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "8.5.2",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.5.2.tgz",
+      "integrity": "sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A==",
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "^10.2.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
+    "node_modules/express/node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/extend": {
@@ -2379,6 +2709,27 @@
         }
       }
     },
+    "node_modules/finalhandler": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/find-my-way": {
       "version": "9.6.0",
       "resolved": "https://registry.npmjs.org/find-my-way/-/find-my-way-9.6.0.tgz",
@@ -2391,6 +2742,24 @@
       },
       "engines": {
         "node": ">=20"
+      }
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/fsevents": {
@@ -2406,6 +2775,15 @@
       ],
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/get-caller-file": {
@@ -2431,6 +2809,43 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/glob": {
       "version": "13.0.6",
       "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
@@ -2446,6 +2861,42 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/hast-util-to-html": {
@@ -2511,6 +2962,15 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/hono": {
+      "version": "4.12.27",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.27.tgz",
+      "integrity": "sha512-1yrb/+w6HWQJrUCLkJ2IF5jNIPvvFkblV5RNOYl6bV+OA6p9GLcMpHFFGTosSvHvcAUibuUukRqhlYI4z32C7Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.9.0"
+      }
+    },
     "node_modules/html-url-attributes": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/html-url-attributes/-/html-url-attributes-3.0.1.tgz",
@@ -2551,6 +3011,22 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/iconv-lite": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/immer": {
       "version": "10.2.0",
       "resolved": "https://registry.npmjs.org/immer/-/immer-10.2.0.tgz",
@@ -2580,6 +3056,15 @@
       "license": "ISC",
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/ip-address": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
       }
     },
     "node_modules/ipaddr.js": {
@@ -2647,6 +3132,27 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "license": "MIT"
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "license": "ISC"
+    },
+    "node_modules/jose": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.3.tgz",
+      "integrity": "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
     "node_modules/json-schema-ref-resolver": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/json-schema-ref-resolver/-/json-schema-ref-resolver-3.0.0.tgz",
@@ -2671,6 +3177,12 @@
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
       "license": "MIT"
+    },
+    "node_modules/json-schema-typed": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
+      "license": "BSD-2-Clause"
     },
     "node_modules/light-my-request": {
       "version": "6.6.0",
@@ -2852,9 +3364,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -2876,9 +3385,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -2900,9 +3406,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -2924,9 +3427,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -3019,6 +3519,15 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/mdast-util-find-and-replace": {
@@ -3289,6 +3798,27 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/micromark": {
@@ -3866,6 +4396,31 @@
         "node": ">=10.0.0"
       }
     },
+    "node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/minimatch": {
       "version": "10.2.5",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
@@ -3915,6 +4470,36 @@
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
+    "node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/obug": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.3.tgz",
@@ -3936,6 +4521,27 @@
       "license": "MIT",
       "engines": {
         "node": ">=14.0.0"
+      }
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
       }
     },
     "node_modules/oniguruma-parser": {
@@ -3980,6 +4586,24 @@
       "integrity": "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==",
       "license": "MIT"
     },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/path-scurry": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
@@ -4003,6 +4627,16 @@
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": "20 || >=22"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/pathe": {
@@ -4068,6 +4702,15 @@
       "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-7.1.0.tgz",
       "integrity": "sha512-BndPH67/JxGExRgiX1dX0w1FvZck5Wa4aal9198SrRhZjH3GxKQUKIBnYJTdj2HDN3UQAS06HlfcSbQj2OHmaw==",
       "license": "MIT"
+    },
+    "node_modules/pkce-challenge": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
+      "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.20.0"
+      }
     },
     "node_modules/playwright": {
       "version": "1.60.0",
@@ -4171,11 +4814,77 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/proxy-addr/node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.15.3",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
+      "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "es-define-property": "^1.0.1",
+        "side-channel": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/quick-format-unescaped": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/quick-format-unescaped/-/quick-format-unescaped-4.0.4.tgz",
       "integrity": "sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==",
       "license": "MIT"
+    },
+    "node_modules/range-parser": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.3.0.tgz",
+      "integrity": "sha512-hek2mFQpPuI4E1BBKrSto+BU3e3x4xuarsbiwr3+lf7p44juvFMV0XFWQAP3xUyqXA4RrXLIoaSUGbSt056ZMw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
     },
     "node_modules/react": {
       "version": "19.2.7",
@@ -4518,6 +5227,22 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/router": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
     "node_modules/rxjs": {
       "version": "7.8.2",
       "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
@@ -4559,6 +5284,12 @@
         "node": ">=10"
       }
     },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
     "node_modules/scheduler": {
       "version": "0.27.0",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
@@ -4581,6 +5312,51 @@
       ],
       "license": "BSD-3-Clause"
     },
+    "node_modules/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.1",
+        "mime-types": "^3.0.2",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/serve-static": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/set-cookie-parser": {
       "version": "2.7.2",
       "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.2.tgz",
@@ -4592,6 +5368,27 @@
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
       "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
       "license": "ISC"
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/shell-quote": {
       "version": "1.8.4",
@@ -4623,6 +5420,78 @@
       },
       "engines": {
         "node": ">=20"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+      "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4",
+        "side-channel-list": "^1.0.1",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/siginfo": {
@@ -4914,6 +5783,37 @@
         "fsevents": "~2.3.3"
       }
     },
+    "node_modules/type-is": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.1.0.tgz",
+      "integrity": "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==",
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^2.0.0",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/type-is/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/typescript": {
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
@@ -5022,6 +5922,15 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/use-sync-external-store": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
@@ -5029,6 +5938,15 @@
       "license": "MIT",
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/vfile": {
@@ -5249,6 +6167,21 @@
         }
       }
     },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/why-is-node-running": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
@@ -5283,6 +6216,12 @@
       "funding": {
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
     },
     "node_modules/y18n": {
       "version": "5.0.8",
@@ -5322,6 +6261,24 @@
         "node": "^20.19.0 || ^22.12.0 || >=23"
       }
     },
+    "node_modules/zod": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.25.2",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.25.28 || ^4"
+      }
+    },
     "node_modules/zwitch": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/zwitch/-/zwitch-2.0.4.tgz",
@@ -5339,7 +6296,9 @@
         "@claudescope/shared": "*",
         "@duckdb/node-api": "^1.5.3-r.3",
         "@fastify/static": "^9.1.3",
-        "fastify": "^5.2.0"
+        "@modelcontextprotocol/sdk": "^1.29.0",
+        "fastify": "^5.2.0",
+        "zod": "^4.4.3"
       },
       "devDependencies": {
         "@types/node": "^22.10.2",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -10,10 +10,12 @@
     "start": "node dist/index.js"
   },
   "dependencies": {
+    "@claudescope/shared": "*",
     "@duckdb/node-api": "^1.5.3-r.3",
     "@fastify/static": "^9.1.3",
-    "@claudescope/shared": "*",
-    "fastify": "^5.2.0"
+    "@modelcontextprotocol/sdk": "^1.29.0",
+    "fastify": "^5.2.0",
+    "zod": "^4.4.3"
   },
   "devDependencies": {
     "@types/node": "^22.10.2",

--- a/packages/server/src/agent/api-client.ts
+++ b/packages/server/src/agent/api-client.ts
@@ -1,0 +1,72 @@
+/**
+ * Typed client for the daemon's localhost HTTP API.
+ *
+ * Agent-facing consumers (the MCP server, the CLI query subcommands) never open
+ * the DuckDB index themselves — the daemon holds the file read-write and DuckDB
+ * allows only one such process — so every read proxies through the running
+ * daemon over loopback HTTP.
+ */
+
+import type {
+  AnalyticsGroupBy,
+  AnalyticsResponse,
+  HealthResponse,
+  MemoryResponse,
+  ProjectMemoryResponse,
+  ProjectsResponse,
+  SearchQuery,
+  SearchResponse,
+  SessionDetailQuery,
+  SessionDetailResponse,
+  SessionMeta,
+  SessionsQuery,
+} from '@claudescope/shared';
+
+/** Query-param bag: undefined/empty values are omitted from the URL. */
+type Params = Record<string, string | number | boolean | undefined>;
+
+export class ApiClient {
+  constructor(readonly baseUrl: string) {}
+
+  private async get<T>(path: string, params?: Params): Promise<T> {
+    const url = new URL(path, this.baseUrl);
+    for (const [k, v] of Object.entries(params ?? {})) {
+      if (v !== undefined && v !== '') url.searchParams.set(k, String(v));
+    }
+    const res = await fetch(url, { signal: AbortSignal.timeout(30_000) });
+    if (!res.ok) throw new Error(`GET ${path} → ${res.status} ${res.statusText}`);
+    return (await res.json()) as T;
+  }
+
+  health(): Promise<HealthResponse & { ready: boolean }> {
+    return this.get('/api/health');
+  }
+
+  projects(): Promise<ProjectsResponse> {
+    return this.get('/api/projects');
+  }
+
+  sessions(q: SessionsQuery = {}): Promise<SessionMeta[]> {
+    return this.get('/api/sessions', q as Params);
+  }
+
+  session(id: string, q: SessionDetailQuery = {}): Promise<SessionDetailResponse> {
+    return this.get(`/api/sessions/${encodeURIComponent(id)}`, q as Params);
+  }
+
+  search(q: SearchQuery): Promise<SearchResponse> {
+    return this.get('/api/search', q as unknown as Params);
+  }
+
+  memory(): Promise<MemoryResponse> {
+    return this.get('/api/memory');
+  }
+
+  projectMemory(projectId: string): Promise<ProjectMemoryResponse> {
+    return this.get(`/api/projects/${encodeURIComponent(projectId)}/memory`);
+  }
+
+  analytics(q: { groupBy: AnalyticsGroupBy; from?: string; to?: string }): Promise<AnalyticsResponse> {
+    return this.get('/api/analytics', q);
+  }
+}

--- a/packages/server/src/agent/mcp.ts
+++ b/packages/server/src/agent/mcp.ts
@@ -18,17 +18,21 @@ import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
 import { z } from 'zod';
 import type { MemorySource, SessionMeta } from '@claudescope/shared';
-import { redactText, threadItemsToMarkdown, truncateText } from '@claudescope/shared';
+import { truncateText } from '@claudescope/shared';
 import { APP_VERSION } from '../config.js';
 import { ensureDaemon } from '../daemon.js';
 import { ApiClient } from './api-client.js';
+import {
+  DEFAULT_LIMIT,
+  DEFAULT_MAX_TOOL_CHARS,
+  DEFAULT_TURNS,
+  day,
+  fmtCost,
+  fmtTokens,
+  shapeSearchResults,
+  shapeSessionMarkdown,
+} from './shape.js';
 
-/** Default hits/rows returned by the list-shaped tools. */
-const DEFAULT_LIMIT = 20;
-/** Default per-tool-payload char cap in `get_session`. */
-const DEFAULT_MAX_TOOL_CHARS = 2000;
-/** Default turns per `get_session` window when no windowing params are given. */
-const DEFAULT_TURNS = 20;
 /** Char cap for memory bodies in `get_memory`. */
 const MEMORY_BODY_CHARS = 2000;
 
@@ -39,10 +43,6 @@ const errorText = (t: string) => ({ content: [{ type: 'text' as const, text: t }
 export interface McpDeps {
   resolveClient: () => Promise<ApiClient>;
 }
-
-const fmtCost = (usd: number): string => `$${usd.toFixed(2)}`;
-const fmtTokens = (n: number): string => n.toLocaleString('en-US');
-const day = (iso: string): string => iso.slice(0, 10);
 
 function sessionLine(s: SessionMeta): string {
   const branch = s.gitBranch ? ` · ${s.gitBranch}` : '';
@@ -126,32 +126,7 @@ export function createMcpServer(deps: McpDeps): McpServer {
         scope: args.scope ?? 'sessions',
         format: 'plain',
       });
-      const sessions = res.sessions.slice(0, limit);
-      const memory = res.memory.slice(0, limit);
-      if (sessions.length === 0 && memory.length === 0) return 'No matches.';
-
-      const parts: string[] = [];
-      if (sessions.length > 0) {
-        parts.push(
-          `${sessions.length} transcript hit(s):`,
-          ...sessions.map(
-            (h) =>
-              `- [${h.role}] ${h.title} (session ${h.sessionId}, project ${h.projectId}, uuid ${h.messageUuid})\n` +
-              `  "${h.snippet}"`,
-          ),
-        );
-      }
-      if (memory.length > 0) {
-        parts.push(
-          `${memory.length} memory hit(s):`,
-          ...memory.map(
-            (h) =>
-              `- ${h.title}${h.category ? ` (${h.category})` : ''} [${h.connectorId}] — ${h.sourcePath}\n` +
-              `  "${h.snippet}"`,
-          ),
-        );
-      }
-      return parts.join('\n');
+      return shapeSearchResults(res, limit);
     }),
   );
 
@@ -205,32 +180,7 @@ export function createMcpServer(deps: McpDeps): McpServer {
         ...windowed,
         maxToolChars: args.maxToolChars ?? DEFAULT_MAX_TOOL_CHARS,
       });
-
-      const { meta, window } = data;
-      const r = args.redact ? redactText : (s: string) => s;
-      const head = [
-        `# ${r(meta.title)}`,
-        `session ${meta.id} [${meta.connectorId}] · project ${meta.projectDisplayName} · ` +
-          `${meta.startedAt} → ${meta.endedAt} · ${fmtTokens(meta.totalTokens)} tok · ${fmtCost(meta.totalCostUsd)}`,
-      ];
-      if (window) {
-        const end = window.offset + window.limit;
-        head.push(
-          `Turns ${window.offset + 1}–${end} of ${window.total}` +
-            (window.anchorFound === false ? ' (around uuid not found — showing the start)' : '') +
-            (end < window.total ? ` — page on with {offset: ${end}}` : ''),
-        );
-      }
-
-      const opts = { redact: args.redact ?? false };
-      const parts = [head.join('\n'), '---', threadItemsToMarkdown(data.thread, opts)];
-      for (const run of data.subagents) {
-        parts.push(
-          `--- subagent · ${run.agentType} — ${r(run.description || run.agentId)} ---`,
-          threadItemsToMarkdown(run.thread, opts),
-        );
-      }
-      return parts.join('\n\n');
+      return shapeSessionMarkdown(data, args.redact ?? false);
     }),
   );
 

--- a/packages/server/src/agent/mcp.ts
+++ b/packages/server/src/agent/mcp.ts
@@ -1,0 +1,349 @@
+/**
+ * `claudescope mcp` — a stdio MCP server that lets coding agents query their
+ * own transcript history ("have I hit this error before?").
+ *
+ * Architecture: every tool proxies the daemon's HTTP API through {@link ApiClient}
+ * (the DuckDB index allows exactly one read-write process — the daemon). The
+ * daemon is ensured lazily on first tool use, so `claude mcp add claudescope --
+ * claudescope mcp` works with zero preconditions; while the index is still
+ * building, tools answer with a short "retry shortly" note instead of hanging.
+ *
+ * Output is compact text/Markdown, not JSON dumps — these strings land directly
+ * in an agent's context window. `get_session` returns a windowed slice with
+ * paging info; tool payloads are capped by default. Redaction is opt-in
+ * (`redact: true`): output stays on this machine unless the caller exports it.
+ */
+
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+import { z } from 'zod';
+import type { MemorySource, SessionMeta } from '@claudescope/shared';
+import { redactText, threadItemsToMarkdown, truncateText } from '@claudescope/shared';
+import { APP_VERSION } from '../config.js';
+import { ensureDaemon } from '../daemon.js';
+import { ApiClient } from './api-client.js';
+
+/** Default hits/rows returned by the list-shaped tools. */
+const DEFAULT_LIMIT = 20;
+/** Default per-tool-payload char cap in `get_session`. */
+const DEFAULT_MAX_TOOL_CHARS = 2000;
+/** Default turns per `get_session` window when no windowing params are given. */
+const DEFAULT_TURNS = 20;
+/** Char cap for memory bodies in `get_memory`. */
+const MEMORY_BODY_CHARS = 2000;
+
+const text = (t: string) => ({ content: [{ type: 'text' as const, text: t }] });
+const errorText = (t: string) => ({ content: [{ type: 'text' as const, text: t }], isError: true });
+
+/** How the server reaches the daemon; injectable so tests point at a fixture app. */
+export interface McpDeps {
+  resolveClient: () => Promise<ApiClient>;
+}
+
+const fmtCost = (usd: number): string => `$${usd.toFixed(2)}`;
+const fmtTokens = (n: number): string => n.toLocaleString('en-US');
+const day = (iso: string): string => iso.slice(0, 10);
+
+function sessionLine(s: SessionMeta): string {
+  const branch = s.gitBranch ? ` · ${s.gitBranch}` : '';
+  return (
+    `- ${s.id} [${s.connectorId}] ${s.title}\n` +
+    `  ${s.projectDisplayName} · ${day(s.startedAt)} → ${day(s.endedAt)} · ` +
+    `${s.messageCount} msgs · ${s.toolCallCount} tools · ${fmtTokens(s.totalTokens)} tok · ` +
+    `${fmtCost(s.totalCostUsd)}${branch}`
+  );
+}
+
+function memorySection(sources: MemorySource[]): string {
+  return sources
+    .map(
+      (m) =>
+        `### ${m.title}${m.category ? ` (${m.category})` : ''}\n` +
+        `_${m.sourcePath} · updated ${day(m.updatedAt)}_\n\n` +
+        truncateText(m.markdown, MEMORY_BODY_CHARS),
+    )
+    .join('\n\n');
+}
+
+/**
+ * Build the MCP server with all six tools registered. Each handler resolves the
+ * client (ensuring the daemon on first use), degrades gracefully while the
+ * index builds, and maps thrown errors to an MCP error result.
+ */
+export function createMcpServer(deps: McpDeps): McpServer {
+  const server = new McpServer({ name: 'claudescope', version: APP_VERSION });
+
+  /** Wrap a handler with daemon resolution, readiness check, and error mapping. */
+  const guarded =
+    <A>(fn: (client: ApiClient, args: A) => Promise<string>) =>
+    async (args: A) => {
+      let client: ApiClient;
+      try {
+        client = await deps.resolveClient();
+      } catch (err) {
+        return errorText(
+          `Could not reach or start the claudescope daemon: ${err instanceof Error ? err.message : String(err)}`,
+        );
+      }
+      try {
+        const health = await client.health();
+        if (!health.ready) {
+          return text('The claudescope index is still building — retry in a few seconds.');
+        }
+        return text(await fn(client, args));
+      } catch (err) {
+        return errorText(`Tool failed: ${err instanceof Error ? err.message : String(err)}`);
+      }
+    };
+
+  server.registerTool(
+    'search_transcripts',
+    {
+      description:
+        'Full-text search (BM25) across all recorded coding-agent transcripts and agent memory. ' +
+        'Returns snippet hits with a sessionId + messageUuid — open a hit with ' +
+        'get_session {sessionId, around: messageUuid}. Use this to answer "have I seen/solved this before?".',
+      inputSchema: {
+        query: z.string().describe('Search terms'),
+        project: z.string().optional().describe('Project id to scope to (from list_projects)'),
+        role: z
+          .enum(['user', 'assistant', 'all'])
+          .optional()
+          .describe('Restrict transcript hits to one side of the conversation (default all)'),
+        scope: z
+          .enum(['sessions', 'memory', 'all'])
+          .optional()
+          .describe('What to search: transcripts, agent memory, or both (default sessions)'),
+        limit: z.number().int().min(1).max(50).optional().describe(`Max hits (default ${DEFAULT_LIMIT})`),
+      },
+    },
+    guarded(async (client, args: { query: string; project?: string; role?: 'user' | 'assistant' | 'all'; scope?: 'sessions' | 'memory' | 'all'; limit?: number }) => {
+      const limit = args.limit ?? DEFAULT_LIMIT;
+      const res = await client.search({
+        q: args.query,
+        project: args.project,
+        type: args.role ?? 'all',
+        scope: args.scope ?? 'sessions',
+        format: 'plain',
+      });
+      const sessions = res.sessions.slice(0, limit);
+      const memory = res.memory.slice(0, limit);
+      if (sessions.length === 0 && memory.length === 0) return 'No matches.';
+
+      const parts: string[] = [];
+      if (sessions.length > 0) {
+        parts.push(
+          `${sessions.length} transcript hit(s):`,
+          ...sessions.map(
+            (h) =>
+              `- [${h.role}] ${h.title} (session ${h.sessionId}, project ${h.projectId}, uuid ${h.messageUuid})\n` +
+              `  "${h.snippet}"`,
+          ),
+        );
+      }
+      if (memory.length > 0) {
+        parts.push(
+          `${memory.length} memory hit(s):`,
+          ...memory.map(
+            (h) =>
+              `- ${h.title}${h.category ? ` (${h.category})` : ''} [${h.connectorId}] — ${h.sourcePath}\n` +
+              `  "${h.snippet}"`,
+          ),
+        );
+      }
+      return parts.join('\n');
+    }),
+  );
+
+  server.registerTool(
+    'list_sessions',
+    {
+      description:
+        'List recorded sessions (most recent first by default), optionally filtered by project, ' +
+        'agent, or a title/text match. Returns compact rows with sessionIds for get_session.',
+      inputSchema: {
+        project: z.string().optional().describe('Project id to scope to (from list_projects)'),
+        agent: z
+          .string()
+          .optional()
+          .describe('Agent connector id, e.g. claude-code, codex, junie, pi, opencode, copilot, antigravity'),
+        sort: z.enum(['recent', 'oldest', 'tokens', 'cost', 'messages']).optional(),
+        q: z.string().optional().describe('Substring filter on the session title'),
+        limit: z.number().int().min(1).max(200).optional().describe(`Max rows (default ${DEFAULT_LIMIT})`),
+      },
+    },
+    guarded(async (client, args: { project?: string; agent?: string; sort?: 'recent' | 'oldest' | 'tokens' | 'cost' | 'messages'; q?: string; limit?: number }) => {
+      const rows = await client.sessions({ ...args, limit: args.limit ?? DEFAULT_LIMIT });
+      if (rows.length === 0) return 'No sessions match.';
+      return rows.map(sessionLine).join('\n');
+    }),
+  );
+
+  server.registerTool(
+    'get_session',
+    {
+      description:
+        'Read one session as compact Markdown. Sessions can be huge, so this returns a WINDOW of ' +
+        `turns (default: first ${DEFAULT_TURNS}) plus the total count — page with offset/limit, or anchor ` +
+        'on a search hit with around (a messageUuid) + radius. Tool payloads are truncated to ' +
+        `maxToolChars (default ${DEFAULT_MAX_TOOL_CHARS}). Set redact: true to mask home paths and likely secrets.`,
+      inputSchema: {
+        sessionId: z.string().describe('Session id (from list_sessions or search_transcripts)'),
+        offset: z.number().int().min(0).optional().describe('0-based index of the first turn'),
+        limit: z.number().int().min(1).optional().describe('Turns to return'),
+        around: z.string().optional().describe('Center the window on this message uuid (overrides offset/limit)'),
+        radius: z.number().int().min(0).optional().describe('Turns on each side of around (default 10)'),
+        maxToolChars: z.number().int().min(0).optional().describe('Char cap per tool payload; 0 = uncapped'),
+        redact: z.boolean().optional().describe('Mask home paths and likely secrets (default false)'),
+      },
+    },
+    guarded(async (client, args: { sessionId: string; offset?: number; limit?: number; around?: string; radius?: number; maxToolChars?: number; redact?: boolean }) => {
+      const windowed = args.around === undefined && args.offset === undefined && args.limit === undefined
+        ? { offset: 0, limit: DEFAULT_TURNS }
+        : { offset: args.offset, limit: args.limit, around: args.around, radius: args.radius };
+      const data = await client.session(args.sessionId, {
+        ...windowed,
+        maxToolChars: args.maxToolChars ?? DEFAULT_MAX_TOOL_CHARS,
+      });
+
+      const { meta, window } = data;
+      const r = args.redact ? redactText : (s: string) => s;
+      const head = [
+        `# ${r(meta.title)}`,
+        `session ${meta.id} [${meta.connectorId}] · project ${meta.projectDisplayName} · ` +
+          `${meta.startedAt} → ${meta.endedAt} · ${fmtTokens(meta.totalTokens)} tok · ${fmtCost(meta.totalCostUsd)}`,
+      ];
+      if (window) {
+        const end = window.offset + window.limit;
+        head.push(
+          `Turns ${window.offset + 1}–${end} of ${window.total}` +
+            (window.anchorFound === false ? ' (around uuid not found — showing the start)' : '') +
+            (end < window.total ? ` — page on with {offset: ${end}}` : ''),
+        );
+      }
+
+      const opts = { redact: args.redact ?? false };
+      const parts = [head.join('\n'), '---', threadItemsToMarkdown(data.thread, opts)];
+      for (const run of data.subagents) {
+        parts.push(
+          `--- subagent · ${run.agentType} — ${r(run.description || run.agentId)} ---`,
+          threadItemsToMarkdown(run.thread, opts),
+        );
+      }
+      return parts.join('\n\n');
+    }),
+  );
+
+  server.registerTool(
+    'list_projects',
+    {
+      description:
+        'List all projects (one per working directory) with session counts, tokens, cost, and ' +
+        'which agents worked in them. Project ids scope search_transcripts/list_sessions/get_memory.',
+      inputSchema: {},
+    },
+    guarded(async (client) => {
+      const rows = await client.projects();
+      if (rows.length === 0) return 'No projects indexed.';
+      return rows
+        .map(
+          (p) =>
+            `- ${p.id} · ${p.cwd} · ${p.sessionCount} sessions · ${fmtTokens(p.totalTokens)} tok · ` +
+            `${fmtCost(p.totalCostUsd)} · agents: ${p.connectorIds.join(', ')} · last active ${day(p.lastActive)}`,
+        )
+        .join('\n');
+    }),
+  );
+
+  server.registerTool(
+    'get_analytics',
+    {
+      description:
+        'Aggregated token/cost usage grouped by project, model, day, or agent, with totals. ' +
+        'Cost is a local list-price estimate, not billing. Dates are YYYY-MM-DD.',
+      inputSchema: {
+        groupBy: z.enum(['project', 'model', 'day', 'agent']).optional().describe('Grouping (default project)'),
+        from: z.string().optional().describe('Start date (inclusive)'),
+        to: z.string().optional().describe('End date (inclusive)'),
+      },
+    },
+    guarded(async (client, args: { groupBy?: 'project' | 'model' | 'day' | 'agent'; from?: string; to?: string }) => {
+      const res = await client.analytics({ groupBy: args.groupBy ?? 'project', from: args.from, to: args.to });
+      if (res.rows.length === 0) return 'No usage in range.';
+      const lines = res.rows.map(
+        (row) =>
+          `- ${row.key}: ${fmtTokens(row.totalTokens)} tok ` +
+          `(in ${fmtTokens(row.inputTokens)}, out ${fmtTokens(row.outputTokens)}, ` +
+          `cache r/w ${fmtTokens(row.cacheReadTokens)}/${fmtTokens(row.cacheCreationTokens)}) · ` +
+          `${fmtCost(row.costUsd)} · ${row.messageCount} responses`,
+      );
+      const t = res.totals;
+      lines.push(
+        `Total: ${fmtTokens(t.totalTokens)} tok · ${fmtCost(t.costUsd)} · ${t.messageCount} responses · ` +
+          `cache hit ${(t.cacheHitRatio * 100).toFixed(0)}%`,
+      );
+      return lines.join('\n');
+    }),
+  );
+
+  server.registerTool(
+    'get_memory',
+    {
+      description:
+        'Read recorded agent memory (instruction files and distilled facts, e.g. CLAUDE.md and ' +
+        'Claude Code memory). Without a project: global memory per agent plus which projects have ' +
+        'any. With a project id: that project’s memory per agent. Long bodies are truncated.',
+      inputSchema: {
+        project: z.string().optional().describe('Project id (from list_projects)'),
+      },
+    },
+    guarded(async (client, args: { project?: string }) => {
+      if (args.project) {
+        const res = await client.projectMemory(args.project);
+        const parts = res.byAgent
+          .filter((a) => a.sources.length > 0)
+          .map((a) => `## ${a.label}\n\n${memorySection(a.sources)}`);
+        return parts.length > 0 ? parts.join('\n\n') : 'No memory recorded for this project.';
+      }
+      const res = await client.memory();
+      const parts = res.global
+        .filter((g) => g.sources.length > 0)
+        .map((g) => `## ${g.label} (global)\n\n${memorySection(g.sources)}`);
+      if (res.projects.length > 0) {
+        parts.push(
+          'Projects with memory (query with {project: id}):',
+          ...res.projects.map(
+            (p) => `- ${p.projectId} (${p.displayName}): ${p.counts.map((c) => `${c.connectorId} ×${c.count}`).join(', ')}`,
+          ),
+        );
+      }
+      return parts.length > 0 ? parts.join('\n\n') : 'No agent memory recorded.';
+    }),
+  );
+
+  return server;
+}
+
+/**
+ * Run the production MCP server on stdio. The daemon is ensured once, lazily,
+ * on the first tool call; a failed attempt is retried on the next call rather
+ * than caching the failure for the whole MCP session.
+ */
+export async function runMcpServer(): Promise<void> {
+  let clientPromise: Promise<ApiClient> | null = null;
+  const resolveClient = (): Promise<ApiClient> => {
+    clientPromise ??= ensureDaemon().then(
+      (d) => new ApiClient(`http://127.0.0.1:${d.port}`),
+      (err) => {
+        clientPromise = null; // retry on the next tool call
+        throw err;
+      },
+    );
+    return clientPromise;
+  };
+
+  const server = createMcpServer({ resolveClient });
+  await server.connect(new StdioServerTransport());
+  // The transport owns the process from here: it resolves connect() immediately
+  // and serves requests until stdin closes (the MCP client disconnecting).
+}

--- a/packages/server/src/agent/query.ts
+++ b/packages/server/src/agent/query.ts
@@ -1,0 +1,167 @@
+/**
+ * CLI query subcommands (`claudescope search|sessions|session|projects|analytics`)
+ * — read-only lookups against the daemon's HTTP API for terminals and scripts.
+ *
+ * Each command returns the string to print: an aligned table / compact Markdown
+ * for humans, or the raw API response as JSON with `--json` (machine-readable;
+ * ignores `--redact` and does no shaping). Daemon startup progress goes to
+ * stderr (ensureDaemon), so stdout stays clean for piping.
+ */
+
+import type { AnalyticsGroupBy, SearchScope, SearchType, SessionSort } from '@claudescope/shared';
+import type { ApiClient } from './api-client.js';
+import {
+  DEFAULT_LIMIT,
+  DEFAULT_MAX_TOOL_CHARS,
+  DEFAULT_TURNS,
+  day,
+  fmtCost,
+  fmtTokens,
+  shapeSearchResults,
+  shapeSessionMarkdown,
+} from './shape.js';
+
+const json = (v: unknown): string => JSON.stringify(v, null, 2);
+
+/** Cap for free-text columns (titles, cwds) so one long value can't blow up the table. */
+const MAX_CELL = 60;
+
+const clip = (s: string): string => (s.length > MAX_CELL ? `${s.slice(0, MAX_CELL - 1)}…` : s);
+
+/**
+ * Dependency-free aligned table: pad each column to its widest cell (header
+ * included); `right` marks numeric columns for right-alignment. Widths are
+ * code-unit based — good enough for a terminal listing.
+ */
+export function table(headers: string[], rows: string[][], right: boolean[] = []): string {
+  const widths = headers.map((h, i) => Math.max(h.length, ...rows.map((r) => (r[i] ?? '').length)));
+  const line = (cells: string[]): string =>
+    cells
+      .map((c, i) => (right[i] ? c.padStart(widths[i] ?? 0) : c.padEnd(widths[i] ?? 0)))
+      .join('  ')
+      .trimEnd();
+  return [line(headers), ...rows.map(line)].join('\n');
+}
+
+export interface SearchArgs {
+  query: string;
+  project?: string;
+  role?: SearchType;
+  scope?: SearchScope;
+  limit?: number;
+  json?: boolean;
+}
+
+export async function querySearch(client: ApiClient, args: SearchArgs): Promise<string> {
+  const res = await client.search({
+    q: args.query,
+    project: args.project,
+    type: args.role ?? 'all',
+    scope: args.scope ?? 'sessions',
+    format: 'plain',
+  });
+  if (args.json) return json(res);
+  return shapeSearchResults(res, args.limit ?? DEFAULT_LIMIT);
+}
+
+export interface SessionsArgs {
+  project?: string;
+  agent?: string;
+  sort?: SessionSort;
+  q?: string;
+  limit?: number;
+  json?: boolean;
+}
+
+export async function querySessions(client: ApiClient, args: SessionsArgs): Promise<string> {
+  const rows = await client.sessions({ ...args, limit: args.limit ?? DEFAULT_LIMIT });
+  if (args.json) return json(rows);
+  if (rows.length === 0) return 'No sessions match.';
+  return table(
+    ['ID', 'AGENT', 'TITLE', 'DATE', 'MSGS', 'TOKENS', 'COST'],
+    rows.map((s) => [
+      s.id,
+      s.connectorId,
+      clip(s.title),
+      day(s.startedAt),
+      String(s.messageCount),
+      fmtTokens(s.totalTokens),
+      fmtCost(s.totalCostUsd),
+    ]),
+    [false, false, false, false, true, true, true],
+  );
+}
+
+export interface SessionArgs {
+  offset?: number;
+  limit?: number;
+  around?: string;
+  radius?: number;
+  maxToolChars?: number;
+  redact?: boolean;
+  json?: boolean;
+}
+
+export async function querySession(client: ApiClient, id: string, args: SessionArgs): Promise<string> {
+  // Same defaulting as the MCP get_session tool: no windowing params → the
+  // first DEFAULT_TURNS turns, so a huge session never dumps whole.
+  const windowed =
+    args.around === undefined && args.offset === undefined && args.limit === undefined
+      ? { offset: 0, limit: DEFAULT_TURNS }
+      : { offset: args.offset, limit: args.limit, around: args.around, radius: args.radius };
+  const data = await client.session(id, {
+    ...windowed,
+    maxToolChars: args.maxToolChars ?? DEFAULT_MAX_TOOL_CHARS,
+  });
+  if (args.json) return json(data);
+  return shapeSessionMarkdown(data, args.redact ?? false);
+}
+
+export async function queryProjects(client: ApiClient, args: { json?: boolean }): Promise<string> {
+  const rows = await client.projects();
+  if (args.json) return json(rows);
+  if (rows.length === 0) return 'No projects indexed.';
+  return table(
+    ['ID', 'PATH', 'SESSIONS', 'TOKENS', 'COST', 'AGENTS', 'LAST ACTIVE'],
+    rows.map((p) => [
+      p.id,
+      clip(p.cwd),
+      String(p.sessionCount),
+      fmtTokens(p.totalTokens),
+      fmtCost(p.totalCostUsd),
+      p.connectorIds.join(','),
+      day(p.lastActive),
+    ]),
+    [false, false, true, true, true, false, false],
+  );
+}
+
+export interface AnalyticsArgs {
+  groupBy?: AnalyticsGroupBy;
+  from?: string;
+  to?: string;
+  json?: boolean;
+}
+
+export async function queryAnalytics(client: ApiClient, args: AnalyticsArgs): Promise<string> {
+  const res = await client.analytics({ groupBy: args.groupBy ?? 'project', from: args.from, to: args.to });
+  if (args.json) return json(res);
+  if (res.rows.length === 0) return 'No usage in range.';
+  const t = res.totals;
+  return (
+    table(
+      ['KEY', 'TOKENS', 'IN', 'OUT', 'COST', 'RESPONSES'],
+      res.rows.map((r) => [
+        clip(r.key),
+        fmtTokens(r.totalTokens),
+        fmtTokens(r.inputTokens),
+        fmtTokens(r.outputTokens),
+        fmtCost(r.costUsd),
+        String(r.messageCount),
+      ]),
+      [false, true, true, true, true, true],
+    ) +
+    `\n\nTotal: ${fmtTokens(t.totalTokens)} tok · ${fmtCost(t.costUsd)} · ${t.messageCount} responses · ` +
+    `cache hit ${(t.cacheHitRatio * 100).toFixed(0)}%`
+  );
+}

--- a/packages/server/src/agent/shape.ts
+++ b/packages/server/src/agent/shape.ts
@@ -1,0 +1,88 @@
+/**
+ * Output shaping shared by the agent-facing consumers — the MCP tools and the
+ * CLI query subcommands. Everything here renders API responses to compact
+ * text/Markdown sized for an agent's context window (or a terminal); nothing
+ * talks to the network.
+ */
+
+import type { SearchResponse, SessionDetailResponse } from '@claudescope/shared';
+import { redactText, threadItemsToMarkdown } from '@claudescope/shared';
+
+/** Default hits/rows returned by the list-shaped tools/commands. */
+export const DEFAULT_LIMIT = 20;
+/** Default per-tool-payload char cap in session output. */
+export const DEFAULT_MAX_TOOL_CHARS = 2000;
+/** Default turns per session window when no windowing params are given. */
+export const DEFAULT_TURNS = 20;
+
+export const fmtCost = (usd: number): string => `$${usd.toFixed(2)}`;
+export const fmtTokens = (n: number): string => n.toLocaleString('en-US');
+export const day = (iso: string): string => iso.slice(0, 10);
+
+/**
+ * Search hits as compact text: transcript hits carry the sessionId +
+ * messageUuid needed to open them windowed (`around`), memory hits their
+ * source path. Snippets are expected in `format: 'plain'`.
+ */
+export function shapeSearchResults(res: SearchResponse, limit: number): string {
+  const sessions = res.sessions.slice(0, limit);
+  const memory = res.memory.slice(0, limit);
+  if (sessions.length === 0 && memory.length === 0) return 'No matches.';
+
+  const parts: string[] = [];
+  if (sessions.length > 0) {
+    parts.push(
+      `${sessions.length} transcript hit(s):`,
+      ...sessions.map(
+        (h) =>
+          `- [${h.role}] ${h.title} (session ${h.sessionId}, project ${h.projectId}, uuid ${h.messageUuid})\n` +
+          `  "${h.snippet}"`,
+      ),
+    );
+  }
+  if (memory.length > 0) {
+    parts.push(
+      `${memory.length} memory hit(s):`,
+      ...memory.map(
+        (h) =>
+          `- ${h.title}${h.category ? ` (${h.category})` : ''} [${h.connectorId}] — ${h.sourcePath}\n` +
+          `  "${h.snippet}"`,
+      ),
+    );
+  }
+  return parts.join('\n');
+}
+
+/**
+ * One session (or a window of it) as compact Markdown: a header with ids and
+ * totals, the paging line when the response is windowed, then the turns and
+ * any subagent runs inside the window. `redact` masks home paths and likely
+ * secrets in the rendered text (the caller decides; --json/raw output skips it).
+ */
+export function shapeSessionMarkdown(data: SessionDetailResponse, redact: boolean): string {
+  const { meta, window } = data;
+  const r = redact ? redactText : (s: string) => s;
+  const head = [
+    `# ${r(meta.title)}`,
+    `session ${meta.id} [${meta.connectorId}] · project ${meta.projectDisplayName} · ` +
+      `${meta.startedAt} → ${meta.endedAt} · ${fmtTokens(meta.totalTokens)} tok · ${fmtCost(meta.totalCostUsd)}`,
+  ];
+  if (window) {
+    const end = window.offset + window.limit;
+    head.push(
+      `Turns ${window.offset + 1}–${end} of ${window.total}` +
+        (window.anchorFound === false ? ' (around uuid not found — showing the start)' : '') +
+        (end < window.total ? ` — page on with {offset: ${end}}` : ''),
+    );
+  }
+
+  const opts = { redact };
+  const parts = [head.join('\n'), '---', threadItemsToMarkdown(data.thread, opts)];
+  for (const run of data.subagents) {
+    parts.push(
+      `--- subagent · ${run.agentType} — ${r(run.description || run.agentId)} ---`,
+      threadItemsToMarkdown(run.thread, opts),
+    );
+  }
+  return parts.join('\n\n');
+}

--- a/packages/server/src/cli.ts
+++ b/packages/server/src/cli.ts
@@ -13,126 +13,45 @@
  *   claudescope update     # upgrade to the latest published version
  */
 
-import { spawn, spawnSync } from 'node:child_process';
-import {
-  existsSync,
-  mkdirSync,
-  openSync,
-  readFileSync,
-  realpathSync,
-  renameSync,
-  rmSync,
-  statSync,
-  writeFileSync,
-} from 'node:fs';
-import { dirname, join } from 'node:path';
+import { spawnSync } from 'node:child_process';
+import { existsSync, mkdirSync, readFileSync, realpathSync, rmSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
 import { createInterface } from 'node:readline/promises';
 import { parseArgs } from 'node:util';
 import { fileURLToPath } from 'node:url';
 import { APP_VERSION, CLAUDE_PROJECTS_DIR, CLAUDESCOPE_HOME, PORT as DEFAULT_PORT } from './config.js';
+import {
+  DAEMON_FILE,
+  EXIT_WAIT_MS,
+  LOG_FILE,
+  classifyExisting,
+  isAlive,
+  isHealthy,
+  readDaemon,
+  spawnDaemon,
+  waitForExit,
+  waitForHealth,
+} from './daemon.js';
+import { runMcpServer } from './agent/mcp.js';
 import { refreshPricing } from './data/pricing-refresh.js';
 import { openBrowser } from './util/open-browser.js';
 
-const __dirname = dirname(fileURLToPath(import.meta.url));
-/** The server bundle, a sibling of this CLI in the published package. */
-const SERVER_ENTRY = join(__dirname, 'server.js');
-const DAEMON_FILE = join(CLAUDESCOPE_HOME, 'daemon.json');
-const LOG_FILE = join(CLAUDESCOPE_HOME, 'daemon.log');
+// Daemon lifecycle primitives live in daemon.js (shared with the MCP server);
+// re-exported here so existing importers (tests) keep working.
+export {
+  classifyExisting,
+  isAlive,
+  isHealthy,
+  readDaemon,
+  waitForExit,
+  waitForHealth,
+  type DaemonRecord,
+  type ExistingState,
+} from './daemon.js';
+
 const UPDATE_CHECK_FILE = join(CLAUDESCOPE_HOME, 'update-check.json');
 const PKG = '@vladar107/claudescope';
 const UPDATE_CHECK_TTL_MS = 24 * 60 * 60 * 1000;
-/** Roll the append-only daemon log once it grows past this, so a long-lived or
- *  crash-looping daemon doesn't grow the log without bound. */
-const LOG_MAX_BYTES = 5 * 1024 * 1024;
-/** How long to wait for a signalled process to actually exit before giving up. */
-const EXIT_WAIT_MS = 5000;
-
-export interface DaemonRecord {
-  pid: number;
-  port: number;
-  url: string;
-  version: string;
-  startedAt: string;
-}
-
-/** Read the daemon record, or null if absent/corrupt. */
-export function readDaemon(): DaemonRecord | null {
-  if (!existsSync(DAEMON_FILE)) return null;
-  try {
-    return JSON.parse(readFileSync(DAEMON_FILE, 'utf8')) as DaemonRecord;
-  } catch {
-    return null;
-  }
-}
-
-/** Is a process with this PID currently alive? */
-export function isAlive(pid: number): boolean {
-  try {
-    process.kill(pid, 0);
-    return true;
-  } catch {
-    return false;
-  }
-}
-
-/** Probe the server's health endpoint (short timeout, never throws). */
-export async function isHealthy(port: number): Promise<boolean> {
-  try {
-    const res = await fetch(`http://127.0.0.1:${port}/api/health`, {
-      signal: AbortSignal.timeout(1500),
-    });
-    return res.ok;
-  } catch {
-    return false;
-  }
-}
-
-/** Poll health until ready or the deadline, printing progress dots. */
-export async function waitForHealth(port: number, timeoutMs: number): Promise<boolean> {
-  const deadline = Date.now() + timeoutMs;
-  while (Date.now() < deadline) {
-    if (await isHealthy(port)) return true;
-    process.stdout.write('.');
-    await new Promise((r) => setTimeout(r, 500));
-  }
-  return false;
-}
-
-/** Poll until the process is gone or the deadline; returns whether it exited. */
-export async function waitForExit(pid: number, timeoutMs: number): Promise<boolean> {
-  const deadline = Date.now() + timeoutMs;
-  while (Date.now() < deadline) {
-    if (!isAlive(pid)) return true;
-    await new Promise((r) => setTimeout(r, 100));
-  }
-  return !isAlive(pid);
-}
-
-/** What the recorded daemon (if any) currently is, so callers can decide whether
- *  to reuse it, clear a stale record, or replace a wedged (alive-but-unhealthy)
- *  process. Injectable probes keep this pure and unit-testable. */
-export type ExistingState = 'healthy' | 'stale' | 'wedged' | 'none';
-export async function classifyExisting(
-  record: DaemonRecord | null,
-  aliveFn: (pid: number) => boolean,
-  healthyFn: (port: number) => Promise<boolean>,
-): Promise<ExistingState> {
-  if (!record) return 'none';
-  if (!aliveFn(record.pid)) return 'stale';
-  return (await healthyFn(record.port)) ? 'healthy' : 'wedged';
-}
-
-/** Roll the daemon log to `.1` once it exceeds {@link LOG_MAX_BYTES}. Best-effort. */
-function rotateLogIfLarge(): void {
-  try {
-    if (existsSync(LOG_FILE) && statSync(LOG_FILE).size > LOG_MAX_BYTES) {
-      rmSync(`${LOG_FILE}.1`, { force: true });
-      renameSync(LOG_FILE, `${LOG_FILE}.1`);
-    }
-  } catch {
-    /* non-fatal: logging is best-effort */
-  }
-}
 
 /** Start the server in the background, idempotently. */
 async function start(port: number, open: boolean): Promise<void> {
@@ -169,28 +88,10 @@ async function start(port: number, open: boolean): Promise<void> {
   }
 
   const url = `http://localhost:${port}`;
-  rotateLogIfLarge();
-  const logFd = openSync(LOG_FILE, 'a');
-  // Detached + stdio→log + unref: the server keeps running after this CLI exits.
-  // OPEN_BROWSER=0 so the daemon never opens a browser; the CLI owns that.
-  const child = spawn(process.execPath, [SERVER_ENTRY], {
-    detached: true,
-    stdio: ['ignore', logFd, logFd],
-    env: { ...process.env, PORT: String(port), OPEN_BROWSER: '0' },
-  });
-  child.unref();
-
-  writeFileSync(
-    DAEMON_FILE,
-    JSON.stringify(
-      { pid: child.pid, port, url, version: APP_VERSION, startedAt: new Date().toISOString() },
-      null,
-      2,
-    ),
-  );
+  spawnDaemon(port);
 
   process.stdout.write('› Starting claudescope');
-  const ok = await waitForHealth(port, 20000);
+  const ok = await waitForHealth(port, 20000, () => process.stdout.write('.'));
   if (!ok) {
     console.error(`\n✗ Server did not become healthy in time. Inspect: claudescope logs`);
     process.exitCode = 1;
@@ -425,6 +326,8 @@ Commands:
   status           Show whether the server is running and if an update exists
   open             Open the running app in your browser
   logs [-f]        Print the server log (-f / --follow to tail it)
+  mcp              Run an MCP stdio server exposing transcript search/reading
+                   (register with: claude mcp add claudescope -- claudescope mcp)
   update [-y]      Upgrade to the latest published version and restart
   pricing update   Fetch current model prices (LiteLLM) into the local rate table
   help             Show this help
@@ -479,6 +382,11 @@ async function main(): Promise<void> {
       break;
     case 'logs':
       logs(Boolean(values.follow));
+      break;
+    case 'mcp':
+      // Stdio MCP server: stdout is the protocol channel — nothing else may
+      // print to it. The server ensures the daemon on first tool use.
+      await runMcpServer();
       break;
     case 'update':
       await update(Boolean(values.yes));

--- a/packages/server/src/cli.ts
+++ b/packages/server/src/cli.ts
@@ -11,6 +11,10 @@
  *   claudescope status     # is it running? is an update available?
  *   claudescope logs -f    # follow the server log
  *   claudescope update     # upgrade to the latest published version
+ *
+ * Read-only query subcommands (search/sessions/session/projects/analytics)
+ * proxy the daemon's HTTP API for terminals and scripts (`--json`); see
+ * agent/query.ts.
  */
 
 import { spawnSync } from 'node:child_process';
@@ -33,6 +37,15 @@ import {
   waitForHealth,
 } from './daemon.js';
 import { runMcpServer } from './agent/mcp.js';
+import { ApiClient } from './agent/api-client.js';
+import {
+  queryAnalytics,
+  queryProjects,
+  querySearch,
+  querySession,
+  querySessions,
+} from './agent/query.js';
+import { ensureDaemon } from './daemon.js';
 import { refreshPricing } from './data/pricing-refresh.js';
 import { openBrowser } from './util/open-browser.js';
 
@@ -306,6 +319,43 @@ async function pricingUpdate(): Promise<void> {
   }
 }
 
+/** A bad flag value or missing argument on a query subcommand. */
+class UsageError extends Error {}
+
+/** Parse a non-negative integer flag; undefined when absent, UsageError when bogus. */
+function intFlag(name: string, v: string | undefined): number | undefined {
+  if (v === undefined) return undefined;
+  const n = Number.parseInt(v, 10);
+  if (!Number.isInteger(n) || n < 0) throw new UsageError(`--${name} expects a non-negative integer, got '${v}'`);
+  return n;
+}
+
+/** Validate an enum-valued flag; undefined when absent, UsageError when bogus. */
+function enumFlag<T extends string>(name: string, v: string | undefined, allowed: readonly T[]): T | undefined {
+  if (v === undefined) return undefined;
+  if (!(allowed as readonly string[]).includes(v)) {
+    throw new UsageError(`--${name} must be one of: ${allowed.join(', ')} (got '${v}')`);
+  }
+  return v as T;
+}
+
+/** Run one read-only query subcommand against the (auto-started) daemon and
+ *  print its output. `prepare` validates flags and returns the command — it runs
+ *  BEFORE the daemon is (maybe) spawned, so a bad flag never starts anything.
+ *  Failures go to stderr with a non-zero exit; empty results are normal output
+ *  ("No matches.") with exit 0. */
+async function runQuery(prepare: () => (client: ApiClient) => Promise<string>): Promise<void> {
+  try {
+    const fn = prepare();
+    const d = await ensureDaemon();
+    const client = new ApiClient(`http://127.0.0.1:${d.port}`);
+    console.log(await fn(client));
+  } catch (err) {
+    console.error(`✗ ${err instanceof Error ? err.message : String(err)}`);
+    process.exitCode = 1;
+  }
+}
+
 /** Print brief usage for the pricing subcommand. */
 function pricingHelp(): void {
   console.log(`Usage: claudescope pricing <subcommand>
@@ -333,6 +383,18 @@ Commands:
   help             Show this help
   version          Print the installed version
 
+Query commands (read-only; start the background server on first use):
+  search "<query>" Full-text search across transcripts and agent memory
+                   [--project id] [--role user|assistant] [--scope sessions|memory|all] [--limit N]
+  sessions         List sessions [--project id] [--agent id]
+                   [--sort recent|oldest|tokens|cost|messages] [--q substr] [--limit N]
+  session <id>     One session as Markdown — a window of turns, pageable
+                   [--offset N] [--limit N] [--around uuid] [--radius N]
+                   [--max-tool-chars N] [--redact]
+  projects         List projects
+  analytics        Token/cost aggregates [--group-by project|model|day|agent] [--from date] [--to date]
+  All query commands accept --json for the raw API response (ignores --redact).
+
 Options:
   --port <n>       Port to listen on (default ${DEFAULT_PORT}, or $PORT)
   --no-open        Don't open the browser on start
@@ -354,6 +416,23 @@ async function main(): Promise<void> {
       yes: { type: 'boolean', short: 'y' },
       // parseArgs has no built-in negation, so the flag is literally `no-open`.
       'no-open': { type: 'boolean' },
+      // Query subcommand flags (search/sessions/session/projects/analytics).
+      project: { type: 'string' },
+      agent: { type: 'string' },
+      role: { type: 'string' },
+      scope: { type: 'string' },
+      sort: { type: 'string' },
+      q: { type: 'string' },
+      limit: { type: 'string' },
+      offset: { type: 'string' },
+      around: { type: 'string' },
+      radius: { type: 'string' },
+      'max-tool-chars': { type: 'string' },
+      redact: { type: 'boolean' },
+      json: { type: 'boolean' },
+      'group-by': { type: 'string' },
+      from: { type: 'string' },
+      to: { type: 'string' },
     },
   });
 
@@ -387,6 +466,64 @@ async function main(): Promise<void> {
       // Stdio MCP server: stdout is the protocol channel — nothing else may
       // print to it. The server ensures the daemon on first tool use.
       await runMcpServer();
+      break;
+    case 'search':
+      await runQuery(() => {
+        const query = positionals[1];
+        if (!query) throw new UsageError('usage: claudescope search "<query>" [--project id] [--role user|assistant] [--scope sessions|memory|all] [--limit N] [--json]');
+        const args = {
+          query,
+          project: values.project,
+          role: enumFlag('role', values.role, ['user', 'assistant', 'all'] as const),
+          scope: enumFlag('scope', values.scope, ['sessions', 'memory', 'all'] as const),
+          limit: intFlag('limit', values.limit),
+          json: values.json,
+        };
+        return (client) => querySearch(client, args);
+      });
+      break;
+    case 'sessions':
+      await runQuery(() => {
+        const args = {
+          project: values.project,
+          agent: values.agent,
+          sort: enumFlag('sort', values.sort, ['recent', 'oldest', 'tokens', 'cost', 'messages'] as const),
+          q: values.q,
+          limit: intFlag('limit', values.limit),
+          json: values.json,
+        };
+        return (client) => querySessions(client, args);
+      });
+      break;
+    case 'session':
+      await runQuery(() => {
+        const id = positionals[1];
+        if (!id) throw new UsageError('usage: claudescope session <id> [--offset N] [--limit N] [--around uuid] [--radius N] [--max-tool-chars N] [--redact] [--json]');
+        const args = {
+          offset: intFlag('offset', values.offset),
+          limit: intFlag('limit', values.limit),
+          around: values.around,
+          radius: intFlag('radius', values.radius),
+          maxToolChars: intFlag('max-tool-chars', values['max-tool-chars']),
+          redact: values.redact,
+          json: values.json,
+        };
+        return (client) => querySession(client, id, args);
+      });
+      break;
+    case 'projects':
+      await runQuery(() => (client) => queryProjects(client, { json: values.json }));
+      break;
+    case 'analytics':
+      await runQuery(() => {
+        const args = {
+          groupBy: enumFlag('group-by', values['group-by'], ['project', 'model', 'day', 'agent'] as const),
+          from: values.from,
+          to: values.to,
+          json: values.json,
+        };
+        return (client) => queryAnalytics(client, args);
+      });
       break;
     case 'update':
       await update(Boolean(values.yes));

--- a/packages/server/src/daemon.ts
+++ b/packages/server/src/daemon.ts
@@ -1,0 +1,227 @@
+/**
+ * Daemon lifecycle primitives, shared by the user-facing CLI commands
+ * (`start`/`stop`/`status`/… in cli.ts) and the MCP server (`claudescope mcp`),
+ * which must silently ensure a daemon is running before it can proxy queries.
+ *
+ * The daemon is one detached server process tracked by `daemon.json` in the
+ * state dir. Everything here writes progress to callbacks or stderr — never to
+ * stdout, which an MCP stdio server owns as its protocol channel.
+ */
+
+import { spawn } from 'node:child_process';
+import {
+  existsSync,
+  mkdirSync,
+  openSync,
+  readFileSync,
+  renameSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { APP_VERSION, CLAUDESCOPE_HOME, PORT as DEFAULT_PORT } from './config.js';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+/** The server bundle, a sibling of the CLI in the published package. */
+export const SERVER_ENTRY = join(__dirname, 'server.js');
+export const DAEMON_FILE = join(CLAUDESCOPE_HOME, 'daemon.json');
+export const LOG_FILE = join(CLAUDESCOPE_HOME, 'daemon.log');
+/** Roll the append-only daemon log once it grows past this, so a long-lived or
+ *  crash-looping daemon doesn't grow the log without bound. */
+const LOG_MAX_BYTES = 5 * 1024 * 1024;
+/** How long to wait for a signalled process to actually exit before giving up. */
+export const EXIT_WAIT_MS = 5000;
+
+export interface DaemonRecord {
+  pid: number;
+  port: number;
+  url: string;
+  version: string;
+  startedAt: string;
+}
+
+/** Read the daemon record, or null if absent/corrupt. */
+export function readDaemon(): DaemonRecord | null {
+  if (!existsSync(DAEMON_FILE)) return null;
+  try {
+    return JSON.parse(readFileSync(DAEMON_FILE, 'utf8')) as DaemonRecord;
+  } catch {
+    return null;
+  }
+}
+
+/** Is a process with this PID currently alive? */
+export function isAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/** Probe the server's health endpoint (short timeout, never throws). */
+export async function isHealthy(port: number): Promise<boolean> {
+  try {
+    const res = await fetch(`http://127.0.0.1:${port}/api/health`, {
+      signal: AbortSignal.timeout(1500),
+    });
+    return res.ok;
+  } catch {
+    return false;
+  }
+}
+
+/** Poll health until ready or the deadline; `onTick` fires per attempt (the CLI
+ *  prints progress dots with it). */
+export async function waitForHealth(
+  port: number,
+  timeoutMs: number,
+  onTick?: () => void,
+): Promise<boolean> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (await isHealthy(port)) return true;
+    onTick?.();
+    await new Promise((r) => setTimeout(r, 500));
+  }
+  return false;
+}
+
+/** Poll until the process is gone or the deadline; returns whether it exited. */
+export async function waitForExit(pid: number, timeoutMs: number): Promise<boolean> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (!isAlive(pid)) return true;
+    await new Promise((r) => setTimeout(r, 100));
+  }
+  return !isAlive(pid);
+}
+
+/** What the recorded daemon (if any) currently is, so callers can decide whether
+ *  to reuse it, clear a stale record, or replace a wedged (alive-but-unhealthy)
+ *  process. Injectable probes keep this pure and unit-testable. */
+export type ExistingState = 'healthy' | 'stale' | 'wedged' | 'none';
+export async function classifyExisting(
+  record: DaemonRecord | null,
+  aliveFn: (pid: number) => boolean,
+  healthyFn: (port: number) => Promise<boolean>,
+): Promise<ExistingState> {
+  if (!record) return 'none';
+  if (!aliveFn(record.pid)) return 'stale';
+  return (await healthyFn(record.port)) ? 'healthy' : 'wedged';
+}
+
+/** Roll the daemon log to `.1` once it exceeds {@link LOG_MAX_BYTES}. Best-effort. */
+export function rotateLogIfLarge(): void {
+  try {
+    if (existsSync(LOG_FILE) && statSync(LOG_FILE).size > LOG_MAX_BYTES) {
+      rmSync(`${LOG_FILE}.1`, { force: true });
+      renameSync(LOG_FILE, `${LOG_FILE}.1`);
+    }
+  } catch {
+    /* non-fatal: logging is best-effort */
+  }
+}
+
+/** Spawn the server detached (stdio → daemon log) and record it in daemon.json.
+ *  Fire-and-forget: callers wait for health themselves. */
+export function spawnDaemon(port: number): void {
+  mkdirSync(CLAUDESCOPE_HOME, { recursive: true });
+  rotateLogIfLarge();
+  const logFd = openSync(LOG_FILE, 'a');
+  // Detached + stdio→log + unref: the server keeps running after this CLI exits.
+  // OPEN_BROWSER=0 so the daemon never opens a browser; the CLI owns that.
+  const child = spawn(process.execPath, [SERVER_ENTRY], {
+    detached: true,
+    stdio: ['ignore', logFd, logFd],
+    env: { ...process.env, PORT: String(port), OPEN_BROWSER: '0' },
+  });
+  child.unref();
+
+  writeFileSync(
+    DAEMON_FILE,
+    JSON.stringify(
+      {
+        pid: child.pid,
+        port,
+        url: `http://localhost:${port}`,
+        version: APP_VERSION,
+        startedAt: new Date().toISOString(),
+      },
+      null,
+      2,
+    ),
+  );
+}
+
+/** A running daemon's address, as ensured by {@link ensureDaemon}. */
+export interface EnsuredDaemon {
+  port: number;
+  url: string;
+}
+
+/** Warn (stderr) when the running daemon was started by a different version of
+ *  the package than this process — a restart aligns them. Best-effort. */
+async function warnOnVersionSkew(port: number, log: (msg: string) => void): Promise<void> {
+  try {
+    const res = await fetch(`http://127.0.0.1:${port}/api/health`, {
+      signal: AbortSignal.timeout(1500),
+    });
+    const json = (await res.json()) as { version?: string };
+    if (json.version && json.version !== APP_VERSION) {
+      log(
+        `⚠ running claudescope daemon is v${json.version}, this CLI is v${APP_VERSION} — ` +
+          'run `claudescope restart` to align them',
+      );
+    }
+  } catch {
+    /* health was just probed; a race here is not worth surfacing */
+  }
+}
+
+/**
+ * Make sure a daemon is running and return its address — the MCP server (and
+ * the query subcommands) call this before proxying. Adopts a healthy daemon
+ * (warning on version skew), clears a stale record, replaces a wedged process,
+ * and spawns a fresh server otherwise. All progress goes to `log` (stderr by
+ * default); throws with a user-actionable message when a daemon can't be had.
+ */
+export async function ensureDaemon(
+  log: (msg: string) => void = (m) => process.stderr.write(`${m}\n`),
+): Promise<EnsuredDaemon> {
+  const existing = readDaemon();
+  const state = await classifyExisting(existing, isAlive, isHealthy);
+  if (state === 'healthy' && existing) {
+    await warnOnVersionSkew(existing.port, log);
+    return { port: existing.port, url: existing.url };
+  }
+  if (state === 'stale') rmSync(DAEMON_FILE, { force: true });
+  if (state === 'wedged' && existing) {
+    // Same replace semantics as `claudescope start`: SIGTERM and wait, rather
+    // than spawning a second server that would fail to bind.
+    log(`claudescope daemon (pid ${existing.pid}) is unresponsive; replacing it…`);
+    try {
+      process.kill(existing.pid, 'SIGTERM');
+    } catch {
+      /* already gone */
+    }
+    if (!(await waitForExit(existing.pid, EXIT_WAIT_MS))) {
+      throw new Error(
+        `could not stop the unresponsive claudescope daemon (pid ${existing.pid}); ` +
+          `kill it manually and retry: kill -9 ${existing.pid}`,
+      );
+    }
+    rmSync(DAEMON_FILE, { force: true });
+  }
+
+  const port = DEFAULT_PORT;
+  log(`starting claudescope daemon on port ${port}…`);
+  spawnDaemon(port);
+  if (!(await waitForHealth(port, 30_000))) {
+    throw new Error('claudescope daemon did not become healthy in time; inspect: claudescope logs');
+  }
+  return { port, url: `http://localhost:${port}` };
+}

--- a/packages/server/test/cli-query.test.ts
+++ b/packages/server/test/cli-query.test.ts
@@ -1,0 +1,146 @@
+/**
+ * CLI query subcommand tests.
+ *
+ * Boots the real Fastify app on an ephemeral port against a synthetic fixture
+ * (the mcp.integration.test.ts pattern) and exercises the query functions with
+ * a real ApiClient — covering the CLI-specific edges: table shaping with long
+ * and non-ASCII titles, --json passthrough (raw response, no redaction), and
+ * the --redact flag masking home paths in the human Markdown output only.
+ */
+
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import type { FastifyInstance } from 'fastify';
+import type { SessionDetailResponse, SessionMeta } from '@claudescope/shared';
+
+// --- temp locations (decided before any server module is imported) ----------
+const work = mkdtempSync(join(tmpdir(), 'claudescope-cliq-'));
+const projectsDir = join(work, 'projects');
+
+process.env.CLAUDE_PROJECTS_DIR = projectsDir;
+process.env.CODEX_SESSIONS_DIR = join(work, 'codex-empty');
+process.env.JUNIE_SESSIONS_DIR = join(work, 'junie-empty');
+process.env.PI_SESSIONS_DIR = join(work, 'pi-empty');
+process.env.OPENCODE_DATA_DIR = join(work, 'opencode-empty');
+process.env.COPILOT_SESSIONS_DIR = join(work, 'copilot-empty');
+process.env.ANTIGRAVITY_CLI_DIR = join(work, 'antigravity-empty');
+process.env.ANTIGRAVITY_DIR = join(work, 'antigravity-empty-desktop');
+process.env.DUCKDB_PATH = join(work, 'index.duckdb');
+process.env.CLAUDESCOPE_HOME = join(work, 'home');
+process.env.REINDEX_INTERVAL_MS = '0';
+
+const jsonl = (events: unknown[]): string => events.map((e) => JSON.stringify(e)).join('\n') + '\n';
+
+const LONG_TITLE = 'A very long session title that keeps going well past the table cell cap ' + 'x'.repeat(40);
+
+function writeFixtures(): void {
+  const projA = join(projectsDir, 'enc-projQ');
+  mkdirSync(projA, { recursive: true });
+  const usage = { input_tokens: 10, output_tokens: 5 };
+
+  // Session 1: long title; a text block with a home path (redaction target).
+  const base1 = { sessionId: 'sessQ1', cwd: '/tmp/projQ', gitBranch: 'main', version: '2.1.0' };
+  writeFileSync(
+    join(projA, 'sessQ1.jsonl'),
+    jsonl([
+      { type: 'ai-title', sessionId: 'sessQ1', aiTitle: LONG_TITLE },
+      { ...base1, type: 'user', uuid: 'q1u1', parentUuid: null, timestamp: '2026-01-02T10:00:00.000Z', isSidechain: false, message: { role: 'user', content: 'where does the needle live?' } },
+      { ...base1, type: 'assistant', uuid: 'q1a1', parentUuid: 'q1u1', timestamp: '2026-01-02T10:00:05.000Z', isSidechain: false, message: { role: 'assistant', model: 'claude-opus-4-8', content: [{ type: 'text', text: 'the needle lives in /Users/testuser/secret/needle.txt' }], usage } },
+    ]),
+  );
+
+  // Session 2: emoji/non-ASCII title (table must not crash or drop the row).
+  const base2 = { sessionId: 'sessQ2', cwd: '/tmp/projQ', gitBranch: 'main', version: '2.1.0' };
+  writeFileSync(
+    join(projA, 'sessQ2.jsonl'),
+    jsonl([
+      { type: 'ai-title', sessionId: 'sessQ2', aiTitle: '🚀 déjà-vu — fix résumé parsing' },
+      { ...base2, type: 'user', uuid: 'q2u1', parentUuid: null, timestamp: '2026-01-03T09:00:00.000Z', isSidechain: false, message: { role: 'user', content: 'unrelated haystack chatter' } },
+      { ...base2, type: 'assistant', uuid: 'q2a1', parentUuid: 'q2u1', timestamp: '2026-01-03T09:00:04.000Z', isSidechain: false, message: { role: 'assistant', model: 'claude-opus-4-8', content: [{ type: 'text', text: 'ok' }], usage } },
+    ]),
+  );
+}
+
+let app: FastifyInstance;
+let closeConnection: () => Promise<void>;
+// Typed as the module to keep imports lazy (env vars must be set first).
+let query: typeof import('../src/agent/query.js');
+let client: import('../src/agent/api-client.js').ApiClient;
+
+beforeAll(async () => {
+  writeFixtures();
+  const Fastify = (await import('fastify')).default;
+  const { registerRoutes } = await import('../src/routes/index.js');
+  const { reindex } = await import('../src/data/index.js');
+  ({ closeConnection } = await import('../src/db/duckdb.js'));
+  const { ApiClient } = await import('../src/agent/api-client.js');
+  query = await import('../src/agent/query.js');
+
+  app = Fastify();
+  await registerRoutes(app);
+  await reindex();
+  await app.listen({ port: 0, host: '127.0.0.1' });
+  const addr = app.server.address();
+  const port = typeof addr === 'object' && addr ? addr.port : 0;
+  client = new ApiClient(`http://127.0.0.1:${port}`);
+});
+
+afterAll(async () => {
+  await app?.close();
+  await closeConnection?.();
+  rmSync(work, { recursive: true, force: true });
+});
+
+describe('cli query subcommands', () => {
+  it('sessions renders an aligned table, clipping long titles and keeping non-ASCII rows', async () => {
+    const out = await query.querySessions(client, {});
+    const lines = out.split('\n');
+    expect(lines[0]).toMatch(/^ID\s+AGENT\s+TITLE\s+DATE\s+MSGS\s+TOKENS\s+COST$/u);
+    // Every row's AGENT column starts where the header's does (pad-aligned).
+    const agentCol = lines[0]!.indexOf('AGENT');
+    for (const row of lines.slice(1)) expect(row.slice(agentCol)).toMatch(/^claude-code\s/u);
+    // The long title is clipped with an ellipsis, never dumped whole.
+    expect(out).toContain('…');
+    expect(out).not.toContain(LONG_TITLE);
+    // The emoji title survives as a row.
+    expect(out).toContain('🚀 déjà-vu');
+  });
+
+  it('sessions --json returns the raw rows', async () => {
+    const out = await query.querySessions(client, { json: true });
+    const rows = JSON.parse(out) as SessionMeta[];
+    expect(rows.map((r) => r.id).sort()).toEqual(['sessQ1', 'sessQ2']);
+    expect(rows[0]).toHaveProperty('totalCostUsd');
+  });
+
+  it('search returns plain snippets; no hits is normal output', async () => {
+    const hit = await query.querySearch(client, { query: 'needle' });
+    expect(hit).toContain('sessQ1');
+    expect(hit).not.toContain('<mark>');
+    const miss = await query.querySearch(client, { query: 'zebra-quux-nonexistent' });
+    expect(miss).toBe('No matches.');
+  });
+
+  it('session --redact masks home paths in Markdown, while --json stays raw', async () => {
+    const plain = await query.querySession(client, 'sessQ1', {});
+    expect(plain).toContain('/Users/testuser/secret/needle.txt');
+    expect(plain).toMatch(/Turns 1–\d+ of \d+/u);
+
+    const redacted = await query.querySession(client, 'sessQ1', { redact: true });
+    expect(redacted).not.toContain('/Users/testuser');
+    expect(redacted).toContain('~/secret/needle.txt');
+
+    // --json is the raw API response: window metadata present, redact ignored.
+    const raw = JSON.parse(await query.querySession(client, 'sessQ1', { redact: true, json: true })) as SessionDetailResponse;
+    expect(raw.window).toMatchObject({ offset: 0 });
+    expect(JSON.stringify(raw)).toContain('/Users/testuser/secret/needle.txt');
+  });
+
+  it('analytics renders rows plus a totals line', async () => {
+    const out = await query.queryAnalytics(client, { groupBy: 'agent' });
+    expect(out).toContain('claude-code');
+    expect(out).toMatch(/Total: [\d,]+ tok · \$\d/u);
+  });
+});

--- a/packages/server/test/mcp.integration.test.ts
+++ b/packages/server/test/mcp.integration.test.ts
@@ -1,0 +1,163 @@
+/**
+ * MCP server integration tests.
+ *
+ * Boots the real Fastify app on an ephemeral port against a synthetic fixture
+ * (the same pattern as api.integration.test.ts), then exercises the MCP tools
+ * end-to-end through an SDK client over an in-memory transport — covering the
+ * agent-facing edges: plain (unescaped) search snippets, windowing + tool-payload
+ * truncation flowing through get_session, and the not-ready degradation while
+ * the index builds. The SDK itself is not under test.
+ */
+
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import type { FastifyInstance } from 'fastify';
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
+
+// --- temp locations (decided before any server module is imported) ----------
+const work = mkdtempSync(join(tmpdir(), 'claudescope-mcp-'));
+const projectsDir = join(work, 'projects');
+
+process.env.CLAUDE_PROJECTS_DIR = projectsDir;
+process.env.CODEX_SESSIONS_DIR = join(work, 'codex-empty');
+process.env.JUNIE_SESSIONS_DIR = join(work, 'junie-empty');
+process.env.PI_SESSIONS_DIR = join(work, 'pi-empty');
+process.env.OPENCODE_DATA_DIR = join(work, 'opencode-empty');
+process.env.COPILOT_SESSIONS_DIR = join(work, 'copilot-empty');
+process.env.ANTIGRAVITY_CLI_DIR = join(work, 'antigravity-empty');
+process.env.ANTIGRAVITY_DIR = join(work, 'antigravity-empty-desktop');
+process.env.DUCKDB_PATH = join(work, 'index.duckdb');
+process.env.CLAUDESCOPE_HOME = join(work, 'home');
+process.env.REINDEX_INTERVAL_MS = '0';
+
+const jsonl = (events: unknown[]): string => events.map((e) => JSON.stringify(e)).join('\n') + '\n';
+
+function writeFixtures(): void {
+  const projA = join(projectsDir, 'enc-projA');
+  mkdirSync(projA, { recursive: true });
+  const base = { sessionId: 'sessM', cwd: '/tmp/projM', gitBranch: 'main', version: '2.1.0' };
+  const usage = { input_tokens: 10, output_tokens: 5 };
+  writeFileSync(
+    join(projA, 'sessM.jsonl'),
+    jsonl([
+      { type: 'ai-title', sessionId: 'sessM', aiTitle: 'MCP fixture session' },
+      { ...base, type: 'user', uuid: 'u1', parentUuid: null, timestamp: '2026-01-01T10:00:00.000Z', isSidechain: false, message: { role: 'user', content: 'the needle is <here> in the haystack' } },
+      { ...base, type: 'assistant', uuid: 'a1', parentUuid: 'u1', timestamp: '2026-01-01T10:00:05.000Z', isSidechain: false, message: { role: 'assistant', model: 'claude-opus-4-8', content: [{ type: 'text', text: 'found it' }], usage } },
+      { ...base, type: 'assistant', uuid: 'a2', parentUuid: 'a1', timestamp: '2026-01-01T10:00:10.000Z', isSidechain: false, message: { role: 'assistant', model: 'claude-opus-4-8', content: [{ type: 'tool_use', id: 't1', name: 'Bash', input: { command: 'echo big' } }], usage } },
+      { ...base, type: 'user', uuid: 'u2', parentUuid: 'a2', timestamp: '2026-01-01T10:00:15.000Z', isSidechain: false, message: { role: 'user', content: [{ type: 'tool_result', tool_use_id: 't1', content: 'R'.repeat(5000) }] } },
+      { ...base, type: 'assistant', uuid: 'a3', parentUuid: 'u2', timestamp: '2026-01-01T10:00:20.000Z', isSidechain: false, message: { role: 'assistant', model: 'claude-opus-4-8', content: [{ type: 'text', text: 'done with the haystack' }], usage } },
+    ]),
+  );
+}
+
+let app: FastifyInstance;
+let closeConnection: () => Promise<void>;
+let client: Client;
+
+/** Wire an MCP client to a server whose ApiClient targets `baseUrl`. */
+async function connectMcp(baseUrl: string): Promise<Client> {
+  const { createMcpServer } = await import('../src/agent/mcp.js');
+  const { ApiClient } = await import('../src/agent/api-client.js');
+  const server = createMcpServer({ resolveClient: async () => new ApiClient(baseUrl) });
+  const [ct, st] = InMemoryTransport.createLinkedPair();
+  const c = new Client({ name: 'test', version: '0.0.0' });
+  await Promise.all([c.connect(ct), server.connect(st)]);
+  return c;
+}
+
+const toolText = (res: unknown): string => {
+  const content = (res as { content: { type: string; text: string }[] }).content;
+  return content.map((c) => c.text).join('\n');
+};
+
+beforeAll(async () => {
+  writeFixtures();
+  const Fastify = (await import('fastify')).default;
+  const { registerRoutes } = await import('../src/routes/index.js');
+  const { reindex } = await import('../src/data/index.js');
+  ({ closeConnection } = await import('../src/db/duckdb.js'));
+
+  app = Fastify();
+  await registerRoutes(app);
+  await reindex();
+  await app.listen({ port: 0, host: '127.0.0.1' });
+  const addr = app.server.address();
+  const port = typeof addr === 'object' && addr ? addr.port : 0;
+  client = await connectMcp(`http://127.0.0.1:${port}`);
+});
+
+afterAll(async () => {
+  await client?.close();
+  await app?.close();
+  await closeConnection?.();
+  rmSync(work, { recursive: true, force: true });
+});
+
+describe('claudescope mcp tools', () => {
+  it('registers the six tools', async () => {
+    const { tools } = await client.listTools();
+    expect(tools.map((t) => t.name).sort()).toEqual([
+      'get_analytics',
+      'get_memory',
+      'get_session',
+      'list_projects',
+      'list_sessions',
+      'search_transcripts',
+    ]);
+  });
+
+  it('search_transcripts returns plain, unescaped snippets with paging anchors', async () => {
+    const res = await client.callTool({ name: 'search_transcripts', arguments: { query: 'needle' } });
+    const text = toolText(res);
+    expect(text).toContain('sessM');
+    expect(text).toContain('uuid u1');
+    // format=plain: the raw `<here>` survives, no HTML escaping or <mark> wrapping.
+    expect(text).toContain('<here>');
+    expect(text).not.toContain('<mark>');
+    expect(text).not.toContain('&lt;');
+  });
+
+  it('get_session windows turns and truncates tool payloads', async () => {
+    const res = await client.callTool({
+      name: 'get_session',
+      arguments: { sessionId: 'sessM', maxToolChars: 100 },
+    });
+    const text = toolText(res);
+    // The 5000-char tool result is capped, with the explicit truncation marker.
+    expect(text).toContain('[truncated,');
+    expect(text).not.toContain('R'.repeat(200));
+    expect(text).toMatch(/Turns 1–\d+ of \d+/u);
+  });
+
+  it('get_session anchors on a message uuid with around/radius', async () => {
+    const res = await client.callTool({
+      name: 'get_session',
+      arguments: { sessionId: 'sessM', around: 'a3', radius: 0 },
+    });
+    const text = toolText(res);
+    expect(text).toContain('done with the haystack');
+    expect(text).not.toContain('found it');
+  });
+
+  it('degrades gracefully while the index is still building', async () => {
+    const Fastify = (await import('fastify')).default;
+    const notReady = Fastify();
+    notReady.get('/api/health', async () => ({ status: 'ok', version: '0.0.0-dev', ready: false }));
+    await notReady.listen({ port: 0, host: '127.0.0.1' });
+    const addr = notReady.server.address();
+    const port = typeof addr === 'object' && addr ? addr.port : 0;
+    const c = await connectMcp(`http://127.0.0.1:${port}`);
+    try {
+      const res = await client.callTool({ name: 'list_projects', arguments: {} });
+      expect(toolText(res)).not.toContain('still building'); // control: ready server answers
+      const notReadyRes = await c.callTool({ name: 'list_projects', arguments: {} });
+      expect(toolText(notReadyRes)).toContain('still building');
+    } finally {
+      await c.close();
+      await notReady.close();
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Roadmap slice 3 of [0035](https://github.com/vladar107/claudescope/blob/main/docs/plans/0035-agent-access-and-analytics-roadmap.md) — agents can now query their own transcript history. **Stacked on #48** (uses its windowing + shared markdown/redact seams); GitHub will retarget to main when #48 merges.

- `claudescope mcp`: stdio MCP server; zero-precondition install via `claude mcp add claudescope -- claudescope mcp`. Six tools: `search_transcripts`, `list_sessions`, `get_session` (windowed compact Markdown, pages via offset or `around` a search hit's messageUuid, tool payloads capped at 2000 chars, opt-in `redact`), `list_projects`, `get_analytics`, `get_memory`.
- Daemon lifecycle factored from cli.ts into `daemon.ts` (re-exported, cli tests unmodified) + new `ensureDaemon()`: adopts a healthy daemon (stderr warning on version skew), clears stale records, replaces wedged processes, spawns fresh otherwise — lazily on first tool call, with failed spawns retried. Nothing writes to stdout (MCP owns it); progress dots became an `onTick` injection for `start`.
- Typed localhost `ApiClient` (reused by the CLI query subcommands in slice 4).
- Tools degrade to "index is still building — retry shortly" while not ready.
- Bundle: SDK + zod inlined via subpath imports (express/hono verified absent); cli.js 12.1kb → 605.5kb; `@duckdb/node-api` stays the only runtime dep. Smoke-tested the bundled CLI over real stdio in a sandboxed `CLAUDESCOPE_HOME`.

⚠️ **flake.nix**: the dependency set changed, so `npmDepsHash` is stale — the CI nix job will fail and print the correct hash to paste in (nix isn't installed on this machine).

## Testing
`npm test` 339/339 (new MCP integration suite: six-tool contract, plain snippets, truncation + paging line, around-anchoring, not-ready degradation), `npm run typecheck` clean.

Plan: docs/plans/0038-mcp-server.md