### PR TITLE
feat(cli): read-only query subcommands — search, sessions, session, projects, analytics

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,6 +192,23 @@ payloads truncated), `get_analytics` (token/cost aggregates), and `get_memory`
 agent's context window; pass `redact: true` to mask home paths and likely
 secrets. Everything stays read-only and on localhost.
 
+### Scripting (CLI)
+
+The same lookups work from the terminal — read-only query subcommands that
+start the background server on first use and print tables (or raw JSON with
+`--json`, handy with `jq`):
+
+```bash
+claudescope search "duckdb lock" --limit 5      # where did I hit this before?
+claudescope sessions --agent codex --sort cost  # priciest Codex sessions
+claudescope session <id> --around <uuid>        # open a search hit, windowed
+claudescope analytics --group-by day --json | jq '.rows[] | [.key, .costUsd]'
+```
+
+`session` prints a pageable window of turns as Markdown (`--offset/--limit`,
+`--redact` to mask paths/secrets); `--json` returns the raw API response
+unredacted. See `claudescope help` for the full flag list.
+
 ---
 
 ## Configuration

--- a/docs/plans/0040-cli-query-subcommands.md
+++ b/docs/plans/0040-cli-query-subcommands.md
@@ -1,0 +1,82 @@
+# 0040 — CLI query subcommands
+
+- **Status:** done
+- **Date:** 2026-07-03
+- **PR:** [#51](https://github.com/vladar107/claudescope/pull/51)
+
+## Context
+
+Roadmap slice 4 of [0035](./0035-agent-access-and-analytics-roadmap.md). Slice
+A2 (plan [0038](./0038-mcp-server.md)) built the agent-facing plumbing — the
+typed `ApiClient` over the daemon's HTTP API, `ensureDaemon()`, and the MCP
+tools' output shaping. This slice exposes the same read-only lookups to
+terminals and scripts as CLI subcommands, so transcript history is one `grep`
+away and `--json` pipes into `jq`.
+
+## Goal
+
+`claudescope search|sessions|session|projects|analytics` — human tables /
+compact Markdown by default, raw JSON with `--json`, auto-starting the daemon,
+sharing one shaping layer with the MCP tools.
+
+## Decisions
+
+- **Shared shaping module (`agent/shape.ts`)** — the search-hit and
+  session-Markdown renderers moved out of `agent/mcp.ts` into a new pure module
+  used by both the MCP tools and the CLI, instead of duplicating them. Tables,
+  however, are CLI-only (`agent/query.ts`): MCP output stays list-shaped for
+  agent contexts, terminals get pad-aligned columns.
+- **`--json` = the raw API response** — no redaction, no clipping beyond what
+  request params ask for. Machine output should be the contract type, not a
+  shaped view; `--redact` applies to the human Markdown only (documented in
+  help/README).
+- **Flag validation before daemon spawn** — `runQuery(prepare)` runs the flag
+  parsing first, so `--limit banana` errors out without starting anything.
+- **Session windowing defaults match MCP** — no windowing flags → the first 20
+  turns with a paging line, `--max-tool-chars` default 2000. A huge session
+  never dumps whole by accident.
+- **Dependency-free tables** — code-unit `padStart`/`padEnd` alignment with a
+  60-char clip on free-text columns. Wide-glyph (emoji/CJK) alignment is
+  imperfect by design; correctness (row present, nothing crashes) over
+  typography.
+
+## Approach
+
+1. Extract `shapeSearchResults` + `shapeSessionMarkdown` (and the small fmt
+   helpers/defaults) from `agent/mcp.ts` into `agent/shape.ts`; mcp.ts
+   re-imports.
+2. New `agent/query.ts`: `querySearch` / `querySessions` / `querySession` /
+   `queryProjects` / `queryAnalytics`, each `(client, args) → Promise<string>`
+   so tests inject a fixture-app client; plus the `table()` helper.
+3. `cli.ts`: new flags in the single `parseArgs` table, `runQuery()` wrapper
+   (validate flags → `ensureDaemon()` → `ApiClient` → print; errors to stderr,
+   exit 1), five dispatch cases, help text.
+4. README: "Scripting (CLI)" subsection under Agent access with jq examples.
+
+## Files affected
+
+- `packages/server/src/agent/shape.ts` — new; shaping shared by MCP + CLI.
+- `packages/server/src/agent/query.ts` — new; the five subcommands + `table()`.
+- `packages/server/src/agent/mcp.ts` — imports the extracted shaping; behavior
+  unchanged (existing MCP tests untouched).
+- `packages/server/src/cli.ts` — flags, `runQuery`, dispatch, help.
+- `README.md` — Scripting subsection.
+- `packages/server/test/cli-query.test.ts` — new integration tests.
+
+## Testing
+
+`npm test` (344 passing, 5 new) and `npm run typecheck` clean. New tests boot
+the real app on an ephemeral port over synthetic fixtures and cover the
+CLI-specific edges: table alignment with a clipped long title and a non-ASCII
+title, `--json` passthrough (raw rows; `window` metadata; redact ignored),
+`--redact` masking home paths in Markdown output, empty-result "No matches."
+as normal output, and the analytics totals line.
+
+## Risks / open questions
+
+- Table alignment is code-unit based; emoji/CJK-heavy titles can look ragged.
+  Acceptable for a listing; revisit only if it bothers real use.
+- `--q` relies on `parseArgs` accepting single-char long option names (verified
+  on the pinned Node).
+- A `tail`-style anchor for `session` (open the END of a session) is a natural
+  follow-up, same as noted for MCP `get_session` in 0038.

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -62,3 +62,4 @@ decision, or a change worth explaining before doing. Skip it for one-line fixes.
 | 0035 | [Roadmap: agent-facing access (MCP + CLI) & analytics depth](./0035-agent-access-and-analytics-roadmap.md) | proposed |
 | 0036 | [API seams for agent consumers (windowing, limits, plain snippets, shared redact/markdown)](./0036-agent-api-seams.md) | done |
 | 0038 | [`claudescope mcp`: agent-facing MCP server](./0038-mcp-server.md) | done |
+| 0040 | [CLI query subcommands (search/sessions/session/projects/analytics)](./0040-cli-query-subcommands.md) | done |

--- a/packages/server/src/agent/mcp.ts
+++ b/packages/server/src/agent/mcp.ts
@@ -18,17 +18,21 @@ import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
 import { z } from 'zod';
 import type { MemorySource, SessionMeta } from '@claudescope/shared';
-import { redactText, threadItemsToMarkdown, truncateText } from '@claudescope/shared';
+import { truncateText } from '@claudescope/shared';
 import { APP_VERSION } from '../config.js';
 import { ensureDaemon } from '../daemon.js';
 import { ApiClient } from './api-client.js';
+import {
+  DEFAULT_LIMIT,
+  DEFAULT_MAX_TOOL_CHARS,
+  DEFAULT_TURNS,
+  day,
+  fmtCost,
+  fmtTokens,
+  shapeSearchResults,
+  shapeSessionMarkdown,
+} from './shape.js';
 
-/** Default hits/rows returned by the list-shaped tools. */
-const DEFAULT_LIMIT = 20;
-/** Default per-tool-payload char cap in `get_session`. */
-const DEFAULT_MAX_TOOL_CHARS = 2000;
-/** Default turns per `get_session` window when no windowing params are given. */
-const DEFAULT_TURNS = 20;
 /** Char cap for memory bodies in `get_memory`. */
 const MEMORY_BODY_CHARS = 2000;
 
@@ -39,10 +43,6 @@ const errorText = (t: string) => ({ content: [{ type: 'text' as const, text: t }
 export interface McpDeps {
   resolveClient: () => Promise<ApiClient>;
 }
-
-const fmtCost = (usd: number): string => `$${usd.toFixed(2)}`;
-const fmtTokens = (n: number): string => n.toLocaleString('en-US');
-const day = (iso: string): string => iso.slice(0, 10);
 
 function sessionLine(s: SessionMeta): string {
   const branch = s.gitBranch ? ` · ${s.gitBranch}` : '';
@@ -126,32 +126,7 @@ export function createMcpServer(deps: McpDeps): McpServer {
         scope: args.scope ?? 'sessions',
         format: 'plain',
       });
-      const sessions = res.sessions.slice(0, limit);
-      const memory = res.memory.slice(0, limit);
-      if (sessions.length === 0 && memory.length === 0) return 'No matches.';
-
-      const parts: string[] = [];
-      if (sessions.length > 0) {
-        parts.push(
-          `${sessions.length} transcript hit(s):`,
-          ...sessions.map(
-            (h) =>
-              `- [${h.role}] ${h.title} (session ${h.sessionId}, project ${h.projectId}, uuid ${h.messageUuid})\n` +
-              `  "${h.snippet}"`,
-          ),
-        );
-      }
-      if (memory.length > 0) {
-        parts.push(
-          `${memory.length} memory hit(s):`,
-          ...memory.map(
-            (h) =>
-              `- ${h.title}${h.category ? ` (${h.category})` : ''} [${h.connectorId}] — ${h.sourcePath}\n` +
-              `  "${h.snippet}"`,
-          ),
-        );
-      }
-      return parts.join('\n');
+      return shapeSearchResults(res, limit);
     }),
   );
 
@@ -205,32 +180,7 @@ export function createMcpServer(deps: McpDeps): McpServer {
         ...windowed,
         maxToolChars: args.maxToolChars ?? DEFAULT_MAX_TOOL_CHARS,
       });
