### PR TITLE
feat(analytics): error/interrupt view + week-in-review digest (page, copy-md, CLI)

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,6 +203,7 @@ claudescope search "duckdb lock" --limit 5      # where did I hit this before?
 claudescope sessions --agent codex --sort cost  # priciest Codex sessions
 claudescope session <id> --around <uuid>        # open a search hit, windowed
 claudescope analytics --group-by day --json | jq '.rows[] | [.key, .costUsd]'
+claudescope digest --from 2026-06-23 --to 2026-06-29   # week in review, as Markdown
 ```
 
 `session` prints a pageable window of turns as Markdown (`--offset/--limit`,

--- a/docs/plans/0041-error-interrupt-analytics.md
+++ b/docs/plans/0041-error-interrupt-analytics.md
@@ -1,0 +1,78 @@
+# 0041 — Error & interrupt analytics
+
+- **Status:** in-progress
+- **Date:** 2026-07-03
+- **PR:** <link, once opened>
+
+## Context
+
+Roadmap 0035, slice 6 (B3 UI). The v10 index (plan 0039) projected
+`events.tool_error_count` but nothing surfaced it, and user interrupts were
+sitting unqueried in `events.text_content`. This slice adds the read layer:
+a per-agent errors/interrupts route and an Analytics view, with the same
+null-not-zero availability contract the cross-agent comparison (plan 0037)
+established.
+
+## Goal
+
+An Analytics → Errors view answering "how often do tool calls fail per agent,
+and how often do I interrupt Claude?" — honest about which agents can't report
+either signal.
+
+## Decisions
+
+- **Errors sum over whichever rows carry the tool_result** — for Claude
+  Code/Codex the `is_error` flag lives on user rows, so the aggregation must
+  not filter on `type = 'assistant'` (tool *calls* do, matching the tools
+  breakdown). Fork copies of result rows all have NULL message ids (every one
+  is `usage_canonical`), so fork copies are excluded by
+  `forked_from_session_id IS NULL` instead; if the original file is later
+  deleted the surviving copy goes uncounted — accepted edge, same as the
+  interrupt count.
+- **Interrupt marker is prefix-anchored** — verified against real transcripts:
+  Claude Code stores `[Request interrupted by user]` /
+  `[Request interrupted by user for tool use]` as the user-message text. A
+  prefix LIKE counts those without false-positiving on messages that *quote*
+  the marker mid-text. Same sidechain/fork exclusions as the activity
+  punchcard. Claude-Code-only → null for every other agent.
+- **`errorSignalsByAgent` is exported** for the digest (slice 7) to reuse —
+  one aggregation, two consumers.
+- **NULL stays NULL** — Junie/Antigravity formats carry no error signal;
+  DuckDB `SUM` of all-NULL groups stays NULL and the route passes it through
+  as `toolErrors: null` with an `availabilityNote`. Copilot's
+  permission-denials counting as errors is carried forward as an open question
+  from plan 0039 (noted per-row).
+
+## Approach
+
+1. `packages/server/src/routes/analytics-errors.ts` — `errorSignalsByAgent`
+   (scoped sessions CTE → per-agent sums) + `GET /api/analytics/errors`
+   shaping n/a semantics; registered in `routes/index.ts`.
+2. Shared types `ErrorAnalyticsRow`/`ErrorAnalyticsResponse` in
+   `packages/shared/src/api.ts`.
+3. Web: `ErrorsTable.tsx` (efficiency-table classes, n/a cells with tooltips),
+   an `errors` view + project scope select in `AnalyticsPage.tsx`, `.tv-na` /
+   `.tv-analytics__select` styles. (Both also land on the sibling PR #49 —
+   dedupe at rebase.)
+
+## Files affected
+
+- `packages/server/src/routes/analytics-errors.ts` (new), `routes/index.ts`
+- `packages/shared/src/api.ts`
+- `packages/web/src/pages/analytics/ErrorsTable.tsx` (new),
+  `AnalyticsPage.tsx`, `analytics.css`, `packages/web/src/api/client.ts`
+- `packages/server/test/analytics-errors.integration.test.ts` (new)
+
+## Testing
+
+Integration suite over synthetic fixtures: Claude Code `is_error` counted with
+a real rate (and a real 0 stays 0), Junie `toolErrors: null` (never 0),
+genuine interrupt counted while a mid-text quote of the marker is not,
+project-slug scoping. `npm test` + `npm run typecheck` green.
+
+## Risks / open questions
+
+- Copilot permission-denials count as errors — split "denied" from "failed"
+  when a consumer needs it (carried from plan 0039).
+- Interrupt detection depends on Claude Code's marker text; a upstream wording
+  change would silently zero the metric (the fixture pins today's wording).

--- a/docs/plans/0041-error-interrupt-analytics.md
+++ b/docs/plans/0041-error-interrupt-analytics.md
@@ -1,8 +1,8 @@
 # 0041 — Error & interrupt analytics
 
-- **Status:** in-progress
+- **Status:** done
 - **Date:** 2026-07-03
-- **PR:** <link, once opened>
+- **PR:** [#53](https://github.com/vladar107/claudescope/pull/53)
 
 ## Context
 

--- a/docs/plans/0042-digest.md
+++ b/docs/plans/0042-digest.md
@@ -1,0 +1,78 @@
+# 0042 — Week-in-review digest (page + copy-as-Markdown + CLI)
+
+- **Status:** done
+- **Date:** 2026-07-03
+- **PR:** [#53](https://github.com/vladar107/claudescope/pull/53)
+
+## Context
+
+Roadmap 0035, slice 7 (B4) — the composition layer built last, on purpose:
+it rolls up what slices 1–6 produced (session aggregates, `file_edits` churn,
+the shared error/interrupt aggregation, streaks) into one "what happened this
+week" answer, in three shapes: an Analytics view, a copyable Markdown
+document, and a `claudescope digest` CLI command.
+
+## Goal
+
+`GET /api/analytics/digest?from=&to=` (default: last 7 days) plus an
+Analytics → Digest view with range presets and "Copy as Markdown", plus
+`claudescope digest [--from] [--to] [--json]` — where the CLI's human output
+and the web copy button emit the **same** Markdown document.
+
+## Decisions
+
+- **Renderer lives in `packages/shared` (`digest-markdown.ts`)** — the web
+  can't import from the server package, and the CLI shouldn't duplicate the
+  document; shared is the only seam both reach (the `shape.ts` helpers stay
+  server-side because only agent-facing consumers use them).
+- **No schema; session-atomic composition** — every sub-query hangs off one
+  scoped-sessions CTE (range on `started_at`), consistent with
+  /api/analytics/sessions and the errors route. Token/cost totals are
+  session-level sums (already usage-deduped), which naturally cover only
+  usage-reporting agents.
+- **Reliability reuses `errorSignalsByAgent`** (plan 0041) — agents whose
+  formats carry no error signal are *listed* (`unknownAgents`), never
+  zero-counted; `interrupts` is null when no Claude Code sessions are in range.
+- **Streak is all-time (UTC days) as of the range end** — momentum, not a
+  range-bound stat; reuses `computeStreaks`. UTC (not client-local like the
+  activity punchcard) keeps the CLI and web consistent without threading an
+  offset through both.
+- **Presets set the page's shared from/to inputs** — one source of truth for
+  the range instead of a digest-private range state.
+
+## Approach
+
+1. Shared: `DigestResponse` types + `digestToMarkdown` renderer.
+2. Server: `routes/analytics-digest.ts` composing totals, top projects, model
+   mix, tool mix, per-agent sessions, biggest session, streak, `file_edits`
+   impact, reliability; registered in `routes/index.ts`.
+3. Web: `DigestView.tsx` (presets, stat cards, lists, copy button) + a
+   `digest` view in `AnalyticsPage.tsx`.
+4. CLI: `ApiClient.digest`, `queryDigest` (human output = the shared
+   renderer), `digest` case + help in `cli.ts`, README example.
+
+## Files affected
+
+- `packages/shared/src/api.ts`, `digest-markdown.ts` (new), `src/index.ts`
+- `packages/server/src/routes/analytics-digest.ts` (new), `routes/index.ts`,
+  `src/agent/api-client.ts`, `src/agent/query.ts`, `src/cli.ts`
+- `packages/web/src/pages/analytics/DigestView.tsx` (new),
+  `AnalyticsPage.tsx`, `analytics.css`, `src/api/client.ts`
+- `packages/server/test/analytics-digest.integration.test.ts` (new),
+  `packages/shared/test/digest-markdown.test.ts` (new), `README.md`
+
+## Testing
+
+Integration: totals compose across a usage-reporting and a no-signal agent
+without zeroing; code impact from canonical `file_edits`; empty range → zero
+totals, empty lists, null biggest session, no NaNs. Renderer: n/a error rate,
+no-signal note, empty-section omission, empty-range document. `npm test` +
+`npm run typecheck` green.
+
+## Risks / open questions
+
+- The digest's default range uses the server clock (UTC); a CLI run just after
+  midnight local may bound the week differently than the web presets (which
+  are local) — acceptable for a summary, revisit if it confuses.
+- Churn numbers are agent-reported (plan 0039 caveat), restated in the UI hint
+  and the Markdown footer line.

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -64,4 +64,5 @@ decision, or a change worth explaining before doing. Skip it for one-line fixes.
 | 0038 | [`claudescope mcp`: agent-facing MCP server](./0038-mcp-server.md) | done |
 | 0039 | [Code-impact index: file_edits + tool_error_count (schema v10)](./0039-file-edits-index.md) | done |
 | 0040 | [CLI query subcommands (search/sessions/session/projects/analytics)](./0040-cli-query-subcommands.md) | done |
-| 0041 | [Error & interrupt analytics](./0041-error-interrupt-analytics.md) | in-progress |
+| 0041 | [Error & interrupt analytics](./0041-error-interrupt-analytics.md) | done |
+| 0042 | [Week-in-review digest (page + copy-md + CLI)](./0042-digest.md) | done |

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -64,3 +64,4 @@ decision, or a change worth explaining before doing. Skip it for one-line fixes.
 | 0038 | [`claudescope mcp`: agent-facing MCP server](./0038-mcp-server.md) | done |
 | 0039 | [Code-impact index: file_edits + tool_error_count (schema v10)](./0039-file-edits-index.md) | done |
 | 0040 | [CLI query subcommands (search/sessions/session/projects/analytics)](./0040-cli-query-subcommands.md) | done |
+| 0041 | [Error & interrupt analytics](./0041-error-interrupt-analytics.md) | in-progress |

--- a/packages/server/src/agent/api-client.ts
+++ b/packages/server/src/agent/api-client.ts
@@ -10,6 +10,7 @@
 import type {
   AnalyticsGroupBy,
   AnalyticsResponse,
+  DigestResponse,
   HealthResponse,
   MemoryResponse,
   ProjectMemoryResponse,
@@ -68,5 +69,9 @@ export class ApiClient {
 
   analytics(q: { groupBy: AnalyticsGroupBy; from?: string; to?: string }): Promise<AnalyticsResponse> {
     return this.get('/api/analytics', q);
+  }
+
+  digest(q: { from?: string; to?: string } = {}): Promise<DigestResponse> {
+    return this.get('/api/analytics/digest', q);
   }
 }

--- a/packages/server/src/agent/query.ts
+++ b/packages/server/src/agent/query.ts
@@ -9,6 +9,7 @@
  */
 
 import type { AnalyticsGroupBy, SearchScope, SearchType, SessionSort } from '@claudescope/shared';
+import { digestToMarkdown } from '@claudescope/shared';
 import type { ApiClient } from './api-client.js';
 import {
   DEFAULT_LIMIT,
@@ -164,4 +165,18 @@ export async function queryAnalytics(client: ApiClient, args: AnalyticsArgs): Pr
     `\n\nTotal: ${fmtTokens(t.totalTokens)} tok · ${fmtCost(t.costUsd)} · ${t.messageCount} responses · ` +
     `cache hit ${(t.cacheHitRatio * 100).toFixed(0)}%`
   );
+}
+
+export interface DigestArgs {
+  from?: string;
+  to?: string;
+  json?: boolean;
+}
+
+/** Week-in-review digest — the human output IS the shared Markdown renderer,
+ *  so the CLI prints exactly what the web "Copy as Markdown" button copies. */
+export async function queryDigest(client: ApiClient, args: DigestArgs): Promise<string> {
+  const res = await client.digest({ from: args.from, to: args.to });
+  if (args.json) return json(res);
+  return digestToMarkdown(res).trimEnd();
 }

--- a/packages/server/src/cli.ts
+++ b/packages/server/src/cli.ts
@@ -40,6 +40,7 @@ import { runMcpServer } from './agent/mcp.js';
 import { ApiClient } from './agent/api-client.js';
 import {
   queryAnalytics,
+  queryDigest,
   queryProjects,
   querySearch,
   querySession,
@@ -393,6 +394,7 @@ Query commands (read-only; start the background server on first use):
                    [--max-tool-chars N] [--redact]
   projects         List projects
   analytics        Token/cost aggregates [--group-by project|model|day|agent] [--from date] [--to date]
+  digest           Week-in-review Markdown [--from date] [--to date] (default: last 7 days)
   All query commands accept --json for the raw API response (ignores --redact).
 
 Options:
@@ -513,6 +515,12 @@ async function main(): Promise<void> {
       break;
     case 'projects':
       await runQuery(() => (client) => queryProjects(client, { json: values.json }));
+      break;
+    case 'digest':
+      await runQuery(() => {
+        const args = { from: values.from, to: values.to, json: values.json };
+        return (client) => queryDigest(client, args);
+      });
       break;
     case 'analytics':
       await runQuery(() => {

--- a/packages/server/src/routes/analytics-digest.ts
+++ b/packages/server/src/routes/analytics-digest.ts
@@ -1,0 +1,237 @@
+/**
+ * GET /api/analytics/digest — a composed "week in review" over the sessions in
+ * range (default: the last 7 days ending now). No schema of its own: it rolls
+ * up the sessions/events/file_edits tables plus the shared error aggregation
+ * (`errorSignalsByAgent`) and the streak helper (`computeStreaks`).
+ *
+ * Semantics, consistent with the rest of analytics:
+ *  - Session-atomic range: a session belongs to the range its START falls in;
+ *    all of its events/edits count with it.
+ *  - Token/cost sums are session-level (already usage-deduped at derivation) —
+ *    they naturally cover only agents that report usage.
+ *  - Code impact reads canonical `file_edits` rows (fork-deduped at index time).
+ *  - The streak is all-time (UTC days) as of the range end — momentum, not a
+ *    range-bound stat.
+ */
+
+import type { FastifyInstance } from 'fastify';
+import type {
+  DigestCountRow,
+  DigestErrors,
+  DigestProjectRow,
+  DigestResponse,
+} from '@claudescope/shared';
+import { getConnection, queryRows, sqlString } from '../db/duckdb.js';
+import { readRow } from '../db/row.js';
+import { projectIdFromCwd } from '../data/project-id.js';
+import { errorSignalsByAgent } from './analytics-errors.js';
+import { computeStreaks } from './analytics-activity.js';
+
+const TOP_LIMIT = 5;
+
+/** Default range: the last 7 UTC days ending now. */
+function defaultRange(): { from: string; to: string } {
+  const now = new Date();
+  const fromDay = new Date(now.getTime() - 6 * 86_400_000).toISOString().slice(0, 10);
+  return { from: `${fromDay}T00:00:00.000Z`, to: now.toISOString() };
+}
+
+export async function registerDigestRoute(app: FastifyInstance): Promise<void> {
+  app.get<{
+    Querystring: { from?: string; to?: string };
+  }>('/api/analytics/digest', async (req): Promise<DigestResponse> => {
+    const conn = await getConnection();
+    const range = defaultRange();
+    const from = req.query.from || range.from;
+    const to = req.query.to || range.to;
+
+    const where = `WHERE started_at >= ${sqlString(from)}::TIMESTAMP AND started_at <= ${sqlString(to)}::TIMESTAMP`;
+    const scopedCte = `WITH scoped AS (SELECT * FROM sessions ${where})`;
+
+    // Totals — session-level sums, plus canonical assistant responses.
+    const totalsRaw = await queryRows(
+      conn,
+      `${scopedCte}
+       SELECT count(*) AS sessions,
+              count(DISTINCT project_cwd) AS projects,
+              COALESCE(sum(total_tokens), 0) AS tokens,
+              COALESCE(sum(total_cost_usd), 0) AS cost
+       FROM scoped`,
+    );
+    const td = readRow(totalsRaw[0] ?? {}, 'digest-totals');
+    const sessions = td.num('sessions');
+
+    const responsesRaw = await queryRows(
+      conn,
+      `${scopedCte}
+       SELECT count(*) AS responses
+       FROM events e JOIN scoped s ON e.session_id = s.id
+       WHERE e.type = 'assistant' AND e.usage_canonical`,
+    );
+
+    // Top projects by cost.
+    const projectsRaw = await queryRows(
+      conn,
+      `${scopedCte}
+       SELECT COALESCE(project_cwd, '') AS cwd, count(*) AS sessions,
+              COALESCE(sum(total_tokens), 0) AS tokens, COALESCE(sum(total_cost_usd), 0) AS cost
+       FROM scoped
+       GROUP BY COALESCE(project_cwd, '')
+       ORDER BY cost DESC, sessions DESC
+       LIMIT ${TOP_LIMIT}`,
+    );
+    const topProjects: DigestProjectRow[] = projectsRaw.map((r) => {
+      const rd = readRow(r, 'digest-projects');
+      const cwd = rd.str('cwd');
+      return {
+        projectId: cwd ? projectIdFromCwd(cwd) : '',
+        cwd,
+        sessions: rd.num('sessions'),
+        totalTokens: rd.num('tokens'),
+        costUsd: rd.num('cost'),
+      };
+    });
+
+    const countRows = async (sql: string, ctx: string): Promise<DigestCountRow[]> =>
+      (await queryRows(conn, sql)).map((r) => {
+        const rd = readRow(r, ctx);
+        return { key: rd.str('key', 'unknown'), count: rd.num('count') };
+      });
+
+    // Model mix (canonical assistant responses per model).
+    const models = await countRows(
+      `${scopedCte}
+       SELECT COALESCE(e.model, 'unknown') AS key, count(*) AS count
+       FROM events e JOIN scoped s ON e.session_id = s.id
+       WHERE e.type = 'assistant' AND e.usage_canonical
+       GROUP BY key ORDER BY count DESC, key LIMIT ${TOP_LIMIT}`,
+      'digest-models',
+    );
+
+    // Tool mix (unnest the CSV, same semantics as /api/analytics/tools).
+    const topTools = await countRows(
+      `${scopedCte}
+       SELECT tool AS key, count(*) AS count
+       FROM (
+         SELECT unnest(string_split(e.tool_names, ',')) AS tool
+         FROM events e JOIN scoped s ON e.session_id = s.id
+         WHERE e.type = 'assistant' AND e.usage_canonical AND e.tool_names <> ''
+       ) t
+       WHERE tool <> ''
+       GROUP BY tool ORDER BY count DESC, tool LIMIT ${TOP_LIMIT}`,
+      'digest-tools',
+    );
+
+    // Sessions per agent.
+    const agents = await countRows(
+      `${scopedCte}
+       SELECT COALESCE(connector_id, 'unknown') AS key, count(*) AS count
+       FROM scoped GROUP BY key ORDER BY count DESC, key`,
+      'digest-agents',
+    );
+
+    // Biggest session by cost (tokens as tiebreak, e.g. a zero-cost corpus).
+    const biggestRaw = await queryRows(
+      conn,
+      `${scopedCte}
+       SELECT id, title, connector_id, total_cost_usd, total_tokens
+       FROM scoped ORDER BY total_cost_usd DESC, total_tokens DESC LIMIT 1`,
+    );
+    const biggestSession = biggestRaw.length
+      ? (() => {
+          const rd = readRow(biggestRaw[0] as Record<string, unknown>, 'digest-biggest');
+          return {
+            id: rd.str('id'),
+            title: rd.str('title'),
+            connectorId: rd.str('connector_id', 'unknown'),
+            costUsd: rd.num('total_cost_usd'),
+            totalTokens: rd.num('total_tokens'),
+          };
+        })()
+      : null;
+
+    // All-time prompt streak (UTC days) as of the range end.
+    const dayRows = await queryRows(
+      conn,
+      `SELECT DISTINCT strftime(e.ts, '%Y-%m-%d') AS day
+       FROM events e
+       WHERE e.type = 'user' AND NOT e.is_sidechain AND e.forked_from_session_id IS NULL`,
+    );
+    const streak = computeStreaks(
+      dayRows.map((r) => readRow(r, 'digest-days').str('day')).filter(Boolean),
+      to.slice(0, 10),
+    );
+
+    // Code impact over canonical file_edits (session-atomic, like everything else).
+    const impactTotalsRaw = await queryRows(
+      conn,
+      `${scopedCte}
+       SELECT COALESCE(sum(fe.additions), 0) AS additions, COALESCE(sum(fe.deletions), 0) AS deletions,
+              count(*) AS edits, count(DISTINCT fe.file_path) AS files_touched
+       FROM file_edits fe JOIN scoped s ON s.id = fe.session_id
+       WHERE fe.edit_canonical`,
+    );
+    const impactFilesRaw = await queryRows(
+      conn,
+      `${scopedCte}
+       SELECT fe.file_path AS path, sum(fe.additions) AS additions, sum(fe.deletions) AS deletions
+       FROM file_edits fe JOIN scoped s ON s.id = fe.session_id
+       WHERE fe.edit_canonical
+       GROUP BY fe.file_path
+       ORDER BY sum(fe.additions) + sum(fe.deletions) DESC, fe.file_path
+       LIMIT ${TOP_LIMIT}`,
+    );
+    const imd = readRow(impactTotalsRaw[0] ?? {}, 'digest-impact');
+    const impact = {
+      additions: imd.num('additions'),
+      deletions: imd.num('deletions'),
+      edits: imd.num('edits'),
+      filesTouched: imd.num('files_touched'),
+      topFiles: impactFilesRaw.map((r) => {
+        const rd = readRow(r, 'digest-impact-files');
+        return { path: rd.str('path'), additions: rd.num('additions'), deletions: rd.num('deletions') };
+      }),
+    };
+
+    // Reliability — roll up the shared per-agent aggregation. Agents whose
+    // formats carry no error signal are listed, not zero-counted.
+    const signals = await errorSignalsByAgent(conn, { from, to });
+    const known = signals.filter((s) => s.toolErrors !== null);
+    const errors: DigestErrors | null = known.length
+      ? {
+          toolCalls: known.reduce((acc, s) => acc + s.toolCalls, 0),
+          toolErrors: known.reduce((acc, s) => acc + (s.toolErrors ?? 0), 0),
+          errorRate: (() => {
+            const calls = known.reduce((acc, s) => acc + s.toolCalls, 0);
+            return calls > 0 ? known.reduce((acc, s) => acc + (s.toolErrors ?? 0), 0) / calls : null;
+          })(),
+          unknownAgents: signals
+            .filter((s) => s.toolErrors === null && s.toolCalls > 0)
+            .map((s) => s.connectorId),
+        }
+      : null;
+    const claude = signals.find((s) => s.connectorId === 'claude-code');
+    const interrupts = claude ? claude.interrupts : null;
+
+    return {
+      from,
+      to,
+      totals: {
+        sessions,
+        activeProjects: td.num('projects'),
+        responses: readRow(responsesRaw[0] ?? {}, 'digest-responses').num('responses'),
+        totalTokens: td.num('tokens'),
+        costUsd: td.num('cost'),
+      },
+      topProjects,
+      models,
+      topTools,
+      agents,
+      biggestSession,
+      streak,
+      impact,
+      errors,
+      interrupts,
+    };
+  });
+}

--- a/packages/server/src/routes/analytics-errors.ts
+++ b/packages/server/src/routes/analytics-errors.ts
@@ -1,0 +1,142 @@
+/**
+ * GET /api/analytics/errors — per-agent error/interrupt signals over the
+ * sessions in scope (optional project + date bounds on the session START —
+ * sessions are atomic here, like /api/analytics/sessions).
+ *
+ * Two signals with very different availability, both exposed n/a-aware:
+ *  - Tool errors: sums of `events.tool_error_count` (whichever rows carry the
+ *    tool_result — user rows for Claude Code/Codex, see the SQL comment).
+ *    The column is NULL for formats with no error signal (Junie's plain-string
+ *    results, Antigravity's typed records), and SQL SUM keeps an all-NULL group
+ *    NULL — so `toolErrors: null` means "can't know", never 0. Copilot counts
+ *    permission-denied calls as errors (see plan 0039's open question).
+ *  - User interrupts: the `[Request interrupted by user…]` marker Claude Code
+ *    writes as the user-message text. Prefix-anchored match (an ordinary
+ *    message *quoting* the marker mid-text must not count), with the same
+ *    sidechain/fork exclusions as the activity punchcard. Claude-Code-only.
+ *
+ * `errorSignalsByAgent` is exported for the digest route, which rolls the same
+ * aggregation up instead of re-deriving it.
+ */
+
+import type { FastifyInstance } from 'fastify';
+import type { DuckDBConnection } from '@duckdb/node-api';
+import type { ErrorAnalyticsResponse, ErrorAnalyticsRow } from '@claudescope/shared';
+import { getConnection, queryRows, sqlString } from '../db/duckdb.js';
+import { readRow } from '../db/row.js';
+import { projectIdFromCwd } from '../data/project-id.js';
+
+/** Prefix of the user-message text Claude Code stores on an interrupt (both
+ *  variants: `…by user]` and `…by user for tool use]`). */
+const INTERRUPT_PREFIX = '[Request interrupted by user';
+
+/** Why a metric is n/a (or skewed), keyed by connector id. */
+const AVAILABILITY_NOTES: Record<string, string> = {
+  junie: 'Junie tool results are plain strings — the format has no error signal.',
+  antigravity: 'Antigravity result records carry no error signal.',
+  copilot: 'Copilot counts permission-denied calls as errors.',
+};
+
+export interface ErrorScope {
+  project?: string;
+  from?: string;
+  to?: string;
+}
+
+/** Raw per-agent aggregates, before n/a shaping. */
+export interface ErrorSignals {
+  connectorId: string;
+  sessions: number;
+  toolCalls: number;
+  /** NULL when every row's tool_error_count is NULL (format has no signal). */
+  toolErrors: number | null;
+  /** Raw marker count — only meaningful for claude-code. */
+  interrupts: number;
+}
+
+/**
+ * Per-agent tool-call/error/interrupt sums over the sessions in scope. Shared
+ * by /api/analytics/errors and the digest.
+ */
+export async function errorSignalsByAgent(
+  conn: DuckDBConnection,
+  scope: ErrorScope,
+): Promise<ErrorSignals[]> {
+  const filters: string[] = [];
+  if (scope.project) {
+    // project is the slug id; resolve it against the sessions' project_cwd
+    // (the same resolution /api/sessions uses).
+    const cwds = await queryRows(
+      conn,
+      'SELECT DISTINCT project_cwd FROM sessions WHERE project_cwd IS NOT NULL',
+    );
+    const match = cwds
+      .map((c) => String(c.project_cwd))
+      .find((c) => projectIdFromCwd(c) === scope.project);
+    filters.push(`project_cwd = ${match ? sqlString(match) : "'\\0'"}`);
+  }
+  if (scope.from) filters.push(`started_at >= ${sqlString(scope.from)}::TIMESTAMP`);
+  if (scope.to) filters.push(`started_at <= ${sqlString(scope.to)}::TIMESTAMP`);
+  const whereSql = filters.length > 0 ? `WHERE ${filters.join(' AND ')}` : '';
+
+  const rows = await queryRows(
+    conn,
+    `WITH scoped AS (SELECT id, connector_id FROM sessions ${whereSql})
+     SELECT
+       COALESCE(sc.connector_id, 'unknown') AS connector_id,
+       count(DISTINCT sc.id) AS sessions,
+       COALESCE(sum(e.tool_use_count) FILTER (WHERE e.type = 'assistant' AND e.usage_canonical), 0) AS tool_calls,
+       -- Errors live wherever the connector recorded the tool_result (user rows
+       -- for Claude Code/Codex), so no type filter. Fork copies of result rows
+       -- have NULL message ids (all elected canonical), so they are excluded by
+       -- origin instead; if the original file is later deleted the surviving
+       -- copy goes uncounted — an accepted edge, same as the interrupt count.
+       sum(e.tool_error_count) FILTER (WHERE e.usage_canonical AND e.forked_from_session_id IS NULL) AS tool_errors,
+       count(*) FILTER (
+         WHERE e.type = 'user' AND NOT e.is_sidechain AND e.forked_from_session_id IS NULL
+           AND e.text_content LIKE ${sqlString(`${INTERRUPT_PREFIX}%`)}
+       ) AS interrupts
+     FROM scoped sc
+     LEFT JOIN events e ON e.session_id = sc.id
+     GROUP BY COALESCE(sc.connector_id, 'unknown')
+     ORDER BY sessions DESC, connector_id`,
+  );
+
+  return rows.map((r) => {
+    const rd = readRow(r, 'analytics-errors');
+    const rawErrors = rd.opt('tool_errors');
+    return {
+      connectorId: rd.str('connector_id', 'unknown'),
+      sessions: rd.num('sessions'),
+      toolCalls: rd.num('tool_calls'),
+      toolErrors: rawErrors == null ? null : Number(rawErrors),
+      interrupts: rd.num('interrupts'),
+    };
+  });
+}
+
+export async function registerErrorsRoute(app: FastifyInstance): Promise<void> {
+  app.get<{
+    Querystring: { project?: string; from?: string; to?: string };
+  }>('/api/analytics/errors', async (req): Promise<ErrorAnalyticsResponse> => {
+    const conn = await getConnection();
+    const signals = await errorSignalsByAgent(conn, req.query);
+
+    const rows: ErrorAnalyticsRow[] = signals.map((s) => {
+      const isClaude = s.connectorId === 'claude-code';
+      const note = AVAILABILITY_NOTES[s.connectorId];
+      return {
+        connectorId: s.connectorId,
+        sessions: s.sessions,
+        toolCalls: s.toolCalls,
+        toolErrors: s.toolErrors,
+        errorRate: s.toolErrors === null || s.toolCalls === 0 ? null : s.toolErrors / s.toolCalls,
+        interrupts: isClaude ? s.interrupts : null,
+        interruptsPerSession: isClaude && s.sessions > 0 ? s.interrupts / s.sessions : null,
+        ...(note ? { availabilityNote: note } : {}),
+      };
+    });
+
+    return { rows };
+  });
+}

--- a/packages/server/src/routes/index.ts
+++ b/packages/server/src/routes/index.ts
@@ -16,6 +16,7 @@ import { registerSessionEfficiencyRoute } from './analytics-sessions.js';
 import { registerActivityRoute } from './analytics-activity.js';
 import { registerToolsRoute } from './analytics-tools.js';
 import { registerImpactRoute } from './analytics-impact.js';
+import { registerErrorsRoute } from './analytics-errors.js';
 import { registerSourcesRoute } from './sources.js';
 import { registerMemoryRoute } from './memory.js';
 
@@ -32,6 +33,7 @@ export async function registerRoutes(app: FastifyInstance): Promise<void> {
   await registerActivityRoute(app);
   await registerToolsRoute(app);
   await registerImpactRoute(app);
+  await registerErrorsRoute(app);
   await registerSourcesRoute(app);
   await registerMemoryRoute(app);
 

--- a/packages/server/src/routes/index.ts
+++ b/packages/server/src/routes/index.ts
@@ -17,6 +17,7 @@ import { registerActivityRoute } from './analytics-activity.js';
 import { registerToolsRoute } from './analytics-tools.js';
 import { registerImpactRoute } from './analytics-impact.js';
 import { registerErrorsRoute } from './analytics-errors.js';
+import { registerDigestRoute } from './analytics-digest.js';
 import { registerSourcesRoute } from './sources.js';
 import { registerMemoryRoute } from './memory.js';
 
@@ -34,6 +35,7 @@ export async function registerRoutes(app: FastifyInstance): Promise<void> {
   await registerToolsRoute(app);
   await registerImpactRoute(app);
   await registerErrorsRoute(app);
+  await registerDigestRoute(app);
   await registerSourcesRoute(app);
   await registerMemoryRoute(app);
 

--- a/packages/server/test/analytics-digest.integration.test.ts
+++ b/packages/server/test/analytics-digest.integration.test.ts
@@ -1,0 +1,197 @@
+/**
+ * /api/analytics/digest integration tests — composition edges, per the repo
+ * doctrine:
+ *
+ *  1. Totals with a no-usage agent in range — Junie-with-tokens and Claude
+ *     sessions sum, while the digest never NaNs or zeroes out because one
+ *     agent's metrics are unavailable; the reliability rollup lists Junie as
+ *     "no signal" instead of counting it.
+ *  2. Empty range → a coherent empty digest (zero totals, empty lists, null
+ *     biggest session — no NaN anywhere).
+ *  3. Code impact comes from canonical `file_edits` joined to the scoped
+ *     sessions (an edit inside the range's session counts).
+ */
+
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import type { FastifyInstance } from 'fastify';
+import type { DigestResponse } from '@claudescope/shared';
+
+const work = mkdtempSync(join(tmpdir(), 'claudescope-digest-'));
+const projectsDir = join(work, 'projects');
+const junieDir = join(work, 'junie');
+
+process.env.CLAUDE_PROJECTS_DIR = projectsDir;
+process.env.CODEX_SESSIONS_DIR = join(work, 'codex-empty');
+process.env.JUNIE_SESSIONS_DIR = junieDir;
+process.env.PI_SESSIONS_DIR = join(work, 'pi-empty');
+process.env.OPENCODE_DATA_DIR = join(work, 'opencode-empty');
+process.env.COPILOT_SESSIONS_DIR = join(work, 'copilot-empty');
+process.env.ANTIGRAVITY_CLI_DIR = join(work, 'antigravity-empty');
+process.env.ANTIGRAVITY_DIR = join(work, 'antigravity-empty-desktop');
+process.env.DUCKDB_PATH = join(work, 'index.duckdb');
+process.env.CLAUDESCOPE_HOME = join(work, 'home');
+process.env.REINDEX_INTERVAL_MS = '0';
+
+const jsonl = (events: unknown[]): string => events.map((e) => JSON.stringify(e)).join('\n') + '\n';
+const ts = (s: number) => `2026-01-01T10:00:${String(s).padStart(2, '0')}.000Z`;
+const CWD = '/tmp/digestproj';
+
+/** Claude session: one costed response, one Edit (2 adds / 1 del), one interrupt. */
+function writeClaudeFixture(): void {
+  const dir = join(projectsDir, '-tmp-digestproj');
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(
+    join(dir, 'digest-claude-1.jsonl'),
+    jsonl([
+      {
+        type: 'user', uuid: 'u0', parentUuid: null, sessionId: 'digest-claude-1',
+        timestamp: ts(0), cwd: CWD, isSidechain: false,
+        message: { role: 'user', content: 'edit the file' },
+      },
+      {
+        type: 'assistant', uuid: 'a1', parentUuid: 'u0', sessionId: 'digest-claude-1',
+        timestamp: ts(1), cwd: CWD, isSidechain: false,
+        message: {
+          role: 'assistant', model: 'claude-opus-4-8', id: 'msg_d1',
+          content: [{ type: 'tool_use', id: 't1', name: 'Edit', input: {
+            file_path: `${CWD}/src/app.ts`, old_string: 'one\ntwo', new_string: 'one\nTWO\nthree',
+          } }],
+          usage: { input_tokens: 100, output_tokens: 50 },
+        },
+      },
+      {
+        type: 'user', uuid: 'u2', parentUuid: 'a1', sessionId: 'digest-claude-1',
+        timestamp: ts(2), cwd: CWD, isSidechain: false,
+        message: { role: 'user', content: [{ type: 'tool_result', tool_use_id: 't1', content: 'ok' }] },
+      },
+      {
+        type: 'user', uuid: 'u3', parentUuid: 'u2', sessionId: 'digest-claude-1',
+        timestamp: ts(3), cwd: CWD, isSidechain: false,
+        message: { role: 'user', content: [{ type: 'text', text: '[Request interrupted by user]' }] },
+      },
+    ]),
+  );
+}
+
+const a2ux = (agentEvent: unknown, sec: number) => ({
+  kind: 'SessionA2uxEvent',
+  event: { state: 'IN_PROGRESS', agentEvent },
+  timestampMs: Date.UTC(2026, 0, 1, 10, 0, sec),
+});
+
+/** Junie session with real token usage but no error signal. */
+function writeJunieFixture(): void {
+  const id = 'session-260101-100000-digest';
+  const dir = join(junieDir, id);
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(
+    join(junieDir, 'index.jsonl'),
+    jsonl([
+      {
+        sessionId: id,
+        createdAt: Date.UTC(2026, 0, 1, 10, 0, 0),
+        updatedAt: Date.UTC(2026, 0, 1, 10, 0, 9),
+        projectDir: '/tmp/junie-digestproj',
+        taskName: 'junie digest fixture',
+      },
+    ]),
+  );
+  writeFileSync(
+    join(dir, 'events.jsonl'),
+    jsonl([
+      { kind: 'UserPromptEvent', prompt: 'poke around' },
+      { kind: 'SendToAgentEvent' },
+      a2ux(
+        {
+          kind: 'LlmResponseMetadataEvent',
+          modelUsage: [
+            { model: 'claude-haiku-4-5-20251001', cost: 0.001, inputTokens: 500, cacheInputTokens: 0, cacheCreateTokens: 0, outputTokens: 100, time: 0 },
+          ],
+        },
+        1,
+      ),
+      a2ux({ kind: 'TerminalBlockUpdatedEvent', stepId: 's1', status: 'IN_PROGRESS', command: 'ls' }, 2),
+      a2ux({ kind: 'TerminalBlockUpdatedEvent', stepId: 's1', status: 'COMPLETED', details: 'a.txt' }, 3),
+    ]),
+  );
+}
+
+let app: FastifyInstance | undefined;
+
+beforeAll(async () => {
+  writeClaudeFixture();
+  writeJunieFixture();
+
+  const Fastify = (await import('fastify')).default;
+  const { registerRoutes } = await import('../src/routes/index.js');
+  const { reindex } = await import('../src/data/index.js');
+
+  app = Fastify();
+  await registerRoutes(app);
+  await reindex();
+  await app.ready();
+});
+
+afterAll(async () => {
+  await app?.close();
+  const { closeConnection } = await import('../src/db/duckdb.js');
+  await closeConnection();
+  rmSync(work, { recursive: true, force: true });
+});
+
+async function fetchDigest(query = ''): Promise<DigestResponse> {
+  const res = await app!.inject({ method: 'GET', url: `/api/analytics/digest${query}` });
+  expect(res.statusCode).toBe(200);
+  return res.json() as DigestResponse;
+}
+
+const RANGE = '?from=2026-01-01T00:00:00.000Z&to=2026-01-01T23:59:59.999Z';
+
+describe('/api/analytics/digest', () => {
+  it('composes totals across agents without zeroing on a no-signal agent', async () => {
+    const d = await fetchDigest(RANGE);
+    expect(d.totals.sessions).toBe(2);
+    expect(d.totals.activeProjects).toBe(2);
+    expect(d.totals.totalTokens).toBeGreaterThan(0);
+    expect(d.totals.costUsd).toBeGreaterThan(0);
+    expect(d.agents.map((a) => a.key).sort()).toEqual(['claude-code', 'junie']);
+    // Reliability: Claude reports (0 errors of 1 call), Junie is listed as
+    // no-signal — not zero-counted.
+    expect(d.errors).not.toBeNull();
+    expect(d.errors!.toolErrors).toBe(0);
+    expect(d.errors!.toolCalls).toBe(1);
+    expect(d.errors!.unknownAgents).toEqual(['junie']);
+    expect(d.interrupts).toBe(1);
+  });
+
+  it('reports code impact from canonical file_edits', async () => {
+    const d = await fetchDigest(RANGE);
+    expect(d.impact.edits).toBe(1);
+    expect(d.impact.additions).toBe(2);
+    expect(d.impact.deletions).toBe(1);
+    expect(d.impact.topFiles).toEqual([
+      { path: `${CWD}/src/app.ts`, additions: 2, deletions: 1 },
+    ]);
+    expect(d.biggestSession).not.toBeNull();
+    expect(d.biggestSession!.id).toBe('digest-claude-1');
+  });
+
+  it('returns a coherent empty digest for an empty range (no NaNs)', async () => {
+    const d = await fetchDigest('?from=2030-01-01T00:00:00.000Z&to=2030-01-02T00:00:00.000Z');
+    expect(d.totals.sessions).toBe(0);
+    expect(d.totals.costUsd).toBe(0);
+    expect(d.topProjects).toEqual([]);
+    expect(d.models).toEqual([]);
+    expect(d.topTools).toEqual([]);
+    expect(d.biggestSession).toBeNull();
+    expect(d.errors).toBeNull();
+    expect(d.interrupts).toBeNull();
+    expect(d.impact.edits).toBe(0);
+    // JSON round-trip would have turned a NaN into null — assert numbers stayed numbers.
+    expect(Number.isFinite(d.totals.totalTokens)).toBe(true);
+    expect(Number.isFinite(d.impact.additions)).toBe(true);
+  });
+});

--- a/packages/server/test/analytics-errors.integration.test.ts
+++ b/packages/server/test/analytics-errors.integration.test.ts
@@ -1,0 +1,207 @@
+/**
+ * /api/analytics/errors integration tests — the n/a contract and the interrupt
+ * marker, per the repo test doctrine (the bug-prone edges, not happy-path glue):
+ *
+ *  1. NULL-vs-counted tool errors — Claude Code counts `is_error` tool_results
+ *     (a real 0 stays 0); Junie's format carries no error signal, so its sums
+ *     must surface as `toolErrors: null` ("can't know"), never 0.
+ *  2. Interrupt marker — prefix-anchored: the genuine Claude Code interrupt
+ *     message counts, an ordinary message QUOTING the marker mid-text does not.
+ *     Interrupts are null (not 0) for every non-Claude agent.
+ */
+
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import type { FastifyInstance } from 'fastify';
+import type { ErrorAnalyticsResponse } from '@claudescope/shared';
+import { projectIdFromCwd } from '../src/data/project-id.js';
+
+const work = mkdtempSync(join(tmpdir(), 'claudescope-errs-'));
+const projectsDir = join(work, 'projects');
+const junieDir = join(work, 'junie');
+
+process.env.CLAUDE_PROJECTS_DIR = projectsDir;
+process.env.CODEX_SESSIONS_DIR = join(work, 'codex-empty');
+process.env.JUNIE_SESSIONS_DIR = junieDir;
+process.env.PI_SESSIONS_DIR = join(work, 'pi-empty');
+process.env.OPENCODE_DATA_DIR = join(work, 'opencode-empty');
+process.env.COPILOT_SESSIONS_DIR = join(work, 'copilot-empty');
+process.env.ANTIGRAVITY_CLI_DIR = join(work, 'antigravity-empty');
+process.env.ANTIGRAVITY_DIR = join(work, 'antigravity-empty-desktop');
+process.env.DUCKDB_PATH = join(work, 'index.duckdb');
+process.env.CLAUDESCOPE_HOME = join(work, 'home');
+process.env.REINDEX_INTERVAL_MS = '0';
+
+const jsonl = (events: unknown[]): string => events.map((e) => JSON.stringify(e)).join('\n') + '\n';
+const ts = (s: number) => `2026-01-01T10:00:${String(s).padStart(2, '0')}.000Z`;
+const CWD = '/tmp/errsproj';
+
+function claudeLine(type: 'user' | 'assistant', uuid: string, parent: string | null, sec: number, message: unknown): unknown {
+  return {
+    type,
+    uuid,
+    parentUuid: parent,
+    sessionId: 'errs-claude-1',
+    timestamp: ts(sec),
+    cwd: CWD,
+    isSidechain: false,
+    message,
+  };
+}
+
+/** Claude session: 2 tool calls (1 errored), 1 genuine interrupt, 1 quote of the marker. */
+function writeClaudeFixture(): void {
+  const dir = join(projectsDir, '-tmp-errsproj');
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(
+    join(dir, 'errs-claude-1.jsonl'),
+    jsonl([
+      claudeLine('user', 'u0', null, 0, { role: 'user', content: 'run the tests' }),
+      claudeLine('assistant', 'a1', 'u0', 1, {
+        role: 'assistant',
+        model: 'claude-opus-4-8',
+        id: 'msg_a1',
+        content: [{ type: 'tool_use', id: 't1', name: 'Bash', input: { command: 'npm test' } }],
+        usage: { input_tokens: 10, output_tokens: 5 },
+      }),
+      claudeLine('user', 'u2', 'a1', 2, {
+        role: 'user',
+        content: [{ type: 'tool_result', tool_use_id: 't1', is_error: true, content: 'FAIL' }],
+      }),
+      claudeLine('assistant', 'a3', 'u2', 3, {
+        role: 'assistant',
+        model: 'claude-opus-4-8',
+        id: 'msg_a3',
+        content: [{ type: 'tool_use', id: 't2', name: 'Read', input: { file_path: `${CWD}/a.ts` } }],
+        usage: { input_tokens: 10, output_tokens: 5 },
+      }),
+      claudeLine('user', 'u4', 'a3', 4, {
+        role: 'user',
+        content: [{ type: 'tool_result', tool_use_id: 't2', content: 'ok' }],
+      }),
+      // A genuine interrupt: the marker IS the message text.
+      claudeLine('user', 'u5', 'u4', 5, {
+        role: 'user',
+        content: [{ type: 'text', text: '[Request interrupted by user for tool use]' }],
+      }),
+      // An ordinary message merely QUOTING the marker — must NOT count.
+      claudeLine('user', 'u6', 'u5', 6, {
+        role: 'user',
+        content: 'earlier we discussed the [Request interrupted by user] marker semantics',
+      }),
+    ]),
+  );
+}
+
+const a2ux = (agentEvent: unknown, sec: number) => ({
+  kind: 'SessionA2uxEvent',
+  event: { state: 'IN_PROGRESS', agentEvent },
+  timestampMs: Date.UTC(2026, 0, 1, 10, 0, sec),
+});
+
+/** Junie session: one tool step + one terminal step — tool calls with NO error signal. */
+function writeJunieFixture(): void {
+  const id = 'session-260101-100000-errs';
+  const dir = join(junieDir, id);
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(
+    join(junieDir, 'index.jsonl'),
+    jsonl([
+      {
+        sessionId: id,
+        createdAt: Date.UTC(2026, 0, 1, 10, 0, 0),
+        updatedAt: Date.UTC(2026, 0, 1, 10, 0, 9),
+        projectDir: '/tmp/junie-errsproj',
+        taskName: 'junie errors fixture',
+      },
+    ]),
+  );
+  writeFileSync(
+    join(dir, 'events.jsonl'),
+    jsonl([
+      { kind: 'UserPromptEvent', prompt: 'poke around' },
+      { kind: 'SendToAgentEvent' },
+      a2ux({ kind: 'ToolBlockUpdatedEvent', stepId: 's1', text: 'Open a.txt', status: 'IN_PROGRESS' }, 1),
+      a2ux(
+        {
+          kind: 'ViewFilesBlockUpdatedEvent',
+          stepId: 's1',
+          status: 'COMPLETED',
+          files: [{ relativePath: 'a.txt', lineFrom: 1, lineTo: 2 }],
+          details: 'looked',
+        },
+        2,
+      ),
+      a2ux({ kind: 'TerminalBlockUpdatedEvent', stepId: 's2', status: 'IN_PROGRESS', command: 'ls' }, 3),
+      a2ux({ kind: 'TerminalBlockUpdatedEvent', stepId: 's2', status: 'COMPLETED', details: 'a.txt' }, 4),
+    ]),
+  );
+}
+
+let app: FastifyInstance | undefined;
+
+beforeAll(async () => {
+  writeClaudeFixture();
+  writeJunieFixture();
+  mkdirSync(join(work, 'codex-empty'), { recursive: true });
+
+  const Fastify = (await import('fastify')).default;
+  const { registerRoutes } = await import('../src/routes/index.js');
+  const { reindex } = await import('../src/data/index.js');
+
+  app = Fastify();
+  await registerRoutes(app);
+  await reindex();
+  await app.ready();
+});
+
+afterAll(async () => {
+  await app?.close();
+  const { closeConnection } = await import('../src/db/duckdb.js');
+  await closeConnection();
+  rmSync(work, { recursive: true, force: true });
+});
+
+async function fetchErrors(query = ''): Promise<ErrorAnalyticsResponse> {
+  const res = await app!.inject({ method: 'GET', url: `/api/analytics/errors${query}` });
+  expect(res.statusCode).toBe(200);
+  return res.json() as ErrorAnalyticsResponse;
+}
+
+describe('/api/analytics/errors', () => {
+  it('counts Claude Code is_error results and keeps a real error rate', async () => {
+    const { rows } = await fetchErrors();
+    const claude = rows.find((r) => r.connectorId === 'claude-code');
+    expect(claude).toBeDefined();
+    expect(claude!.toolCalls).toBe(2);
+    expect(claude!.toolErrors).toBe(1);
+    expect(claude!.errorRate).toBeCloseTo(0.5);
+  });
+
+  it('surfaces Junie tool errors as null (no signal), never 0', async () => {
+    const { rows } = await fetchErrors();
+    const junie = rows.find((r) => r.connectorId === 'junie');
+    expect(junie).toBeDefined();
+    expect(junie!.toolCalls).toBeGreaterThan(0);
+    expect(junie!.toolErrors).toBeNull();
+    expect(junie!.errorRate).toBeNull();
+    expect(junie!.availabilityNote).toMatch(/no error signal/i);
+  });
+
+  it('counts the genuine interrupt but not a mid-text quote of the marker', async () => {
+    const { rows } = await fetchErrors();
+    const claude = rows.find((r) => r.connectorId === 'claude-code')!;
+    expect(claude.interrupts).toBe(1);
+    expect(claude.interruptsPerSession).toBeCloseTo(1);
+    const junie = rows.find((r) => r.connectorId === 'junie')!;
+    expect(junie.interrupts).toBeNull();
+    expect(junie.interruptsPerSession).toBeNull();
+  });
+
+  it('scopes by project slug', async () => {
+    const { rows } = await fetchErrors(`?project=${projectIdFromCwd(CWD)}`);
+    expect(rows.map((r) => r.connectorId)).toEqual(['claude-code']);
+  });
+});

--- a/packages/shared/src/api.ts
+++ b/packages/shared/src/api.ts
@@ -571,3 +571,108 @@ export interface ToolUsageRow {
 export interface ToolUsageResponse {
   rows: ToolUsageRow[];
 }
+
+// ---------------------------------------------------------------------------
+// Analytics — error/interrupt signals and the periodic digest
+// ---------------------------------------------------------------------------
+
+/** One agent's error/interrupt signals (GET /api/analytics/errors). */
+export interface ErrorAnalyticsRow {
+  connectorId: string;
+  sessions: number;
+  /** Canonical tool calls (deduped, same semantics as the tools breakdown). */
+  toolCalls: number;
+  /**
+   * Failed tool calls (`tool_error_count` sums). `null` when the source format
+   * carries no error signal (Junie, Antigravity) — "can't know", never 0.
+   */
+  toolErrors: number | null;
+  /** toolErrors / toolCalls; null when unknowable or there are no calls. */
+  errorRate: number | null;
+  /**
+   * User interrupts (the `[Request interrupted by user…]` transcript marker).
+   * Recorded by Claude Code only — null for every other agent.
+   */
+  interrupts: number | null;
+  interruptsPerSession: number | null;
+  /** Why a metric is n/a (or skewed), when it is. */
+  availabilityNote?: string;
+}
+
+/** GET /api/analytics/errors */
+export interface ErrorAnalyticsResponse {
+  rows: ErrorAnalyticsRow[];
+}
+
+/** Digest totals — session-atomic: a session belongs to the range its start falls in. */
+export interface DigestTotals {
+  sessions: number;
+  activeProjects: number;
+  /** Canonical assistant responses. */
+  responses: number;
+  /** Token/cost sums cover only agents that report usage (Antigravity none; crashed Copilot sessions none). */
+  totalTokens: number;
+  costUsd: number;
+}
+
+export interface DigestProjectRow {
+  projectId: string;
+  cwd: string;
+  sessions: number;
+  totalTokens: number;
+  costUsd: number;
+}
+
+/** A key → count line (model mix, tool mix, sessions per agent). */
+export interface DigestCountRow {
+  key: string;
+  count: number;
+}
+
+export interface DigestBiggestSession {
+  id: string;
+  title: string;
+  connectorId: string;
+  costUsd: number;
+  totalTokens: number;
+}
+
+/** Agent-reported churn over the range (see /api/analytics/impact — not git truth). */
+export interface DigestImpact {
+  additions: number;
+  deletions: number;
+  edits: number;
+  filesTouched: number;
+  /** Top files by churn (additions + deletions). */
+  topFiles: { path: string; additions: number; deletions: number }[];
+}
+
+/** Tool-error rollup over agents whose formats record errors. */
+export interface DigestErrors {
+  toolCalls: number;
+  toolErrors: number;
+  errorRate: number | null;
+  /** Agents in range whose formats carry no error signal (excluded from the counts). */
+  unknownAgents: string[];
+}
+
+/** GET /api/analytics/digest */
+export interface DigestResponse {
+  /** Resolved inclusive range (ISO timestamps); defaults to the last 7 days. */
+  from: string;
+  to: string;
+  totals: DigestTotals;
+  topProjects: DigestProjectRow[];
+  models: DigestCountRow[];
+  topTools: DigestCountRow[];
+  /** Sessions per agent. */
+  agents: DigestCountRow[];
+  biggestSession: DigestBiggestSession | null;
+  /** All-time prompt streak (UTC days) as of the range end. */
+  streak: StreakInfo;
+  impact: DigestImpact;
+  /** null when no agent in range records tool errors. */
+  errors: DigestErrors | null;
+  /** Claude Code user interrupts in range; null when no Claude Code sessions. */
+  interrupts: number | null;
+}

--- a/packages/shared/src/digest-markdown.ts
+++ b/packages/shared/src/digest-markdown.ts
@@ -1,0 +1,98 @@
+/**
+ * Render a digest (GET /api/analytics/digest) to Markdown — shared by the web
+ * "Copy as Markdown" button and the `claudescope digest` CLI so both emit the
+ * same document. Pure; sections with nothing to say are omitted.
+ */
+
+import type { DigestResponse } from './api.js';
+
+const cost = (usd: number): string => `$${usd.toFixed(2)}`;
+const num = (n: number): string => n.toLocaleString('en-US');
+const day = (iso: string): string => iso.slice(0, 10);
+const pct = (ratio: number): string => `${(ratio * 100).toFixed(1)}%`;
+
+export function digestToMarkdown(d: DigestResponse): string {
+  const out: string[] = [`# Week in review — ${day(d.from)} → ${day(d.to)}`, ''];
+
+  if (d.totals.sessions === 0) {
+    out.push('_No sessions in range._');
+    return out.join('\n') + '\n';
+  }
+
+  const t = d.totals;
+  out.push(
+    `**${num(t.sessions)}** sessions across **${num(t.activeProjects)}** projects · ` +
+      `${num(t.responses)} responses · ${num(t.totalTokens)} tokens · ${cost(t.costUsd)}`,
+    '',
+    '_Cost is a list-price estimate; token/cost totals cover only agents that report usage._',
+  );
+
+  if (d.topProjects.length > 0) {
+    out.push('', '## Top projects', '');
+    for (const p of d.topProjects) {
+      out.push(`- **${p.cwd || '(unknown)'}** — ${p.sessions} sessions · ${num(p.totalTokens)} tok · ${cost(p.costUsd)}`);
+    }
+  }
+
+  if (d.impact.edits > 0) {
+    out.push(
+      '',
+      '## Code impact',
+      '',
+      `+${num(d.impact.additions)} / −${num(d.impact.deletions)} lines over ` +
+        `${num(d.impact.filesTouched)} files (${num(d.impact.edits)} edits, agent-reported)`,
+    );
+    if (d.impact.topFiles.length > 0) {
+      out.push('');
+      for (const f of d.impact.topFiles) {
+        out.push(`- \`${f.path}\` (+${num(f.additions)}/−${num(f.deletions)})`);
+      }
+    }
+  }
+
+  if (d.agents.length > 0) {
+    out.push('', '## Agents', '');
+    out.push(d.agents.map((a) => `${a.key} ×${a.count}`).join(' · '));
+  }
+
+  if (d.models.length > 0) {
+    out.push('', '## Models', '');
+    out.push(d.models.map((m) => `${m.key} (${num(m.count)})`).join(' · '));
+  }
+
+  if (d.topTools.length > 0) {
+    out.push('', '## Top tools', '');
+    out.push(d.topTools.map((tl) => `${tl.key} (${num(tl.count)})`).join(' · '));
+  }
+
+  const reliability: string[] = [];
+  if (d.errors) {
+    const rate = d.errors.errorRate === null ? 'n/a' : pct(d.errors.errorRate);
+    reliability.push(
+      `- Tool errors: ${num(d.errors.toolErrors)} of ${num(d.errors.toolCalls)} calls (${rate})` +
+        (d.errors.unknownAgents.length > 0 ? ` — no signal from ${d.errors.unknownAgents.join(', ')}` : ''),
+    );
+  }
+  if (d.interrupts !== null) {
+    reliability.push(`- Interrupts (Claude Code): ${num(d.interrupts)}`);
+  }
+  if (reliability.length > 0) {
+    out.push('', '## Reliability', '', ...reliability);
+  }
+
+  const momentum: string[] = [];
+  if (d.streak.current > 0 || d.streak.longest > 0) {
+    momentum.push(`- Prompt streak: ${d.streak.current} days (longest ${d.streak.longest})`);
+  }
+  if (d.biggestSession) {
+    const b = d.biggestSession;
+    momentum.push(
+      `- Biggest session: “${b.title}” [${b.connectorId}] — ${num(b.totalTokens)} tok · ${cost(b.costUsd)}`,
+    );
+  }
+  if (momentum.length > 0) {
+    out.push('', '## Momentum', '', ...momentum);
+  }
+
+  return out.join('\n') + '\n';
+}

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -9,3 +9,4 @@ export * from './diff.js';
 export * from './redact.js';
 export * from './markdown.js';
 export * from './changeset.js';
