### PR TITLE
feat(daemon): self-heal into newly installed versions

### DIFF
--- a/packages/server/src/cli.ts
+++ b/packages/server/src/cli.ts
@@ -23,16 +23,24 @@ import { join } from 'node:path';
 import { createInterface } from 'node:readline/promises';
 import { parseArgs } from 'node:util';
 import { fileURLToPath } from 'node:url';
-import { APP_VERSION, CLAUDE_PROJECTS_DIR, CLAUDESCOPE_HOME, PORT as DEFAULT_PORT } from './config.js';
+import {
+  APP_VERSION,
+  CLAUDE_PROJECTS_DIR,
+  CLAUDESCOPE_HOME,
+  PORT as DEFAULT_PORT,
+  autoRestartEnabled,
+} from './config.js';
 import {
   DAEMON_FILE,
   EXIT_WAIT_MS,
   LOG_FILE,
   classifyExisting,
+  fetchDaemonHealth,
   isAlive,
   isHealthy,
   readDaemon,
   spawnDaemon,
+  terminateDaemon,
   waitForExit,
   waitForHealth,
 } from './daemon.js';
@@ -74,9 +82,31 @@ async function start(port: number, open: boolean): Promise<void> {
   const existing = readDaemon();
   const state = await classifyExisting(existing, isAlive, isHealthy);
   if (state === 'healthy' && existing) {
-    console.log(`✓ claudescope is already running → ${existing.url}`);
-    if (open) openBrowser(existing.url);
-    return;
+    // A healthy daemon left over from a previous install still runs old code
+    // (and an old index schema). Restart it into this CLI's version instead of
+    // adopting it — CLAUDESCOPE_AUTO_RESTART=0 keeps the old warn-and-adopt.
+    const runningVersion = (await fetchDaemonHealth(existing.port))?.version;
+    const skewed = runningVersion !== undefined && runningVersion !== APP_VERSION;
+    if (!skewed || !autoRestartEnabled()) {
+      if (skewed) {
+        console.log(
+          `⚠ running daemon is v${runningVersion}, this CLI is v${APP_VERSION} ` +
+            '(auto-restart disabled — run `claudescope restart` to align them)',
+        );
+      }
+      console.log(`✓ claudescope is already running → ${existing.url}`);
+      if (open) openBrowser(existing.url);
+      return;
+    }
+    console.log(`› Running daemon is v${runningVersion}, this CLI is v${APP_VERSION} — restarting it…`);
+    try {
+      await terminateDaemon(existing);
+    } catch (err) {
+      console.error(`✗ ${err instanceof Error ? err.message : String(err)}`);
+      process.exitCode = 1;
+      return;
+    }
+    // Fall through to spawn the current version below.
   }
   // Clear a stale record left by a crashed/killed process.
   if (state === 'stale') rmSync(DAEMON_FILE, { force: true });
@@ -86,19 +116,12 @@ async function start(port: number, open: boolean): Promise<void> {
   if (state === 'wedged' && existing) {
     console.log(`claudescope (pid ${existing.pid}) is unresponsive; restarting it…`);
     try {
-      process.kill(existing.pid, 'SIGTERM');
-    } catch {
-      /* already gone */
-    }
-    if (!(await waitForExit(existing.pid, EXIT_WAIT_MS))) {
-      console.error(
-        `✗ Could not stop the unresponsive process (pid ${existing.pid}). ` +
-          `Kill it manually and retry: kill -9 ${existing.pid}`,
-      );
+      await terminateDaemon(existing);
+    } catch (err) {
+      console.error(`✗ ${err instanceof Error ? err.message : String(err)}`);
       process.exitCode = 1;
       return;
     }
-    rmSync(DAEMON_FILE, { force: true });
   }
 
   const url = `http://localhost:${port}`;
@@ -404,7 +427,8 @@ Options:
 
 State (index, pricing, logs, PID) lives in ${CLAUDESCOPE_HOME}
 (override with $CLAUDESCOPE_HOME). Sessions are read from
-${CLAUDE_PROJECTS_DIR} (override with $CLAUDE_PROJECTS_DIR).`);
+${CLAUDE_PROJECTS_DIR} (override with $CLAUDE_PROJECTS_DIR).
+CLAUDESCOPE_AUTO_RESTART=0 disables automatic daemon restarts on version skew.`);
 }
 
 async function main(): Promise<void> {

--- a/packages/server/src/config.ts
+++ b/packages/server/src/config.ts
@@ -204,6 +204,25 @@ export const PRICING_REFRESH_INTERVAL_MS = Number(
 );
 
 /**
+ * How often (ms) the daemon checks whether the installed `claudescope` on PATH
+ * is a different version than the running process and, if so, restarts itself
+ * into the new code (post-update self-heal — see self-restart.ts). Set
+ * SELF_RESTART_INTERVAL_MS=0 to disable. Default 5 min.
+ */
+export const SELF_RESTART_INTERVAL_MS = Number(
+  process.env.SELF_RESTART_INTERVAL_MS ?? 5 * 60 * 1000,
+);
+
+/**
+ * Whether the daemon/CLI may automatically restart a version-skewed daemon.
+ * Read per call — not frozen at import — so CLAUDESCOPE_AUTO_RESTART=0 applies
+ * to a long-lived process and tests can flip it.
+ */
+export function autoRestartEnabled(): boolean {
+  return process.env.CLAUDESCOPE_AUTO_RESTART !== '0';
+}
+
+/**
  * Built web assets served in production. Resolved for both the bundled layout
  * (`<pkg>/web` next to the server bundle) and the dev layout
  * (`packages/web/dist`). Override with WEB_DIST_DIR.

--- a/packages/server/src/daemon.ts
+++ b/packages/server/src/daemon.ts
@@ -259,7 +259,9 @@ export async function ensureDaemon(
     await p.terminate(existing);
   }
 
-  const port = DEFAULT_PORT;
+  // Respawn a healed (healthy-but-skewed) daemon on its original port — a
+  // user-chosen --port must survive an MCP/query heal. Fresh spawns default.
+  const port = state === 'healthy' && existing ? existing.port : DEFAULT_PORT;
   log(`starting claudescope daemon on port ${port}…`);
   p.spawn(port);
   if (!(await p.waitHealthy(port, 30_000))) {

--- a/packages/server/src/daemon.ts
+++ b/packages/server/src/daemon.ts
@@ -21,7 +21,8 @@ import {
 } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { APP_VERSION, CLAUDESCOPE_HOME, PORT as DEFAULT_PORT } from './config.js';
+import type { HealthResponse } from '@claudescope/shared';
+import { APP_VERSION, CLAUDESCOPE_HOME, PORT as DEFAULT_PORT, autoRestartEnabled } from './config.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 /** The server bundle, a sibling of the CLI in the published package. */
@@ -100,6 +101,39 @@ export async function waitForExit(pid: number, timeoutMs: number): Promise<boole
   return !isAlive(pid);
 }
 