-
-      const { meta, window } = data;
-      const r = args.redact ? redactText : (s: string) => s;
-      const head = [
-        `# ${r(meta.title)}`,
-        `session ${meta.id} [${meta.connectorId}] · project ${meta.projectDisplayName} · ` +
-          `${meta.startedAt} → ${meta.endedAt} · ${fmtTokens(meta.totalTokens)} tok · ${fmtCost(meta.totalCostUsd)}`,
-      ];
-      if (window) {
-        const end = window.offset + window.limit;
-        head.push(
-          `Turns ${window.offset + 1}–${end} of ${window.total}` +
-            (window.anchorFound === false ? ' (around uuid not found — showing the start)' : '') +
-            (end < window.total ? ` — page on with {offset: ${end}}` : ''),
-        );
-      }
-
-      const opts = { redact: args.redact ?? false };
-      const parts = [head.join('\n'), '---', threadItemsToMarkdown(data.thread, opts)];
-      for (const run of data.subagents) {
-        parts.push(
-          `--- subagent · ${run.agentType} — ${r(run.description || run.agentId)} ---`,
-          threadItemsToMarkdown(run.thread, opts),
-        );
-      }
-      return parts.join('\n\n');
+      return shapeSessionMarkdown(data, args.redact ?? false);
     }),
   );
 