+export * from './digest-markdown.js';

--- a/packages/shared/test/digest-markdown.test.ts
+++ b/packages/shared/test/digest-markdown.test.ts
@@ -1,0 +1,79 @@
+/**
+ * digestToMarkdown edges: n/a rendering for an unknowable error rate, the
+ * no-signal agents note, empty-section omission, and the empty-range document.
+ */
+
+import { describe, expect, it } from 'vitest';
+import type { DigestResponse } from '../src/api.js';
+import { digestToMarkdown } from '../src/digest-markdown.js';
+
+function base(overrides: Partial<DigestResponse> = {}): DigestResponse {
+  return {
+    from: '2026-06-23T00:00:00.000Z',
+    to: '2026-06-29T23:59:59.999Z',
+    totals: { sessions: 3, activeProjects: 2, responses: 40, totalTokens: 12345, costUsd: 1.5 },
+    topProjects: [
+      { projectId: 'p-1', cwd: '/src/app', sessions: 2, totalTokens: 10000, costUsd: 1.2 },
+    ],
+    models: [{ key: 'claude-opus-4-8', count: 30 }],
+    topTools: [{ key: 'Bash', count: 12 }],
+    agents: [{ key: 'claude-code', count: 3 }],
+    biggestSession: { id: 's1', title: 'Fix the bug', connectorId: 'claude-code', costUsd: 1.0, totalTokens: 8000 },
+    streak: { current: 4, longest: 9, lastActiveDay: '2026-06-29' },
+    impact: {
+      additions: 120,
+      deletions: 30,
+      edits: 15,
+      filesTouched: 6,
+      topFiles: [{ path: '/src/app/index.ts', additions: 80, deletions: 10 }],
+    },
+    errors: { toolCalls: 100, toolErrors: 4, errorRate: 0.04, unknownAgents: ['junie'] },
+    interrupts: 2,
+    ...overrides,
+  };
+}
+
+describe('digestToMarkdown', () => {
+  it('renders the full document with the no-signal agents note', () => {
+    const md = digestToMarkdown(base());
+    expect(md).toContain('# Week in review — 2026-06-23 → 2026-06-29');
+    expect(md).toContain('Tool errors: 4 of 100 calls (4.0%) — no signal from junie');
+    expect(md).toContain('Interrupts (Claude Code): 2');
+    expect(md).toContain('- `/src/app/index.ts` (+80/−10)');
+    expect(md).toContain('Prompt streak: 4 days (longest 9)');
+  });
+
+  it('renders n/a when the error rate is unknowable', () => {
+    const md = digestToMarkdown(
+      base({ errors: { toolCalls: 0, toolErrors: 0, errorRate: null, unknownAgents: [] } }),
+    );
+    expect(md).toContain('(n/a)');
+  });
+
+  it('omits sections with nothing to say', () => {
+    const md = digestToMarkdown(
+      base({
+        impact: { additions: 0, deletions: 0, edits: 0, filesTouched: 0, topFiles: [] },
+        errors: null,
+        interrupts: null,
+        streak: { current: 0, longest: 0, lastActiveDay: null },
+        biggestSession: null,
+        topTools: [],
+        models: [],
+      }),
+    );
+    expect(md).not.toContain('## Code impact');
+    expect(md).not.toContain('## Reliability');
+    expect(md).not.toContain('## Momentum');
+    expect(md).not.toContain('## Top tools');
+    expect(md).not.toContain('## Models');
+  });
+
+  it('collapses to a one-line document for an empty range', () => {
+    const md = digestToMarkdown(
+      base({ totals: { sessions: 0, activeProjects: 0, responses: 0, totalTokens: 0, costUsd: 0 } }),
+    );
+    expect(md).toContain('_No sessions in range._');
+    expect(md).not.toContain('##');
+  });
+});