+/** Fetch and parse the daemon's /api/health (short timeout). Null on any
+ *  failure — unreachable, non-ok, or unparsable — so callers treat "no info"
+ *  and "no daemon" the same way. */
+export async function fetchDaemonHealth(port: number): Promise<HealthResponse | null> {
+  try {
+    const res = await fetch(`http://127.0.0.1:${port}/api/health`, {
+      signal: AbortSignal.timeout(1500),
+    });
+    if (!res.ok) return null;
+    return (await res.json()) as HealthResponse;
+  } catch {
+    return null;
+  }
+}
+
+/** SIGTERM the recorded daemon, wait for it to actually exit, and clear
+ *  daemon.json (so a follow-up spawn can rebind the port). Throws with a
+ *  kill -9 hint when the process refuses to die within {@link EXIT_WAIT_MS}. */
+export async function terminateDaemon(record: DaemonRecord): Promise<void> {
+  try {
+    process.kill(record.pid, 'SIGTERM');
+  } catch {
+    /* already gone */
+  }
+  if (!(await waitForExit(record.pid, EXIT_WAIT_MS))) {
+    throw new Error(
+      `could not stop the claudescope daemon (pid ${record.pid}); ` +
+        `kill it manually and retry: kill -9 ${record.pid}`,
+    );
+  }
+  rmSync(DAEMON_FILE, { force: true });
+}
+
 /** What the recorded daemon (if any) currently is, so callers can decide whether
  *  to reuse it, clear a stale record, or replace a wedged (alive-but-unhealthy)
  *  process. Injectable probes keep this pure and unit-testable. */
@@ -163,64 +197,72 @@ export interface EnsuredDaemon {
   url: string;
 }
 
