### PR TITLE
feat(cost): provider-aware pricing — zero-rate local model providers

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -206,6 +206,11 @@ The CLI `update` command (`cli.ts`) detects the install method and defers to
   layer for families and the default rate. Usage is deduplicated by billed API
   call (`message.id`): multi-block splits and fork/resume copies repeat usage
   across rows, and only the canonical row (elected at index time) is counted.
+  pi/Codex/opencode also record the serving *provider*, and pricing's
+  `providers` section overrides model rates for it entirely (shipped defaults
+  zero-rate local runtimes like LM Studio/Ollama). Pricing changes apply
+  **prospectively** — cost is stamped per event at index time, so only an index
+  rebuild re-prices already-indexed history.
 - **Release is maintainer-only** and tag-triggered (npm Trusted Publishing /
   OIDC). See `CONTRIBUTING.md`.
 

--- a/README.md
+++ b/README.md
@@ -280,20 +280,34 @@ just a `SUM` over events; a project/session total is the sum of its events.
 
 Rates are resolved in a layered lookup:
 
-1. **Fetched exact id** — `~/.claudescope/pricing.fetched.json` (auto-refreshed
+1. **Provider override** — if the agent recorded which model *provider* served
+   the response (pi, Codex, and opencode do) and it matches an entry in
+   `pricing.json`'s `providers` map (matched case-insensitively), that entry's
+   rates apply outright and the steps below are skipped — this is how local
+   runtimes are zero-rated regardless of what model id they report. The
+   shipped default zero-rates nine known local-runtime ids: `ollama`,
+   `lmstudio`, `lm-studio`, `llama.cpp`, `llamacpp`, `vllm`, `oss`, `local`,
+   `mlx`. Add your own id to `providers` (e.g. a custom Ollama gateway key) to
+   zero-rate it too.
+2. **Fetched exact id** — `~/.claudescope/pricing.fetched.json` (auto-refreshed
    daily from [LiteLLM's community price table](https://github.com/BerriAI/litellm/blob/main/model_prices_and_context_window.json),
    covering Anthropic, OpenAI, Gemini, xAI, Mistral, and DeepSeek models).
-2. **Local exact id** — `~/.claudescope/pricing.json` (seeded on first run from
+3. **Local exact id** — `~/.claudescope/pricing.json` (seeded on first run from
    the shipped default; user-editable; takes precedence over the fetched snapshot
    for any id it defines explicitly).
-3. **Family match** — `opus` / `sonnet` / `haiku` / `gemini` / `gpt` substring in
+4. **Family match** — `opus` / `sonnet` / `haiku` / `gemini` / `gpt` substring in
    the model id → the matching family rate from `pricing.json`.
-4. **Default** — the `default` entry in `pricing.json`.
+5. **Default** — the `default` entry in `pricing.json`.
 
 The family step means version- or date-suffixed ids (e.g. `claude-haiku-4-5-20251001`,
 `gpt-5.x-codex`, `gemini-2.5-flash`) still price correctly. `pricing.json` is the
 user-editable fallback and override layer for families and the default rate; the
 fetched snapshot provides exact per-model rates for all known models.
+
+Claude Code, Junie, Copilot CLI, and Antigravity record no model provider in
+their transcripts, so a local run there can't be auto-detected via step 1 — the
+escape hatch is pinning the exact model id to a zero rate in `pricing.json`'s
+`models` section.
 
 Shipped fallback rates (USD per 1M tokens):
 
@@ -312,9 +326,16 @@ Shipped fallback rates (USD per 1M tokens):
 - Rates **auto-refresh daily** in the background while the server runs. Run
   `claudescope pricing update` to force a refresh at any time. New rates apply
   to newly indexed events; existing indexed costs are unchanged.
-- Edit `~/.claudescope/pricing.json` to override families, the default rate, or
-  pin specific model prices. Re-index (`POST /api/reindex` or `claudescope
-  restart`) to recompute stored costs at the new rates.
+- Edit `~/.claudescope/pricing.json` to override families, the default rate,
+  specific model prices, or the `providers` map. Pricing changes apply
+  **prospectively**: cost is stamped per event at index time, so an edit only
+  affects events indexed *after* the change — re-indexing (`POST /api/reindex`
+  or `claudescope restart`) picks up new/changed files at the new rates but
+  does not recompute costs already stored for unchanged files. A full re-price
+  of your whole history happens only when the index itself is rebuilt from
+  scratch — an app upgrade that bumps the schema, corruption recovery, or
+  manually deleting `~/.claudescope/index.duckdb*` (it's a derived cache, safe
+  to delete; it rebuilds from your transcripts).
 - `pricing.json` carries a `schemaVersion`. When an upgrade ships a newer default
   (new families/models or a changed default rate), the app **reconciles your copy
   on startup**: it backs the old file up to `pricing.json.bak`, adds the new

--- a/docs/plans/0044-provider-aware-cost.md
+++ b/docs/plans/0044-provider-aware-cost.md
@@ -1,8 +1,8 @@
 # 0044 — Provider-aware cost: local vs remote model sessions
 
-- **Status:** in-progress
+- **Status:** done
 - **Date:** 2026-07-13
-- **PR:** <link, once opened>
+- **PR:** https://github.com/vladar107/claudescope/pull/56
 
 ## Context
 

--- a/docs/plans/0044-provider-aware-cost.md
+++ b/docs/plans/0044-provider-aware-cost.md
@@ -103,7 +103,7 @@ retroactively re-pricing history that's already indexed.
 - `packages/server/src/routes/sessions.ts` `rowToSessionMeta`: splits the
   `providers` CSV like `models`; computes `hasLocalProvider` from a cached
   `loadPricing()` call + `isZeroRated` per provider.
-- `packages/server/src/agent/mcp.ts` `sessionLine`: appends ` (local)` after
+- `packages/server/src/agent/mcp.ts` `sessionLine`: appends `(local)` after
   the cost segment when `hasLocalProvider`; JSON outputs (CLI `--json`, the
   API) pick up the new fields automatically since they serialize `SessionMeta`
   directly — no separate CLI-side change needed.

--- a/docs/plans/0044-provider-aware-cost.md
+++ b/docs/plans/0044-provider-aware-cost.md
@@ -1,0 +1,168 @@
+# 0044 — Provider-aware cost: local vs remote model sessions
+
+- **Status:** in-progress
+- **Date:** 2026-07-13
+- **PR:** <link, once opened>
+
+## Context
+
+A pi session run against a **local** LM Studio model (`openai/gpt-oss-20b`)
+showed **$0.081** in Claudescope. Root cause: cost is computed at index time as
+tokens × rates resolved by exact model id → family substring → default
+(`buildCostExpr`, `packages/server/src/data/index.ts`). `openai/gpt-oss-20b` has
+no exact/fetched rate (the LiteLLM fetcher skips slash-prefixed ids) but
+matches the `gpt` **family** ($2.50/M in, $15/M out) → phantom cost for a free
+local run.
+
+The pricing path had no concept of *where* a model ran. Decisions locked with
+the user before implementation:
+
+- Keep the uniform "store tokens, compute cost from pricing config at index
+  time" design — never trust agent-reported cost (pi's own `usage.cost` stays
+  ignored).
+- Add a per-assistant-event `provider` column and a `providers` rate-override
+  section in pricing config; known local runtimes zero-rate.
+- **No retroactive re-costing.** Pricing changes apply prospectively (to newly
+  indexed files) — the existing, accepted trade-off. Historical costs stay as
+  stamped at index time; a full re-price happens only when the derived index
+  is rebuilt (schema bump on upgrade, corruption recovery, or deleting
+  `~/.claudescope/index.duckdb`). The README's previous "re-index recomputes
+  stored costs" claim was wrong and is corrected here to describe this.
+
+## Goal
+
+A session run entirely on a local model provider shows **$0** and is visibly
+tagged **local** everywhere cost is surfaced (API, UI, CLI, MCP) — without ever
+retroactively re-pricing history that's already indexed.
+
+## Decisions
+
+- **Provider signal varies by agent** — pi (`message.provider`, per-message,
+  sessions can mix providers), Codex (`session_meta.model_provider`,
+  session-level, applied to every assistant row), and opencode (`providerID`,
+  per-message) all record it. Junie, Copilot CLI, Claude Code, and Antigravity
+  record no provider at all — local runs there can't be auto-detected; the
+  escape hatch is pinning the exact model id to a zero rate in `pricing.json`'s
+  `models` section.
+- **Seed a known-local set, but stay user-extensible.** Arbitrary custom
+  provider ids exist (Codex TOML keys, pi `models.json`, opencode config), so
+  the shipped default zero-rates nine known local-runtime ids (`ollama`,
+  `lmstudio`, `lm-studio`, `llama.cpp`, `llamacpp`, `vllm`, `oss`, `local`,
+  `mlx`) and falls through to model pricing for any unknown id — a real remote
+  custom gateway (e.g. Codex's `custom-gateway`) must never get zero-rated by
+  accident.
+- **Provider override wins outright.** When a provider matches a `providers`
+  entry, that entry's rates apply and the model-id/family/default chain is
+  skipped entirely — this is deliberately a full override, not a partial one.
+- **`hasLocalProvider` is server-computed**, not derived client-side, so the
+  local rate set is a single source of truth and clients never duplicate it.
+- **DDL signature bump (schema v11)** for `events.provider` +
+  `sessions.providers` triggers the one-time full index rebuild that also
+  re-prices already-indexed local sessions to $0 — the intended one-time
+  correction, not a general re-pricing mechanism.
+
+## Approach
+
+### Pricing config + connectors
+
+- `packages/shared/src/pricing.ts`: `PricingConfig.providers?: Record<string,
+  ModelRates>` (lowercase provider id → rates, matched case-insensitively,
+  overrides the models/families/default chain) + exported `isZeroRated(r)`
+  helper (all four rates 0).
+- `packages/server/pricing.json`: `schemaVersion: 3`, seeded `providers` zero-
+  rating the nine local-runtime ids above.
+- `packages/server/src/config.ts`: `PRICING_SCHEMA_VERSION = 3`; the
+  shipped/user reconcile merge gained a `providers` entry (previously only
+  `models`/`families`/`default` were merged — a user's custom provider id now
+  survives a v2→v3 migration alongside the new shipped set).
+- `connectors/types.ts`: `provider` added to `CANONICAL_EVENT_COLUMNS`
+  (nullable — NULL where the format records no signal). All seven connectors
+  updated: pi and opencode extract it per-message; Codex captures
+  `model_provider` once per session and stamps it on every assistant row;
+  Junie/Copilot/Antigravity/Claude Code project `CAST(NULL AS VARCHAR)`.
+
+### Schema + indexer (schema v11)
+
+- `db/schema.ts`: `events.provider VARCHAR` (after `model`) and
+  `sessions.providers VARCHAR` (distinct-providers CSV, same convention as
+  `models`); `SCHEMA_VERSION = 11` — the DDL-signature change auto-discards and
+  rebuilds the index on next start, which is also how already-indexed local
+  sessions get re-priced to $0 once.
+- `data/index.ts`: `buildCostExpr` wraps the existing rate chain in a `CASE
+  WHEN lower(ev.provider) = '<id>' THEN <rate> …` per `pricing.providers`
+  entry, falling through to the model chain via `ELSE` (NULL/unlisted
+  providers never match, so unlisted-provider and no-provider events are
+  unaffected); the events INSERT carries `ev.provider`;
+  `rebuildSessions` aggregates `list_distinct(...) FILTER (WHERE provider IS
+  NOT NULL)` into the `providers` CSV column.
+
+### API, CLI/MCP, docs (this pass)
+
+- `packages/shared/src/api.ts` `SessionMeta`: added `providers: string[]` and
+  `hasLocalProvider?: boolean` (server-computed).
+- `packages/server/src/routes/sessions.ts` `rowToSessionMeta`: splits the
+  `providers` CSV like `models`; computes `hasLocalProvider` from a cached
+  `loadPricing()` call + `isZeroRated` per provider.
+- `packages/server/src/agent/mcp.ts` `sessionLine`: appends ` (local)` after
+  the cost segment when `hasLocalProvider`; JSON outputs (CLI `--json`, the
+  API) pick up the new fields automatically since they serialize `SessionMeta`
+  directly — no separate CLI-side change needed.
+- `README.md` "Cost methodology": documents the provider override as lookup
+  step 1 (ahead of fetched/local exact id, family, default), lists the nine
+  seeded local ids, notes the four agents with no provider signal, and
+  rewrites the previously-false "re-index recomputes stored costs" bullet to
+  describe the real prospective-pricing behavior and when a full rebuild
+  actually happens.
+- `CLAUDE.md` "Cost is a local estimate" gotcha: extended with the
+  provider-override + prospective-pricing facts.
+
+### UI (parallel wave, `packages/web` — not touched by this pass)
+
+- New `components/LocalBadge.tsx` mirroring `AgentBadge`; rendered next to
+  `ModelChips` in `pages/browse/SessionList.tsx` and
+  `pages/session/SessionPage.tsx` when `hasLocalProvider`; a muted
+  `.tv-chip--local` style in `styles/global.css`.
+
+## Files affected
+
+- `packages/shared/src/pricing.ts` — `providers` + `isZeroRated`.
+- `packages/shared/src/api.ts` — `SessionMeta.providers` / `.hasLocalProvider`.
+- `packages/server/pricing.json`, `src/config.ts` — seeded zero-rating +
+  reconcile merge.
+- `packages/server/src/connectors/types.ts` + all seven connectors' `*.ts` /
+  `normalize.ts` — `provider` column end to end.
+- `packages/server/src/db/schema.ts` (v11), `src/data/index.ts` — provider
+  column + cost-expression override + `providers` session aggregate.
+- `packages/server/src/routes/sessions.ts` — `rowToSessionMeta` reads
+  `providers` / computes `hasLocalProvider`.
+- `packages/server/src/agent/mcp.ts` — `sessionLine` `(local)` marker.
+- `README.md`, `CLAUDE.md` — pricing docs.
+- `packages/web/src/components/LocalBadge.tsx` (new),
+  `components/index.ts`, `pages/browse/SessionList.tsx`,
+  `pages/session/SessionPage.tsx`, `styles/global.css` — local badge (parallel
+  wave).
+
+## Testing
+
+`npm run typecheck` (`tsc -b`) — clean. `npm test` — 45 files / 374 tests
+passing.
+
+Dedicated provider-pricing tests (mixed-provider session cost split, unknown-
+provider fallthrough, v2→v3 reconcile preserving a custom provider id) were
+part of the original plan's Wave 4 and are **not yet added** — existing fixture
+suites already carry `provider`/`providerID`/`model_provider` values on assistant
+rows (pi, Codex, opencode integration tests) and continue to pass unchanged,
+but they predate and don't specifically exercise the zero-rating logic. See
+Risks below.
+
+## Risks / open questions
+
+- **Wave 4 tests outstanding**: `test/pricing.test.ts` (provider beats exact-id,
+  unknown provider falls through, v2→v3 reconcile keeps a custom entry),
+  `pi.integration.test.ts` (mixed lmstudio/openai-codex session →
+  `providers` CSV + split cost + `hasLocalProvider`), `codex.integration.test.ts`
+  (`model_provider` propagates session-wide), `opencode.integration.test.ts`
+  (`providers === ['openai']`) are all still to write.
+- Manual end-to-end verification (start the server, confirm the v11 rebuild,
+  check `/api/sessions`, the UI badge in light/dark, `claudescope sessions
+  --json`, and the MCP `(local)` marker) has not been run in this pass.

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -68,4 +68,4 @@ decision, or a change worth explaining before doing. Skip it for one-line fixes.
 | 0041 | [Error & interrupt analytics](./0041-error-interrupt-analytics.md) | done |
 | 0042 | [Week-in-review digest (page + copy-md + CLI)](./0042-digest.md) | done |
 | 0043 | [Retire the Activity tab: redistribute its pieces](./0043-activity-tab-redistribution.md) | done |
-| 0044 | [Provider-aware cost: local vs remote model sessions](./0044-provider-aware-cost.md) | in-progress |
+| 0044 | [Provider-aware cost: local vs remote model sessions](./0044-provider-aware-cost.md) | done |

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -68,3 +68,4 @@ decision, or a change worth explaining before doing. Skip it for one-line fixes.
 | 0041 | [Error & interrupt analytics](./0041-error-interrupt-analytics.md) | done |
 | 0042 | [Week-in-review digest (page + copy-md + CLI)](./0042-digest.md) | done |
 | 0043 | [Retire the Activity tab: redistribute its pieces](./0043-activity-tab-redistribution.md) | done |
+| 0044 | [Provider-aware cost: local vs remote model sessions](./0044-provider-aware-cost.md) | in-progress |

--- a/packages/server/pricing.json
+++ b/packages/server/pricing.json
@@ -1,5 +1,16 @@
 {
-  "schemaVersion": 2,
+  "schemaVersion": 3,
+  "providers": {
+    "ollama": { "input": 0, "output": 0, "cacheWrite": 0, "cacheRead": 0 },
+    "lmstudio": { "input": 0, "output": 0, "cacheWrite": 0, "cacheRead": 0 },
+    "lm-studio": { "input": 0, "output": 0, "cacheWrite": 0, "cacheRead": 0 },
+    "llama.cpp": { "input": 0, "output": 0, "cacheWrite": 0, "cacheRead": 0 },
+    "llamacpp": { "input": 0, "output": 0, "cacheWrite": 0, "cacheRead": 0 },
+    "vllm": { "input": 0, "output": 0, "cacheWrite": 0, "cacheRead": 0 },
+    "oss": { "input": 0, "output": 0, "cacheWrite": 0, "cacheRead": 0 },
+    "local": { "input": 0, "output": 0, "cacheWrite": 0, "cacheRead": 0 },
+    "mlx": { "input": 0, "output": 0, "cacheWrite": 0, "cacheRead": 0 }
+  },
   "models": {
     "claude-opus-4-1": { "input": 15, "output": 75, "cacheWrite": 18.75, "cacheRead": 1.5 },
     "claude-opus-4": { "input": 15, "output": 75, "cacheWrite": 18.75, "cacheRead": 1.5 },

--- a/packages/server/src/agent/mcp.ts
+++ b/packages/server/src/agent/mcp.ts
@@ -46,11 +46,12 @@ export interface McpDeps {
 
 function sessionLine(s: SessionMeta): string {
   const branch = s.gitBranch ? ` · ${s.gitBranch}` : '';
+  const local = s.hasLocalProvider ? ' (local)' : '';
   return (
     `- ${s.id} [${s.connectorId}] ${s.title}\n` +
     `  ${s.projectDisplayName} · ${day(s.startedAt)} → ${day(s.endedAt)} · ` +
     `${s.messageCount} msgs · ${s.toolCallCount} tools · ${fmtTokens(s.totalTokens)} tok · ` +
-    `${fmtCost(s.totalCostUsd)}${branch}`
+    `${fmtCost(s.totalCostUsd)}${local}${branch}`
   );
 }
 

--- a/packages/server/src/config.ts
+++ b/packages/server/src/config.ts
@@ -231,15 +231,15 @@ export const APP_VERSION =
  * shadowing it. A monotonic integer (not a content hash): the user copy is meant
  * to be edited, so only a real shipped change should trigger a reconcile.
  */
-export const PRICING_SCHEMA_VERSION = 2;
+export const PRICING_SCHEMA_VERSION = 3;
 
 /**
  * Reconcile the user-editable pricing file with the shipped default.
  *
  * Non-destructive and self-healing: on first run it seeds the user copy; when the
  * shipped schema version is newer than the user's, it backs up the old file to
- * `<path>.bak`, then merges so NEW shipped keys (models/families) appear while
- * every value the user customized wins. A corrupt user file is left untouched
+ * `<path>.bak`, then merges so NEW shipped keys (models/families/providers) appear
+ * while every value the user customized wins. A corrupt user file is left untouched
  * (never discard user data). Paths are injectable for tests.
  */
 export function reconcilePricingConfig(
@@ -279,6 +279,7 @@ export function reconcilePricingConfig(
     schemaVersion: shippedV,
     models: { ...shipped.models, ...user.models },
     families: { ...(shipped.families ?? {}), ...(user.families ?? {}) },
+    providers: { ...(shipped.providers ?? {}), ...(user.providers ?? {}) },
     default: user.default ?? shipped.default,
   };
   // Atomic write: stage to a temp file then rename, so a reader never sees a torn

--- a/packages/server/src/connectors/antigravity/antigravity.ts
+++ b/packages/server/src/connectors/antigravity/antigravity.ts
@@ -82,7 +82,7 @@ function eventsProjectionSql(filePath: string): string {
   return `
     SELECT
       file_path, session_id, uuid, parent_uuid, role, type, ts, cwd, git_branch,
-      model, input_tokens, output_tokens, cache_read_tokens, cache_write_tokens,
+      model, CAST(NULL AS VARCHAR) AS provider, input_tokens, output_tokens, cache_read_tokens, cache_write_tokens,
       service_tier, is_sidechain, tool_use_count, tool_names, tool_error_count, text_content,
       CAST(NULL AS VARCHAR) AS message_id, CAST(NULL AS VARCHAR) AS forked_from_session_id
     FROM read_ndjson(${path}, format='newline_delimited', maximum_object_size=268435456, ignore_errors=true, columns={

--- a/packages/server/src/connectors/claude-code/claude-code.ts
+++ b/packages/server/src/connectors/claude-code/claude-code.ts
@@ -158,6 +158,7 @@ function eventsProjectionSql(filePath: string): string {
       cwd,
       gitBranch AS git_branch,
       json_extract_string(message, '$.model') AS model,
+      CAST(NULL AS VARCHAR) AS provider,
       COALESCE(try_cast(json_extract(message, '$.usage.input_tokens') AS BIGINT), 0) AS input_tokens,
       COALESCE(try_cast(json_extract(message, '$.usage.output_tokens') AS BIGINT), 0) AS output_tokens,
       COALESCE(try_cast(json_extract(message, '$.usage.cache_read_input_tokens') AS BIGINT), 0) AS cache_read_tokens,

--- a/packages/server/src/connectors/codex/codex.ts
+++ b/packages/server/src/connectors/codex/codex.ts
@@ -56,13 +56,13 @@ function eventsProjectionSql(filePath: string): string {
   return `
     SELECT
       file_path, session_id, uuid, parent_uuid, role, type, ts, cwd, git_branch,
-      model, input_tokens, output_tokens, cache_read_tokens, cache_write_tokens,
+      model, provider, input_tokens, output_tokens, cache_read_tokens, cache_write_tokens,
       service_tier, is_sidechain, tool_use_count, tool_names, tool_error_count, text_content,
       CAST(NULL AS VARCHAR) AS message_id, CAST(NULL AS VARCHAR) AS forked_from_session_id
     FROM read_ndjson(${path}, format='newline_delimited', maximum_object_size=268435456, ignore_errors=true, columns={
       file_path:'VARCHAR', session_id:'VARCHAR', uuid:'VARCHAR', parent_uuid:'VARCHAR',
       role:'VARCHAR', type:'VARCHAR', ts:'TIMESTAMP', cwd:'VARCHAR', git_branch:'VARCHAR',
-      model:'VARCHAR', input_tokens:'BIGINT', output_tokens:'BIGINT', cache_read_tokens:'BIGINT',
+      model:'VARCHAR', provider:'VARCHAR', input_tokens:'BIGINT', output_tokens:'BIGINT', cache_read_tokens:'BIGINT',
       cache_write_tokens:'BIGINT', service_tier:'VARCHAR', is_sidechain:'BOOLEAN',
       tool_use_count:'INTEGER', tool_names:'VARCHAR', tool_error_count:'INTEGER', text_content:'VARCHAR'
     })`;

--- a/packages/server/src/connectors/codex/normalize.ts
+++ b/packages/server/src/connectors/codex/normalize.ts
@@ -51,6 +51,9 @@ export interface CodexSession {
   agentRole?: string;
   cwd: string;
   gitBranch?: string;
+  /** `model_provider` from session_meta — session-level, applied to every
+   *  assistant row (e.g. 'openai'). */
+  modelProvider?: string;
   events: (UserEvent | AssistantEvent)[];
   /** Spawned child thread id → Task correlation meta, from this rollout's
    *  `spawn_agent` calls (description must equal the Task block's). */
@@ -473,6 +476,7 @@ export function parseRollout(path: string): CodexSession | null {
   const cwd = str(meta.cwd);
   const git = meta.git as Record<string, unknown> | undefined;
   const gitBranch = git ? str(git.branch) || str(git.ref) || undefined : undefined;
+  const modelProvider = str(meta.model_provider) || undefined;
 
   // A `thread_source: "subagent"` rollout is re-parented under its ROOT thread
   // (multi-level: walk the cross-file parent map), so it folds into the parent
@@ -691,7 +695,7 @@ export function parseRollout(path: string): CodexSession | null {
   }
   flush();
 
-  return { sessionId, indexSessionId, isSidechain, agentRole, cwd, gitBranch, events, spawnedAgents };
+  return { sessionId, indexSessionId, isSidechain, agentRole, cwd, gitBranch, modelProvider, events, spawnedAgents };
 }
 
 /** A canonical index row (matches the events NDJSON the projection reads). */
@@ -706,6 +710,7 @@ export interface CanonicalRow {
   cwd: string;
   git_branch: string | null;
   model: string | null;
+  provider: string | null;
   input_tokens: number;
   output_tokens: number;
   cache_read_tokens: number;
@@ -743,6 +748,7 @@ export function toCanonicalRows(session: CodexSession, filePath: string): Canoni
       cwd: session.cwd,
       git_branch: session.gitBranch ?? null,
       model: (msg as { model?: string }).model ?? null,
+      provider: e.type === 'assistant' ? (session.modelProvider ?? null) : null,
       input_tokens: num(usage?.input_tokens),
       output_tokens: num(usage?.output_tokens),
       cache_read_tokens: num(usage?.cache_read_input_tokens),

--- a/packages/server/src/connectors/copilot/copilot.ts
+++ b/packages/server/src/connectors/copilot/copilot.ts
@@ -67,7 +67,7 @@ function eventsProjectionSql(filePath: string): string {
   return `
     SELECT
       file_path, session_id, uuid, parent_uuid, role, type, ts, cwd, git_branch,
-      model, input_tokens, output_tokens, cache_read_tokens, cache_write_tokens,
+      model, CAST(NULL AS VARCHAR) AS provider, input_tokens, output_tokens, cache_read_tokens, cache_write_tokens,
       service_tier, is_sidechain, tool_use_count, tool_names, tool_error_count, text_content,
       CAST(NULL AS VARCHAR) AS message_id, CAST(NULL AS VARCHAR) AS forked_from_session_id
     FROM read_ndjson(${path}, format='newline_delimited', maximum_object_size=268435456, ignore_errors=true, columns={

--- a/packages/server/src/connectors/junie/junie.ts
+++ b/packages/server/src/connectors/junie/junie.ts
@@ -81,7 +81,7 @@ function eventsProjectionSql(filePath: string): string {
   return `
     SELECT
       file_path, session_id, uuid, parent_uuid, role, type, ts, cwd, git_branch,
-      model, input_tokens, output_tokens, cache_read_tokens, cache_write_tokens,
+      model, CAST(NULL AS VARCHAR) AS provider, input_tokens, output_tokens, cache_read_tokens, cache_write_tokens,
       service_tier, is_sidechain, tool_use_count, tool_names, tool_error_count, text_content,
       CAST(NULL AS VARCHAR) AS message_id, CAST(NULL AS VARCHAR) AS forked_from_session_id
     FROM read_ndjson(${path}, format='newline_delimited', maximum_object_size=268435456, ignore_errors=true, columns={

--- a/packages/server/src/connectors/opencode/normalize.ts
+++ b/packages/server/src/connectors/opencode/normalize.ts
@@ -292,6 +292,8 @@ export function buildEvents(session: OpencodeRawSession): (UserEvent | Assistant
       }
       const model =
         str(data.modelID) || str((data.model as Record<string, unknown> | undefined)?.modelID);
+      const provider =
+        str(data.providerID) || str((data.model as Record<string, unknown> | undefined)?.providerID);
       const uuid = nextUuid();
       const parentUuid = prevUuid;
       prevUuid = uuid;
@@ -303,7 +305,7 @@ export function buildEvents(session: OpencodeRawSession): (UserEvent | Assistant
         cwd,
         isSidechain,
         type: 'assistant',
-        message: { role: 'assistant', model, content: blocks, usage: toUsage(data.tokens) },
+        message: { role: 'assistant', model, provider: provider || undefined, content: blocks, usage: toUsage(data.tokens) },
       } as AssistantEvent);
       // Tool results ride a following synthetic user turn (assembler pairs by id).
       if (toolResults.length > 0) {
@@ -393,6 +395,7 @@ export interface CanonicalRow {
   cwd: string;
   git_branch: string | null;
   model: string | null;
+  provider: string | null;
   input_tokens: number;
   output_tokens: number;
   cache_read_tokens: number;
@@ -429,6 +432,7 @@ export function toCanonicalRows(session: OpencodeRawSession, filePath: string): 
       cwd: session.directory,
       git_branch: null,
       model: (msg as { model?: string }).model ?? null,
+      provider: (msg as { provider?: string }).provider ?? null,
       input_tokens: num(usage?.input_tokens),
       output_tokens: num(usage?.output_tokens),
       cache_read_tokens: num(usage?.cache_read_input_tokens),

--- a/packages/server/src/connectors/opencode/opencode.ts
+++ b/packages/server/src/connectors/opencode/opencode.ts
@@ -72,13 +72,13 @@ function eventsProjectionSql(filePath: string): string {
   return `
     SELECT
       file_path, session_id, uuid, parent_uuid, role, type, ts, cwd, git_branch,
-      model, input_tokens, output_tokens, cache_read_tokens, cache_write_tokens,
+      model, provider, input_tokens, output_tokens, cache_read_tokens, cache_write_tokens,
       service_tier, is_sidechain, tool_use_count, tool_names, tool_error_count, text_content,
       CAST(NULL AS VARCHAR) AS message_id, CAST(NULL AS VARCHAR) AS forked_from_session_id
     FROM read_ndjson(${path}, format='newline_delimited', maximum_object_size=268435456, ignore_errors=true, columns={
       file_path:'VARCHAR', session_id:'VARCHAR', uuid:'VARCHAR', parent_uuid:'VARCHAR',
       role:'VARCHAR', type:'VARCHAR', ts:'TIMESTAMP', cwd:'VARCHAR', git_branch:'VARCHAR',
-      model:'VARCHAR', input_tokens:'BIGINT', output_tokens:'BIGINT', cache_read_tokens:'BIGINT',
+      model:'VARCHAR', provider:'VARCHAR', input_tokens:'BIGINT', output_tokens:'BIGINT', cache_read_tokens:'BIGINT',
       cache_write_tokens:'BIGINT', service_tier:'VARCHAR', is_sidechain:'BOOLEAN',
       tool_use_count:'INTEGER', tool_names:'VARCHAR', tool_error_count:'INTEGER', text_content:'VARCHAR'
     })`;

--- a/packages/server/src/connectors/pi/normalize.ts
+++ b/packages/server/src/connectors/pi/normalize.ts
@@ -221,6 +221,7 @@ interface PiLine {
     role?: string;
     content?: unknown;
     model?: string;
+    provider?: string;
     usage?: unknown;
     toolCallId?: string;
     /** Set on `toolResult` records — the tool the result belongs to. */
@@ -367,6 +368,7 @@ export function parsePiSession(path: string): PiSession | null {
         message: {
           role: 'assistant',
           model: str(msg.model),
+          provider: str(msg.provider) || undefined,
           content: assistantBlocks(msg.content),
           usage: toUsage(msg.usage),
         },
@@ -467,6 +469,7 @@ export interface CanonicalRow {
   cwd: string;
   git_branch: string | null;
   model: string | null;
+  provider: string | null;
   input_tokens: number;
   output_tokens: number;
   cache_read_tokens: number;
@@ -500,6 +503,7 @@ export function toCanonicalRows(session: PiSession, filePath: string): Canonical
       cwd: session.cwd,
       git_branch: null,
       model: (msg as { model?: string }).model ?? null,
+      provider: (msg as { provider?: string }).provider ?? null,
       input_tokens: num(usage?.input_tokens),
       output_tokens: num(usage?.output_tokens),
       cache_read_tokens: num(usage?.cache_read_input_tokens),

--- a/packages/server/src/connectors/pi/pi.ts
+++ b/packages/server/src/connectors/pi/pi.ts
@@ -83,13 +83,13 @@ function eventsProjectionSql(filePath: string): string {
   return `
     SELECT
       file_path, session_id, uuid, parent_uuid, role, type, ts, cwd, git_branch,
-      model, input_tokens, output_tokens, cache_read_tokens, cache_write_tokens,
+      model, provider, input_tokens, output_tokens, cache_read_tokens, cache_write_tokens,
       service_tier, is_sidechain, tool_use_count, tool_names, tool_error_count, text_content,
       CAST(NULL AS VARCHAR) AS message_id, CAST(NULL AS VARCHAR) AS forked_from_session_id
     FROM read_ndjson(${path}, format='newline_delimited', maximum_object_size=268435456, ignore_errors=true, columns={
       file_path:'VARCHAR', session_id:'VARCHAR', uuid:'VARCHAR', parent_uuid:'VARCHAR',
       role:'VARCHAR', type:'VARCHAR', ts:'TIMESTAMP', cwd:'VARCHAR', git_branch:'VARCHAR',
-      model:'VARCHAR', input_tokens:'BIGINT', output_tokens:'BIGINT', cache_read_tokens:'BIGINT',
+      model:'VARCHAR', provider:'VARCHAR', input_tokens:'BIGINT', output_tokens:'BIGINT', cache_read_tokens:'BIGINT',
       cache_write_tokens:'BIGINT', service_tier:'VARCHAR', is_sidechain:'BOOLEAN',
       tool_use_count:'INTEGER', tool_names:'VARCHAR', tool_error_count:'INTEGER', text_content:'VARCHAR'
     })`;

--- a/packages/server/src/connectors/types.ts
+++ b/packages/server/src/connectors/types.ts
@@ -38,6 +38,9 @@ export const CANONICAL_EVENT_COLUMNS = [
   'cwd',
   'git_branch',
   'model',
+  // Model provider that served the turn (e.g. 'lmstudio', 'anthropic', 'openai').
+  // Nullable — NULL when the source format records no provider signal (pi/codex/opencode do).
+  'provider',
   'input_tokens',
   'output_tokens',
   'cache_read_tokens',

--- a/packages/server/src/data/index.ts
+++ b/packages/server/src/data/index.ts
@@ -103,7 +103,18 @@ function buildCostExpr(pricing: PricingConfig): string {
     const familyExpr =
       cases.length > 0 ? `CASE ${cases.join(' ')} ELSE ${pricing.default[field]} END` : `${pricing.default[field]}`;
     // Exact-id rate (join) wins; then family; then default.
-    return `COALESCE(${RATES_ALIAS}.${column}, ${familyExpr})`;
+    const modelExpr = `COALESCE(${RATES_ALIAS}.${column}, ${familyExpr})`;
+    // A listed provider OVERRIDES the whole model chain (this is how local
+    // runtimes are zero-rated). `lower(NULL) = 'x'` is NULL in DuckDB, so
+    // NULL/unlisted providers fall through to the model chain via ELSE.
+    const providerCases: string[] = [];
+    for (const [id, rates] of Object.entries(pricing.providers ?? {})) {
+      const pat = sqlString(id.toLowerCase());
+      providerCases.push(`WHEN lower(${EVENTS_ALIAS}.provider) = ${pat} THEN ${rates[field]}`);
+    }
+    return providerCases.length > 0
+      ? `CASE ${providerCases.join(' ')} ELSE ${modelExpr} END`
+      : modelExpr;
   };
 
   // Cost is only attributable to assistant events (the ones carrying usage).
@@ -148,7 +159,7 @@ async function loadFile(
     INSERT INTO events
     SELECT
       ev.file_path, ev.session_id, ev.uuid, ev.parent_uuid, ev.role, ev.type, ev.ts, ev.cwd, ev.git_branch,
-      ev.model, ev.input_tokens, ev.output_tokens, ev.cache_read_tokens, ev.cache_write_tokens,
+      ev.model, ev.provider, ev.input_tokens, ev.output_tokens, ev.cache_read_tokens, ev.cache_write_tokens,
       ev.service_tier, ev.is_sidechain, ev.tool_use_count, ev.tool_names,
       ${costExpr} AS cost_usd,
       ev.text_content,
@@ -258,7 +269,8 @@ async function rebuildSessions(conn: DuckDBConnection): Promise<void> {
         COALESCE(sum(cache_write_tokens) FILTER (WHERE usage_canonical), 0) AS cache_write_tokens,
         COALESCE(sum(cost_usd) FILTER (WHERE usage_canonical), 0) AS total_cost_usd,
         bool_or(is_sidechain) AS has_sidechain,
-        list_distinct(list(model) FILTER (WHERE model IS NOT NULL)) AS model_list
+        list_distinct(list(model) FILTER (WHERE model IS NOT NULL)) AS model_list,
+        list_distinct(list(provider) FILTER (WHERE provider IS NOT NULL)) AS provider_list
       FROM events GROUP BY session_id
     )
     SELECT
@@ -279,6 +291,7 @@ async function rebuildSessions(conn: DuckDBConnection): Promise<void> {
       a.cache_read_tokens,
       a.cache_write_tokens,
       array_to_string(a.model_list, ',') AS models,
+      array_to_string(a.provider_list, ',') AS providers,
       NULL AS git_branch,
       p.pr_url,
       COALESCE(fs.size_bytes, 0) AS size_bytes,

--- a/packages/server/src/db/schema.ts
+++ b/packages/server/src/db/schema.ts
@@ -30,7 +30,9 @@
 // v10: code-impact analytics — per-tool-call `file_edits` rows (extracted at
 //      index time from the assembled thread) + nullable `events.tool_error_count`
 //      (NULL = the source format carries no error signal, distinct from 0).
-export const SCHEMA_VERSION = 10;
+// v11: provider-aware cost — events.provider + sessions.providers; providers
+//      listed in pricing 'providers' zero-rate at index time.
+export const SCHEMA_VERSION = 11;
 
 /** All DDL statements, executed in order at startup. Idempotent. */
 export const SCHEMA_DDL: readonly string[] = [
@@ -59,6 +61,9 @@ export const SCHEMA_DDL: readonly string[] = [
      cwd          VARCHAR,
      git_branch   VARCHAR,
      model        VARCHAR,
+     -- Model provider recorded by the agent (pi/codex/opencode); NULL when the
+     -- format has no provider signal.
+     provider     VARCHAR,
      input_tokens        BIGINT DEFAULT 0,
      output_tokens       BIGINT DEFAULT 0,
      cache_read_tokens   BIGINT DEFAULT 0,
@@ -95,6 +100,7 @@ export const SCHEMA_DDL: readonly string[] = [
      cache_read_tokens  BIGINT DEFAULT 0,
      cache_write_tokens BIGINT DEFAULT 0,
      models        VARCHAR,
+     providers     VARCHAR,
      git_branch    VARCHAR,
      pr_url        VARCHAR,
      size_bytes    BIGINT DEFAULT 0,

--- a/packages/server/src/routes/sessions.ts
+++ b/packages/server/src/routes/sessions.ts
@@ -12,12 +12,14 @@ import type {
   SessionMeta,
   SessionSort,
 } from '@claudescope/shared';
+import { isZeroRated } from '@claudescope/shared';
 import { getConnection, queryRows, sqlString } from '../db/duckdb.js';
 import { readRow } from '../db/row.js';
 import { displayNameFromCwd, projectIdFromCwd } from '../data/project-id.js';
 import { toIso } from './projects.js';
 import { assembleThread, buildSubagentRuns } from '../data/parser.js';
 import { loadSessionData } from '../data/session-loader.js';
+import { loadPricing } from '../data/pricing.js';
 import { connectorById } from '../connectors/registry.js';
 import { buildResumeInfo } from '../connectors/resume.js';
 import { resolveWindow, subagentsInWindow, truncateToolChars } from '../data/window.js';
@@ -41,6 +43,13 @@ function rowToSessionMeta(r: Record<string, unknown>): SessionMeta {
   const rd = readRow(r, 'sessions');
   const cwd = rd.str('project_cwd');
   const modelsStr = rd.str('models');
+  const providersStr = rd.str('providers');
+  const providers = providersStr ? providersStr.split(',').filter(Boolean) : [];
+  const pricing = loadPricing();
+  const hasLocalProvider = providers.some((p) => {
+    const rates = pricing.providers?.[p.toLowerCase()];
+    return rates !== undefined && isZeroRated(rates);
+  });
   const meta: SessionMeta = {
     id: rd.str('id'),
     projectId: cwd ? projectIdFromCwd(cwd) : '',
@@ -53,10 +62,12 @@ function rowToSessionMeta(r: Record<string, unknown>): SessionMeta {
     totalTokens: rd.num('total_tokens'),
     totalCostUsd: rd.num('total_cost_usd'),
     models: modelsStr ? modelsStr.split(',').filter(Boolean) : [],
+    providers,
     sizeBytes: rd.num('size_bytes'),
     hasSidechain: rd.bool('has_sidechain'),
     connectorId: rd.str('connector_id') || 'claude-code',
   };
+  if (hasLocalProvider) meta.hasLocalProvider = true;
   if (rd.bool('title_derived')) meta.titleDerived = true;
   const gitBranch = rd.str('git_branch');
   if (gitBranch) meta.gitBranch = gitBranch;

--- a/packages/server/test/codex.integration.test.ts
+++ b/packages/server/test/codex.integration.test.ts
@@ -137,6 +137,31 @@ function writeOrphanRollout(): string {
   return file;
 }
 
+/**
+ * A rollout whose `session_meta.model_provider` is a local runtime (`lmstudio`).
+ * The provider is session-level, so it stamps every assistant row and zero-rates
+ * the whole session via the provider override — even though the model (`gpt-5.4`)
+ * has a real rate and both turns carry usage. Prices off the shipped pricing.json.
+ */
+function writeLocalRollout(): string {
+  const dir = join(codexDir, '2026', '01', '03');
+  mkdirSync(dir, { recursive: true });
+  const file = join(dir, 'rollout-2026-01-03T09-00-00-019f4444-aaaa-7bbb-8ccc-000000000003.jsonl');
+  writeFileSync(
+    file,
+    jsonl([
+      { type: 'session_meta', timestamp: ts(50), payload: { id: 'codex-local-1', cwd: '/tmp/codexproj', cli_version: '0.122.0', model_provider: 'lmstudio', git: { branch: 'main' } } },
+      { type: 'turn_context', timestamp: ts(51), payload: { model: 'gpt-5.4', cwd: '/tmp/codexproj' } },
+      { type: 'response_item', timestamp: ts(52), payload: { type: 'message', role: 'user', content: [{ type: 'input_text', text: 'run this offline on my machine' }] } },
+      { type: 'response_item', timestamp: ts(53), payload: { type: 'message', role: 'assistant', content: [{ type: 'output_text', text: 'first local turn' }] } },
+      { type: 'event_msg', timestamp: ts(54), payload: { type: 'token_count', info: { last_token_usage: { input_tokens: 1000, cached_input_tokens: 0, output_tokens: 300 } }, rate_limits: {} } },
+      { type: 'response_item', timestamp: ts(55), payload: { type: 'message', role: 'assistant', content: [{ type: 'output_text', text: 'second local turn' }] } },
+      { type: 'event_msg', timestamp: ts(56), payload: { type: 'token_count', info: { last_token_usage: { input_tokens: 500, cached_input_tokens: 0, output_tokens: 100 } }, rate_limits: {} } },
+    ]),
+  );
+  return file;
+}
+
 let app: FastifyInstance;
 let closeConnection: () => Promise<void>;
 
@@ -145,6 +170,7 @@ beforeAll(async () => {
   writeRollout();
   writeChildRollout();
   writeOrphanRollout();
+  writeLocalRollout();
 
   const Fastify = (await import('fastify')).default;
   const { registerRoutes } = await import('../src/routes/index.js');
@@ -170,7 +196,7 @@ describe('Codex session indexing', () => {
     const sessions = (await get('/api/sessions')).json();
     // The child rollout folds into its parent (never its own session); the orphan
     // child indexes under its absent root id `codex-gone`.
-    expect(sessions.map((s: { id: string }) => s.id).sort()).toEqual(['codex-gone', 'codex-sess-1']);
+    expect(sessions.map((s: { id: string }) => s.id).sort()).toEqual(['codex-gone', 'codex-local-1', 'codex-sess-1']);
     const main = sessions.find((s: { id: string }) => s.id === 'codex-sess-1');
     expect(main.models).toContain('gpt-5.4');
     expect(main.connectorId).toBe('codex');
@@ -209,6 +235,16 @@ describe('Codex session indexing', () => {
   it('groups analytics by the OpenAI model', async () => {
     const { rows } = (await get('/api/analytics?groupBy=model')).json();
     expect(rows.map((r: { key: string }) => r.key)).toContain('gpt-5.4');
+  });
+
+  it('zero-rates a session via a local model_provider propagated session-wide', async () => {
+    const sessions = (await get('/api/sessions')).json();
+    const s = sessions.find((x: { id: string }) => x.id === 'codex-local-1');
+    // model_provider is session-level → stamped on every assistant row, so the
+    // provider override zero-rates the session even though gpt-5.4 has a real rate.
+    expect(s.totalCostUsd).toBe(0);
+    expect(s.providers).toEqual(['lmstudio']);
+    expect(s.hasLocalProvider).toBe(true);
   });
 
   it('finds the Codex session via full-text search', async () => {

--- a/packages/server/test/opencode.integration.test.ts
+++ b/packages/server/test/opencode.integration.test.ts
@@ -226,6 +226,14 @@ describe('opencode session indexing', () => {
     expect(s.totalCostUsd).toBeCloseTo(0.0020175, 6);
   });
 
+  it('exposes the per-message provider without flagging a non-local one', async () => {
+    const s = (await get('/api/sessions')).json().find((x: { id: string }) => x.id === 'ses_test1');
+    // Every assistant message carries providerID 'openai' (incl. the folded child).
+    expect(s.providers).toEqual(['openai']);
+    // 'openai' isn't in the pricing `providers` table → not a local/zero-rated one.
+    expect(s.hasLocalProvider).toBeFalsy();
+  });
+
   it('finds the session via full-text search, including subagent text under the parent', async () => {
     const { sessions: results } = (await get('/api/search?q=patched')).json();
     expect(results.some((r: { sessionId: string }) => r.sessionId === 'ses_test1')).toBe(true);

--- a/packages/server/test/pi.integration.test.ts
+++ b/packages/server/test/pi.integration.test.ts
@@ -40,6 +40,7 @@ process.env.REINDEX_INTERVAL_MS = '0';
 const jsonl = (events: unknown[]): string => events.map((e) => JSON.stringify(e)).join('\n') + '\n';
 const ts = (s: number) => `2026-06-15T10:00:${String(s).padStart(2, '0')}.000Z`;
 const ts2 = (s: number) => `2026-06-15T11:00:${String(s).padStart(2, '0')}.000Z`;
+const ts3 = (s: number) => `2026-06-15T13:00:${String(s).padStart(2, '0')}.000Z`;
 
 // Composite tool ids as pi writes them (`call_…|fc_…`) — must survive verbatim
 // on both the tool_use and its tool_result, or the pairing breaks.
@@ -196,6 +197,36 @@ function writeEmptyParentSession(): void {
   );
 }
 
+/**
+ * A session mixing two providers within ONE session: a `lmstudio` (local, shipped
+ * zero-rated) turn and an `openai-codex` (unlisted → priced by model) turn, both on
+ * `gpt-5.4-mini`. Proves the per-turn provider CASE: only the openai-codex turn
+ * costs anything, both providers surface on the session, and the local one flips
+ * `hasLocalProvider`. Prices off the shipped pricing.json (no PRICING_PATH set).
+ */
+function writeMixedProviderSession(): void {
+  const dir = join(piDir, '--tmp-piproj--');
+  writeFileSync(
+    join(dir, '2026-06-15T13-00-00-000Z_04cccccc-1111-7222-8333-444455556666.jsonl'),
+    jsonl([
+      { type: 'session', version: 3, id: 'pi-sess-3', timestamp: ts3(0), cwd: '/tmp/piproj' },
+      { type: 'message', id: 'u1', parentId: null, timestamp: ts3(1), message: { role: 'user', content: [{ type: 'text', text: 'mix a local model with a cloud one' }] } },
+      // Local provider turn: nonzero usage, but zero-rated by the provider override.
+      { type: 'message', id: 'a1', parentId: 'u1', timestamp: ts3(2), message: {
+        role: 'assistant', model: 'gpt-5.4-mini', provider: 'lmstudio',
+        content: [{ type: 'text', text: 'answered on the local runtime' }],
+        usage: { input: 1000, output: 500, cacheRead: 0, cacheWrite: 0, totalTokens: 1500 },
+      } },
+      // Cloud provider turn: unlisted provider → priced by gpt-5.4-mini.
+      { type: 'message', id: 'a2', parentId: 'a1', timestamp: ts3(3), message: {
+        role: 'assistant', model: 'gpt-5.4-mini', provider: 'openai-codex',
+        content: [{ type: 'text', text: 'answered on the cloud model' }],
+        usage: { input: 200, output: 100, cacheRead: 0, cacheWrite: 0, totalTokens: 300 },
+      } },
+    ]),
+  );
+}
+
 let app: FastifyInstance;
 let closeConnection: () => Promise<void>;
 
@@ -204,6 +235,7 @@ beforeAll(async () => {
   writeSession();
   writeSubagentSession();
   writeEmptyParentSession();
+  writeMixedProviderSession();
 
   const Fastify = (await import('fastify')).default;
   const { registerRoutes } = await import('../src/routes/index.js');
@@ -235,6 +267,7 @@ describe('pi session indexing', () => {
       'pi-orphan-1',
       'pi-sess-1',
       'pi-sess-2',
+      'pi-sess-3',
     ]);
     const s1 = sessions.find((s: { id: string }) => s.id === 'pi-sess-1');
     expect(s1.models).toContain('gpt-5.4-mini');
@@ -397,5 +430,19 @@ describe('pi subagent embedding', () => {
     const detail = (await get('/api/sessions/pi-orphan-1')).json();
     expect(JSON.stringify(detail.thread)).toContain('orphan child with no parent');
     expect(detail.subagents).toEqual([]);
+  });
+});
+
+describe('pi provider-aware cost', () => {
+  it('records both providers, prices only the cloud turn, and flags the local one', async () => {
+    const s = (await get('/api/sessions')).json().find((x: { id: string }) => x.id === 'pi-sess-3');
+    // Both per-turn providers surface on the session (CSV order isn't guaranteed).
+    expect([...s.providers].sort()).toEqual(['lmstudio', 'openai-codex']);
+    // Only the openai-codex turn costs anything: gpt-5.4-mini @ 0.75/4.50,
+    // 200 in + 100 out = (200*0.75 + 100*4.5)/1e6 = 0.0006. The lmstudio turn is
+    // zero-rated by the shipped provider override despite its 1000+500 usage.
+    expect(s.totalCostUsd).toBeCloseTo(0.0006, 6);
+    // A zero-rated provider on the session sets the local marker.
+    expect(s.hasLocalProvider).toBe(true);
   });
 });

--- a/packages/server/test/pricing.test.ts
+++ b/packages/server/test/pricing.test.ts
@@ -157,6 +157,11 @@ describe('reconcilePricingConfig — versioned migration', () => {
       opus: { input: 5, output: 25, cacheWrite: 6.25, cacheRead: 0.5 },
       newfam: { input: 7, output: 7, cacheWrite: 7, cacheRead: 7 },
     },
+    // The v3 shipped default carries a `providers` layer (local runtimes zero-rated).
+    providers: {
+      lmstudio: { input: 0, output: 0, cacheWrite: 0, cacheRead: 0 },
+      ollama: { input: 0, output: 0, cacheWrite: 0, cacheRead: 0 },
+    },
     default: { input: 3, output: 15, cacheWrite: 3.75, cacheRead: 0.3 },
   };
 
@@ -209,6 +214,46 @@ describe('reconcilePricingConfig — versioned migration', () => {
     expect(merged.families.newfam).toEqual(SHIPPED.families.newfam);
   });
 
+  it('adds the shipped providers set when migrating a v2 copy that predates providers', () => {
+    // A v2 user copy from before the `providers` layer existed → the migration
+    // must fold in the shipped providers (the local-runtime zero-rate table).
+    const v2User = {
+      schemaVersion: 2,
+      models: { 'shared-model': { input: 99, output: 99, cacheWrite: 99, cacheRead: 99 } },
+      families: { opus: { input: 100, output: 100, cacheWrite: 100, cacheRead: 100 } },
+      default: { input: 42, output: 42, cacheWrite: 42, cacheRead: 42 },
+    };
+    writeJson(userPath, v2User);
+
+    reconcilePricingConfig(userPath, defaultPath);
+
+    const merged = JSON.parse(readFileSync(userPath, 'utf8'));
+    expect(merged.schemaVersion).toBe(PRICING_SCHEMA_VERSION);
+    // User edits still win where they overlap…
+    expect(merged.models['shared-model']).toEqual(v2User.models['shared-model']);
+    // …and the shipped providers layer is now present and zero-rated.
+    expect(merged.providers.lmstudio).toEqual({ input: 0, output: 0, cacheWrite: 0, cacheRead: 0 });
+  });
+
+  it('keeps a user-defined provider entry through the merge and still gains shipped ids', () => {
+    const withProxy = {
+      schemaVersion: 2,
+      models: {},
+      // A custom provider the user added — must survive the merge verbatim.
+      providers: { 'my-proxy': { input: 4, output: 8, cacheWrite: 0, cacheRead: 1 } },
+      default: { input: 3, output: 15, cacheWrite: 3.75, cacheRead: 0.3 },
+    };
+    writeJson(userPath, withProxy);
+
+    reconcilePricingConfig(userPath, defaultPath);
+
+    const merged = JSON.parse(readFileSync(userPath, 'utf8'));
+    // The user's custom provider survives untouched…
+    expect(merged.providers['my-proxy']).toEqual({ input: 4, output: 8, cacheWrite: 0, cacheRead: 1 });
+    // …alongside the shipped ids the migration adds.
+    expect(merged.providers.lmstudio).toEqual({ input: 0, output: 0, cacheWrite: 0, cacheRead: 0 });
+  });
+
   it('is a no-op when the user copy is already current (no rewrite, no backup)', () => {
     writeJson(userPath, SHIPPED);
     const before = statSync(userPath).mtimeMs;
@@ -235,14 +280,36 @@ describe('cost via the pricing join table', () => {
     events.map((e) => JSON.stringify(e)).join('\n') + '\n';
 
   beforeAll(async () => {
-    // Base pricing for the cost test: an exact id, a family substring, a default.
-    writeJson(pricingPath, BASE);
+    // Base pricing for the cost test: an exact id, a family substring, a default,
+    // plus a `providers` layer zero-rating a local runtime. A provider match must
+    // OVERRIDE the whole model chain (exact id / family / default).
+    writeJson(pricingPath, {
+      ...BASE,
+      providers: { lmstudio: { input: 0, output: 0, cacheWrite: 0, cacheRead: 0 } },
+    });
+    bumpMtime(pricingPath);
     // Fetched layer overrides the exact-id rate to prove the join uses it.
     writeJson(fetchedPath, {
       fetchedAt: new Date().toISOString(),
       models: { 'claude-opus-4-8': { input: 30, output: 150, cacheWrite: 0, cacheRead: 0 } },
     });
     bumpMtime(fetchedPath);
+
+    // A pi session exercising provider precedence in the cost CASE: one turn on a
+    // local provider (`lmstudio`) and one on an unknown provider (`custom-gateway`),
+    // both on `claude-opus-4-8` — a model with a real exact-id rate (fetched 30).
+    const piDir = process.env.PI_SESSIONS_DIR as string;
+    const piSess = join(piDir, '--tmp-piproj--');
+    mkdirSync(piSess, { recursive: true });
+    writeFileSync(
+      join(piSess, '2026-01-01T10-00-00-000Z_pricing-pi.jsonl'),
+      jsonl([
+        { type: 'session', version: 3, id: 'pricing-pi-1', timestamp: '2026-01-01T10:00:00.000Z', cwd: '/tmp/piproj' },
+        { type: 'message', id: 'pu1', parentId: null, timestamp: '2026-01-01T10:00:01.000Z', message: { role: 'user', content: [{ type: 'text', text: 'local vs gateway' }] } },
+        { type: 'message', id: 'pa1', parentId: 'pu1', timestamp: '2026-01-01T10:00:02.000Z', message: { role: 'assistant', model: 'claude-opus-4-8', provider: 'lmstudio', content: [{ type: 'text', text: 'served locally' }], usage: { input: 100, output: 0, cacheRead: 0, cacheWrite: 0 } } },
+        { type: 'message', id: 'pa2', parentId: 'pa1', timestamp: '2026-01-01T10:00:03.000Z', message: { role: 'assistant', model: 'claude-opus-4-8', provider: 'custom-gateway', content: [{ type: 'text', text: 'served via gateway' }], usage: { input: 100, output: 0, cacheRead: 0, cacheWrite: 0 } } },
+      ]),
+    );
 
     const proj = join(projectsDir, 'enc-projX');
     mkdirSync(proj, { recursive: true });
@@ -290,6 +357,28 @@ describe('cost via the pricing join table', () => {
 
   it('falls back to the default rate when neither id nor family matches', async () => {
     expect(await costOf('x3')).toBeCloseTo((100 * 1) / 1e6, 12);
+  });
+
+  const costWhere = async (where: string): Promise<number> => {
+    const conn = await getConnection();
+    const rows = await queryRows(conn, `SELECT cost_usd FROM events WHERE ${where}`);
+    expect(rows).toHaveLength(1);
+    return Number(rows[0]?.cost_usd);
+  };
+
+  it('lets a local provider override the exact-id model rate (cost 0)', async () => {
+    // `lmstudio` is zero-rated in `providers`; the turn is on `claude-opus-4-8`,
+    // which has a real exact-id rate (fetched 30) — the provider match must win.
+    expect(await costWhere("session_id = 'pricing-pi-1' AND provider = 'lmstudio'")).toBe(0);
+  });
+
+  it('falls through to the model chain for an unknown provider', async () => {
+    // `custom-gateway` isn't listed → the CASE falls through to the model chain,
+    // pricing by the exact-id rate exactly like the NULL-provider Claude turn x1
+    // (same model + 100 input tokens).
+    const gateway = await costWhere("session_id = 'pricing-pi-1' AND provider = 'custom-gateway'");
+    expect(gateway).toBeCloseTo((100 * 30) / 1e6, 12);
+    expect(gateway).toBeCloseTo(await costOf('x1'), 12);
   });
 });
 

--- a/packages/shared/src/api.ts
+++ b/packages/shared/src/api.ts
@@ -57,6 +57,10 @@ export interface SessionMeta {
   totalTokens: number;
   totalCostUsd: number;
   models: ModelId[];
+  /** Distinct model providers recorded on the session's assistant events (may be empty). */
+  providers: string[];
+  /** True when any recorded provider is zero-rated in pricing (a local runtime) — drives the "local" badge. */
+  hasLocalProvider?: boolean;
   gitBranch?: string;
   prUrl?: string;
   sizeBytes: number;

--- a/packages/shared/src/pricing.ts
+++ b/packages/shared/src/pricing.ts
@@ -39,6 +39,21 @@ export interface PricingConfig {
    * resolves. Checked after `models`, before `default`.
    */
   families?: Record<string, ModelRates>;
+  /**
+   * Per-provider rate table, keyed by lowercase provider id, matched
+   * case-insensitively against the provider recorded on an assistant event (pi
+   * `message.provider`, Codex `session_meta.model_provider`, opencode
+   * `providerID`). A match OVERRIDES the models/families/default chain entirely —
+   * this is how local runtimes (`ollama`, `lmstudio`, …) are zero-rated
+   * regardless of model id. Events with no recorded provider, or an unlisted
+   * provider, price by model as before.
+   */
+  providers?: Record<string, ModelRates>;
   /** Fallback rates used when neither an exact id nor a family matches. */
   default: ModelRates;
+}
+
+/** True when every rate is 0 — the marker for a "local" (free) provider. */
+export function isZeroRated(r: ModelRates): boolean {
+  return r.input === 0 && r.output === 0 && r.cacheWrite === 0 && r.cacheRead === 0;
 }

--- a/packages/web/src/components/LocalBadge.tsx
+++ b/packages/web/src/components/LocalBadge.tsx
@@ -1,0 +1,9 @@
+/** A small chip flagging a session that ran on a local model provider (no API cost). */
+
+export function LocalBadge() {
+  return (
+    <span className="tv-chip tv-chip--local" title="Ran on a local model provider — no API cost">
+      local
+    </span>
+  );
+}

--- a/packages/web/src/components/index.ts
+++ b/packages/web/src/components/index.ts
@@ -13,6 +13,7 @@ export { Spinner, type SpinnerProps } from './Spinner.js';
 export { ErrorBox, type ErrorBoxProps } from './ErrorBox.js';
 export { ErrorBoundary, type ErrorBoundaryProps } from './ErrorBoundary.js';
 export { AgentBadge, agentLabel, type AgentBadgeProps } from './AgentBadge.js';
+export { LocalBadge } from './LocalBadge.js';
 export { ModelChips, shortModel, type ModelChipsProps } from './ModelChips.js';
 export { SummaryStrip, type SummaryItem } from './SummaryStrip.js';
 export { SearchField, type SearchFieldProps } from './SearchField.js';

--- a/packages/web/src/pages/browse/SessionList.tsx
+++ b/packages/web/src/pages/browse/SessionList.tsx
@@ -2,7 +2,7 @@ import { useEffect, useMemo, useState } from 'react';
 import { Link } from 'react-router-dom';
 import type { SessionMeta, SessionSort } from '@claudescope/shared';
 import { api, ApiError } from '../../api/client.js';
-import { AgentBadge, agentLabel, ErrorBox, formatCost, formatCount, ModelChips, SearchField, Spinner } from '../../components';
+import { AgentBadge, agentLabel, ErrorBox, formatCost, formatCount, LocalBadge, ModelChips, SearchField, Spinner } from '../../components';
 import { formatBytes, formatDateTime, timeAgo } from './format.js';
 import { useProjectContext } from './ProjectLayout.js';
 
@@ -180,6 +180,7 @@ function SessionRow({ session }: { session: SessionMeta }) {
         <div className="tv-session-row__meta-line">
           <AgentBadge connectorId={session.connectorId} />
           <ModelChips models={session.models} />
+          {session.hasLocalProvider ? <LocalBadge /> : null}
           <span className="tv-session-row__sep" aria-hidden="true">
             │
           </span>

--- a/packages/web/src/pages/session/SessionPage.tsx
+++ b/packages/web/src/pages/session/SessionPage.tsx
@@ -3,7 +3,7 @@ import { Link, useParams, useSearchParams } from 'react-router-dom';
 import { ArrowUpRight, GitBranch, GitPullRequest, MessageSquare, RefreshCw, Wrench } from 'lucide-react';
 import type { SessionDetailResponse, SubagentRun } from '@claudescope/shared';
 import { api, ApiError } from '../../api/client.js';
-import { AgentBadge, ErrorBox, formatCost, formatCount, ModelChips, Spinner } from '../../components';
+import { AgentBadge, ErrorBox, formatCost, formatCount, LocalBadge, ModelChips, Spinner } from '../../components';
 import { formatBytes, formatDateTime, formatDuration } from '../browse/format.js';
 import { hasRenderableContent } from './blocks.js';
 import { SubagentBlock, SubagentJumpMenu, ThreadList, useHashTarget } from './ThreadView.js';
@@ -457,6 +457,7 @@ function SessionView({
         <div className="tv-session__primary">
           <AgentBadge connectorId={meta.connectorId} />
           <ModelChips models={meta.models} />
+          {meta.hasLocalProvider ? <LocalBadge /> : null}
           <span className="tv-session__sep" aria-hidden="true">
             │
           </span>

--- a/packages/web/src/styles/global.css
+++ b/packages/web/src/styles/global.css
@@ -335,6 +335,16 @@ button {
 .tv-chip--cache {
   border-color: #3fb95055;
 }
+/* Local-provider badge — muted green, echoing the Junie hue used for
+   agent-run-locally cues elsewhere; flags a session with no API cost. */
+.tv-chip--local {
+  border-color: #3fb95066;
+  background: #3fb9501a;
+  color: #56d964;
+}
+:root[data-theme='light'] .tv-chip--local {
+  color: #1a7f37;
+}
 /* Overflow chip ("+N") for capped lists like <ModelChips> — a button that opens
    a popover listing the remaining items. */
 .tv-chip--more {


### PR DESCRIPTION
## Summary

Sessions run against **local** model runtimes (LM Studio, Ollama, vLLM, …) were priced at hosted rates — the cost path only knew model ids, so a local `openai/gpt-oss-20b` pi session showed $0.081 via the `gpt` family fallback. This adds provider awareness end to end:

- **Provider recorded from transcripts that carry one**: pi (`message.provider`, per message — sessions can mix providers), Codex (`session_meta.model_provider`, session-level), opencode (`providerID`). Formats with no signal (Claude Code, Junie, Copilot CLI, Antigravity) emit NULL — their local runs are undetectable; the documented escape hatch is pinning the exact model id at 0.
- **Pricing `providers` section** (pricing.json schemaVersion 3): a provider match overrides the whole model/family/default chain. Shipped defaults zero-rate 9 known local runtimes; unknown ids (e.g. a custom remote gateway) fall through to model pricing. Startup reconcile merges the new section, preserving user entries.
- **Schema v11**: `events.provider` + `sessions.providers`; the bump forces a one-time full rebuild that re-prices existing local sessions.
- **Surfaces**: `SessionMeta.providers` + `hasLocalProvider`; green `local` badge next to the model chips (session list + header, both themes); `(local)` tag in MCP session lines.
- **Docs**: README documents the provider override as lookup step 1 and corrects a false claim — re-indexing does **not** recompute stored costs; pricing is prospective (stamped at index time), only an index rebuild re-prices history.

Plan: [docs/plans/0044-provider-aware-cost.md](docs/plans/0044-provider-aware-cost.md)

## Testing

- `npm run typecheck` + `npm test`: 45 files, 381 tests (7 new: provider-beats-exact-id, unknown-provider fallthrough, pricing reconcile v2→v3 incl. custom user entries, mixed-provider pi session, Codex session-level propagation, opencode providerID flow).
- Verified live against real data: the LM Studio session now shows `providers: ["lmstudio"]`, `hasLocalProvider: true`, **$0** (tokens still counted); a real `custom-gateway` Codex session stays priced; 182 remote sessions unchanged.