--- a/packages/server/src/agent/query.ts
+++ b/packages/server/src/agent/query.ts
@@ -1,0 +1,167 @@
+/**
+ * CLI query subcommands (`claudescope search|sessions|session|projects|analytics`)
+ * — read-only lookups against the daemon's HTTP API for terminals and scripts.
+ *
+ * Each command returns the string to print: an aligned table / compact Markdown
+ * for humans, or the raw API response as JSON with `--json` (machine-readable;
+ * ignores `--redact` and does no shaping). Daemon startup progress goes to
+ * stderr (ensureDaemon), so stdout stays clean for piping.
+ */
+
+import type { AnalyticsGroupBy, SearchScope, SearchType, SessionSort } from '@claudescope/shared';
+import type { ApiClient } from './api-client.js';
+import {
+  DEFAULT_LIMIT,
+  DEFAULT_MAX_TOOL_CHARS,
+  DEFAULT_TURNS,
+  day,
+  fmtCost,
+  fmtTokens,
+  shapeSearchResults,
+  shapeSessionMarkdown,
+} from './shape.js';
+
+const json = (v: unknown): string => JSON.stringify(v, null, 2);
+
+/** Cap for free-text columns (titles, cwds) so one long value can't blow up the table. */
+const MAX_CELL = 60;
+
+const clip = (s: string): string => (s.length > MAX_CELL ? `${s.slice(0, MAX_CELL - 1)}…` : s);
+
+/**
+ * Dependency-free aligned table: pad each column to its widest cell (header
+ * included); `right` marks numeric columns for right-alignment. Widths are
+ * code-unit based — good enough for a terminal listing.
+ */
+export function table(headers: string[], rows: string[][], right: boolean[] = []): string {
+  const widths = headers.map((h, i) => Math.max(h.length, ...rows.map((r) => (r[i] ?? '').length)));
+  const line = (cells: string[]): string =>
+    cells
+      .map((c, i) => (right[i] ? c.padStart(widths[i] ?? 0) : c.padEnd(widths[i] ?? 0)))
+      .join('  ')
+      .trimEnd();
+  return [line(headers), ...rows.map(line)].join('\n');
+}
+
+export interface SearchArgs {
+  query: string;
+  project?: string;
+  role?: SearchType;
+  scope?: SearchScope;
+  limit?: number;
+  json?: boolean;
+}
+
+export async function querySearch(client: ApiClient, args: SearchArgs): Promise<string> {
+  const res = await client.search({
+    q: args.query,
+    project: args.project,
+    type: args.role ?? 'all',
+    scope: args.scope ?? 'sessions',
+    format: 'plain',
+  });
+  if (args.json) return json(res);
+  return shapeSearchResults(res, args.limit ?? DEFAULT_LIMIT);
+}
+
+export interface SessionsArgs {
+  project?: string;
+  agent?: string;
+  sort?: SessionSort;
+  q?: string;
+  limit?: number;
+  json?: boolean;
+}
+
+export async function querySessions(client: ApiClient, args: SessionsArgs): Promise<string> {
+  const rows = await client.sessions({ ...args, limit: args.limit ?? DEFAULT_LIMIT });
+  if (args.json) return json(rows);
+  if (rows.length === 0) return 'No sessions match.';
+  return table(
+    ['ID', 'AGENT', 'TITLE', 'DATE', 'MSGS', 'TOKENS', 'COST'],
+    rows.map((s) => [
+      s.id,
+      s.connectorId,
+      clip(s.title),
+      day(s.startedAt),
+      String(s.messageCount),
+      fmtTokens(s.totalTokens),
+      fmtCost(s.totalCostUsd),
+    ]),
+    [false, false, false, false, true, true, true],
+  );
+}
+
+export interface SessionArgs {
+  offset?: number;
+  limit?: number;
+  around?: string;
+  radius?: number;
+  maxToolChars?: number;
+  redact?: boolean;
+  json?: boolean;
+}
+
+export async function querySession(client: ApiClient, id: string, args: SessionArgs): Promise<string> {
+  // Same defaulting as the MCP get_session tool: no windowing params → the
+  // first DEFAULT_TURNS turns, so a huge session never dumps whole.
+  const windowed =
+    args.around === undefined && args.offset === undefined && args.limit === undefined
+      ? { offset: 0, limit: DEFAULT_TURNS }
+      : { offset: args.offset, limit: args.limit, around: args.around, radius: args.radius };
+  const data = await client.session(id, {
+    ...windowed,
+    maxToolChars: args.maxToolChars ?? DEFAULT_MAX_TOOL_CHARS,
+  });
+  if (args.json) return json(data);
+  return shapeSessionMarkdown(data, args.redact ?? false);
+}
+
+export async function queryProjects(client: ApiClient, args: { json?: boolean }): Promise<string> {
+  const rows = await client.projects();
+  if (args.json) return json(rows);
+  if (rows.length === 0) return 'No projects indexed.';
+  return table(
+    ['ID', 'PATH', 'SESSIONS', 'TOKENS', 'COST', 'AGENTS', 'LAST ACTIVE'],
+    rows.map((p) => [
+      p.id,
+      clip(p.cwd),
+      String(p.sessionCount),
+      fmtTokens(p.totalTokens),
+      fmtCost(p.totalCostUsd),
+      p.connectorIds.join(','),
+      day(p.lastActive),
+    ]),
+    [false, false, true, true, true, false, false],
+  );
+}
+
+export interface AnalyticsArgs {
+  groupBy?: AnalyticsGroupBy;
+  from?: string;
+  to?: string;
+  json?: boolean;
+}
+
+export async function queryAnalytics(client: ApiClient, args: AnalyticsArgs): Promise<string> {
+  const res = await client.analytics({ groupBy: args.groupBy ?? 'project', from: args.from, to: args.to });
+  if (args.json) return json(res);
+  if (res.rows.length === 0) return 'No usage in range.';
+  const t = res.totals;
+  return (
+    table(
+      ['KEY', 'TOKENS', 'IN', 'OUT', 'COST', 'RESPONSES'],
+      res.rows.map((r) => [
+        clip(r.key),
+        fmtTokens(r.totalTokens),
+        fmtTokens(r.inputTokens),
+        fmtTokens(r.outputTokens),
+        fmtCost(r.costUsd),
+        String(r.messageCount),
+      ]),
+      [false, true, true, true, true, true],
+    ) +
+    `\n\nTotal: ${fmtTokens(t.totalTokens)} tok · ${fmtCost(t.costUsd)} · ${t.messageCount} responses · ` +
+    `cache hit ${(t.cacheHitRatio * 100).toFixed(0)}%`
+  );
+}