-/** Warn (stderr) when the running daemon was started by a different version of
- *  the package than this process — a restart aligns them. Best-effort. */
-async function warnOnVersionSkew(port: number, log: (msg: string) => void): Promise<void> {
-  try {
-    const res = await fetch(`http://127.0.0.1:${port}/api/health`, {
-      signal: AbortSignal.timeout(1500),
-    });
-    const json = (await res.json()) as { version?: string };
-    if (json.version && json.version !== APP_VERSION) {
-      log(
-        `⚠ running claudescope daemon is v${json.version}, this CLI is v${APP_VERSION} — ` +
-          'run `claudescope restart` to align them',
-      );
-    }
-  } catch {
-    /* health was just probed; a race here is not worth surfacing */
-  }
+/** Injectable process/network probes for {@link ensureDaemon}, following the
+ *  {@link classifyExisting} pattern — tests never spawn or kill anything. */
+export interface DaemonProbes {
+  alive: (pid: number) => boolean;
+  healthy: (port: number) => Promise<boolean>;
+  health: (port: number) => Promise<HealthResponse | null>;
+  terminate: (record: DaemonRecord) => Promise<void>;
+  spawn: (port: number) => void;
+  waitHealthy: (port: number, timeoutMs: number) => Promise<boolean>;
 }
 
+const realProbes: DaemonProbes = {
+  alive: isAlive,
+  healthy: isHealthy,
+  health: fetchDaemonHealth,
+  terminate: terminateDaemon,
+  spawn: spawnDaemon,
+  waitHealthy: waitForHealth,
+};
+
 /**
- * Make sure a daemon is running and return its address — the MCP server (and
- * the query subcommands) call this before proxying. Adopts a healthy daemon
- * (warning on version skew), clears a stale record, replaces a wedged process,
- * and spawns a fresh server otherwise. All progress goes to `log` (stderr by
- * default); throws with a user-actionable message when a daemon can't be had.
+ * Make sure a daemon of THIS package version is running and return its address
+ * — the MCP server (and the query subcommands) call this before proxying.
+ * Adopts a healthy daemon; when its version differs from this CLI's, restarts
+ * it into the current install (unless CLAUDESCOPE_AUTO_RESTART=0, which keeps
+ * the old warn-and-adopt behavior). Clears a stale record, replaces a wedged
+ * process, and spawns a fresh server otherwise. All progress goes to `log`
+ * (stderr by default); throws with a user-actionable message when a daemon
+ * can't be had.
  */
 export async function ensureDaemon(
   log: (msg: string) => void = (m) => process.stderr.write(`${m}\n`),
+  probes: Partial<DaemonProbes> = {},
 ): Promise<EnsuredDaemon> {
+  const p = { ...realProbes, ...probes };
   const existing = readDaemon();
-  const state = await classifyExisting(existing, isAlive, isHealthy);
+  const state = await classifyExisting(existing, p.alive, p.healthy);
   if (state === 'healthy' && existing) {
-    await warnOnVersionSkew(existing.port, log);
-    return { port: existing.port, url: existing.url };
+    const runningVersion = (await p.health(existing.port))?.version;
+    const skewed = runningVersion !== undefined && runningVersion !== APP_VERSION;
+    if (!skewed) return { port: existing.port, url: existing.url };
+    if (!autoRestartEnabled()) {
+      log(
+        `⚠ running claudescope daemon is v${runningVersion}, this CLI is v${APP_VERSION} — ` +
+          'run `claudescope restart` to align them',
+      );
+      return { port: existing.port, url: existing.url };
+    }
+    log(
+      `claudescope daemon is v${runningVersion}, this CLI is v${APP_VERSION} — restarting it…`,
+    );
+    await p.terminate(existing);
+    // Fall through to the spawn below, which starts the current version.
   }
   if (state === 'stale') rmSync(DAEMON_FILE, { force: true });
   if (state === 'wedged' && existing) {
     // Same replace semantics as `claudescope start`: SIGTERM and wait, rather
     // than spawning a second server that would fail to bind.
     log(`claudescope daemon (pid ${existing.pid}) is unresponsive; replacing it…`);
-    try {
-      process.kill(existing.pid, 'SIGTERM');
-    } catch {
-      /* already gone */
-    }
-    if (!(await waitForExit(existing.pid, EXIT_WAIT_MS))) {
-      throw new Error(
-        `could not stop the unresponsive claudescope daemon (pid ${existing.pid}); ` +
-          `kill it manually and retry: kill -9 ${existing.pid}`,
-      );
-    }
-    rmSync(DAEMON_FILE, { force: true });
+    await p.terminate(existing);
   }
 
   const port = DEFAULT_PORT;
   log(`starting claudescope daemon on port ${port}…`);
-  spawnDaemon(port);
-  if (!(await waitForHealth(port, 30_000))) {
+  p.spawn(port);
+  if (!(await p.waitHealthy(port, 30_000))) {
     throw new Error('claudescope daemon did not become healthy in time; inspect: claudescope logs');
   }
   return { port, url: `http://localhost:${port}` };

--- a/packages/server/src/data/index.ts
+++ b/packages/server/src/data/index.ts
@@ -33,6 +33,11 @@ export function isIndexReady(): boolean {
   return ready;
 }
 
+/** Whether a reindex pass is currently running (self-restart defers on it). */
+export function isReindexInFlight(): boolean {
+  return inFlight !== null;
+}
+
 /** The four rate fields, in canonical → SQL-column order. */
 const RATE_FIELDS = [
   ['input', 'input', 'input_tokens'],

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -15,6 +15,7 @@ import {
   PORT,
   PRICING_REFRESH_INTERVAL_MS,
   REINDEX_INTERVAL_MS,
+  SELF_RESTART_INTERVAL_MS,
   WEB_DIST_DIR,
   ensureStateDir,
 } from './config.js';
@@ -22,6 +23,7 @@ import { registerRoutes } from './routes/index.js';
 import { registerHostGuard, registerSecurityHeaders } from './security.js';
 import { reindex } from './data/index.js';
 import { refreshPricing } from './data/pricing-refresh.js';
+import { maybeSelfRestart } from './self-restart.js';
 import { openBrowser } from './util/open-browser.js';
 
 /** How old a fetched-pricing snapshot may be before a boot refresh fires. */
@@ -113,6 +115,20 @@ async function main(): Promise<void> {
     const pricingTimer = setInterval(runPricingRefresh, PRICING_REFRESH_INTERVAL_MS);
     pricingTimer.unref();
     app.addHook('onClose', async () => clearInterval(pricingTimer));
+  }
+
+  // Post-update self-heal: periodically check whether the installed
+  // `claudescope` on PATH is a newer/different version than this process and,
+  // if so, hand off to `claudescope restart` so brew/nix/out-of-band npm
+  // upgrades take effect without a manual restart. Dev builds never restart.
+  if (SELF_RESTART_INTERVAL_MS > 0 && APP_VERSION !== '0.0.0-dev') {
+    const selfRestartTimer = setInterval(() => {
+      maybeSelfRestart((m) => app.log.info(m)).catch((err) =>
+        app.log.warn({ err }, 'self-restart check failed'),
+      );
+    }, SELF_RESTART_INTERVAL_MS);
+    selfRestartTimer.unref();
+    app.addHook('onClose', async () => clearInterval(selfRestartTimer));
   }
 
   // In production, serve the built SPA. In dev, Vite serves it and proxies /api.

--- a/packages/server/src/self-restart.ts
+++ b/packages/server/src/self-restart.ts
@@ -34,8 +34,10 @@ export interface RestartMarker {
 /** At most one restart attempt per target version per window. */
 const RETRY_WINDOW_MS = 60 * 60 * 1000;
 
-/** What `claudescope version` prints when it worked — not an error banner. */
-const VERSION_RE = /^\d+\.\d+\.\d+/;
+/** What `claudescope version` prints when it worked — a bare x.y.z release.
+ *  Anchored: `0.0.0-dev` (an npm-linked dev build on PATH) must never become a
+ *  restart target, since the resulting dev daemon would never self-heal back. */
+const VERSION_RE = /^\d+\.\d+\.\d+$/;
 
 /** Set once a hand-off has been spawned so a slow CLI is never spawned twice. */
 let restartInitiated = false;
@@ -121,6 +123,10 @@ export async function maybeSelfRestart(log: (msg: string) => void): Promise<void
   const installed = await readInstalledVersion(bin);
   if (!installed) return;
   if (!shouldSelfRestart(installed, APP_VERSION, readMarker(), Date.now())) return;
+
+  // A reindex pass may have started while we probed the installed version
+  // (up to 5s) — never SIGTERM the daemon mid-pass; the next tick retries.
+  if (isReindexInFlight() || !isIndexReady()) return;
 
   // Write the marker BEFORE spawning: if the hand-off wedges or crashes, the
   // guard still rate-limits retries to one per target per hour.

--- a/packages/server/src/self-restart.ts
+++ b/packages/server/src/self-restart.ts
@@ -1,0 +1,155 @@
+/**
+ * Post-update self-heal for the daemon.
+ *
+ * A long-lived daemon keeps running old code (and an old index schema) after
+ * the package is upgraded — `claudescope update` restarts it on the npm path,
+ * but brew/nix and out-of-band upgrades leave it stale until a manual
+ * `claudescope restart`. This module lets the daemon notice that the installed
+ * `claudescope` on PATH reports a different version than the running process
+ * and hand off to `<bin> restart` — the CLI already owns the race-free
+ * stop → wait → start sequence, and the freshly installed CLI spawns its own
+ * (new) server bundle.
+ *
+ * Detection spawns `<bin> version` (prints the bare version, no side effects)
+ * rather than walking the filesystem for a package.json — that works the same
+ * across npm symlinks, Homebrew Cellar symlinks, and Nix makeWrapper scripts.
+ */
+
+import { execFile, spawn } from 'node:child_process';
+import { existsSync, openSync, readFileSync, writeFileSync } from 'node:fs';
+import { delimiter, join } from 'node:path';
+import { APP_VERSION, CLAUDESCOPE_HOME, autoRestartEnabled } from './config.js';
+import { LOG_FILE } from './daemon.js';
+import { isIndexReady, isReindexInFlight } from './data/index.js';
+
+/** Records the last restart attempt (target version + timestamp) so a failed
+ *  hand-off or an in-progress install never turns into a restart loop. */
+export const SELF_RESTART_MARKER = join(CLAUDESCOPE_HOME, 'self-restart.json');
+
+export interface RestartMarker {
+  target: string;
+  at: string;
+}
+
+/** At most one restart attempt per target version per window. */
+const RETRY_WINDOW_MS = 60 * 60 * 1000;
+
+/** What `claudescope version` prints when it worked — not an error banner. */
+const VERSION_RE = /^\d+\.\d+\.\d+/;
+
+/** Set once a hand-off has been spawned so a slow CLI is never spawned twice. */
+let restartInitiated = false;
+
+/** Resolve the `claudescope` bin from PATH. Null when it isn't installed there
+ *  (e.g. npx-only usage) — the caller skips silently and retries next tick. */
+export function resolveInstalledBin(
+  pathEnv: string = process.env.PATH ?? '',
+  platform: NodeJS.Platform = process.platform,
+): string | null {
+  const names =
+    platform === 'win32' ? ['claudescope.cmd', 'claudescope.exe', 'claudescope'] : ['claudescope'];
+  for (const dir of pathEnv.split(delimiter)) {
+    if (!dir) continue;
+    for (const name of names) {
+      const candidate = join(dir, name);
+      if (existsSync(candidate)) return candidate;
+    }
+  }
+  return null;
+}
+
+/** Ask the installed bin its version by running `<bin> version`. Null when the
+ *  spawn fails, hangs past the timeout, or prints something that isn't x.y.z. */
+export function readInstalledVersion(bin: string, timeoutMs = 5000): Promise<string | null> {
+  return new Promise((resolve) => {
+    execFile(
+      bin,
+      ['version'],
+      { timeout: timeoutMs, shell: process.platform === 'win32' },
+      (err, stdout) => {
+        if (err) return resolve(null);
+        const v = stdout.trim();
+        resolve(VERSION_RE.test(v) ? v : null);
+      },
+    );
+  });
+}
+
+/** Read the loop-guard marker, or null if absent/corrupt. */
+export function readMarker(): RestartMarker | null {
+  if (!existsSync(SELF_RESTART_MARKER)) return null;
+  try {
+    return JSON.parse(readFileSync(SELF_RESTART_MARKER, 'utf8')) as RestartMarker;
+  } catch {
+    return null;
+  }
+}
+
+/** Loop guard: restart only when the installed version really is a version,
+ *  differs from the running one, and we haven't already tried restarting into
+ *  this exact target within {@link RETRY_WINDOW_MS}. A different target (e.g.
+ *  the user upgraded again, or downgraded) resets the guard. */
+export function shouldSelfRestart(
+  installed: string,
+  running: string,
+  marker: RestartMarker | null,
+  now: number,
+): boolean {
+  if (!VERSION_RE.test(installed)) return false;
+  if (installed === running) return false;
+  if (marker && marker.target === installed) {
+    const at = Date.parse(marker.at);
+    if (Number.isFinite(at) && now - at < RETRY_WINDOW_MS) return false;
+  }
+  return true;
+}
+
+/**
+ * Timer body: when the on-disk install is a different version, hand off to
+ * `<bin> restart --no-open` (detached, output → daemon log) and let the new
+ * CLI SIGTERM this process. Skips: dev builds, CLAUDESCOPE_AUTO_RESTART=0, a
+ * hand-off already in flight, a reindex pass in progress (never interrupt a
+ * build), an unresolvable install, and the marker's retry window.
+ */
+export async function maybeSelfRestart(log: (msg: string) => void): Promise<void> {
+  if (APP_VERSION === '0.0.0-dev' || !autoRestartEnabled()) return;
+  if (restartInitiated) return;
+  if (isReindexInFlight() || !isIndexReady()) return;
+
+  const bin = resolveInstalledBin();
+  if (!bin) return;
+  const installed = await readInstalledVersion(bin);
+  if (!installed) return;
+  if (!shouldSelfRestart(installed, APP_VERSION, readMarker(), Date.now())) return;
+
+  // Write the marker BEFORE spawning: if the hand-off wedges or crashes, the
+  // guard still rate-limits retries to one per target per hour.
+  writeFileSync(
+    SELF_RESTART_MARKER,
+    JSON.stringify({ target: installed, at: new Date().toISOString() }, null, 2),
+  );
+  log(
+    `installed claudescope is v${installed}, this daemon is v${APP_VERSION} — ` +
+      'restarting into the new version',
+  );
+  try {
+    // Detached + unref: the child survives this process's SIGTERM (own process
+    // group). `restart` stops this daemon, waits for the port, starts the new one.
+    const logFd = openSync(LOG_FILE, 'a');
+    const child = spawn(bin, ['restart', '--no-open'], {
+      detached: true,
+      stdio: ['ignore', logFd, logFd],
+      env: process.env,
+      shell: process.platform === 'win32',
+    });
+    child.on('error', (err) => {
+      log(`self-restart hand-off failed to spawn: ${err.message}`);
+      restartInitiated = false; // marker still rate-limits the retry
+    });
+    child.unref();
+    restartInitiated = true;
+  } catch (err) {
+    log(`self-restart hand-off failed: ${err instanceof Error ? err.message : String(err)}`);
+    restartInitiated = false;
+  }
+}

--- a/packages/server/test/cli.test.ts
+++ b/packages/server/test/cli.test.ts
@@ -22,6 +22,7 @@ process.env.CLAUDESCOPE_HOME = home;
 const DAEMON_FILE = join(home, 'daemon.json');
 
 const cli = await import('../src/cli.js');
+const daemon = await import('../src/daemon.js');
 
 const record = (over: Partial<import('../src/cli.js').DaemonRecord> = {}) => ({
   pid: 4242,
@@ -144,5 +145,107 @@ describe('waitForExit', () => {
   it('resolves false if the process never exits within the budget', async () => {
     vi.spyOn(process, 'kill').mockReturnValue(true);
     expect(await cli.waitForExit(4242, 300)).toBe(false);
+  });
+});
+
+describe('fetchDaemonHealth', () => {
+  it('parses the health payload', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => ({
+        ok: true,
+        json: async () => ({ status: 'ok', version: '1.2.3', ready: true }),
+      })),
+    );
+    expect(await daemon.fetchDaemonHealth(4317)).toMatchObject({ version: '1.2.3' });
+  });
+
+  it('is null on a non-ok response', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => ({ ok: false })));
+    expect(await daemon.fetchDaemonHealth(4317)).toBeNull();
+  });
+
+  it('is null when fetch rejects (server down)', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => {
+      throw new Error('ECONNREFUSED');
+    }));
+    expect(await daemon.fetchDaemonHealth(4317)).toBeNull();
+  });
+
+  it('is null on an unparsable body', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => ({
+        ok: true,
+        json: async () => {
+          throw new Error('invalid json');
+        },
+      })),
+    );
+    expect(await daemon.fetchDaemonHealth(4317)).toBeNull();
+  });
+});
+
+describe('ensureDaemon version healing', () => {
+  // Probes replace every process/network touch (classifyExisting precedent):
+  // these tests never spawn or kill anything.
+  const probes = (over: Partial<import('../src/daemon.js').DaemonProbes> = {}) => ({
+    alive: () => true,
+    healthy: async () => true,
+    terminate: vi.fn(async () => {}),
+    spawn: vi.fn(),
+    waitHealthy: async () => true,
+    ...over,
+  });
+
+  afterEach(() => {
+    delete process.env.CLAUDESCOPE_AUTO_RESTART;
+  });
+
+  it('adopts a healthy daemon of the same version without touching it', async () => {
+    writeFileSync(DAEMON_FILE, JSON.stringify(record()));
+    const p = probes({
+      health: async () => ({ status: 'ok' as const, version: '0.0.0-dev' }),
+    });
+    const d = await daemon.ensureDaemon(() => {}, p);
+    expect(d).toMatchObject({ port: 4317, url: 'http://localhost:4317' });
+    expect(p.terminate).not.toHaveBeenCalled();
+    expect(p.spawn).not.toHaveBeenCalled();
+  });
+
+  it('restarts a healthy daemon whose version differs from this CLI', async () => {
+    writeFileSync(DAEMON_FILE, JSON.stringify(record()));
+    const p = probes({
+      health: async () => ({ status: 'ok' as const, version: '9.9.9' }),
+    });
+    const d = await daemon.ensureDaemon(() => {}, p);
+    expect(p.terminate).toHaveBeenCalledOnce();
+    expect(p.spawn).toHaveBeenCalledOnce();
+    expect(d.port).toBe(4317);
+  });
+
+  it('CLAUDESCOPE_AUTO_RESTART=0 warns and adopts the skewed daemon', async () => {
+    process.env.CLAUDESCOPE_AUTO_RESTART = '0';
+    writeFileSync(DAEMON_FILE, JSON.stringify(record()));
+    const logs: string[] = [];
+    const p = probes({
+      health: async () => ({ status: 'ok' as const, version: '9.9.9' }),
+    });
+    const d = await daemon.ensureDaemon((m) => logs.push(m), p);
+    expect(d).toMatchObject({ port: 4317, url: 'http://localhost:4317' });
+    expect(p.terminate).not.toHaveBeenCalled();
+    expect(p.spawn).not.toHaveBeenCalled();
+    expect(logs.join('\n')).toContain('v9.9.9');
+    expect(logs.join('\n')).toContain('claudescope restart');
+  });
+
+  it('a health probe failure (null) is treated as no-skew and adopts', async () => {
+    // The daemon was healthy a moment ago; a race on the second fetch must not
+    // trigger a restart of a perfectly good process.
+    writeFileSync(DAEMON_FILE, JSON.stringify(record()));
+    const p = probes({ health: async () => null });
+    const d = await daemon.ensureDaemon(() => {}, p);
+    expect(d.port).toBe(4317);
+    expect(p.terminate).not.toHaveBeenCalled();
   });
 });