--- a/packages/web/src/api/client.ts
+++ b/packages/web/src/api/client.ts
@@ -24,6 +24,8 @@ import type {
   SessionsResponse,
   SourcesResponse,
   ToolUsageResponse,
+  ErrorAnalyticsResponse,
+  DigestResponse,
 } from '@claudescope/shared';
 
 /** Thrown when an `/api/*` response is not 2xx. Carries the HTTP status. */
@@ -166,6 +168,22 @@ export const api = {
   /** GET /api/analytics/tools?from=&to= */
   analyticsTools(params: { from?: string; to?: string }, signal?: AbortSignal): Promise<ToolUsageResponse> {
     return request<ToolUsageResponse>(`/analytics/tools${qs({ from: params.from, to: params.to })}`, { signal });
+  },
+
+  /** GET /api/analytics/errors?project=&from=&to= */
+  analyticsErrors(
+    params: { project?: string; from?: string; to?: string },
+    signal?: AbortSignal,
+  ): Promise<ErrorAnalyticsResponse> {
+    return request<ErrorAnalyticsResponse>(
+      `/analytics/errors${qs({ project: params.project, from: params.from, to: params.to })}`,
+      { signal },
+    );
+  },
+
+  /** GET /api/analytics/digest?from=&to= */
+  analyticsDigest(params: { from?: string; to?: string }, signal?: AbortSignal): Promise<DigestResponse> {
+    return request<DigestResponse>(`/analytics/digest${qs({ from: params.from, to: params.to })}`, { signal });
   },
 
   /** GET /api/analytics/sessions?from=&to=&sort=&dir=&limit=&minResponses= */

--- a/packages/web/src/pages/analytics/AnalyticsPage.tsx
+++ b/packages/web/src/pages/analytics/AnalyticsPage.tsx
@@ -17,6 +17,7 @@ import type { ReactNode } from 'react';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import type {
   ActivityResponse,
+  ErrorAnalyticsResponse,
   AnalyticsGroupBy,
   AnalyticsResponse,
   AnalyticsTotals,
@@ -29,6 +30,7 @@ import type {
 import { api } from '../../api/client.js';
 import { ErrorBox, Spinner } from '../../components/index.js';
 import { ActivityHeatmap } from './ActivityHeatmap.js';
+import { ErrorsTable } from './ErrorsTable.js';
 import { BreakdownChart } from './BreakdownChart.js';
 import { ToolUsageChart } from './ToolUsageChart.js';
 import type { BreakdownMetric, BreakdownSort } from './BreakdownChart.js';
@@ -68,7 +70,7 @@ export function AnalyticsPage() {
   const [to, setTo] = useState('');
   // Cache tokens dwarf input/output and clutter the charts — hidden by default.
   const [showCache, setShowCache] = useState(false);
-  const [view, setView] = useState<'overview' | 'sessions' | 'activity'>('overview');
+  const [view, setView] = useState<'overview' | 'sessions' | 'activity' | 'errors'>('overview');
   const [effSort, setEffSort] = useState<SessionEfficiencySort>('cost');
   const [effDir, setEffDir] = useState<SortDir>('desc');
   const [eff, setEff] = useState<{
@@ -77,6 +79,14 @@ export function AnalyticsPage() {
     error: unknown;
   }>({ data: null, loading: true, error: null });
   const [effRetry, setEffRetry] = useState(0);
+  // Errors view: optional project scope ('' = whole corpus) + fetch state.
+  const [errProject, setErrProject] = useState('');
+  const [errs, setErrs] = useState<{
+    data: ErrorAnalyticsResponse | null;
+    loading: boolean;
+    error: unknown;
+  }>({ data: null, loading: true, error: null });
+  const [errsRetry, setErrsRetry] = useState(0);
   // Breakdown chart controls (default to tokens, preserving prior behavior):
   // `metric` picks what the bars render, `sortBy` picks the row order.
   const [metric, setMetric] = useState<BreakdownMetric>('tokens');
@@ -144,6 +154,20 @@ export function AnalyticsPage() {
       });
     return () => ctrl.abort();
   }, [view, range.from, range.to, effSort, effDir, effRetry]);
+
+  useEffect(() => {
+    if (view !== 'errors') return;
+    const ctrl = new AbortController();
+    setErrs((s) => ({ ...s, loading: true, error: null }));
+    api
+      .analyticsErrors({ project: errProject || undefined, from: range.from, to: range.to }, ctrl.signal)
+      .then((data) => setErrs({ data, loading: false, error: null }))
+      .catch((error) => {
+        if (ctrl.signal.aborted) return;
+        setErrs({ data: null, loading: false, error });
+      });
+    return () => ctrl.abort();
+  }, [view, errProject, range.from, range.to, errsRetry]);
 
   useEffect(() => {
     const ctrl = new AbortController();
@@ -235,8 +259,39 @@ export function AnalyticsPage() {
             >
               Activity
             </button>
+            <button
+              type="button"
+              className={view === 'errors' ? 'tv-segmented__btn is-active' : 'tv-segmented__btn'}
+              aria-pressed={view === 'errors'}
+              onClick={() => setView('errors')}
+            >
+              Errors
+            </button>
           </div>
         </div>
+
+        {view === 'errors' && (
+          <div className="tv-analytics__field">
+            <label className="tv-analytics__field-label" htmlFor="tv-errors-project">
+              Project
+            </label>
+            <select
+              id="tv-errors-project"
+              className="tv-analytics__select"
+              value={errProject}
+              onChange={(e) => setErrProject(e.target.value)}
+            >
+              <option value="">All projects</option>
+              {[...projectsById.values()]
+                .sort((a, b) => a.displayName.localeCompare(b.displayName))
+                .map((p) => (
+                  <option key={p.id} value={p.id}>
+                    {p.displayName}
+                  </option>
+                ))}
+            </select>
+          </div>
+        )}
 
         {view === 'overview' && (
           <div className="tv-analytics__field">
@@ -298,7 +353,7 @@ export function AnalyticsPage() {
           </button>
         )}
 
-        {view !== 'activity' && (
+        {view !== 'activity' && view !== 'errors' && (
           <label className="tv-analytics__toggle">
             <input
               type="checkbox"
@@ -333,6 +388,22 @@ export function AnalyticsPage() {
             onSortChange={onEffSort}
             showCache={showCache}
           />
+        )
+      ) : view === 'errors' ? (
+        errs.error ? (
+          <ErrorBox
+            error={errs.error}
+            title="Failed to load error analytics"
+            onRetry={() => setErrsRetry((n) => n + 1)}
+          />
+        ) : errs.loading && !errs.data ? (
+          <div className="tv-card">
+            <Spinner label="Loading…" />
+          </div>
+        ) : !errs.data || errs.data.rows.length === 0 ? (
+          <div className="tv-card tv-chart-empty">No sessions in range.</div>
+        ) : (
+          <ErrorsTable rows={errs.data.rows} />
         )
       ) : view === 'activity' ? (
         <div className="tv-analytics__charts">

--- a/packages/web/src/pages/analytics/AnalyticsPage.tsx
+++ b/packages/web/src/pages/analytics/AnalyticsPage.tsx
@@ -17,6 +17,7 @@ import type { ReactNode } from 'react';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import type {
   ActivityResponse,
+  DigestResponse,
   ErrorAnalyticsResponse,
   AnalyticsGroupBy,
   AnalyticsResponse,
@@ -30,6 +31,7 @@ import type {
 import { api } from '../../api/client.js';
 import { ErrorBox, Spinner } from '../../components/index.js';
 import { ActivityHeatmap } from './ActivityHeatmap.js';
+import { DigestView } from './DigestView.js';
 import { ErrorsTable } from './ErrorsTable.js';
 import { BreakdownChart } from './BreakdownChart.js';
 import { ToolUsageChart } from './ToolUsageChart.js';
@@ -70,7 +72,7 @@ export function AnalyticsPage() {
   const [to, setTo] = useState('');
   // Cache tokens dwarf input/output and clutter the charts — hidden by default.
   const [showCache, setShowCache] = useState(false);
-  const [view, setView] = useState<'overview' | 'sessions' | 'activity' | 'errors'>('overview');
+  const [view, setView] = useState<'overview' | 'sessions' | 'activity' | 'errors' | 'digest'>('overview');
   const [effSort, setEffSort] = useState<SessionEfficiencySort>('cost');
   const [effDir, setEffDir] = useState<SortDir>('desc');
   const [eff, setEff] = useState<{
@@ -87,6 +89,13 @@ export function AnalyticsPage() {
     error: unknown;
   }>({ data: null, loading: true, error: null });
   const [errsRetry, setErrsRetry] = useState(0);
+  // Digest view fetch state (range comes from the shared from/to inputs).
+  const [digest, setDigest] = useState<{
+    data: DigestResponse | null;
+    loading: boolean;
+    error: unknown;
+  }>({ data: null, loading: true, error: null });
+  const [digestRetry, setDigestRetry] = useState(0);
   // Breakdown chart controls (default to tokens, preserving prior behavior):
   // `metric` picks what the bars render, `sortBy` picks the row order.
   const [metric, setMetric] = useState<BreakdownMetric>('tokens');
@@ -168,6 +177,20 @@ export function AnalyticsPage() {
       });
     return () => ctrl.abort();
   }, [view, errProject, range.from, range.to, errsRetry]);
+
+  useEffect(() => {
+    if (view !== 'digest') return;
+    const ctrl = new AbortController();
+    setDigest((s) => ({ ...s, loading: true, error: null }));
+    api
+      .analyticsDigest({ from: range.from, to: range.to }, ctrl.signal)
+      .then((data) => setDigest({ data, loading: false, error: null }))
+      .catch((error) => {
+        if (ctrl.signal.aborted) return;
+        setDigest({ data: null, loading: false, error });
+      });
+    return () => ctrl.abort();
+  }, [view, range.from, range.to, digestRetry]);
 
   useEffect(() => {
     const ctrl = new AbortController();
@@ -267,6 +290,14 @@ export function AnalyticsPage() {
             >
               Errors
             </button>
+            <button
+              type="button"
+              className={view === 'digest' ? 'tv-segmented__btn is-active' : 'tv-segmented__btn'}
+              aria-pressed={view === 'digest'}
+              onClick={() => setView('digest')}
+            >
+              Digest
+            </button>
           </div>
         </div>
 
@@ -353,7 +384,7 @@ export function AnalyticsPage() {
           </button>
         )}
 
-        {view !== 'activity' && view !== 'errors' && (
+        {view !== 'activity' && view !== 'errors' && view !== 'digest' && (
           <label className="tv-analytics__toggle">
             <input
               type="checkbox"
@@ -387,6 +418,28 @@ export function AnalyticsPage() {
             dir={effDir}
             onSortChange={onEffSort}
             showCache={showCache}
+          />
+        )
+      ) : view === 'digest' ? (
+        digest.error ? (
+          <ErrorBox
+            error={digest.error}
+            title="Failed to load the digest"
+            onRetry={() => setDigestRetry((n) => n + 1)}
+          />
+        ) : digest.loading && !digest.data ? (
+          <div className="tv-card">
+            <Spinner label="Loading…" />
+          </div>
+        ) : !digest.data ? (
+          <div className="tv-card tv-chart-empty">No data.</div>
+        ) : (
+          <DigestView
+            data={digest.data}
+            onRange={(f, t) => {
+              setFrom(f);
+              setTo(t);
+            }}
           />
         )
       ) : view === 'errors' ? (

--- a/packages/web/src/pages/analytics/DigestView.tsx
+++ b/packages/web/src/pages/analytics/DigestView.tsx
@@ -1,0 +1,174 @@
+/**
+ * Week-in-review digest (Analytics → Digest): stat cards + short lists over
+ * the selected range, with a "Copy as Markdown" button that emits the exact
+ * document `claudescope digest` prints (shared renderer in
+ * `@claudescope/shared`). Range presets set the page's from/to inputs, so the
+ * digest range and the shared date fields stay one source of truth.
+ */
+import { useState } from 'react';
+import type { DigestResponse } from '@claudescope/shared';
+import { digestToMarkdown } from '@claudescope/shared';
+import { AgentBadge } from '../../components/index.js';
+import { formatCount, formatCost, formatPct } from './format.js';
+
+/** Monday of the week containing `d` (local). */
+function mondayOf(d: Date): Date {
+  const out = new Date(d);
+  out.setDate(d.getDate() - ((d.getDay() + 6) % 7));
+  return out;
+}
+const isoDay = (d: Date): string =>
+  `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`;
+
+export interface DigestPreset {
+  label: string;
+  from: string;
+  to: string;
+}
+
+/** "This week" (Monday → today) and "Last week" (previous Monday → Sunday). */
+export function digestPresets(now = new Date()): DigestPreset[] {
+  const monday = mondayOf(now);
+  const lastMonday = new Date(monday);
+  lastMonday.setDate(monday.getDate() - 7);
+  const lastSunday = new Date(monday);
+  lastSunday.setDate(monday.getDate() - 1);
+  return [
+    { label: 'This week', from: isoDay(monday), to: isoDay(now) },
+    { label: 'Last week', from: isoDay(lastMonday), to: isoDay(lastSunday) },
+  ];
+}
+
+export function DigestView({
+  data,
+  onRange,
+}: {
+  data: DigestResponse;
+  onRange: (from: string, to: string) => void;
+}) {
+  const [copied, setCopied] = useState(false);
+
+  const copy = () => {
+    void navigator.clipboard.writeText(digestToMarkdown(data)).then(() => {
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1500);
+    });
+  };
+
+  const t = data.totals;
+  const day = (iso: string) => iso.slice(0, 10);
+
+  return (
+    <div className="tv-digest">
+      <div className="tv-digest__bar">
+        <div className="tv-segmented tv-segmented--sm" role="group" aria-label="Range preset">
+          {digestPresets().map((p) => (
+            <button
+              key={p.label}
+              type="button"
+              className="tv-segmented__btn"
+              onClick={() => onRange(p.from, p.to)}
+            >
+              {p.label}
+            </button>
+          ))}
+        </div>
+        <span className="tv-eff__hint">
+          {day(data.from)} → {day(data.to)}
+        </span>
+        <button type="button" className="tv-analytics__clear" onClick={copy}>
+          {copied ? 'Copied ✓' : 'Copy as Markdown'}
+        </button>
+      </div>
+
+      {t.sessions === 0 ? (
+        <div className="tv-card tv-chart-empty">No sessions in range.</div>
+      ) : (
+        <>
+          <div className="tv-analytics__cards">
+            <Stat label="Sessions" value={formatCount(t.sessions)} sub={`${t.activeProjects} projects · ${formatCount(t.responses)} responses`} />
+            <Stat label="Cost" value={formatCost(t.costUsd)} sub={`${formatCount(t.totalTokens)} tokens · usage-reporting agents only`} />
+            <Stat
+              label="Code impact"
+              value={`+${formatCount(data.impact.additions)} / −${formatCount(data.impact.deletions)}`}
+              sub={`${formatCount(data.impact.filesTouched)} files · ${formatCount(data.impact.edits)} edits · agent-reported`}
+            />
+            <Stat
+              label="Streak"
+              value={`${data.streak.current}d`}
+              sub={`longest ${data.streak.longest}d${data.errors ? ` · tool errors ${data.errors.errorRate === null ? 'n/a' : formatPct(data.errors.errorRate)}` : ''}${data.interrupts !== null ? ` · ${data.interrupts} interrupts` : ''}`}
+            />
+          </div>
+
+          <div className="tv-analytics__charts">
+            <ListCard title="Top projects" hint="by cost">
+              {data.topProjects.map((p) => (
+                <li key={p.projectId || '(unknown)'}>
+                  <code>{p.cwd || '(unknown)'}</code> — {p.sessions} sessions · {formatCount(p.totalTokens)} tok ·{' '}
+                  {formatCost(p.costUsd)}
+                </li>
+              ))}
+            </ListCard>
+
+            <ListCard title="Most-churned files" hint="agent-reported, not git truth">
+              {data.impact.topFiles.length === 0 ? (
+                <li className="tv-digest__empty">No edits in range.</li>
+              ) : (
+                data.impact.topFiles.map((f) => (
+                  <li key={f.path}>
+                    <code>{f.path}</code> (+{formatCount(f.additions)}/−{formatCount(f.deletions)})
+                  </li>
+                ))
+              )}
+            </ListCard>
+
+            <ListCard title="Agents & models" hint="sessions per agent · responses per model">
+              <li>
+                {data.agents.map((a) => (
+                  <span key={a.key} className="tv-digest__agent">
+                    <AgentBadge connectorId={a.key} /> ×{a.count}{' '}
+                  </span>
+                ))}
+              </li>
+              <li>{data.models.map((m) => `${m.key} (${formatCount(m.count)})`).join(' · ')}</li>
+            </ListCard>
+
+            <ListCard title="Highlights" hint="top tools · biggest session">
+              <li>{data.topTools.map((tl) => `${tl.key} (${formatCount(tl.count)})`).join(' · ') || '—'}</li>
+              {data.biggestSession && (
+                <li>
+                  Biggest session: “{data.biggestSession.title}” — {formatCount(data.biggestSession.totalTokens)} tok
+                  · {formatCost(data.biggestSession.costUsd)}
+                </li>
+              )}
+            </ListCard>
+          </div>
+        </>
+      )}
+    </div>
+  );
+}
+
+function Stat({ label, value, sub }: { label: string; value: string; sub?: string }) {
+  return (
+    <div className="tv-card tv-stat-card">
+      <span className="tv-stat-card__label">{label}</span>
+      <span className="tv-stat-card__value">{value}</span>
+      {sub && <span className="tv-stat-card__sub">{sub}</span>}
+    </div>
+  );
+}
+
+function ListCard({ title, hint, children }: { title: string; hint?: string; children: React.ReactNode }) {
+  return (
+    <section className="tv-card tv-chart-card">
+      <div className="tv-chart-card__head">
+        <div className="tv-chart-card__heading">
+          <h2 className="tv-chart-card__title">{title}</h2>
+          {hint && <span className="tv-chart-card__hint">{hint}</span>}
+        </div>
+      </div>
+      <ul className="tv-digest__list">{children}</ul>
+    </section>
+  );
+}

--- a/packages/web/src/pages/analytics/ErrorsTable.tsx
+++ b/packages/web/src/pages/analytics/ErrorsTable.tsx
@@ -1,0 +1,78 @@
+/**
+ * Error/interrupt signals table (Analytics → Errors): one row per agent.
+ * Metrics an agent's source format cannot report arrive as `null` from the API
+ * and render as "n/a" with the reason in the tooltip — never 0 (Junie and
+ * Antigravity have no tool-error signal; interrupts are recorded by Claude
+ * Code only). Reuses the session-efficiency table classes.
+ */
+import type { ErrorAnalyticsRow } from '@claudescope/shared';
+import { AgentBadge } from '../../components/index.js';
+import { formatPct } from './format.js';
+
+const intFmt = (n: number) => Math.round(n).toLocaleString();
+
+interface Col {
+  label: string;
+  title?: string;
+  value: (r: ErrorAnalyticsRow) => number | null;
+  fmt: (n: number) => string;
+}
+
+const COLS: Col[] = [
+  { label: 'Sessions', value: (r) => r.sessions, fmt: intFmt },
+  { label: 'Tool calls', value: (r) => r.toolCalls, fmt: intFmt },
+  { label: 'Errors', title: 'Failed tool calls (is_error results)', value: (r) => r.toolErrors, fmt: intFmt },
+  { label: 'Error rate', value: (r) => r.errorRate, fmt: formatPct },
+  { label: 'Interrupts', title: 'User interrupts (Claude Code records these)', value: (r) => r.interrupts, fmt: intFmt },
+  { label: 'Interrupts/session', value: (r) => r.interruptsPerSession, fmt: (n) => n.toFixed(2) },
+];
+
+export function ErrorsTable({ rows }: { rows: ErrorAnalyticsRow[] }) {
+  return (
+    <section className="tv-card tv-eff">
+      <div className="tv-eff__head">
+        <h2 className="tv-eff__title">Errors & interrupts</h2>
+        <span className="tv-eff__hint">
+          n/a = the agent's format doesn't record it (hover for why) · interrupts are Claude Code only
+        </span>
+      </div>
+      <div className="tv-eff__scroll">
+        <table className="tv-eff__table">
+          <thead>
+            <tr>
+              <th>Agent</th>
+              {COLS.map((c) => (
+                <th key={c.label} className="tv-eff__num" title={c.title}>
+                  {c.label}
+                </th>
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            {rows.map((row) => (
+              <tr key={row.connectorId}>
+                <td>
+                  <AgentBadge connectorId={row.connectorId} />
+                </td>
+                {COLS.map((c) => {
+                  const v = c.value(row);
+                  return (
+                    <td key={c.label} className="tv-eff__num">
+                      {v === null ? (
+                        <span className="tv-na" title={row.availabilityNote ?? 'Not recorded by this agent'}>
+                          n/a
+                        </span>
+                      ) : (
+                        c.fmt(v)
+                      )}
+                    </td>
+                  );
+                })}
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </section>
+  );
+}

--- a/packages/web/src/pages/analytics/analytics.css
+++ b/packages/web/src/pages/analytics/analytics.css
@@ -445,3 +445,30 @@
   padding: var(--tv-space-2) var(--tv-space-3);
   max-width: 220px;
 }
+
+/* Digest view. */
+.tv-digest__bar {
+  display: flex;
+  align-items: center;
+  gap: var(--tv-space-4);
+  margin-bottom: var(--tv-space-4);
+  flex-wrap: wrap;
+}
+.tv-digest__list {
+  margin: 0;
+  padding-left: var(--tv-space-5);
+  display: grid;
+  gap: var(--tv-space-2);
+  font-size: var(--tv-fs-md);
+}
+.tv-digest__list code {
+  font-size: 12px;
+  word-break: break-all;
+}
+.tv-digest__empty {
+  color: var(--tv-fg-muted);
+  list-style: none;
+}
+.tv-digest__agent {
+  margin-right: var(--tv-space-2);
+}

--- a/packages/web/src/pages/analytics/analytics.css
+++ b/packages/web/src/pages/analytics/analytics.css
@@ -426,3 +426,22 @@
   font-size: 9px;
   vertical-align: 1px;
 }
+
+/* n/a marker for metrics an agent's source format cannot report (hover = why). */
+.tv-na {
+  color: var(--tv-fg-muted);
+  font-size: 12px;
+  cursor: help;
+}
+
+/* Project scope <select> — mirrors the date inputs. */
+.tv-analytics__select {
+  background: var(--tv-bg-inset);
+  border: 1px solid var(--tv-border);
+  border-radius: var(--tv-radius-sm);
+  color: var(--tv-fg);
+  font-family: inherit;
+  font-size: var(--tv-fs-md);
+  padding: var(--tv-space-2) var(--tv-space-3);
+  max-width: 220px;
+}


### PR DESCRIPTION
## Summary

Roadmap slices 6 and 7 of [0035](https://github.com/vladar107/claudescope/blob/main/docs/plans/0035-agent-access-and-analytics-roadmap.md) — the last wave. **Stacked on #48**; retargets when it merges.

**Slice 6 — error/interrupt analytics** (plan 0041):
- `GET /api/analytics/errors?project=&from=&to=` — per-agent tool-call/error/interrupt signals with the null-not-zero contract: `toolErrors` stays NULL for Junie/Antigravity (no error signal in the format), interrupts are Claude-Code-only (prefix-anchored match on both `[Request interrupted by user…]` variants, verified against real transcripts; quoting the marker mid-text doesn't count).
- Implementation note: `is_error` tool results live on **user** rows (Claude Code/Codex), so errors aren't filtered to assistant rows — fork copies are excluded via `forked_from_session_id` instead.
- New **Errors** view in Analytics (n/a-aware table, project + date filters).

**Slice 7 — digest** (plan 0042):
- `GET /api/analytics/digest?from=&to=` (default last 7 UTC days): totals, top projects, model/tool mix, per-agent sessions, biggest session, streak, code impact from `file_edits`, error summary (reuses slice 6's aggregation), interrupts.
- **Digest** view with date presets and a **Copy as Markdown** button; `claudescope digest [--from --to] [--json]` prints exactly the same markdown (shared renderer in `packages/shared/src/digest-markdown.ts`).

Known follow-up: `AnalyticsPage.tsx`/`analytics.css`/plans-index conflict trivially with sibling #49 — resolved at rebase when the second one lands.

## Testing
`npm test` 365/365 (11 new: NULL-vs-counted error semantics, interrupt marker precision, digest composition with a no-token agent, empty range, markdown renderer edges), `npm run typecheck` clean.

Plans: docs/plans/0041-error-interrupt-analytics.md, docs/plans/0042-digest.md