--- a/packages/server/src/agent/shape.ts
+++ b/packages/server/src/agent/shape.ts
@@ -1,0 +1,88 @@
+/**
+ * Output shaping shared by the agent-facing consumers — the MCP tools and the
+ * CLI query subcommands. Everything here renders API responses to compact
+ * text/Markdown sized for an agent's context window (or a terminal); nothing
+ * talks to the network.
+ */
+
+import type { SearchResponse, SessionDetailResponse } from '@claudescope/shared';
+import { redactText, threadItemsToMarkdown } from '@claudescope/shared';
+
+/** Default hits/rows returned by the list-shaped tools/commands. */
+export const DEFAULT_LIMIT = 20;
+/** Default per-tool-payload char cap in session output. */
+export const DEFAULT_MAX_TOOL_CHARS = 2000;
+/** Default turns per session window when no windowing params are given. */
+export const DEFAULT_TURNS = 20;
+
+export const fmtCost = (usd: number): string => `$${usd.toFixed(2)}`;
+export const fmtTokens = (n: number): string => n.toLocaleString('en-US');
+export const day = (iso: string): string => iso.slice(0, 10);
+
+/**
+ * Search hits as compact text: transcript hits carry the sessionId +
+ * messageUuid needed to open them windowed (`around`), memory hits their
+ * source path. Snippets are expected in `format: 'plain'`.
+ */
+export function shapeSearchResults(res: SearchResponse, limit: number): string {
+  const sessions = res.sessions.slice(0, limit);
+  const memory = res.memory.slice(0, limit);
+  if (sessions.length === 0 && memory.length === 0) return 'No matches.';
+
+  const parts: string[] = [];
+  if (sessions.length > 0) {
+    parts.push(
+      `${sessions.length} transcript hit(s):`,
+      ...sessions.map(
+        (h) =>
+          `- [${h.role}] ${h.title} (session ${h.sessionId}, project ${h.projectId}, uuid ${h.messageUuid})\n` +
+          `  "${h.snippet}"`,
+      ),
+    );
+  }
+  if (memory.length > 0) {
+    parts.push(
+      `${memory.length} memory hit(s):`,
+      ...memory.map(
+        (h) =>
+          `- ${h.title}${h.category ? ` (${h.category})` : ''} [${h.connectorId}] — ${h.sourcePath}\n` +
+          `  "${h.snippet}"`,
+      ),
+    );
+  }
+  return parts.join('\n');
+}
+
+/**
+ * One session (or a window of it) as compact Markdown: a header with ids and
+ * totals, the paging line when the response is windowed, then the turns and
+ * any subagent runs inside the window. `redact` masks home paths and likely
+ * secrets in the rendered text (the caller decides; --json/raw output skips it).
+ */
+export function shapeSessionMarkdown(data: SessionDetailResponse, redact: boolean): string {
+  const { meta, window } = data;
+  const r = redact ? redactText : (s: string) => s;
+  const head = [
+    `# ${r(meta.title)}`,
+    `session ${meta.id} [${meta.connectorId}] · project ${meta.projectDisplayName} · ` +
+      `${meta.startedAt} → ${meta.endedAt} · ${fmtTokens(meta.totalTokens)} tok · ${fmtCost(meta.totalCostUsd)}`,
+  ];
+  if (window) {
+    const end = window.offset + window.limit;
+    head.push(
+      `Turns ${window.offset + 1}–${end} of ${window.total}` +
+        (window.anchorFound === false ? ' (around uuid not found — showing the start)' : '') +
+        (end < window.total ? ` — page on with {offset: ${end}}` : ''),
+    );
+  }
+
+  const opts = { redact };
+  const parts = [head.join('\n'), '---', threadItemsToMarkdown(data.thread, opts)];
+  for (const run of data.subagents) {
+    parts.push(
+      `--- subagent · ${run.agentType} — ${r(run.description || run.agentId)} ---`,
+      threadItemsToMarkdown(run.thread, opts),
+    );
+  }
+  return parts.join('\n\n');
+}

