### PR TITLE
feat(index): code-impact index — file_edits + tool_error_count (schema v10)

### DIFF
--- a/docs/plans/0039-file-edits-index.md
+++ b/docs/plans/0039-file-edits-index.md
@@ -1,0 +1,109 @@
+# 0039 — Code-impact index: `file_edits` + `tool_error_count` (schema v10)
+
+- **Status:** done
+- **Date:** 2026-07-03
+- **PR:** [#52](https://github.com/vladar107/claudescope/pull/52)
+
+## Context
+
+Roadmap [0035](./0035-agent-access-and-analytics-roadmap.md), sequencing row 5
+(Track B slices B2+B3, the schema part). Code-impact metrics (LOC churn, files
+touched) need edit data *indexed*, not assembled per-session at read time; tool
+failure rates need `is_error` *projected*, not buried in raw blocks. Both are
+index changes, and a schema-signature mismatch rebuilds the whole index, so
+they ship in one v10 bump — one rebuild for users.
+
+## Goal
+
+A `file_edits` table (one row per canonical Edit/MultiEdit/Write call, with
+exact LCS add/del counts, fork-deduped) plus a nullable
+`events.tool_error_count` column, and a minimal `/api/analytics/impact` route
+over them. UI arrives in roadmap rows 6–7.
+
+## Decisions
+
+- **Extraction reuses `connector.loadSession()`** (roadmap option A): the
+  indexer re-runs the exact session-view path (load → assemble → shared
+  changeset collector) for sessions touched by a pass, so every normalization
+  guarantee (apply_patch fan-out, Copilot only-successful-edits, Junie
+  full-file before/after) holds for free. Rejected for now: per-connector
+  `.edits.ndjson` sidecars (faster, but touches all 7 connectors).
+- **Session-scoped delete/reload, not per-file** — a deviation from the
+  roadmap's `source_file` sketch: the extraction unit is the session (its edits
+  span main + subagent files), so rows key on `session_id` and the indexer
+  collects the touched session set (loaded files + removed files' sessions) and
+  re-extracts those wholesale. A `source_file` column would be arbitrary for
+  multi-file sessions and adds nothing to incremental correctness.
+- **Exact LCS diff, not line-count approximations** — Junie stores the whole
+  file as `old_string`/`new_string`; approximations would overcount by the
+  file size. `Write` counts as pure additions (matching the Files-changed tab).
+- **Fork dedup mirrors `electCanonicalUsage`** — fork copies preserve `uuid` +
+  `tool_use_id`, so `edit_canonical` is elected globally per
+  `(uuid, tool_use_id, file_path)`, preferring rows whose events carry no
+  `forkedFrom` marker. Rows are kept (not deleted) so deleting the original
+  file re-elects the surviving fork copy. Synthetic uuids are session-prefixed
+  in every connector, so cross-session collisions can't false-positive.
+- **`tool_error_count` is NULL when unknowable, never 0** — Junie (results are
+  `modified: path` strings) and Antigravity (typed records carry no error
+  signal) emit NULL; claude-code counts in SQL, codex/pi/opencode/copilot count
+  in TS at normalize time (the v8 `tool_names` playbook). Copilot
+  permission-denials currently count as errors — open question below.
+- **One LATERAL block scan in the Claude projection** — adding a fourth
+  correlated `json_each` subquery per row regressed cold indexing ~20%
+  (interleaved A/B, over the 10% CI gate). The four block aggregates
+  (text, tool_use count, tool names, tool errors) now come from a single
+  `LEFT JOIN LATERAL` scan, which benches at parity or slightly better than
+  the pre-v10 baseline.
+
+## Approach
+
+1. Hoist the changeset collector to `packages/shared/src/changeset.ts`
+   (per-call `collectEditCalls` with `(uuid, toolUseId)` addressing;
+   `buildChangeset` rebuilt on top; web re-imports via a shim).
+2. Schema v10 (`db/schema.ts`): `file_edits` table + index, nullable
+   `events.tool_error_count` appended last (positional INSERT stays aligned).
+3. `tool_error_count` through the seam: `CANONICAL_EVENT_COLUMNS` +
+   `connectors/tool-errors.ts` helper + all seven connectors.
+4. Extraction (`data/file-edits.ts`): `refreshFileEdits` (delete + re-extract
+   per touched session, `tool_names` LIKE pre-filter so edit-free sessions are
+   never parsed, per-session failure isolation) and `electCanonicalEdits`;
+   wired into `doReindex` after `electCanonicalUsage`.
+5. Route `GET /api/analytics/impact?groupBy=agent|day|file&project=&from=&to=`
+   (`routes/analytics-impact.ts`; `file` capped at 200 rows). Types in
+   `shared/src/api.ts`. **No UI in this slice** — roadmap rows 6–7 consume it.
+
+## Files affected
+
+- `packages/shared/src/changeset.ts` (new), `diff.ts` consumers, `api.ts`
+  (Impact types); `packages/web/src/pages/session/changeset.ts` → shim.
+- `packages/server/src/db/schema.ts` — v10.
+- `packages/server/src/connectors/` — `types.ts`, `tool-errors.ts` (new),
+  claude-code LATERAL projection, six normalizers + projections.
+- `packages/server/src/data/` — `file-edits.ts` (new), `index.ts` wiring.
+- `packages/server/src/routes/` — `analytics-impact.ts` (new), `index.ts`.
+
+## Testing
+
+`packages/server/test/file-edits.integration.test.ts` (9 tests, fixture-built
+index per repo doctrine): Codex apply_patch fan-out lands per-file rows with
+exact counts; fork copies stored but only the original canonical; Junie
+full-file before/after → exact one-line diff; Copilot denied edit excluded;
+`tool_error_count` NULL for Junie vs counted for Claude/Codex; impact route
+grouping/filtering; incremental re-extraction (clean replace, no dupes) and
+re-election after the original file is deleted. Shared collector edges in
+`packages/shared/test/changeset.test.ts` (moved from web). Full suite: 344
+passing; `tsc -b` clean.
+
+Perf (interleaved A/B, `npm run bench`, 2 cycles × 3 runs): cold index
+859–863 ms (v10) vs 882–922 ms (base); no-op and single-file reindex unchanged.
+The naive correlated-subquery version regressed ~20% — caught and fixed by the
+LATERAL fold before landing.
+
+## Risks / open questions
+
+- Copilot permission-denials count in `tool_error_count`; whether to split
+  "denied" from "failed" is deferred to the error-analytics UI slice (row 6).
+- Churn is agent-reported, not git truth: reverted/overwritten edits count
+  each time — documented on the route and types.
+- The impact route duplicates the small project-slug resolution loop used by
+  analytics routes on parallel branches; worth a shared helper once both land.

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -62,4 +62,5 @@ decision, or a change worth explaining before doing. Skip it for one-line fixes.
 | 0035 | [Roadmap: agent-facing access (MCP + CLI) & analytics depth](./0035-agent-access-and-analytics-roadmap.md) | proposed |
 | 0036 | [API seams for agent consumers (windowing, limits, plain snippets, shared redact/markdown)](./0036-agent-api-seams.md) | done |
 | 0038 | [`claudescope mcp`: agent-facing MCP server](./0038-mcp-server.md) | done |
+| 0039 | [Code-impact index: file_edits + tool_error_count (schema v10)](./0039-file-edits-index.md) | done |
 | 0040 | [CLI query subcommands (search/sessions/session/projects/analytics)](./0040-cli-query-subcommands.md) | done |

--- a/packages/server/src/connectors/antigravity/antigravity.ts
+++ b/packages/server/src/connectors/antigravity/antigravity.ts
@@ -83,14 +83,14 @@ function eventsProjectionSql(filePath: string): string {
     SELECT
       file_path, session_id, uuid, parent_uuid, role, type, ts, cwd, git_branch,
       model, input_tokens, output_tokens, cache_read_tokens, cache_write_tokens,
-      service_tier, is_sidechain, tool_use_count, tool_names, text_content,
+      service_tier, is_sidechain, tool_use_count, tool_names, tool_error_count, text_content,
       CAST(NULL AS VARCHAR) AS message_id, CAST(NULL AS VARCHAR) AS forked_from_session_id
     FROM read_ndjson(${path}, format='newline_delimited', maximum_object_size=268435456, ignore_errors=true, columns={
       file_path:'VARCHAR', session_id:'VARCHAR', uuid:'VARCHAR', parent_uuid:'VARCHAR',
       role:'VARCHAR', type:'VARCHAR', ts:'TIMESTAMP', cwd:'VARCHAR', git_branch:'VARCHAR',
       model:'VARCHAR', input_tokens:'BIGINT', output_tokens:'BIGINT', cache_read_tokens:'BIGINT',
       cache_write_tokens:'BIGINT', service_tier:'VARCHAR', is_sidechain:'BOOLEAN',
-      tool_use_count:'INTEGER', tool_names:'VARCHAR', text_content:'VARCHAR'
+      tool_use_count:'INTEGER', tool_names:'VARCHAR', tool_error_count:'INTEGER', text_content:'VARCHAR'
     })`;
 }
 

--- a/packages/server/src/connectors/antigravity/normalize.ts
+++ b/packages/server/src/connectors/antigravity/normalize.ts
@@ -607,6 +607,7 @@ export interface CanonicalRow {
   is_sidechain: boolean;
   tool_use_count: number;
   tool_names: string;
+  tool_error_count: number | null;
   text_content: string;
 }
 
@@ -638,6 +639,7 @@ export function toCanonicalRows(session: AntigravitySession, filePath: string): 
       is_sidechain: session.isSidechain,
       tool_use_count: content.filter((b) => b.type === 'tool_use').length,
       tool_names: toolNamesCsv(content),
+      tool_error_count: null, // Antigravity's typed result records carry no error signal
       text_content: text,
     };
   });

--- a/packages/server/src/connectors/claude-code/claude-code.ts
+++ b/packages/server/src/connectors/claude-code/claude-code.ts
@@ -29,49 +29,78 @@ import { globalMemory, projectMemory } from './memory.js';
 const READ_OPTS = `union_by_name=true, format='newline_delimited', maximum_object_size=268435456, ignore_errors=true`;
 
 /**
- * SQL extracting FTS-searchable plain text from a `message` JSON value.
- * `message.content` is either a plain string or an array of blocks; for arrays
- * we concatenate the `text`/`thinking` block bodies.
+ * One shared pass over a message's content blocks, as a LATERAL join: plain
+ * text (text/thinking bodies for FTS), tool_use count + names, and the count
+ * of tool_results flagged `is_error` — four aggregates from a single
+ * `json_each` scan per row (correlated subqueries would re-scan the array per
+ * aggregate, which measurably slows cold indexing). For a plain-string
+ * `content` the scan yields scalar rows no block filter matches, so every
+ * aggregate comes back empty and the CASEs in the SELECT keep the original
+ * per-shape semantics (string content → its text, zero tools).
  */
-const TEXT_CONTENT_EXPR = `
-  CASE
-    WHEN message IS NULL THEN NULL
-    WHEN json_type(message -> '$.content') = 'VARCHAR'
-      THEN json_extract_string(message, '$.content')
-    ELSE (
-      SELECT string_agg(
+const BLOCK_AGG_LATERAL = `
+  LEFT JOIN LATERAL (
+    SELECT
+      count(*) FILTER (
+        WHERE json_extract_string(b.value, '$.type') = 'tool_use'
+      ) AS tool_use_count,
+      string_agg(json_extract_string(b.value, '$.name'), ',') FILTER (
+        WHERE json_extract_string(b.value, '$.type') = 'tool_use'
+          AND json_extract_string(b.value, '$.name') IS NOT NULL
+      ) AS tool_names,
+      count(*) FILTER (
+        WHERE json_extract_string(b.value, '$.type') = 'tool_result'
+          AND json_extract_string(b.value, '$.is_error') = 'true'
+      ) AS tool_error_count,
+      string_agg(
         coalesce(
           json_extract_string(b.value, '$.text'),
           json_extract_string(b.value, '$.thinking')
         ),
         ' '
-      )
-      FROM json_each(message, '$.content') AS b
-      WHERE json_extract_string(b.value, '$.type') IN ('text', 'thinking')
-    )
+      ) FILTER (
+        WHERE json_extract_string(b.value, '$.type') IN ('text', 'thinking')
+      ) AS block_text
+    FROM json_each(message, '$.content') AS b
+  ) blocks ON TRUE`;
+
+/** True when the message's `content` is a plain string rather than blocks. */
+const STRING_CONTENT = `json_type(message -> '$.content') = 'VARCHAR'`;
+
+/**
+ * FTS-searchable plain text: the string content itself, or the concatenated
+ * text/thinking block bodies (NULL when there are none).
+ */
+const TEXT_CONTENT_EXPR = `
+  CASE
+    WHEN message IS NULL THEN NULL
+    WHEN ${STRING_CONTENT} THEN json_extract_string(message, '$.content')
+    ELSE blocks.block_text
   END`;
 
-/** Count of `tool_use` blocks inside a message's content array (0 for strings). */
+/** Count of `tool_use` blocks (0 for strings). */
 const TOOL_USE_COUNT_EXPR = `
   CASE
-    WHEN message IS NULL OR json_type(message -> '$.content') = 'VARCHAR' THEN 0
-    ELSE (
-      SELECT count(*)
-      FROM json_each(message, '$.content') AS b
-      WHERE json_extract_string(b.value, '$.type') = 'tool_use'
-    )
+    WHEN message IS NULL OR ${STRING_CONTENT} THEN 0
+    ELSE COALESCE(blocks.tool_use_count, 0)
   END`;
 
-/** Comma-joined `$.name` of `tool_use` blocks in a message's content array. */
+/**
+ * Count of `tool_result` blocks flagged `is_error` (0 for strings/no errors).
+ * Claude Code records the flag natively, so the count is always known — never
+ * NULL (unlike Junie/Antigravity).
+ */
+const TOOL_ERROR_COUNT_EXPR = `
+  CASE
+    WHEN message IS NULL OR ${STRING_CONTENT} THEN 0
+    ELSE COALESCE(blocks.tool_error_count, 0)
+  END`;
+
+/** Comma-joined `$.name` of `tool_use` blocks ('' when there are none). */
 const TOOL_NAMES_EXPR = `
   CASE
-    WHEN message IS NULL OR json_type(message -> '$.content') = 'VARCHAR' THEN ''
-    ELSE COALESCE((
-      SELECT string_agg(json_extract_string(b.value, '$.name'), ',')
-      FROM json_each(message, '$.content') AS b
-      WHERE json_extract_string(b.value, '$.type') = 'tool_use'
-        AND json_extract_string(b.value, '$.name') IS NOT NULL
-    ), '')
+    WHEN message IS NULL OR ${STRING_CONTENT} THEN ''
+    ELSE COALESCE(blocks.tool_names, '')
   END`;
 
 /**
@@ -137,10 +166,12 @@ function eventsProjectionSql(filePath: string): string {
       COALESCE(isSidechain, FALSE) AS is_sidechain,
       ${TOOL_USE_COUNT_EXPR} AS tool_use_count,
       ${TOOL_NAMES_EXPR} AS tool_names,
+      ${TOOL_ERROR_COUNT_EXPR} AS tool_error_count,
       ${TEXT_CONTENT_EXPR} AS text_content,
       json_extract_string(message, '$.id') AS message_id,
       json_extract_string(forkedFrom, '$.sessionId') AS forked_from_session_id
     FROM ${readFn}
+    ${BLOCK_AGG_LATERAL}
     WHERE type IN ('user', 'assistant')`;
 }
 

--- a/packages/server/src/connectors/codex/codex.ts
+++ b/packages/server/src/connectors/codex/codex.ts
@@ -57,14 +57,14 @@ function eventsProjectionSql(filePath: string): string {
     SELECT
       file_path, session_id, uuid, parent_uuid, role, type, ts, cwd, git_branch,
       model, input_tokens, output_tokens, cache_read_tokens, cache_write_tokens,
-      service_tier, is_sidechain, tool_use_count, tool_names, text_content,
+      service_tier, is_sidechain, tool_use_count, tool_names, tool_error_count, text_content,
       CAST(NULL AS VARCHAR) AS message_id, CAST(NULL AS VARCHAR) AS forked_from_session_id
     FROM read_ndjson(${path}, format='newline_delimited', maximum_object_size=268435456, ignore_errors=true, columns={
       file_path:'VARCHAR', session_id:'VARCHAR', uuid:'VARCHAR', parent_uuid:'VARCHAR',
       role:'VARCHAR', type:'VARCHAR', ts:'TIMESTAMP', cwd:'VARCHAR', git_branch:'VARCHAR',
       model:'VARCHAR', input_tokens:'BIGINT', output_tokens:'BIGINT', cache_read_tokens:'BIGINT',
       cache_write_tokens:'BIGINT', service_tier:'VARCHAR', is_sidechain:'BOOLEAN',
-      tool_use_count:'INTEGER', tool_names:'VARCHAR', text_content:'VARCHAR'
+      tool_use_count:'INTEGER', tool_names:'VARCHAR', tool_error_count:'INTEGER', text_content:'VARCHAR'
     })`;
 }
 

--- a/packages/server/src/connectors/codex/normalize.ts
+++ b/packages/server/src/connectors/codex/normalize.ts
@@ -32,6 +32,7 @@ import type {
 } from '@claudescope/shared';
 import { CODEX_SESSIONS_DIR } from '../../config.js';
 import { toolNamesCsv } from '../tool-names.js';
+import { toolErrorCount } from '../tool-errors.js';
 
 interface CodexLine {
   type?: string;
@@ -713,6 +714,7 @@ export interface CanonicalRow {
   is_sidechain: boolean;
   tool_use_count: number;
   tool_names: string;
+  tool_error_count: number | null;
   text_content: string;
 }
 
@@ -749,6 +751,7 @@ export function toCanonicalRows(session: CodexSession, filePath: string): Canoni
       is_sidechain: session.isSidechain,
       tool_use_count: arr.filter((b) => b.type === 'tool_use').length,
       tool_names: toolNamesCsv(arr),
+      tool_error_count: toolErrorCount(arr),
       text_content: text,
     };
   });

--- a/packages/server/src/connectors/copilot/copilot.ts
+++ b/packages/server/src/connectors/copilot/copilot.ts
@@ -68,14 +68,14 @@ function eventsProjectionSql(filePath: string): string {
     SELECT
       file_path, session_id, uuid, parent_uuid, role, type, ts, cwd, git_branch,
       model, input_tokens, output_tokens, cache_read_tokens, cache_write_tokens,
-      service_tier, is_sidechain, tool_use_count, tool_names, text_content,
+      service_tier, is_sidechain, tool_use_count, tool_names, tool_error_count, text_content,
       CAST(NULL AS VARCHAR) AS message_id, CAST(NULL AS VARCHAR) AS forked_from_session_id
     FROM read_ndjson(${path}, format='newline_delimited', maximum_object_size=268435456, ignore_errors=true, columns={
       file_path:'VARCHAR', session_id:'VARCHAR', uuid:'VARCHAR', parent_uuid:'VARCHAR',
       role:'VARCHAR', type:'VARCHAR', ts:'TIMESTAMP', cwd:'VARCHAR', git_branch:'VARCHAR',
       model:'VARCHAR', input_tokens:'BIGINT', output_tokens:'BIGINT', cache_read_tokens:'BIGINT',
       cache_write_tokens:'BIGINT', service_tier:'VARCHAR', is_sidechain:'BOOLEAN',
-      tool_use_count:'INTEGER', tool_names:'VARCHAR', text_content:'VARCHAR'
+      tool_use_count:'INTEGER', tool_names:'VARCHAR', tool_error_count:'INTEGER', text_content:'VARCHAR'
     })`;
 }
 

--- a/packages/server/src/connectors/copilot/normalize.ts
+++ b/packages/server/src/connectors/copilot/normalize.ts
@@ -50,6 +50,7 @@ import type {
 } from '@claudescope/shared';
 import { resolveImageWithin } from '../safe-image.js';
 import { toolNamesCsv } from '../tool-names.js';
+import { toolErrorCount } from '../tool-errors.js';
 
 /** One inline subagent run, segmented out of the parent's event stream. */
 export interface CopilotSubagent {
@@ -484,6 +485,7 @@ export interface CanonicalRow {
   is_sidechain: boolean;
   tool_use_count: number;
   tool_names: string;
+  tool_error_count: number | null;
   text_content: string;
   /** Session title (read by auxProjections; ignored by the events projection). */
   title: string;
@@ -521,6 +523,7 @@ export function toCanonicalRows(session: CopilotSession, filePath: string): Cano
       is_sidechain: e.isSidechain === true,
       tool_use_count: content.filter((b) => b.type === 'tool_use').length,
       tool_names: toolNamesCsv(content),
+      tool_error_count: toolErrorCount(content),
       text_content: text,
       title: session.title,
     };

--- a/packages/server/src/connectors/junie/junie.ts
+++ b/packages/server/src/connectors/junie/junie.ts
@@ -82,14 +82,14 @@ function eventsProjectionSql(filePath: string): string {
     SELECT
       file_path, session_id, uuid, parent_uuid, role, type, ts, cwd, git_branch,
       model, input_tokens, output_tokens, cache_read_tokens, cache_write_tokens,
-      service_tier, is_sidechain, tool_use_count, tool_names, text_content,
+      service_tier, is_sidechain, tool_use_count, tool_names, tool_error_count, text_content,
       CAST(NULL AS VARCHAR) AS message_id, CAST(NULL AS VARCHAR) AS forked_from_session_id
     FROM read_ndjson(${path}, format='newline_delimited', maximum_object_size=268435456, ignore_errors=true, columns={
       file_path:'VARCHAR', session_id:'VARCHAR', uuid:'VARCHAR', parent_uuid:'VARCHAR',
       role:'VARCHAR', type:'VARCHAR', ts:'TIMESTAMP', cwd:'VARCHAR', git_branch:'VARCHAR',
       model:'VARCHAR', input_tokens:'BIGINT', output_tokens:'BIGINT', cache_read_tokens:'BIGINT',
       cache_write_tokens:'BIGINT', service_tier:'VARCHAR', is_sidechain:'BOOLEAN',
-      tool_use_count:'INTEGER', tool_names:'VARCHAR', text_content:'VARCHAR'
+      tool_use_count:'INTEGER', tool_names:'VARCHAR', tool_error_count:'INTEGER', text_content:'VARCHAR'
     })`;
 }
 

--- a/packages/server/src/connectors/junie/normalize.ts
+++ b/packages/server/src/connectors/junie/normalize.ts
@@ -435,6 +435,7 @@ export interface CanonicalRow {
   is_sidechain: boolean;
   tool_use_count: number;
   tool_names: string;
+  tool_error_count: number | null;
   text_content: string;
   /** Not a canonical column — read separately by the title aux projection. */
   title: string;
@@ -476,6 +477,7 @@ export function toCanonicalRows(session: JunieSession, filePath: string): Canoni
       is_sidechain: false,
       tool_use_count: arr.filter((b) => b.type === 'tool_use').length,
       tool_names: toolNamesCsv(arr),
+      tool_error_count: null, // Junie results are 'modified: path' strings — no error signal
       text_content: text,
       title: session.title,
     };

--- a/packages/server/src/connectors/opencode/normalize.ts
+++ b/packages/server/src/connectors/opencode/normalize.ts
@@ -34,6 +34,7 @@ import type {
 } from '@claudescope/shared';
 import type { OpencodeRawSession } from './db.js';
 import { toolNamesCsv } from '../tool-names.js';
+import { toolErrorCount } from '../tool-errors.js';
 
 const str = (v: unknown): string => (typeof v === 'string' ? v : '');
 const num = (v: unknown): number => (typeof v === 'number' && Number.isFinite(v) ? v : 0);
@@ -400,6 +401,7 @@ export interface CanonicalRow {
   is_sidechain: boolean;
   tool_use_count: number;
   tool_names: string;
+  tool_error_count: number | null;
   text_content: string;
   /** Session title (read by auxProjections; ignored by the events projection). */
   title: string;
@@ -435,6 +437,7 @@ export function toCanonicalRows(session: OpencodeRawSession, filePath: string): 
       is_sidechain: isSidechain,
       tool_use_count: content.filter((b) => b.type === 'tool_use').length,
       tool_names: toolNamesCsv(content),
+      tool_error_count: toolErrorCount(content),
       text_content: text,
       // A child's title must not clobber the parent's via the titles projection
       // (both files now share one session_id) — emit none for sidechain rows.

--- a/packages/server/src/connectors/opencode/opencode.ts
+++ b/packages/server/src/connectors/opencode/opencode.ts
@@ -73,14 +73,14 @@ function eventsProjectionSql(filePath: string): string {
     SELECT
       file_path, session_id, uuid, parent_uuid, role, type, ts, cwd, git_branch,
       model, input_tokens, output_tokens, cache_read_tokens, cache_write_tokens,
-      service_tier, is_sidechain, tool_use_count, tool_names, text_content,
+      service_tier, is_sidechain, tool_use_count, tool_names, tool_error_count, text_content,
       CAST(NULL AS VARCHAR) AS message_id, CAST(NULL AS VARCHAR) AS forked_from_session_id
     FROM read_ndjson(${path}, format='newline_delimited', maximum_object_size=268435456, ignore_errors=true, columns={
       file_path:'VARCHAR', session_id:'VARCHAR', uuid:'VARCHAR', parent_uuid:'VARCHAR',
       role:'VARCHAR', type:'VARCHAR', ts:'TIMESTAMP', cwd:'VARCHAR', git_branch:'VARCHAR',
       model:'VARCHAR', input_tokens:'BIGINT', output_tokens:'BIGINT', cache_read_tokens:'BIGINT',
       cache_write_tokens:'BIGINT', service_tier:'VARCHAR', is_sidechain:'BOOLEAN',
-      tool_use_count:'INTEGER', tool_names:'VARCHAR', text_content:'VARCHAR'
+      tool_use_count:'INTEGER', tool_names:'VARCHAR', tool_error_count:'INTEGER', text_content:'VARCHAR'
     })`;
 }
 

--- a/packages/server/src/connectors/pi/normalize.ts
+++ b/packages/server/src/connectors/pi/normalize.ts
@@ -36,6 +36,7 @@ import { existsSync, readFileSync, statSync } from 'node:fs';
 import { basename, dirname } from 'node:path';
 import type { AssistantEvent, ContentBlock, MessageUsage, UserEvent } from '@claudescope/shared';
 import { toolNamesCsv } from '../tool-names.js';
+import { toolErrorCount } from '../tool-errors.js';
 
 export interface PiSession {
   /** Indexing key: the parent's session id for a nested subagent, else the own id. */
@@ -474,6 +475,7 @@ export interface CanonicalRow {
   is_sidechain: boolean;
   tool_use_count: number;
   tool_names: string;
+  tool_error_count: number | null;
   text_content: string;
 }
 
@@ -506,6 +508,7 @@ export function toCanonicalRows(session: PiSession, filePath: string): Canonical
       is_sidechain: session.isSidechain,
       tool_use_count: content.filter((b) => b.type === 'tool_use').length,
       tool_names: toolNamesCsv(content),
+      tool_error_count: toolErrorCount(content),
       text_content: text,
     };
   });

--- a/packages/server/src/connectors/pi/pi.ts
+++ b/packages/server/src/connectors/pi/pi.ts
@@ -84,14 +84,14 @@ function eventsProjectionSql(filePath: string): string {
     SELECT
       file_path, session_id, uuid, parent_uuid, role, type, ts, cwd, git_branch,
       model, input_tokens, output_tokens, cache_read_tokens, cache_write_tokens,
-      service_tier, is_sidechain, tool_use_count, tool_names, text_content,
+      service_tier, is_sidechain, tool_use_count, tool_names, tool_error_count, text_content,
       CAST(NULL AS VARCHAR) AS message_id, CAST(NULL AS VARCHAR) AS forked_from_session_id
     FROM read_ndjson(${path}, format='newline_delimited', maximum_object_size=268435456, ignore_errors=true, columns={
       file_path:'VARCHAR', session_id:'VARCHAR', uuid:'VARCHAR', parent_uuid:'VARCHAR',
       role:'VARCHAR', type:'VARCHAR', ts:'TIMESTAMP', cwd:'VARCHAR', git_branch:'VARCHAR',
       model:'VARCHAR', input_tokens:'BIGINT', output_tokens:'BIGINT', cache_read_tokens:'BIGINT',
       cache_write_tokens:'BIGINT', service_tier:'VARCHAR', is_sidechain:'BOOLEAN',
-      tool_use_count:'INTEGER', tool_names:'VARCHAR', text_content:'VARCHAR'
+      tool_use_count:'INTEGER', tool_names:'VARCHAR', tool_error_count:'INTEGER', text_content:'VARCHAR'
     })`;
 }
 

--- a/packages/server/src/connectors/tool-errors.ts
+++ b/packages/server/src/connectors/tool-errors.ts
@@ -1,0 +1,12 @@
+/**
+ * Count of failed tool calls on a canonical row: `tool_result` blocks flagged
+ * `is_error`. Stored in the nullable `events.tool_error_count` column — a
+ * connector whose source format carries no error signal at all (Junie's
+ * "modified: path" result strings, Antigravity's typed result records) emits
+ * NULL so "no errors" and "can't know" stay distinguishable in analytics.
+ */
+export function toolErrorCount(
+  blocks: ReadonlyArray<{ type: string; is_error?: boolean }>,
+): number {
+  return blocks.filter((b) => b.type === 'tool_result' && b.is_error === true).length;
+}

--- a/packages/server/src/connectors/types.ts
+++ b/packages/server/src/connectors/types.ts
@@ -46,6 +46,7 @@ export const CANONICAL_EVENT_COLUMNS = [
   'is_sidechain',
   'tool_use_count',
   'tool_names',
+  'tool_error_count',
   'text_content',
 ] as const;
 

--- a/packages/server/src/data/file-edits.ts
+++ b/packages/server/src/data/file-edits.ts
@@ -1,0 +1,129 @@
+/**
+ * Index-time extraction of `file_edits` rows — the code-impact analog of the
+ * events load.
+ *
+ * The extraction unit is the SESSION (a session's edits span its main +
+ * subagent files), so the indexer hands over every session touched by a pass
+ * (loaded, reloaded, or losing a file) and this module deletes + re-extracts
+ * those sessions' rows. The heavy lifting reuses the exact session-view path —
+ * `loadSessionData` → thread assembly → the shared changeset collector — so
+ * every connector normalization guarantee (Codex/opencode apply_patch fan-out,
+ * Copilot's only-successful-edits rule, Junie's full-file before/after blocks)
+ * holds here for free.
+ *
+ * Fork/resume copies duplicate edit calls across sessions with uuid and
+ * tool_use_id preserved; {@link electCanonicalEdits} marks one row per
+ * (uuid, tool_use_id, file_path) as the counted one, preferring the original
+ * over fork copies — mirroring `electCanonicalUsage`.
+ */
+
+import type { DuckDBConnection } from '@duckdb/node-api';
+import { collectEditCalls, fileStats } from '@claudescope/shared';
+import { queryRows, sqlString } from '../db/duckdb.js';
+import { assembleThread, buildSubagentRuns } from './parser.js';
+import { loadSessionData } from './session-loader.js';
+
+/** Insert batch size — keeps the VALUES statement well under DuckDB limits. */
+const INSERT_CHUNK = 500;
+
+/**
+ * Sessions whose events actually contain an edit-bearing canonical tool.
+ * `tool_names` is a comma-joined CSV, so a substring match is a safe pre-filter
+ * ('Edit' also matches MultiEdit; a false positive only costs a parse that
+ * finds no canonical edit blocks).
+ */
+async function editBearing(conn: DuckDBConnection, sessionIds: string[]): Promise<string[]> {
+  const ids = sessionIds.map(sqlString).join(', ');
+  const rows = await queryRows(
+    conn,
+    `SELECT DISTINCT session_id FROM events
+     WHERE session_id IN (${ids})
+       AND (tool_names LIKE '%Edit%' OR tool_names LIKE '%Write%')`,
+  );
+  return rows.map((r) => String(r.session_id));
+}
+
+/**
+ * Delete + re-extract `file_edits` for the given sessions. A session that no
+ * longer has files (fully removed) simply loses its rows; a session with no
+ * edit-bearing events is deleted but never parsed (tool_names pre-filter).
+ */
+export async function refreshFileEdits(
+  conn: DuckDBConnection,
+  sessionIds: Iterable<string>,
+): Promise<void> {
+  const affected = [...new Set(sessionIds)].filter((s) => s.length > 0);
+  if (affected.length === 0) return;
+
+  for (let i = 0; i < affected.length; i += INSERT_CHUNK) {
+    const ids = affected
+      .slice(i, i + INSERT_CHUNK)
+      .map(sqlString)
+      .join(', ');
+    await conn.run(`DELETE FROM file_edits WHERE session_id IN (${ids})`);
+  }
+
+  const toExtract = await editBearing(conn, affected);
+  for (const sessionId of toExtract) {
+    // Isolate per-session failures like loadFile isolates per-file ones: one
+    // unparseable session must not abort the whole pass.
+    try {
+      const { mainEvents, subagents } = await loadSessionData(sessionId);
+      if (mainEvents.length === 0 && subagents.length === 0) continue;
+      const thread = assembleThread(mainEvents);
+      const runs = buildSubagentRuns(thread, subagents);
+
+      const values: string[] = [];
+      for (const call of collectEditCalls(thread, runs)) {
+        const { additions, deletions } = fileStats(call.edits);
+        values.push(
+          `(${sqlString(sessionId)}, ${sqlString(call.uuid)}, ${sqlString(call.toolUseId)},
+            try_cast(${sqlString(call.timestamp)} AS TIMESTAMP), ${call.isSidechain},
+            ${sqlString(call.toolName)}, ${sqlString(call.path)}, ${additions}, ${deletions}, TRUE)`,
+        );
+      }
+      for (let i = 0; i < values.length; i += INSERT_CHUNK) {
+        await conn.run(
+          `INSERT INTO file_edits VALUES ${values.slice(i, i + INSERT_CHUNK).join(', ')}`,
+        );
+      }
+    } catch (err) {
+      console.warn(`claudescope: skipping file-edit extraction for session ${sessionId}:`, err);
+    }
+  }
+}
+
+/**
+ * Mark exactly one `file_edits` row per (uuid, tool_use_id, file_path) as the
+ * counted one. Duplicates only arise from fork/resume copies (uuids are
+ * session-scoped or globally unique in every connector), and the fork copy's
+ * events carry `forked_from_session_id` — prefer rows whose session events
+ * don't, then a deterministic session_id tiebreak. Runs globally each changed
+ * pass (cheap at this scale), so it stays correct when the original file is
+ * later deleted: the surviving fork copy gets re-elected.
+ */
+export async function electCanonicalEdits(conn: DuckDBConnection): Promise<void> {
+  await conn.run(`UPDATE file_edits SET edit_canonical = TRUE`);
+  await conn.run(`
+    UPDATE file_edits SET edit_canonical = FALSE
+    FROM (
+      SELECT session_id, uuid, tool_use_id, file_path,
+             row_number() OVER (
+               PARTITION BY uuid, tool_use_id, file_path
+               ORDER BY forked ASC, session_id
+             ) AS rn
+      FROM (
+        SELECT fe.session_id, fe.uuid, fe.tool_use_id, fe.file_path,
+               COALESCE(bool_or(e.forked_from_session_id IS NOT NULL), FALSE) AS forked
+        FROM file_edits fe
+        LEFT JOIN events e ON e.session_id = fe.session_id AND e.uuid = fe.uuid
+        GROUP BY fe.session_id, fe.uuid, fe.tool_use_id, fe.file_path
+      )
+    ) w
+    WHERE file_edits.session_id = w.session_id
+      AND file_edits.uuid = w.uuid
+      AND file_edits.tool_use_id = w.tool_use_id
+      AND file_edits.file_path = w.file_path
+      AND w.rn > 1
+  `);
+}

--- a/packages/server/src/data/index.ts
+++ b/packages/server/src/data/index.ts
@@ -22,6 +22,7 @@ import { connectors } from '../connectors/registry.js';
 import type { AgentConnector, DiscoveredFile } from '../connectors/types.js';
 import { loadPricing } from './pricing.js';
 import { cleanFallbackTitle } from './title.js';
+import { electCanonicalEdits, refreshFileEdits } from './file-edits.js';
 
 /** Tracks whether the initial index build has finished (server readiness). */
 let ready = false;
@@ -151,7 +152,8 @@ async function loadFile(
       ev.service_tier, ev.is_sidechain, ev.tool_use_count, ev.tool_names,
       ${costExpr} AS cost_usd,
       ev.text_content,
-      ev.message_id, ev.forked_from_session_id, TRUE AS usage_canonical
+      ev.message_id, ev.forked_from_session_id, TRUE AS usage_canonical,
+      ev.tool_error_count
     FROM (
       ${connector.eventsProjectionSql(file.path)}
     ) AS ev
@@ -419,11 +421,22 @@ async function doReindex(): Promise<ReindexResponse> {
 
   const discoveredPaths = new Set(discovered.map((d) => d.file.path));
 
+  // Sessions touched by this pass (files loaded, reloaded, or removed) — the
+  // unit `file_edits` extraction is refreshed by (see data/file-edits.ts).
+  const editSessions = new Set<string>();
+
   // Drop files that no longer exist on disk (and their events) — but skip files
   // owned by a connector whose discovery failed this pass (transient, not gone).
   let removed = 0;
   for (const [path, meta] of existing) {
     if (!discoveredPaths.has(path) && !(meta.connectorId && failedConnectors.has(meta.connectorId))) {
+      // A removed file's session must re-extract (or drop) its file_edits rows;
+      // resolve the ids while the events still exist.
+      const gone = await queryRows(
+        conn,
+        `SELECT DISTINCT session_id FROM events WHERE file_path = ${sqlString(path)}`,
+      );
+      for (const r of gone) editSessions.add(String(r.session_id ?? ''));
       // Delete stale aux rows before clearing events: the subquery reads events
       // to resolve session ids, so aux deletes must precede the events delete.
       await conn.run(`DELETE FROM titles   WHERE session_id IN (SELECT DISTINCT session_id FROM events WHERE file_path = ${sqlString(path)})`);
@@ -456,6 +469,7 @@ async function doReindex(): Promise<ReindexResponse> {
         `SELECT session_id FROM events WHERE file_path = ${sqlString(file.path)} LIMIT 1`,
       );
       const sessionId = sidRows.length > 0 ? String(sidRows[0]?.session_id ?? '') : null;
+      if (sessionId) editSessions.add(sessionId);
       const cwdRows = await queryRows(
         conn,
         `SELECT cwd FROM events WHERE file_path = ${sqlString(file.path)} AND cwd IS NOT NULL LIMIT 1`,
@@ -485,6 +499,10 @@ async function doReindex(): Promise<ReindexResponse> {
   // Something changed: re-elect the usage-canonical rows globally, then rebuild
   // derived tables + FTS so additions, edits, and removals are all reflected.
   await electCanonicalUsage(conn);
+  // Refresh code-impact rows for the touched sessions, then re-elect the
+  // canonical edit per (uuid, tool_use_id) globally (fork copies dedup).
+  await refreshFileEdits(conn, editSessions);
+  await electCanonicalEdits(conn);
   await rebuildSessions(conn);
   await rebuildFtsIndex(conn);
 

--- a/packages/server/src/db/schema.ts
+++ b/packages/server/src/db/schema.ts
@@ -27,7 +27,10 @@
 // v8: per-event tool_names (comma-joined canonical tool names) for the tool-usage breakdown.
 // v9: subagent embedding for codex/pi/opencode/copilot — child transcripts re-key
 //     to their root session (is_sidechain), so stale child-as-session rows must go.
-export const SCHEMA_VERSION = 9;
+// v10: code-impact analytics — per-tool-call `file_edits` rows (extracted at
+//      index time from the assembled thread) + nullable `events.tool_error_count`
+//      (NULL = the source format carries no error signal, distinct from 0).
+export const SCHEMA_VERSION = 10;
 
 /** All DDL statements, executed in order at startup. Idempotent. */
 export const SCHEMA_DDL: readonly string[] = [
@@ -68,7 +71,10 @@ export const SCHEMA_DDL: readonly string[] = [
      text_content VARCHAR,
      message_id   VARCHAR,
      forked_from_session_id VARCHAR,
-     usage_canonical BOOLEAN DEFAULT TRUE
+     usage_canonical BOOLEAN DEFAULT TRUE,
+     -- Failed tool calls on the row (tool_result blocks with is_error). NULL when
+     -- the source format has no error signal (Junie, Antigravity) — not 0.
+     tool_error_count INTEGER
    )`,
 
   `CREATE TABLE IF NOT EXISTS sessions (
@@ -108,7 +114,27 @@ export const SCHEMA_DDL: readonly string[] = [
      title      VARCHAR
    )`,
 
+  // One row per edit-bearing tool call (canonical Edit/MultiEdit/Write),
+  // extracted at index time from the assembled thread (see data/file-edits.ts).
+  // Rows are deleted/re-extracted per SESSION (the extraction unit — a session
+  // spans its main + subagent files). Fork/resume copies duplicate calls across
+  // sessions; `edit_canonical` marks one row per (uuid, tool_use_id, file_path)
+  // as the counted one (see electCanonicalEdits), mirroring usage_canonical.
+  `CREATE TABLE IF NOT EXISTS file_edits (
+     session_id   VARCHAR NOT NULL,
+     uuid         VARCHAR,
+     tool_use_id  VARCHAR DEFAULT '',
+     ts           TIMESTAMP,
+     is_sidechain BOOLEAN DEFAULT FALSE,
+     tool_name    VARCHAR,
+     file_path    VARCHAR NOT NULL,
+     additions    INTEGER DEFAULT 0,
+     deletions    INTEGER DEFAULT 0,
+     edit_canonical BOOLEAN DEFAULT TRUE
+   )`,
+
   `CREATE INDEX IF NOT EXISTS idx_events_session ON events (session_id)`,
   `CREATE INDEX IF NOT EXISTS idx_events_cwd ON events (cwd)`,
   `CREATE INDEX IF NOT EXISTS idx_events_ts ON events (ts)`,
+  `CREATE INDEX IF NOT EXISTS idx_file_edits_session ON file_edits (session_id)`,
 ];

--- a/packages/server/src/routes/analytics-impact.ts
+++ b/packages/server/src/routes/analytics-impact.ts
@@ -1,0 +1,117 @@
+/**
+ * GET /api/analytics/impact — code-impact aggregation over `file_edits`
+ * (LOC added/removed, files touched, edit-call counts), grouped by agent, day,
+ * or file, with optional project + inclusive date bounds.
+ *
+ * The metric is agent-reported churn from canonical Edit/MultiEdit/Write tool
+ * calls — not git truth (reverted/overwritten edits count each time). Rows are
+ * already deduplicated across fork/resume copies at index time
+ * (`edit_canonical` — see data/file-edits.ts), so plain SUMs are safe. Every
+ * connector maps its edits to the canonical tools, so unlike token metrics this
+ * comparison is fair across all agents.
+ *
+ * Date bounds filter on the edit's own timestamp, falling back to the session
+ * start for formats whose tool calls carry no timestamp.
+ */
+
+import type { FastifyInstance } from 'fastify';
+import type { ImpactGroupBy, ImpactResponse, ImpactRow, ImpactTotals } from '@claudescope/shared';
+import { getConnection, queryRows, sqlString } from '../db/duckdb.js';
+import { readRow } from '../db/row.js';
+import { projectIdFromCwd } from '../data/project-id.js';
+
+/** Cap for `groupBy=file` — the long tail of one-touch files isn't informative. */
+const FILE_ROW_LIMIT = 200;
+
+function keyExpr(groupBy: ImpactGroupBy): string {
+  switch (groupBy) {
+    case 'day':
+      return "strftime(COALESCE(fe.ts, s.started_at), '%Y-%m-%d')";
+    case 'file':
+      return 'fe.file_path';
+    case 'agent':
+    default:
+      return "COALESCE(s.connector_id, 'unknown')";
+  }
+}
+
+export async function registerImpactRoute(app: FastifyInstance): Promise<void> {
+  app.get<{
+    Querystring: { groupBy?: string; project?: string; from?: string; to?: string };
+  }>('/api/analytics/impact', async (req): Promise<ImpactResponse> => {
+    const conn = await getConnection();
+    const groupBy: ImpactGroupBy = ['agent', 'day', 'file'].includes(req.query.groupBy ?? '')
+      ? (req.query.groupBy as ImpactGroupBy)
+      : 'agent';
+
+    const filters: string[] = ['fe.edit_canonical'];
+    if (req.query.project) {
+      // project is the slug id; resolve it against the sessions' project_cwd
+      // (the same resolution /api/sessions uses).
+      const cwds = await queryRows(
+        conn,
+        'SELECT DISTINCT project_cwd FROM sessions WHERE project_cwd IS NOT NULL',
+      );
+      const match = cwds
+        .map((c) => String(c.project_cwd))
+        .find((c) => projectIdFromCwd(c) === req.query.project);
+      filters.push(`s.project_cwd = ${match ? sqlString(match) : "'\\0'"}`);
+    }
+    const tsExpr = 'COALESCE(fe.ts, s.started_at)';
+    if (req.query.from) filters.push(`${tsExpr} >= ${sqlString(req.query.from)}::TIMESTAMP`);
+    if (req.query.to) filters.push(`${tsExpr} <= ${sqlString(req.query.to)}::TIMESTAMP`);
+
+    const baseSql = `
+      FROM file_edits fe
+      JOIN sessions s ON s.id = fe.session_id
+      WHERE ${filters.join(' AND ')}`;
+
+    const limitSql = groupBy === 'file' ? ` LIMIT ${FILE_ROW_LIMIT}` : '';
+    const rowsRaw = await queryRows(
+      conn,
+      `SELECT
+         ${keyExpr(groupBy)} AS group_key,
+         sum(fe.additions) AS additions,
+         sum(fe.deletions) AS deletions,
+         count(*) AS edits,
+         count(DISTINCT fe.file_path) AS files_touched,
+         count(DISTINCT fe.session_id) AS sessions
+       ${baseSql}
+       GROUP BY group_key
+       ORDER BY sum(fe.additions) + sum(fe.deletions) DESC, group_key${limitSql}`,
+    );
+
+    const rows: ImpactRow[] = rowsRaw.map((r) => {
+      const rd = readRow(r, 'analytics-impact');
+      return {
+        key: rd.str('group_key', 'unknown'),
+        additions: rd.num('additions'),
+        deletions: rd.num('deletions'),
+        edits: rd.num('edits'),
+        filesTouched: rd.num('files_touched'),
+        sessions: rd.num('sessions'),
+      };
+    });
+
+    const totalRaw = await queryRows(
+      conn,
+      `SELECT
+         COALESCE(sum(fe.additions), 0) AS additions,
+         COALESCE(sum(fe.deletions), 0) AS deletions,
+         count(*) AS edits,
+         count(DISTINCT fe.file_path) AS files_touched,
+         count(DISTINCT fe.session_id) AS sessions
+       ${baseSql}`,
+    );
+    const td = readRow(totalRaw[0] ?? {}, 'analytics-impact-totals');
+    const totals: ImpactTotals = {
+      additions: td.num('additions'),
+      deletions: td.num('deletions'),
+      edits: td.num('edits'),
+      filesTouched: td.num('files_touched'),
+      sessions: td.num('sessions'),
+    };
+
+    return { rows, totals };
+  });
+}

--- a/packages/server/src/routes/index.ts
+++ b/packages/server/src/routes/index.ts
@@ -15,6 +15,7 @@ import { registerAnalyticsRoute } from './analytics.js';
 import { registerSessionEfficiencyRoute } from './analytics-sessions.js';
 import { registerActivityRoute } from './analytics-activity.js';
 import { registerToolsRoute } from './analytics-tools.js';
+import { registerImpactRoute } from './analytics-impact.js';
 import { registerSourcesRoute } from './sources.js';
 import { registerMemoryRoute } from './memory.js';
 
@@ -30,6 +31,7 @@ export async function registerRoutes(app: FastifyInstance): Promise<void> {
   await registerSessionEfficiencyRoute(app);
   await registerActivityRoute(app);
   await registerToolsRoute(app);
+  await registerImpactRoute(app);
   await registerSourcesRoute(app);
   await registerMemoryRoute(app);
 

--- a/packages/server/test/file-edits.integration.test.ts
+++ b/packages/server/test/file-edits.integration.test.ts
@@ -1,0 +1,406 @@
+/**
+ * `file_edits` extraction + code-impact analytics integration tests — the
+ * bug-prone domain edges, per the repo test doctrine:
+ *
+ *  1. Fork dedup — forking a Claude session copies the whole history (uuids and
+ *     tool_use ids preserved, `forkedFrom` marker set). Both sessions' edits
+ *     land in `file_edits`, but only the ORIGINAL's rows are `edit_canonical`,
+ *     so /api/analytics/impact counts each edit once.
+ *  2. Codex apply_patch fan-out — one `custom_tool_call` touching N files fans
+ *     out to canonical Write/MultiEdit blocks per file; each must land as its
+ *     own row with exact LCS add/del counts.
+ *  3. `tool_error_count` — Claude Code counts `is_error` tool_results in SQL
+ *     (0 when none); Codex counts in TS at normalize time.
+ *  4. Incremental correctness — editing a source file re-extracts its session's
+ *     rows (clean replace, no duplicates); deleting the original re-elects the
+ *     surviving fork copy.
+ *
+ * (Junie's full-file-diff counts and NULL tool_error_count, and Copilot's
+ * denied-edit exclusion, are asserted in their own connector suites, which
+ * already carry those fixtures.)
+ */
+
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import type { FastifyInstance } from 'fastify';
+import type { DuckDBConnection } from '@duckdb/node-api';
+
+const work = mkdtempSync(join(tmpdir(), 'claudescope-fedits-'));
+const projectsDir = join(work, 'projects');
+const codexDir = join(work, 'codex');
+const junieDir = join(work, 'junie');
+const copilotDir = join(work, 'copilot');
+
+process.env.CLAUDE_PROJECTS_DIR = projectsDir;
+process.env.CODEX_SESSIONS_DIR = codexDir;
+process.env.JUNIE_SESSIONS_DIR = junieDir;
+process.env.PI_SESSIONS_DIR = join(work, 'pi-empty');
+process.env.OPENCODE_DATA_DIR = join(work, 'opencode-empty');
+process.env.COPILOT_SESSIONS_DIR = copilotDir;
+process.env.ANTIGRAVITY_CLI_DIR = join(work, 'antigravity-empty');
+process.env.ANTIGRAVITY_DIR = join(work, 'antigravity-empty-desktop');
+process.env.DUCKDB_PATH = join(work, 'index.duckdb');
+process.env.CLAUDESCOPE_HOME = join(work, 'home');
+process.env.REINDEX_INTERVAL_MS = '0';
+
+const jsonl = (events: unknown[]): string => events.map((e) => JSON.stringify(e)).join('\n') + '\n';
+const ts = (s: number) => `2026-01-01T10:00:${String(s).padStart(2, '0')}.000Z`;
+
+const CWD = '/tmp/feditsproj';
+
+/** An assistant line carrying tool_use blocks (Claude transcript shape). */
+function asst(opts: {
+  uuid: string;
+  parentUuid: string | null;
+  sessionId: string;
+  timestamp: string;
+  blocks: unknown[];
+  forkedFrom?: { sessionId: string; messageUuid: string };
+}): Record<string, unknown> {
+  const line: Record<string, unknown> = {
+    type: 'assistant',
+    uuid: opts.uuid,
+    parentUuid: opts.parentUuid,
+    sessionId: opts.sessionId,
+    timestamp: opts.timestamp,
+    cwd: CWD,
+    isSidechain: false,
+    message: { role: 'assistant', model: 'claude-opus-4-8', content: opts.blocks },
+  };
+  if (opts.forkedFrom) line.forkedFrom = opts.forkedFrom;
+  return line;
+}
+
+/** A user line whose content is tool_result blocks (or plain text). */
+function user(opts: {
+  uuid: string;
+  parentUuid: string | null;
+  sessionId: string;
+  timestamp: string;
+  content: unknown;
+  forkedFrom?: { sessionId: string; messageUuid: string };
+}): Record<string, unknown> {
+  const line: Record<string, unknown> = {
+    type: 'user',
+    uuid: opts.uuid,
+    parentUuid: opts.parentUuid,
+    sessionId: opts.sessionId,
+    timestamp: opts.timestamp,
+    cwd: CWD,
+    isSidechain: false,
+    message: { role: 'user', content: opts.content },
+  };
+  if (opts.forkedFrom) line.forkedFrom = opts.forkedFrom;
+  return line;
+}
+
+/**
+ * The original Claude session: one Edit (2 adds / 1 del), a failing Bash
+ * (is_error tool_result), and one Write (3 adds). The fork copy repeats the
+ * same lines under a new session id with `forkedFrom` markers.
+ */
+function claudeLines(sessionId: string, forkedFrom?: string): unknown[] {
+  const fork = forkedFrom
+    ? (uuid: string) => ({ forkedFrom: { sessionId: forkedFrom, messageUuid: uuid } })
+    : () => ({});
+  return [
+    user({ uuid: 'u0', parentUuid: null, sessionId, timestamp: ts(0), content: 'fix the bug', ...fork('u0') }),
+    asst({
+      uuid: 'a1', parentUuid: 'u0', sessionId, timestamp: ts(1), ...fork('a1'),
+      blocks: [
+        { type: 'tool_use', id: 'toolu_edit1', name: 'Edit', input: {
+          file_path: `${CWD}/src/app.ts`, old_string: 'one\ntwo', new_string: 'one\nTWO\nthree',
+        } },
+      ],
+    }),
+    user({
+      uuid: 'u2', parentUuid: 'a1', sessionId, timestamp: ts(2), ...fork('u2'),
+      content: [{ type: 'tool_result', tool_use_id: 'toolu_edit1', content: 'ok' }],
+    }),
+    asst({
+      uuid: 'a3', parentUuid: 'u2', sessionId, timestamp: ts(3), ...fork('a3'),
+      blocks: [{ type: 'tool_use', id: 'toolu_bash1', name: 'Bash', input: { command: 'npm test' } }],
+    }),
+    user({
+      uuid: 'u4', parentUuid: 'a3', sessionId, timestamp: ts(4), ...fork('u4'),
+      content: [{ type: 'tool_result', tool_use_id: 'toolu_bash1', content: '1 test failed', is_error: true }],
+    }),
+    asst({
+      uuid: 'a5', parentUuid: 'u4', sessionId, timestamp: ts(5), ...fork('a5'),
+      blocks: [
+        { type: 'tool_use', id: 'toolu_write1', name: 'Write', input: {
+          file_path: `${CWD}/notes.md`, content: 'alpha\nbeta\ngamma',
+        } },
+      ],
+    }),
+  ];
+}
+
+function writeFixtures(): void {
+  const proj = join(projectsDir, 'enc-fedits');
+  mkdirSync(proj, { recursive: true });
+  writeFileSync(join(proj, 'sessOrig.jsonl'), jsonl(claudeLines('sessOrig')));
+  writeFileSync(join(proj, 'sessFork.jsonl'), jsonl(claudeLines('sessFork', 'sessOrig')));
+
+  // Codex rollout: one apply_patch fanning out to TWO files (Add + Update) and
+  // a second single-file patch — per-file rows with exact counts.
+  const dir = join(codexDir, '2026', '01', '01');
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(
+    join(dir, 'rollout-2026-01-01T10-00-00-019db3da-f840-7142-a548-5bd30f5fe572.jsonl'),
+    jsonl([
+      { type: 'session_meta', timestamp: ts(0), payload: { id: 'codex-fe-1', cwd: '/tmp/codexfe', cli_version: '0.122.0', model_provider: 'openai', git: { branch: 'main' } } },
+      { type: 'turn_context', timestamp: ts(1), payload: { model: 'gpt-5.4', cwd: '/tmp/codexfe' } },
+      { type: 'response_item', timestamp: ts(2), payload: { type: 'message', role: 'user', content: [{ type: 'input_text', text: 'patch things' }] } },
+      { type: 'response_item', timestamp: ts(3), payload: { type: 'custom_tool_call', name: 'apply_patch', call_id: 'call_ap1', input: '*** Begin Patch\n*** Add File: /tmp/codexfe/notes.md\n+hello\n+world\n*** Update File: /tmp/codexfe/src/app.ts\n@@\n context line\n-old value\n+new value\n*** End Patch' } },
+      { type: 'response_item', timestamp: ts(4), payload: { type: 'custom_tool_call_output', call_id: 'call_ap1', output: 'Done!' } },
+      { type: 'response_item', timestamp: ts(5), payload: { type: 'custom_tool_call', name: 'apply_patch', call_id: 'call_ap2', input: '*** Begin Patch\n*** Update File: /tmp/codexfe/single.ts\n@@\n-a\n+b\n*** End Patch' } },
+      { type: 'response_item', timestamp: ts(6), payload: { type: 'custom_tool_call_output', call_id: 'call_ap2', output: 'Done!' } },
+      { type: 'response_item', timestamp: ts(7), payload: { type: 'message', role: 'assistant', content: [{ type: 'output_text', text: 'patched' }] } },
+    ]),
+  );
+
+  // Junie: stores the FULL before/after file per change — the extraction must
+  // record the exact one-line diff, not whole-file counts.
+  const JUNIE_ID = 'session-260101-100000-fedits';
+  const a2ux = (agentEvent: unknown, sec: number) => ({
+    kind: 'SessionA2uxEvent',
+    event: { state: 'IN_PROGRESS', agentEvent },
+    timestampMs: Date.UTC(2026, 0, 1, 10, 0, sec),
+  });
+  const before = Array.from({ length: 10 }, (_, i) => `line ${i}`).join('\n') + '\n';
+  const after = before.replace('line 5', 'line five');
+  mkdirSync(join(junieDir, JUNIE_ID), { recursive: true });
+  writeFileSync(
+    join(junieDir, 'index.jsonl'),
+    jsonl([{ sessionId: JUNIE_ID, createdAt: Date.UTC(2026, 0, 1, 10, 0, 0), updatedAt: Date.UTC(2026, 0, 1, 10, 0, 9), projectDir: '/tmp/junfe', taskName: 'edit a file' }]),
+  );
+  writeFileSync(
+    join(junieDir, JUNIE_ID, 'events.jsonl'),
+    jsonl([
+      { kind: 'UserPromptEvent', prompt: 'change line 5' },
+      a2ux({
+        kind: 'FileChangesBlockUpdatedEvent',
+        stepId: 'step-E',
+        status: 'COMPLETED',
+        changes: [{
+          beforeContent: { kind: 'TextFileContent', text: before },
+          afterContent: { kind: 'TextFileContent', text: after },
+          beforeRelativePath: 'src/big.ts',
+          afterRelativePath: 'src/big.ts',
+        }],
+      }, 3),
+      { kind: 'TaskState', state: 'COMPLETED', timestampMs: Date.UTC(2026, 0, 1, 10, 0, 9) },
+    ]),
+  );
+
+  // Copilot: a successful edit lands; a DENIED edit stays under its raw name
+  // (only-successful-edits normalization rule) and must NOT produce a row.
+  let evtId = 0;
+  const cev = (type: string, data: unknown) => ({ type, data, id: `e${evtId++}`, timestamp: ts(evtId), parentId: null });
+  mkdirSync(join(copilotDir, 'cfe'), { recursive: true });
+  writeFileSync(
+    join(copilotDir, 'cfe', 'workspace.yaml'),
+    'id: cfe\ncwd: /tmp/cpfe\nbranch: main\nname: fedits\nuser_named: false\n',
+  );
+  writeFileSync(
+    join(copilotDir, 'cfe', 'events.jsonl'),
+    jsonl([
+      cev('session.start', { sessionId: 'copilot-fe-1', context: { cwd: '/tmp/cpfe', branch: 'main' } }),
+      cev('user.message', { content: 'edit both files' }),
+      cev('assistant.message', {
+        messageId: 'm1', model: 'gpt-5-mini', content: 'editing',
+        toolRequests: [
+          { toolCallId: 'c-ok', name: 'edit', arguments: { path: '/tmp/cpfe/ok.ts', old_str: 'a', new_str: 'b' } },
+          { toolCallId: 'c-deny', name: 'edit', arguments: { path: '/tmp/cpfe/deny.ts', old_str: 'x', new_str: 'y' } },
+        ],
+      }),
+      cev('tool.execution_complete', { toolCallId: 'c-ok', success: true, result: { content: 'File ok.ts updated.' } }),
+      cev('permission.requested', { requestId: 'r1', permissionRequest: { kind: 'write', toolCallId: 'c-deny', fileName: '/tmp/cpfe/deny.ts' } }),
+      cev('permission.completed', { requestId: 'r1', toolCallId: 'c-deny', result: { kind: 'denied-interactively-by-user' } }),
+      cev('session.shutdown', { tokenDetails: { input: { tokenCount: 10 }, output: { tokenCount: 5 } } }),
+    ]),
+  );
+}
+
+let app: FastifyInstance;
+let conn: DuckDBConnection;
+let closeConnection: () => Promise<void>;
+let reindex: () => Promise<unknown>;
+let queryRows: (c: DuckDBConnection, sql: string) => Promise<Record<string, unknown>[]>;
+
+beforeAll(async () => {
+  writeFixtures();
+
+  const Fastify = (await import('fastify')).default;
+  const { registerRoutes } = await import('../src/routes/index.js');
+  ({ reindex } = await import('../src/data/index.js'));
+  const duckdb = await import('../src/db/duckdb.js');
+  ({ closeConnection, queryRows } = duckdb);
+
+  app = Fastify();
+  await registerRoutes(app);
+  await reindex();
+  await app.ready();
+  conn = await duckdb.getConnection();
+});
+
+afterAll(async () => {
+  await app?.close();
+  await closeConnection?.();
+  rmSync(work, { recursive: true, force: true });
+});
+
+const get = async (url: string) => app.inject({ method: 'GET', url });
+
+describe('file_edits extraction', () => {
+  it('fans Codex apply_patch out to per-file rows with exact LCS counts', async () => {
+    const rows = await queryRows(
+      conn,
+      `SELECT file_path, tool_name, additions, deletions FROM file_edits
+       WHERE session_id = 'codex-fe-1' ORDER BY file_path`,
+    );
+    expect(
+      rows.map((r) => [r.file_path, r.tool_name, Number(r.additions), Number(r.deletions)]),
+    ).toEqual([
+      ['/tmp/codexfe/notes.md', 'Write', 2, 0],
+      ['/tmp/codexfe/single.ts', expect.stringMatching(/Edit/), 1, 1],
+      ['/tmp/codexfe/src/app.ts', expect.stringMatching(/Edit/), 1, 1],
+    ]);
+  });
+
+  it('keeps fork copies but elects only the original session canonical', async () => {
+    const rows = await queryRows(
+      conn,
+      `SELECT session_id, file_path, edit_canonical FROM file_edits
+       WHERE session_id IN ('sessOrig', 'sessFork') ORDER BY session_id, file_path`,
+    );
+    // Both sessions carry both edits (2 each)…
+    expect(rows).toHaveLength(4);
+    // …but only the original's are canonical.
+    for (const r of rows) {
+      expect(Boolean(r.edit_canonical)).toBe(r.session_id === 'sessOrig');
+    }
+  });
+
+  it('records Junie full-file before/after as the exact diff, not whole-file counts', async () => {
+    const rows = await queryRows(
+      conn,
+      `SELECT file_path, additions, deletions FROM file_edits
+       WHERE session_id = 'session-260101-100000-fedits'`,
+    );
+    expect(rows.map((r) => [r.file_path, Number(r.additions), Number(r.deletions)])).toEqual([
+      ['src/big.ts', 1, 1], // one changed line in a 10-line file
+    ]);
+  });
+
+  it('excludes Copilot denied edits (only successful edits are canonical)', async () => {
+    const rows = await queryRows(
+      conn,
+      `SELECT file_path FROM file_edits WHERE session_id = 'copilot-fe-1'`,
+    );
+    expect(rows.map((r) => r.file_path)).toEqual(['/tmp/cpfe/ok.ts']);
+  });
+
+  it('leaves tool_error_count NULL for Junie (no error signal in the format)', async () => {
+    const rows = await queryRows(
+      conn,
+      `SELECT count(*) AS total, count(*) FILTER (WHERE tool_error_count IS NULL) AS nulls
+       FROM events WHERE session_id = 'session-260101-100000-fedits'`,
+    );
+    expect(Number(rows[0]!.total)).toBeGreaterThan(0);
+    expect(Number(rows[0]!.nulls)).toBe(Number(rows[0]!.total));
+  });
+
+  it('counts is_error tool_results for Claude (SQL) and Codex (TS) — never NULL', async () => {
+    const claude = await queryRows(
+      conn,
+      `SELECT COALESCE(sum(tool_error_count), 0) AS errs,
+              count(*) FILTER (WHERE tool_error_count IS NULL) AS nulls
+       FROM events WHERE session_id = 'sessOrig'`,
+    );
+    expect(Number(claude[0]!.errs)).toBe(1); // the failing Bash
+    expect(Number(claude[0]!.nulls)).toBe(0);
+
+    const codex = await queryRows(
+      conn,
+      `SELECT count(*) FILTER (WHERE tool_error_count IS NULL) AS nulls
+       FROM events WHERE session_id = 'codex-fe-1'`,
+    );
+    expect(Number(codex[0]!.nulls)).toBe(0);
+  });
+});
+
+describe('GET /api/analytics/impact', () => {
+  it('counts forked edits once and groups by agent', async () => {
+    const res = await get('/api/analytics/impact?groupBy=agent');
+    if (res.statusCode !== 200) console.error('impact route error:', res.body);
+    const body = res.json();
+    const claude = body.rows.find((r: { key: string }) => r.key === 'claude-code');
+    // Only sessOrig's rows count: Edit (+2/−1) + Write (+3/−0).
+    expect(claude).toMatchObject({ additions: 5, deletions: 1, edits: 2, filesTouched: 2, sessions: 1 });
+    const codex = body.rows.find((r: { key: string }) => r.key === 'codex');
+    expect(codex).toMatchObject({ additions: 4, deletions: 2, edits: 3, filesTouched: 3, sessions: 1 });
+    // claude 5/1 + codex 4/2 + junie 1/1 + copilot 1/1, forked copies excluded.
+    expect(body.totals).toMatchObject({ additions: 11, deletions: 5, edits: 7, filesTouched: 7 });
+  });
+
+  it('filters by project and groups by file and day', async () => {
+    const { projectIdFromCwd } = await import('../src/data/project-id.js');
+    const byFile = (
+      await get(`/api/analytics/impact?groupBy=file&project=${projectIdFromCwd(CWD)}`)
+    ).json();
+    expect(byFile.rows.map((r: { key: string }) => r.key).sort()).toEqual([
+      `${CWD}/notes.md`,
+      `${CWD}/src/app.ts`,
+    ]);
+
+    const byDay = (await get('/api/analytics/impact?groupBy=day')).json();
+    expect(byDay.rows).toHaveLength(1);
+    expect(byDay.rows[0]).toMatchObject({ key: '2026-01-01', additions: 11, deletions: 5 });
+  });
+});
+
+describe('incremental re-extraction', () => {
+  it('replaces a changed session cleanly and re-elects after the original is deleted', async () => {
+    // Append another Write to the FORK file: its session re-extracts (no dupes),
+    // and the new (un-forked) edit is canonical because only the fork has it.
+    const proj = join(projectsDir, 'enc-fedits');
+    const extra = asst({
+      uuid: 'a9', parentUuid: 'a5', sessionId: 'sessFork', timestamp: ts(9),
+      blocks: [
+        { type: 'tool_use', id: 'toolu_write9', name: 'Write', input: {
+          file_path: `${CWD}/fresh.ts`, content: 'x',
+        } },
+      ],
+    });
+    writeFileSync(
+      join(proj, 'sessFork.jsonl'),
+      jsonl([...claudeLines('sessFork', 'sessOrig'), extra]),
+    );
+    await reindex();
+
+    const fork = await queryRows(
+      conn,
+      `SELECT file_path, edit_canonical FROM file_edits WHERE session_id = 'sessFork' ORDER BY file_path`,
+    );
+    expect(fork).toHaveLength(3); // clean replace: 2 copied + 1 new, no dupes
+    expect(fork.filter((r) => Boolean(r.edit_canonical)).map((r) => r.file_path)).toEqual([
+      `${CWD}/fresh.ts`,
+    ]);
+
+    // Delete the original file: the fork's copies must be re-elected canonical
+    // (the impact numbers re-attach to the surviving session).
+    rmSync(join(proj, 'sessOrig.jsonl'));
+    await reindex();
+    const after = await queryRows(
+      conn,
+      `SELECT session_id, count(*) FILTER (WHERE edit_canonical) AS canon
+       FROM file_edits GROUP BY session_id ORDER BY session_id`,
+    );
+    expect(after.find((r) => r.session_id === 'sessOrig')).toBeUndefined();
+    expect(Number(after.find((r) => r.session_id === 'sessFork')?.canon)).toBe(3);
+  });
+});

--- a/packages/shared/src/api.ts
+++ b/packages/shared/src/api.ts
@@ -366,6 +366,38 @@ export interface AnalyticsResponse {
   totals: AnalyticsTotals;
 }
 
+export type ImpactGroupBy = 'agent' | 'day' | 'file';
+
+/**
+ * One code-impact aggregation row: agent-reported churn from canonical
+ * Edit/MultiEdit/Write tool calls (deduped across fork copies at index time).
+ * NOT git truth — reverted/overwritten edits count each time they were made.
+ */
+export interface ImpactRow {
+  /** The group key value (connector id, YYYY-MM-DD day, or file path). */
+  key: string;
+  additions: number;
+  deletions: number;
+  /** Edit-bearing tool calls in the group. */
+  edits: number;
+  filesTouched: number;
+  sessions: number;
+}
+
+export interface ImpactTotals {
+  additions: number;
+  deletions: number;
+  edits: number;
+  filesTouched: number;
+  sessions: number;
+}
+
+/** GET /api/analytics/impact */
+export interface ImpactResponse {
+  rows: ImpactRow[];
+  totals: ImpactTotals;
+}
+
 /** POST /api/reindex */
 export interface ReindexResponse {
   reindexed: number;

--- a/packages/shared/src/changeset.ts
+++ b/packages/shared/src/changeset.ts
@@ -1,0 +1,119 @@
+/**
+ * Derive a session "changeset" — every file the agent touched via Edit /
+ * MultiEdit / Write. Pure (no React/DOM/DB), shared by the web Files-changed
+ * tab (grouped by path) and the server's index-time `file_edits` extraction
+ * (one record per edit-bearing tool call).
+ */
+
+import type { SubagentRun, ThreadItem } from './thread.js';
+import { diffStats, extOf, lineDiff } from './diff.js';
+
+export interface FileEdit {
+  oldText: string;
+  newText: string;
+}
+
+export interface FileChange {
+  path: string;
+  lang?: string;
+  edits: FileEdit[];
+}
+
+/**
+ * One edit-bearing tool call (canonical `Edit`/`MultiEdit`/`Write`) with its
+ * addressing metadata, so index-time extraction can key rows by
+ * `(uuid, tool_use_id)` for fork dedup. `edits` holds one pair for
+ * Edit/Write and one per inner edit for MultiEdit.
+ */
+export interface EditToolCall {
+  path: string;
+  toolName: string;
+  /** uuid of the thread item carrying the tool_use block. */
+  uuid: string;
+  /** The tool_use block id ('' when the format carries none). */
+  toolUseId: string;
+  timestamp: string;
+  isSidechain: boolean;
+  edits: FileEdit[];
+}
+
+/** Added/removed line counts for a file's edits. Computed lazily (runs lineDiff). */
+export function fileStats(edits: FileEdit[]): { additions: number; deletions: number } {
+  let additions = 0;
+  let deletions = 0;
+  for (const e of edits) {
+    const s = diffStats(lineDiff(e.oldText, e.newText));
+    additions += s.additions;
+    deletions += s.deletions;
+  }
+  return { additions, deletions };
+}
+
+const str = (v: unknown): string => (typeof v === 'string' ? v : '');
+
+function collect(thread: ThreadItem[], sidechain: boolean, out: EditToolCall[]): void {
+  for (const turn of thread) {
+    for (const block of turn.blocks) {
+      if (block.kind !== 'tool') continue;
+      const input = (block.input ?? {}) as Record<string, unknown>;
+      const path = typeof input.file_path === 'string' ? input.file_path : '';
+      if (!path) continue;
+
+      let edits: FileEdit[] | null = null;
+      if (block.name === 'Edit') {
+        edits = [{ oldText: str(input.old_string), newText: str(input.new_string) }];
+      } else if (block.name === 'MultiEdit') {
+        const list = Array.isArray(input.edits) ? input.edits : [];
+        edits = list.map((e) => {
+          const er = (e ?? {}) as Record<string, unknown>;
+          return { oldText: str(er.old_string), newText: str(er.new_string) };
+        });
+      } else if (block.name === 'Write') {
+        edits = [{ oldText: '', newText: str(input.content) }];
+      }
+      if (!edits) continue;
+
+      out.push({
+        path,
+        toolName: block.name,
+        uuid: turn.uuid,
+        toolUseId: block.id ?? '',
+        timestamp: turn.timestamp,
+        isSidechain: sidechain || turn.isSidechain,
+        edits,
+      });
+    }
+  }
+}
+
+/**
+ * Every edit-bearing tool call in a session (main thread first, then each
+ * subagent run), in document order.
+ */
+export function collectEditCalls(thread: ThreadItem[], subagents: SubagentRun[]): EditToolCall[] {
+  const out: EditToolCall[] = [];
+  collect(thread, false, out);
+  for (const run of subagents) collect(run.thread, true, out);
+  return out;
+}
+
+/**
+ * Build the changeset for a session (main thread + subagents), in the order
+ * files were first touched. Cheap: only groups edits by file — line-level
+ * add/remove stats are computed lazily per file via {@link fileStats}.
+ */
+export function buildChangeset(thread: ThreadItem[], subagents: SubagentRun[]): FileChange[] {
+  const byPath = new Map<string, FileEdit[]>();
+  for (const call of collectEditCalls(thread, subagents)) {
+    const list = byPath.get(call.path) ?? [];
+    list.push(...call.edits);
+    byPath.set(call.path, list);
+  }
+
+  const changes: FileChange[] = [];
+  for (const [path, edits] of byPath) {
+    const lang = extOf(path);
+    changes.push({ path, edits, ...(lang ? { lang } : {}) });
+  }
+  return changes;
+}

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -8,3 +8,4 @@ export * from './categories.js';
 export * from './diff.js';
 export * from './redact.js';
 export * from './markdown.js';
+export * from './changeset.js';

--- a/packages/shared/test/changeset.test.ts
+++ b/packages/shared/test/changeset.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import type { SubagentRun, ThreadItem } from '@claudescope/shared';
-import { buildChangeset, fileStats } from '../src/pages/session/changeset.js';
+import { buildChangeset, collectEditCalls, fileStats } from '../src/changeset.js';
 
 function turn(blocks: ThreadItem['blocks']): ThreadItem {
   return { uuid: 'u', parentUuid: null, role: 'assistant', timestamp: 't', isSidechain: false, blocks };
@@ -51,5 +51,39 @@ describe('buildChangeset', () => {
   it('ignores non-file tools and returns empty when nothing changed', () => {
     const thread = [turn([tool('Bash', { command: 'ls' }), tool('Read', { file_path: 'x.ts' })])];
     expect(buildChangeset(thread, [])).toEqual([]);
+  });
+});
+
+describe('collectEditCalls', () => {
+  it('keys each edit-bearing call by (uuid, toolUseId) and flags subagent edits', () => {
+    const main: ThreadItem[] = [
+      {
+        uuid: 'u1', parentUuid: null, role: 'assistant', timestamp: '2026-01-01T00:00:00Z',
+        isSidechain: false,
+        blocks: [
+          { kind: 'tool', id: 'call_1', name: 'MultiEdit', input: {
+            file_path: 'src/a.ts',
+            edits: [
+              { old_string: 'a', new_string: 'b' },
+              { old_string: 'c', new_string: 'd' },
+            ],
+          } },
+        ],
+      },
+    ];
+    const sub: SubagentRun = {
+      agentId: 's1', agentType: 'Explore', description: 'd',
+      messageCount: 1, toolCallCount: 1, totalTokens: 0,
+      thread: [turn([tool('Write', { file_path: 'sub/c.py', content: 'print(1)' })])],
+    };
+    const calls = collectEditCalls(main, [sub]);
+    expect(calls).toHaveLength(2);
+    expect(calls[0]).toMatchObject({
+      path: 'src/a.ts', toolName: 'MultiEdit', uuid: 'u1', toolUseId: 'call_1',
+      isSidechain: false,
+    });
+    // One call, two inner edits — not two calls.
+    expect(calls[0]!.edits).toHaveLength(2);
+    expect(calls[1]).toMatchObject({ path: 'sub/c.py', toolName: 'Write', isSidechain: true });
   });
 });

--- a/packages/web/src/pages/session/changeset.ts
+++ b/packages/web/src/pages/session/changeset.ts
@@ -1,82 +1,8 @@
 /**
- * Derive a session "changeset" — every file the agent touched via Edit /
- * MultiEdit / Write, grouped by path, with added/removed line counts. Pure
- * (no React/DOM), so it's unit-testable.
+ * Session changeset derivation re-exported from the shared package (it moved
+ * there so the server can extract `file_edits` rows at index time from the
+ * same collector the Files-changed tab renders).
  */
 
-import type { SubagentRun, ThreadItem } from '@claudescope/shared';
-import { diffStats, extOf, lineDiff } from '../../components/diff.js';
-
-export interface FileEdit {
-  oldText: string;
-  newText: string;
-}
-
-export interface FileChange {
-  path: string;
-  lang?: string;
-  edits: FileEdit[];
-}
-
-/** Added/removed line counts for a file's edits. Computed lazily (runs lineDiff). */
-export function fileStats(edits: FileEdit[]): { additions: number; deletions: number } {
-  let additions = 0;
-  let deletions = 0;
-  for (const e of edits) {
-    const s = diffStats(lineDiff(e.oldText, e.newText));
-    additions += s.additions;
-    deletions += s.deletions;
-  }
-  return { additions, deletions };
-}
-
-const str = (v: unknown): string => (typeof v === 'string' ? v : '');
-
-function collect(thread: ThreadItem[], byPath: Map<string, FileEdit[]>): void {
-  for (const turn of thread) {
-    for (const block of turn.blocks) {
-      if (block.kind !== 'tool') continue;
-      const input = (block.input ?? {}) as Record<string, unknown>;
-      const path = typeof input.file_path === 'string' ? input.file_path : '';
-      if (!path) continue;
-
-      const push = (edits: FileEdit[]) => {
-        const list = byPath.get(path) ?? [];
-        list.push(...edits);
-        byPath.set(path, list);
-      };
-
-      if (block.name === 'Edit') {
-        push([{ oldText: str(input.old_string), newText: str(input.new_string) }]);
-      } else if (block.name === 'MultiEdit') {
-        const edits = Array.isArray(input.edits) ? input.edits : [];
-        push(
-          edits.map((e) => {
-            const er = (e ?? {}) as Record<string, unknown>;
-            return { oldText: str(er.old_string), newText: str(er.new_string) };
-          }),
-        );
-      } else if (block.name === 'Write') {
-        push([{ oldText: '', newText: str(input.content) }]);
-      }
-    }
-  }
-}
-
-/**
- * Build the changeset for a session (main thread + subagents), in the order
- * files were first touched. Cheap: only groups edits by file — line-level
- * add/remove stats are computed lazily per file via {@link fileStats}.
- */
-export function buildChangeset(thread: ThreadItem[], subagents: SubagentRun[]): FileChange[] {
-  const byPath = new Map<string, FileEdit[]>();
-  collect(thread, byPath);
-  for (const run of subagents) collect(run.thread, byPath);
-
-  const changes: FileChange[] = [];
-  for (const [path, edits] of byPath) {
-    const lang = extOf(path);
-    changes.push({ path, edits, ...(lang ? { lang } : {}) });
-  }
-  return changes;
-}
+export { buildChangeset, fileStats } from '@claudescope/shared';
+export type { FileChange, FileEdit } from '@claudescope/shared';


### PR DESCRIPTION
## Summary

Roadmap slice 5 of [0035](https://github.com/vladar107/claudescope/blob/main/docs/plans/0035-agent-access-and-analytics-roadmap.md) — the single v10 index bump carrying all Track B schema changes (one rebuild for users). **Stacked on #48** (uses its shared LCS diff hoist); retargets when #48 merges.

- **`file_edits` table**: one row per canonical Edit/MultiEdit/Write call (file, +/− LOC via exact line diff, sidechain flag), extracted at index time by reusing the session-view path (`loadSessionData` → thread → shared changeset collector) — so apply_patch fan-out (Codex/opencode), Copilot's only-successful-edits rule, and Junie's full-file before/after all hold for free. Sessions pre-filtered by `tool_names` so edit-free sessions never parse. Fork/resume copies deduped via `edit_canonical` election per `(uuid, tool_use_id, file_path)`, mirroring `electCanonicalUsage` (re-elects when the original is deleted).
- **`events.tool_error_count`** (nullable): failed tool calls per canonical row — SQL expr for Claude Code, TS-counted in the six normalizers. **NULL where the format carries no error signal** (Junie, Antigravity), keeping "no errors" and "can't know" distinct. Copilot permission-denials count as errors for now (split deferred to slice 6).
- **`GET /api/analytics/impact?groupBy=agent|day|file&project=&from=&to=`** — LOC added/removed, files touched, edit counts; fair across all 7 agents (unlike token metrics). No UI in this slice — slices 6–7 consume it. Metric is agent-reported churn, not git truth (documented).
- Changeset collector hoisted from web into `packages/shared`; web re-imports, behavior unchanged.

Perf (`npm run bench`): cold index at parity or slightly better than base (859–863ms vs 882–922ms in the interleaved A/B; corroborated by an independent run — a naive correlated-subquery draft regressed ~20% and was replaced by a LATERAL fold before landing). No-op and single-file reindex unchanged.

## Testing
`npm test` 344/344 — new integration suite covers the domain edges: apply_patch fan-out lands per-file rows, Copilot denied edits excluded, Junie full-file diff yields exact counts (no whole-file overcounts), fork copies don't double-count, NULL-vs-counted error semantics, incremental re-extraction and re-election after source deletion. `npm run typecheck` clean.

Plan: docs/plans/0039-file-edits-index.md