--- a/packages/server/test/cli.test.ts
+++ b/packages/server/test/cli.test.ts
@@ -224,6 +224,21 @@ describe('ensureDaemon version healing', () => {
     expect(d.port).toBe(4317);
   });
 
+  it('a skew heal respawns on the daemon’s original port, not the default', async () => {
+    // A user-chosen --port must survive an MCP/query heal — relocating the
+    // daemon to 4317 would strand the record and the user's bookmarks.
+    writeFileSync(
+      DAEMON_FILE,
+      JSON.stringify(record({ port: 5000, url: 'http://localhost:5000' })),
+    );
+    const p = probes({
+      health: async () => ({ status: 'ok' as const, version: '9.9.9' }),
+    });
+    const d = await daemon.ensureDaemon(() => {}, p);
+    expect(p.spawn).toHaveBeenCalledWith(5000);
+    expect(d).toMatchObject({ port: 5000, url: 'http://localhost:5000' });
+  });
+
   it('CLAUDESCOPE_AUTO_RESTART=0 warns and adopts the skewed daemon', async () => {
     process.env.CLAUDESCOPE_AUTO_RESTART = '0';
     writeFileSync(DAEMON_FILE, JSON.stringify(record()));

--- a/packages/server/test/self-restart.test.ts
+++ b/packages/server/test/self-restart.test.ts
@@ -82,6 +82,11 @@ describe.skipIf(process.platform === 'win32')('readInstalledVersion', () => {
     expect(await sr.readInstalledVersion(bin)).toBeNull();
   });
 
+  it('rejects a dev build on PATH (npm link) — never a valid restart target', async () => {
+    const bin = fakeBin('ver-dev', 'echo 0.0.0-dev');
+    expect(await sr.readInstalledVersion(bin)).toBeNull();
+  });
+
   it('returns null when the bin exits non-zero', async () => {
     const bin = fakeBin('ver-fail', 'exit 1');
     expect(await sr.readInstalledVersion(bin)).toBeNull();

--- a/packages/server/test/self-restart.test.ts
+++ b/packages/server/test/self-restart.test.ts
@@ -1,0 +1,143 @@
+/**
+ * Unit tests for the post-update self-heal helpers in self-restart.ts: bin
+ * resolution from PATH, installed-version probing via `<bin> version` (the
+ * channel-agnostic detection that works for npm symlinks, brew Cellar, and nix
+ * makeWrapper scripts alike), and the marker-based loop guard that keeps a
+ * failed hand-off or an in-progress install from becoming a restart storm.
+ *
+ * CLAUDESCOPE_HOME is set before importing the module (config.ts reads env at
+ * import time). No real daemon is ever spawned — only tiny fake bin scripts.
+ */
+
+import { afterAll, describe, expect, it } from 'vitest';
+import { chmodSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { delimiter, join } from 'node:path';
+
+const work = mkdtempSync(join(tmpdir(), 'claudescope-selfrestart-'));
+const home = join(work, 'home');
+mkdirSync(home, { recursive: true });
+process.env.CLAUDESCOPE_HOME = home;
+
+const sr = await import('../src/self-restart.js');
+
+afterAll(() => rmSync(work, { recursive: true, force: true }));
+
+/** A directory containing an (empty, executable) `claudescope` bin. */
+function binDir(name: string, binName = 'claudescope'): string {
+  const dir = join(work, name);
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(join(dir, binName), '#!/bin/sh\n');
+  chmodSync(join(dir, binName), 0o755);
+  return dir;
+}
+
+/** An executable fake `claudescope` whose body is the given shell script. */
+function fakeBin(name: string, script: string): string {
+  const dir = join(work, name);
+  mkdirSync(dir, { recursive: true });
+  const bin = join(dir, 'claudescope');
+  writeFileSync(bin, `#!/bin/sh\n${script}\n`);
+  chmodSync(bin, 0o755);
+  return bin;
+}
+
+describe('resolveInstalledBin', () => {
+  it('finds the bin on PATH', () => {
+    const dir = binDir('path-hit');
+    expect(sr.resolveInstalledBin(dir, 'linux')).toBe(join(dir, 'claudescope'));
+  });
+
+  it('returns null when no PATH entry has it', () => {
+    const empty = join(work, 'path-empty');
+    mkdirSync(empty, { recursive: true });
+    expect(sr.resolveInstalledBin([empty, '/nonexistent'].join(delimiter), 'linux')).toBeNull();
+  });
+
+  it('picks the first match in PATH order (shadowing works as in a shell)', () => {
+    const first = binDir('path-first');
+    const second = binDir('path-second');
+    expect(sr.resolveInstalledBin([first, second].join(delimiter), 'linux')).toBe(
+      join(first, 'claudescope'),
+    );
+  });
+
+  it('finds .cmd shims on win32 but ignores them elsewhere', () => {
+    const dir = binDir('path-cmd', 'claudescope.cmd');
+    expect(sr.resolveInstalledBin(dir, 'win32')).toBe(join(dir, 'claudescope.cmd'));
+    expect(sr.resolveInstalledBin(dir, 'linux')).toBeNull();
+  });
+});
+
+// Fake-bin shell scripts need a POSIX shell; the helpers themselves are
+// platform-independent and covered by the matrix above on Windows.
+describe.skipIf(process.platform === 'win32')('readInstalledVersion', () => {
+  it('returns the version the bin prints', async () => {
+    const bin = fakeBin('ver-ok', 'echo 0.12.0');
+    expect(await sr.readInstalledVersion(bin)).toBe('0.12.0');
+  });
+
+  it('rejects output that is not x.y.z (an error banner, a wrapper failure)', async () => {
+    const bin = fakeBin('ver-garbage', 'echo "command not found"');
+    expect(await sr.readInstalledVersion(bin)).toBeNull();
+  });
+
+  it('returns null when the bin exits non-zero', async () => {
+    const bin = fakeBin('ver-fail', 'exit 1');
+    expect(await sr.readInstalledVersion(bin)).toBeNull();
+  });
+
+  it('times out a hung bin instead of blocking the daemon', async () => {
+    const bin = fakeBin('ver-hang', 'sleep 30');
+    expect(await sr.readInstalledVersion(bin, 250)).toBeNull();
+  });
+
+  it('returns null when the bin does not exist', async () => {
+    expect(await sr.readInstalledVersion(join(work, 'no-such-bin'))).toBeNull();
+  });
+});
+
+describe('shouldSelfRestart', () => {
+  const now = Date.parse('2026-07-13T12:00:00.000Z');
+  const marker = (target: string, ageMs: number) => ({
+    target,
+    at: new Date(now - ageMs).toISOString(),
+  });
+
+  it('restarts when versions differ and there is no marker', () => {
+    expect(sr.shouldSelfRestart('0.12.0', '0.11.0', null, now)).toBe(true);
+  });
+
+  it('never restarts into the version already running', () => {
+    expect(sr.shouldSelfRestart('0.11.0', '0.11.0', null, now)).toBe(false);
+  });
+
+  it('suppresses a retry for the same target within the window', () => {
+    expect(sr.shouldSelfRestart('0.12.0', '0.11.0', marker('0.12.0', 5 * 60 * 1000), now)).toBe(
+      false,
+    );
+  });
+
+  it('retries the same target once the window has passed', () => {
+    expect(sr.shouldSelfRestart('0.12.0', '0.11.0', marker('0.12.0', 2 * 60 * 60 * 1000), now)).toBe(
+      true,
+    );
+  });
+
+  it('a marker for a different target does not block (new upgrade resets the guard)', () => {
+    expect(sr.shouldSelfRestart('0.13.0', '0.11.0', marker('0.12.0', 5 * 60 * 1000), now)).toBe(
+      true,
+    );
+  });
+
+  it('rejects installed strings that are not versions', () => {
+    expect(sr.shouldSelfRestart('', '0.11.0', null, now)).toBe(false);
+    expect(sr.shouldSelfRestart('link', '0.11.0', null, now)).toBe(false);
+  });
+
+  it('a corrupt marker timestamp does not wedge the guard shut', () => {
+    expect(
+      sr.shouldSelfRestart('0.12.0', '0.11.0', { target: '0.12.0', at: 'not-a-date' }, now),
+    ).toBe(true);
+  });
+});


### PR DESCRIPTION
## Problem

The index schema check and discard-and-rebuild run only at process startup, and the daemon is a long-lived detached process. Only the npm path of `claudescope update` restarts it — **brew/nix installs get a printed upgrade hint, and out-of-band upgrades get nothing**. The old daemon keeps serving old code and an old index schema until a manual `claudescope restart`; the only nudge was a stderr warning on the query/MCP path.

## What this does

**Daemon self-heal** (`self-restart.ts`): every `SELF_RESTART_INTERVAL_MS` (default 5 min) the daemon resolves the `claudescope` bin on PATH and asks it its version by spawning `<bin> version` — channel-agnostic detection that works identically for npm bin symlinks, Homebrew Cellar symlinks, and Nix `makeWrapper` scripts (a `package.json` walk would fail on nix). When the installed version differs from the running one, it hands off to a detached `<bin> restart --no-open`: the (new) CLI owns the race-free stop → wait-for-exit → start sequence and spawns its own sibling server bundle. The child survives the parent's SIGTERM (own process group); env inheritance keeps `PORT`/`CLAUDESCOPE_HOME` correct.

**CLI healing** (`daemon.ts`/`cli.ts`): `claudescope start` and the query/MCP path (`ensureDaemon`) now fetch `/api/health` and, on version skew, terminate + respawn the daemon instead of adopting it (previously: silent adopt / warn-only). The duplicated SIGTERM/wait/clear block is extracted into `terminateDaemon()`; `ensureDaemon` takes injectable probes (the `classifyExisting` pattern) so tests never spawn or kill processes.

**Opt-out**: `CLAUDESCOPE_AUTO_RESTART=0` disables all automatic restarts (daemon and CLI; read per call, documented in `claudescope help`). `SELF_RESTART_INTERVAL_MS=0` disables just the background check.

## Loop guard & failure modes

| Failure | Outcome |
|---|---|
| Bin not on PATH (npx-only) / version unreadable | Skip silently; retry next tick (cheap) |
| Hand-off spawn fails | Warn to daemon log; `self-restart.json` marker limits retries to 1/hour per target |
| New daemon still the old version (PATH shadowing, partial install) | Its own check hits the marker → one skew log, **no restart loop**; retried after 1 h |
| CLI can't kill the daemon in 5 s | `restart` exits non-zero into daemon.log; no spawn storm; a later CLI touch heals |
| Update lands mid-reindex | Deferred to the next tick — never interrupts an index build |
| Intentional downgrade | Restarts into the older version once, then stable |

The marker is written **before** spawning, so even a crashed hand-off stays rate-limited. Dev builds (`0.0.0-dev`) never self-restart.

## Tests

- `self-restart.test.ts`: PATH resolution (incl. win32 `.cmd`, shadowing order), `<bin> version` probing against fake bin scripts (valid / garbage / non-zero exit / hang → timeout), and the `shouldSelfRestart` guard matrix (same-target window, expired window, different target, non-version strings, corrupt marker timestamp).
- `cli.test.ts`: `fetchDaemonHealth` (parse / non-ok / reject / bad JSON) and `ensureDaemon` healing via injected probes (same-version adopt, skew → terminate+spawn, opt-out → warn+adopt, health-probe race → adopt).

`npm test` (405 passed) and `npm run typecheck` are green. No global installs or real daemons are touched by the suite.

Part of the indexing-UX/self-healing plan — the full plan lands as `docs/plans/0045` via the sibling indexing-progress PR.