--- a/packages/server/src/cli.ts
+++ b/packages/server/src/cli.ts
@@ -11,6 +11,10 @@
  *   claudescope status     # is it running? is an update available?
  *   claudescope logs -f    # follow the server log
  *   claudescope update     # upgrade to the latest published version
+ *
+ * Read-only query subcommands (search/sessions/session/projects/analytics)
+ * proxy the daemon's HTTP API for terminals and scripts (`--json`); see
+ * agent/query.ts.
  */
 
 import { spawnSync } from 'node:child_process';
@@ -33,6 +37,15 @@ import {
   waitForHealth,
 } from './daemon.js';
 import { runMcpServer } from './agent/mcp.js';
+import { ApiClient } from './agent/api-client.js';
+import {
+  queryAnalytics,
+  queryProjects,
+  querySearch,
+  querySession,
+  querySessions,
+} from './agent/query.js';
+import { ensureDaemon } from './daemon.js';
 import { refreshPricing } from './data/pricing-refresh.js';
 import { openBrowser } from './util/open-browser.js';
 
@@ -306,6 +319,43 @@ async function pricingUpdate(): Promise<void> {
   }
 }
 
+/** A bad flag value or missing argument on a query subcommand. */
+class UsageError extends Error {}
+
+/** Parse a non-negative integer flag; undefined when absent, UsageError when bogus. */
+function intFlag(name: string, v: string | undefined): number | undefined {
+  if (v === undefined) return undefined;
+  const n = Number.parseInt(v, 10);
+  if (!Number.isInteger(n) || n < 0) throw new UsageError(`--${name} expects a non-negative integer, got '${v}'`);
+  return n;
+}
+
+/** Validate an enum-valued flag; undefined when absent, UsageError when bogus. */
+function enumFlag<T extends string>(name: string, v: string | undefined, allowed: readonly T[]): T | undefined {
+  if (v === undefined) return undefined;
+  if (!(allowed as readonly string[]).includes(v)) {
+    throw new UsageError(`--${name} must be one of: ${allowed.join(', ')} (got '${v}')`);
+  }
+  return v as T;
+}
+
+/** Run one read-only query subcommand against the (auto-started) daemon and
+ *  print its output. `prepare` validates flags and returns the command — it runs
+ *  BEFORE the daemon is (maybe) spawned, so a bad flag never starts anything.
+ *  Failures go to stderr with a non-zero exit; empty results are normal output
+ *  ("No matches.") with exit 0. */
+async function runQuery(prepare: () => (client: ApiClient) => Promise<string>): Promise<void> {
+  try {
+    const fn = prepare();
+    const d = await ensureDaemon();
+    const client = new ApiClient(`http://127.0.0.1:${d.port}`);
+    console.log(await fn(client));
+  } catch (err) {
+    console.error(`✗ ${err instanceof Error ? err.message : String(err)}`);
+    process.exitCode = 1;
+  }
+}
+
 /** Print brief usage for the pricing subcommand. */
 function pricingHelp(): void {
   console.log(`Usage: claudescope pricing <subcommand>
@@ -333,6 +383,18 @@ Commands:
   help             Show this help
   version          Print the installed version
 
+Query commands (read-only; start the background server on first use):
+  search "<query>" Full-text search across transcripts and agent memory
+                   [--project id] [--role user|assistant] [--scope sessions|memory|all] [--limit N]
+  sessions         List sessions [--project id] [--agent id]
+                   [--sort recent|oldest|tokens|cost|messages] [--q substr] [--limit N]
+  session <id>     One session as Markdown — a window of turns, pageable
+                   [--offset N] [--limit N] [--around uuid] [--radius N]
+                   [--max-tool-chars N] [--redact]
+  projects         List projects
+  analytics        Token/cost aggregates [--group-by project|model|day|agent] [--from date] [--to date]
+  All query commands accept --json for the raw API response (ignores --redact).
+
 Options:
   --port <n>       Port to listen on (default ${DEFAULT_PORT}, or $PORT)
   --no-open        Don't open the browser on start
@@ -354,6 +416,23 @@ async function main(): Promise<void> {
       yes: { type: 'boolean', short: 'y' },
       // parseArgs has no built-in negation, so the flag is literally `no-open`.
       'no-open': { type: 'boolean' },
+      // Query subcommand flags (search/sessions/session/projects/analytics).
+      project: { type: 'string' },
+      agent: { type: 'string' },
+      role: { type: 'string' },
+      scope: { type: 'string' },
+      sort: { type: 'string' },
+      q: { type: 'string' },
+      limit: { type: 'string' },
+      offset: { type: 'string' },
+      around: { type: 'string' },
+      radius: { type: 'string' },
+      'max-tool-chars': { type: 'string' },
+      redact: { type: 'boolean' },
+      json: { type: 'boolean' },
+      'group-by': { type: 'string' },
+      from: { type: 'string' },
+      to: { type: 'string' },
     },
   });
 
@@ -387,6 +466,64 @@ async function main(): Promise<void> {
       // Stdio MCP server: stdout is the protocol channel — nothing else may
       // print to it. The server ensures the daemon on first tool use.
       await runMcpServer();
+      break;
+    case 'search':
+      await runQuery(() => {
+        const query = positionals[1];
+        if (!query) throw new UsageError('usage: claudescope search "<query>" [--project id] [--role user|assistant] [--scope sessions|memory|all] [--limit N] [--json]');
+        const args = {
+          query,
+          project: values.project,
+          role: enumFlag('role', values.role, ['user', 'assistant', 'all'] as const),
+          scope: enumFlag('scope', values.scope, ['sessions', 'memory', 'all'] as const),
+          limit: intFlag('limit', values.limit),
+          json: values.json,
+        };
+        return (client) => querySearch(client, args);
+      });
+      break;
+    case 'sessions':
+      await runQuery(() => {
+        const args = {
+          project: values.project,
+          agent: values.agent,
+          sort: enumFlag('sort', values.sort, ['recent', 'oldest', 'tokens', 'cost', 'messages'] as const),
+          q: values.q,
+          limit: intFlag('limit', values.limit),
+          json: values.json,
+        };
+        return (client) => querySessions(client, args);
+      });
+      break;
+    case 'session':
+      await runQuery(() => {
+        const id = positionals[1];
+        if (!id) throw new UsageError('usage: claudescope session <id> [--offset N] [--limit N] [--around uuid] [--radius N] [--max-tool-chars N] [--redact] [--json]');
+        const args = {
+          offset: intFlag('offset', values.offset),
+          limit: intFlag('limit', values.limit),
+          around: values.around,
+          radius: intFlag('radius', values.radius),
+          maxToolChars: intFlag('max-tool-chars', values['max-tool-chars']),
+          redact: values.redact,
+          json: values.json,
+        };
+        return (client) => querySession(client, id, args);
+      });
+      break;
+    case 'projects':
+      await runQuery(() => (client) => queryProjects(client, { json: values.json }));
+      break;
+    case 'analytics':
+      await runQuery(() => {
+        const args = {
+          groupBy: enumFlag('group-by', values['group-by'], ['project', 'model', 'day', 'agent'] as const),
+          from: values.from,
+          to: values.to,
+          json: values.json,
+        };
+        return (client) => queryAnalytics(client, args);
+      });
       break;
     case 'update':
       await update(Boolean(values.yes));

--- a/packages/server/test/cli-query.test.ts
+++ b/packages/server/test/cli-query.test.ts
@@ -1,0 +1,146 @@
+/**
+ * CLI query subcommand tests.
+ *
+ * Boots the real Fastify app on an ephemeral port against a synthetic fixture
+ * (the mcp.integration.test.ts pattern) and exercises the query functions with
+ * a real ApiClient — covering the CLI-specific edges: table shaping with long
+ * and non-ASCII titles, --json passthrough (raw response, no redaction), and
+ * the --redact flag masking home paths in the human Markdown output only.
+ */
+
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import type { FastifyInstance } from 'fastify';
+import type { SessionDetailResponse, SessionMeta } from '@claudescope/shared';
+
+// --- temp locations (decided before any server module is imported) ----------
+const work = mkdtempSync(join(tmpdir(), 'claudescope-cliq-'));
+const projectsDir = join(work, 'projects');
+
+process.env.CLAUDE_PROJECTS_DIR = projectsDir;
+process.env.CODEX_SESSIONS_DIR = join(work, 'codex-empty');
+process.env.JUNIE_SESSIONS_DIR = join(work, 'junie-empty');
+process.env.PI_SESSIONS_DIR = join(work, 'pi-empty');
+process.env.OPENCODE_DATA_DIR = join(work, 'opencode-empty');
+process.env.COPILOT_SESSIONS_DIR = join(work, 'copilot-empty');
+process.env.ANTIGRAVITY_CLI_DIR = join(work, 'antigravity-empty');
+process.env.ANTIGRAVITY_DIR = join(work, 'antigravity-empty-desktop');
+process.env.DUCKDB_PATH = join(work, 'index.duckdb');
+process.env.CLAUDESCOPE_HOME = join(work, 'home');
+process.env.REINDEX_INTERVAL_MS = '0';
+
+const jsonl = (events: unknown[]): string => events.map((e) => JSON.stringify(e)).join('\n') + '\n';
+
+const LONG_TITLE = 'A very long session title that keeps going well past the table cell cap ' + 'x'.repeat(40);
+
+function writeFixtures(): void {
+  const projA = join(projectsDir, 'enc-projQ');
+  mkdirSync(projA, { recursive: true });
+  const usage = { input_tokens: 10, output_tokens: 5 };
+
+  // Session 1: long title; a text block with a home path (redaction target).
+  const base1 = { sessionId: 'sessQ1', cwd: '/tmp/projQ', gitBranch: 'main', version: '2.1.0' };
+  writeFileSync(
+    join(projA, 'sessQ1.jsonl'),
+    jsonl([
+      { type: 'ai-title', sessionId: 'sessQ1', aiTitle: LONG_TITLE },
+      { ...base1, type: 'user', uuid: 'q1u1', parentUuid: null, timestamp: '2026-01-02T10:00:00.000Z', isSidechain: false, message: { role: 'user', content: 'where does the needle live?' } },
+      { ...base1, type: 'assistant', uuid: 'q1a1', parentUuid: 'q1u1', timestamp: '2026-01-02T10:00:05.000Z', isSidechain: false, message: { role: 'assistant', model: 'claude-opus-4-8', content: [{ type: 'text', text: 'the needle lives in /Users/testuser/secret/needle.txt' }], usage } },
+    ]),
+  );
+
+  // Session 2: emoji/non-ASCII title (table must not crash or drop the row).
+  const base2 = { sessionId: 'sessQ2', cwd: '/tmp/projQ', gitBranch: 'main', version: '2.1.0' };
+  writeFileSync(
+    join(projA, 'sessQ2.jsonl'),
+    jsonl([
+      { type: 'ai-title', sessionId: 'sessQ2', aiTitle: '🚀 déjà-vu — fix résumé parsing' },
+      { ...base2, type: 'user', uuid: 'q2u1', parentUuid: null, timestamp: '2026-01-03T09:00:00.000Z', isSidechain: false, message: { role: 'user', content: 'unrelated haystack chatter' } },
+      { ...base2, type: 'assistant', uuid: 'q2a1', parentUuid: 'q2u1', timestamp: '2026-01-03T09:00:04.000Z', isSidechain: false, message: { role: 'assistant', model: 'claude-opus-4-8', content: [{ type: 'text', text: 'ok' }], usage } },
+    ]),
+  );
+}
+
+let app: FastifyInstance;
+let closeConnection: () => Promise<void>;
+// Typed as the module to keep imports lazy (env vars must be set first).
+let query: typeof import('../src/agent/query.js');
+let client: import('../src/agent/api-client.js').ApiClient;
+
+beforeAll(async () => {
+  writeFixtures();
+  const Fastify = (await import('fastify')).default;
+  const { registerRoutes } = await import('../src/routes/index.js');
+  const { reindex } = await import('../src/data/index.js');
+  ({ closeConnection } = await import('../src/db/duckdb.js'));
+  const { ApiClient } = await import('../src/agent/api-client.js');
+  query = await import('../src/agent/query.js');
+
+  app = Fastify();
+  await registerRoutes(app);
+  await reindex();
+  await app.listen({ port: 0, host: '127.0.0.1' });
+  const addr = app.server.address();
+  const port = typeof addr === 'object' && addr ? addr.port : 0;
+  client = new ApiClient(`http://127.0.0.1:${port}`);
+});
+
+afterAll(async () => {
+  await app?.close();
+  await closeConnection?.();
+  rmSync(work, { recursive: true, force: true });
+});
+
+describe('cli query subcommands', () => {
+  it('sessions renders an aligned table, clipping long titles and keeping non-ASCII rows', async () => {
+    const out = await query.querySessions(client, {});
+    const lines = out.split('\n');
+    expect(lines[0]).toMatch(/^ID\s+AGENT\s+TITLE\s+DATE\s+MSGS\s+TOKENS\s+COST$/u);
+    // Every row's AGENT column starts where the header's does (pad-aligned).
+    const agentCol = lines[0]!.indexOf('AGENT');
+    for (const row of lines.slice(1)) expect(row.slice(agentCol)).toMatch(/^claude-code\s/u);
+    // The long title is clipped with an ellipsis, never dumped whole.
+    expect(out).toContain('…');
+    expect(out).not.toContain(LONG_TITLE);
+    // The emoji title survives as a row.
+    expect(out).toContain('🚀 déjà-vu');
+  });
+
+  it('sessions --json returns the raw rows', async () => {
+    const out = await query.querySessions(client, { json: true });
+    const rows = JSON.parse(out) as SessionMeta[];
+    expect(rows.map((r) => r.id).sort()).toEqual(['sessQ1', 'sessQ2']);
+    expect(rows[0]).toHaveProperty('totalCostUsd');
+  });
+
+  it('search returns plain snippets; no hits is normal output', async () => {
+    const hit = await query.querySearch(client, { query: 'needle' });
+    expect(hit).toContain('sessQ1');
+    expect(hit).not.toContain('<mark>');
+    const miss = await query.querySearch(client, { query: 'zebra-quux-nonexistent' });
+    expect(miss).toBe('No matches.');
+  });
+
+  it('session --redact masks home paths in Markdown, while --json stays raw', async () => {
+    const plain = await query.querySession(client, 'sessQ1', {});
+    expect(plain).toContain('/Users/testuser/secret/needle.txt');
+    expect(plain).toMatch(/Turns 1–\d+ of \d+/u);
+
+    const redacted = await query.querySession(client, 'sessQ1', { redact: true });
+    expect(redacted).not.toContain('/Users/testuser');
+    expect(redacted).toContain('~/secret/needle.txt');
+
+    // --json is the raw API response: window metadata present, redact ignored.
+    const raw = JSON.parse(await query.querySession(client, 'sessQ1', { redact: true, json: true })) as SessionDetailResponse;
+    expect(raw.window).toMatchObject({ offset: 0 });
+    expect(JSON.stringify(raw)).toContain('/Users/testuser/secret/needle.txt');
+  });
+
+  it('analytics renders rows plus a totals line', async () => {
+    const out = await query.queryAnalytics(client, { groupBy: 'agent' });
+    expect(out).toContain('claude-code');
+    expect(out).toMatch(/Total: [\d,]+ tok · \$\d/u);
+  });
+});


### PR DESCRIPTION
## Summary

Roadmap slice 4 of [0035](https://github.com/vladar107/claudescope/blob/main/docs/plans/0035-agent-access-and-analytics-roadmap.md) — the scripting face of agent access. **Stacked on #50** (reuses its `ApiClient`/`ensureDaemon`; retargets when #50 merges).

- `claudescope search "<q>"` · `sessions` · `session <id>` · `projects` · `analytics` — read-only lookups that auto-start the daemon (progress on stderr, output on stdout for piping).
- Human output: dependency-free aligned tables / the same windowed compact Markdown as the MCP `get_session` (shaping extracted from mcp.ts into `agent/shape.ts`, shared — MCP behavior identical, its tests unmodified).
- `--json` prints the raw API response for scripts (documented: ignores `--redact`); `--redact` masks paths/secrets in human session output.
- Flag validation runs before the daemon is (maybe) spawned — a bad flag never starts anything. Failures exit 1; empty results are normal exit-0 output.
- README gained a "Scripting (CLI)" subsection with jq examples.

## Testing
`npm test` 344/344 (new: table alignment incl. emoji/long-title clipping, --json passthrough with window metadata, --redact masking, empty-result exit-0, analytics totals), `npm run typecheck` clean.

Plan: docs/plans/0040-cli-query-subcommands.md