### PR TITLE
feat(index): report indexing progress and grow the project list during first build

### DIFF
--- a/docs/plans/0045-indexing-ux-and-self-healing-updates.md
+++ b/docs/plans/0045-indexing-ux-and-self-healing-updates.md
@@ -1,0 +1,125 @@
+# 0045 — Indexing UX + post-update self-healing
+
+- **Status:** in-progress
+- **Date:** 2026-07-13
+- **PR:** PR 1 (indexing visibility): [#58](https://github.com/vladar107/claudescope/pull/58) · PR 2 (update nudge): TBD · PR 3 (self-healing): [#57](https://github.com/vladar107/claudescope/pull/57)
+
+## Context
+
+Two UX gaps:
+
+1. **First start looks broken.** The server intentionally listens before the
+   index exists and builds it in the background (`packages/server/src/index.ts`).
+   `/api/health` already returns `ready: isIndexReady()`, but no UI code reads
+   it: `BrowsePage` fetches `/api/projects` once, gets `[]` mid-build, and shows
+   "No projects indexed yet." — indistinguishable from a machine with no
+   transcripts. No polling exists anywhere in the web app; the server tracks no
+   progress counts.
+2. **Updates don't take effect until a manual restart.** The schema-signature
+   check + discard/rebuild run only at process startup (`db/duckdb.ts`,
+   connection singleton), and the daemon is long-lived and detached. Only the
+   npm path of `claudescope update` restarts the daemon; brew/nix get a printed
+   hint, out-of-band upgrades get nothing. The version-skew warning
+   (`daemon.ts`) is stderr-only and fires only on the query/MCP paths.
+
+A schema bump triggers a full rebuild — exactly when indexing is slowest — so
+one progress UX covers both first start and post-update rebuilds.
+
+## Goal
+
+The UI always distinguishes "index building (with live progress, list growing)"
+from "genuinely nothing found"; after any update (npm/brew/nix/out-of-band) the
+daemon migrates itself to the new version without a manual
+`claudescope restart`; the sidebar nudges when a newer version is published.
+
+## Decisions
+
+- **Extend `/api/health`, no new endpoint** — the handler already returns
+  `ready` beyond its declared type (fixed here); new fields read in-memory
+  state so health stays cheap for liveness probes; optional fields degrade
+  gracefully across old/new CLI–daemon combinations (a new `/api/status` would
+  404 against an old daemon).
+- **Polling, not SSE** — localhost single-user app; the UI polls health at 1s
+  only while building and stops entirely once ready + idle.
+- **Mid-pass partial finalization** — `/api/projects` reads the derived
+  `sessions` table, which was rebuilt only at the *end* of a pass; a
+  live-growing list therefore requires a throttled (3s) mid-pass
+  `electCanonicalUsage` + `rebuildSessions`, gated on `!ready` so steady-state
+  passes are unchanged. FTS rebuild + CHECKPOINT (WAL-hazardous) stay
+  end-of-pass only.
+- **Installed-version detection spawns `<bin> version`** — `claudescope
+  version` prints the bare version with no side effects; works identically for
+  npm symlinks, brew Cellar symlinks, and the nix `makeWrapper` script (where a
+  `package.json` walk from the realpathed bin would fail).
+- **Self-heal hands off via `spawn(bin, ['restart', '--no-open'])`** — the CLI
+  already owns the race-free stop→wait→start sequence and spawns the *new*
+  bundle's `server.js`; a marker file (`~/.claudescope/self-restart.json`, one
+  attempt per target version per hour) plus a `restartInitiated` flag guard
+  against restart loops and spawn storms. Never fires mid-reindex or before
+  ready. Opt-out: `CLAUDESCOPE_AUTO_RESTART=0`.
+- **CLI heals too** — `claudescope start` and `ensureDaemon` (queries/MCP)
+  restart a healthy-but-version-skewed daemon instead of warn-only, so any CLI
+  touch aligns daemon and installed code.
+
+## Approach
+
+Three PRs; PR 1 ∥ PR 3 independent, PR 2 after PR 1 (its sidebar hint consumes
+PR 1's `StatusProvider`).
+
+1. **PR 1 — indexing visibility.** Shared `IndexingProgress` +
+   `HealthResponse.ready`/`indexing?`; progress counter (skipped files still
+   advance it; cleared in `finally`) + mid-pass partial finalization in
+   `data/index.ts`; `StatusProvider` health poller (1s while building, 5s while
+   unreachable, stops when idle); BrowsePage: live label
+   ("Indexing N of M transcripts…" / "Finishing up the index…"), silently
+   growing grid, and a ready+empty state that lists the watched source dirs
+   (or says none were found).
+2. **PR 2 — update nudge.** Extract the 24h-cached npm-registry check from
+   `cli.ts` into `update-check.ts`; daemon refreshes it hourly (network ≤
+   1/day) and exposes `updateAvailable` on `/api/health`; sidebar renders a
+   muted "vX.Y.Z available — `claudescope update`" hint.
+3. **PR 3 — self-healing.** New `self-restart.ts` (resolve bin on PATH → spawn
+   `version` → compare → marker-guarded detached `restart --no-open`), a 5-min
+   daemon timer (`SELF_RESTART_INTERVAL_MS`, 0 disables, dev builds skip);
+   `fetchDaemonHealth` + `terminateDaemon` extraction; skew-restart in
+   `start()` and `ensureDaemon`.
+
+## Files affected
+
+- `packages/shared/src/api.ts` — `IndexingProgress`, `HealthResponse` (+
+  `updateAvailable` in PR 2).
+- `packages/server/src/data/index.ts` — progress state, changed-set precompute,
+  partial finalization (+ `isReindexInFlight` in PR 3).
+- `packages/server/src/routes/index.ts` — health payload.
+- `packages/server/src/agent/api-client.ts` — drop the `& { ready }` patch.
+- `packages/web/src/status/StatusProvider.tsx` (new), `main.tsx`,
+  `pages/browse/BrowsePage.tsx`, `pages/browse/browse.css` — poller + states.
+- `packages/server/src/update-check.ts` (new, PR 2), `src/index.ts` timers,
+  `App.tsx` sidebar hint.
+- `packages/server/src/self-restart.ts` (new, PR 3), `daemon.ts`, `cli.ts`,
+  `config.ts`.
+
+## Testing
+
+- `index-progress.integration.test.ts` — monotonic counter with a stable total,
+  skipped-unreadable file still reaches `processed === total`, sessions grow
+  mid-first-build (`PARTIAL_REBUILD_MS=0`), no-change pass exposes no
+  `indexing` key.
+- `update-check.test.ts` (PR 2) — `isNewer` edge inputs, cache TTL behavior,
+  `updateAvailable` gating.
+- `self-restart.test.ts` (PR 3) — bin resolution, `version`-spawn parsing
+  (garbage/timeout → null), `shouldSelfRestart` loop-guard matrix; `cli.test.ts`
+  ensureDaemon skew paths via injectable probes.
+- Manual: fresh `CLAUDESCOPE_HOME` first start shows live progress and a
+  growing grid; tampered `schema_signature` rebuild shows the same; two bundled
+  versions exercise self-heal + loop guard; `CLAUDESCOPE_AUTO_RESTART=0` warns
+  and adopts.
+
+## Risks / open questions
+
+- Mid-pass `rebuildSessions` cost — throttled to 1/3s and first-build-only;
+  fallback is counter-only UX (delete the block).
+- Timing-based tests — sampling is per-event-loop-turn with monotonicity-style
+  assertions; weakest assertions get dropped rather than shipped flaky.
+- SIGTERM mid-WAL on self-restart — unchanged from today's manual `restart`,
+  and strictly safer (never fires mid-reindex).

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -69,3 +69,4 @@ decision, or a change worth explaining before doing. Skip it for one-line fixes.
 | 0042 | [Week-in-review digest (page + copy-md + CLI)](./0042-digest.md) | done |
 | 0043 | [Retire the Activity tab: redistribute its pieces](./0043-activity-tab-redistribution.md) | done |
 | 0044 | [Provider-aware cost: local vs remote model sessions](./0044-provider-aware-cost.md) | done |
+| 0045 | [Indexing UX + post-update self-healing](./0045-indexing-ux-and-self-healing-updates.md) | in-progress |

--- a/packages/server/src/agent/api-client.ts
+++ b/packages/server/src/agent/api-client.ts
@@ -39,7 +39,7 @@ export class ApiClient {
     return (await res.json()) as T;
   }
 
-  health(): Promise<HealthResponse & { ready: boolean }> {
+  health(): Promise<HealthResponse> {
     return this.get('/api/health');
   }
 

--- a/packages/server/src/data/index.ts
+++ b/packages/server/src/data/index.ts
@@ -16,7 +16,7 @@
  */
 
 import type { DuckDBConnection } from '@duckdb/node-api';
-import type { PricingConfig, ReindexResponse } from '@claudescope/shared';
+import type { IndexingProgress, PricingConfig, ReindexResponse } from '@claudescope/shared';
 import { getConnection, queryRows, sqlString } from '../db/duckdb.js';
 import { connectors } from '../connectors/registry.js';
 import type { AgentConnector, DiscoveredFile } from '../connectors/types.js';
@@ -28,6 +28,13 @@ import { electCanonicalEdits, refreshFileEdits } from './file-edits.js';
 let ready = false;
 /** Serializes concurrent reindex calls so they never run simultaneously. */
 let inFlight: Promise<ReindexResponse> | null = null;
+/** Live progress of the current pass (changed files loaded vs. total). Non-null
+ *  only while a pass with work is running; surfaced on /api/health. */
+let progress: IndexingProgress | null = null;
+
+/** Min interval between mid-first-build partial `sessions` rebuilds (ms).
+ *  Env-overridable so tests can force a rebuild after every file. */
+const PARTIAL_REBUILD_MS = Number(process.env.PARTIAL_REBUILD_MS ?? 3000);
 
 export function isIndexReady(): boolean {
   return ready;
@@ -36,6 +43,10 @@ export function isIndexReady(): boolean {
 /** Whether a reindex pass is currently running (self-restart defers on it). */
 export function isReindexInFlight(): boolean {
   return inFlight !== null;
+}
+
+export function getIndexProgress(): IndexingProgress | null {
+  return progress;
 }
 
 /** The four rate fields, in canonical → SQL-column order. */
@@ -465,65 +476,88 @@ async function doReindex(): Promise<ReindexResponse> {
     }
   }
 
-  let reindexed = 0;
-  for (const { file, connector } of discovered) {
+  // Precompute the changed set so progress reports a stable total up front.
+  const changed = discovered.filter(({ file }) => {
     const prev = existing.get(file.path);
-    if (prev && prev.mtime === file.mtimeMs && prev.size === file.size) {
-      continue; // unchanged
+    return !(prev && prev.mtime === file.mtimeMs && prev.size === file.size);
+  });
+
+  let reindexed = 0;
+  if (changed.length > 0) progress = { processed: 0, total: changed.length };
+  // Timestamp of the last mid-pass partial `sessions` rebuild (first build only).
+  let lastPartialRebuild = start;
+  try {
+    for (const { file, connector } of changed) {
+      // Isolate per-file failures: a file DuckDB can't read at all (beyond the
+      // per-line `ignore_errors` tolerance) must not abort the whole reindex and
+      // wedge every other session. Skip it (its `files` row keeps the old mtime,
+      // so a later edit retries it) and carry on.
+      try {
+        await ensurePricingTable();
+        await loadFile(conn, connector, file, costExpr);
+
+        // Determine the session id from loaded events (filename usually matches,
+        // but the event sessionId is authoritative).
+        const sidRows = await queryRows(
+          conn,
+          `SELECT session_id FROM events WHERE file_path = ${sqlString(file.path)} LIMIT 1`,
+        );
+        const sessionId = sidRows.length > 0 ? String(sidRows[0]?.session_id ?? '') : null;
+        if (sessionId) editSessions.add(sessionId);
+        const cwdRows = await queryRows(
+          conn,
+          `SELECT cwd FROM events WHERE file_path = ${sqlString(file.path)} AND cwd IS NOT NULL LIMIT 1`,
+        );
+        const cwd = cwdRows.length > 0 ? String(cwdRows[0]?.cwd ?? '') : null;
+
+        await conn.run(`
+          INSERT OR REPLACE INTO files (path, mtime_ms, size_bytes, session_id, project_cwd, connector_id, indexed_at)
+          VALUES (${sqlString(file.path)}, ${file.mtimeMs}, ${file.size},
+                  ${sessionId ? sqlString(sessionId) : 'NULL'},
+                  ${cwd ? sqlString(cwd) : 'NULL'}, ${sqlString(connector.id)}, now())
+        `);
+        reindexed += 1;
+
+        // During the first build (server not yet ready), periodically rebuild
+        // the derived `sessions` so /api/projects grows while indexing instead
+        // of staying empty until the pass finalizes. Deliberately excludes the
+        // file-edits refresh (analytics-only) and the FTS rebuild + CHECKPOINT
+        // (the expensive, WAL-hazardous part). Steady-state passes skip this.
+        if (!ready && Date.now() - lastPartialRebuild >= PARTIAL_REBUILD_MS) {
+          await electCanonicalUsage(conn);
+          await rebuildSessions(conn);
+          lastPartialRebuild = Date.now();
+        }
+      } catch (err) {
+        console.warn(`claudescope: skipping unreadable transcript ${file.path}:`, err);
+      } finally {
+        // Skipped files still advance the counter so processed reaches total.
+        if (progress) progress.processed += 1;
+      }
     }
 
-    // Isolate per-file failures: a file DuckDB can't read at all (beyond the
-    // per-line `ignore_errors` tolerance) must not abort the whole reindex and
-    // wedge every other session. Skip it (its `files` row keeps the old mtime,
-    // so a later edit retries it) and carry on.
-    try {
-      await ensurePricingTable();
-      await loadFile(conn, connector, file, costExpr);
-
-      // Determine the session id from loaded events (filename usually matches,
-      // but the event sessionId is authoritative).
-      const sidRows = await queryRows(
-        conn,
-        `SELECT session_id FROM events WHERE file_path = ${sqlString(file.path)} LIMIT 1`,
-      );
-      const sessionId = sidRows.length > 0 ? String(sidRows[0]?.session_id ?? '') : null;
-      if (sessionId) editSessions.add(sessionId);
-      const cwdRows = await queryRows(
-        conn,
-        `SELECT cwd FROM events WHERE file_path = ${sqlString(file.path)} AND cwd IS NOT NULL LIMIT 1`,
-      );
-      const cwd = cwdRows.length > 0 ? String(cwdRows[0]?.cwd ?? '') : null;
-
-      await conn.run(`
-        INSERT OR REPLACE INTO files (path, mtime_ms, size_bytes, session_id, project_cwd, connector_id, indexed_at)
-        VALUES (${sqlString(file.path)}, ${file.mtimeMs}, ${file.size},
-                ${sessionId ? sqlString(sessionId) : 'NULL'},
-                ${cwd ? sqlString(cwd) : 'NULL'}, ${sqlString(connector.id)}, now())
-      `);
-      reindexed += 1;
-    } catch (err) {
-      console.warn(`claudescope: skipping unreadable transcript ${file.path}:`, err);
+    // Nothing changed on disk: skip the (relatively expensive) derived-table and
+    // FTS rebuild + CHECKPOINT entirely. This keeps periodic auto-reindex polls
+    // cheap — they only stat files and bail when there's no new data.
+    if (reindexed === 0 && removed === 0) {
+      ready = true;
+      return { reindexed, durationMs: Date.now() - start };
     }
-  }
 
-  // Nothing changed on disk: skip the (relatively expensive) derived-table and
-  // FTS rebuild + CHECKPOINT entirely. This keeps periodic auto-reindex polls
-  // cheap — they only stat files and bail when there's no new data.
-  if (reindexed === 0 && removed === 0) {
+    // Something changed: re-elect the usage-canonical rows globally, then rebuild
+    // derived tables + FTS so additions, edits, and removals are all reflected.
+    await electCanonicalUsage(conn);
+    // Refresh code-impact rows for the touched sessions, then re-elect the
+    // canonical edit per (uuid, tool_use_id) globally (fork copies dedup).
+    await refreshFileEdits(conn, editSessions);
+    await electCanonicalEdits(conn);
+    await rebuildSessions(conn);
+    await rebuildFtsIndex(conn);
+
     ready = true;
     return { reindexed, durationMs: Date.now() - start };
+  } finally {
+    // Progress stays visible through finalization ("finishing up"), then clears.
+    progress = null;
   }
-
-  // Something changed: re-elect the usage-canonical rows globally, then rebuild
-  // derived tables + FTS so additions, edits, and removals are all reflected.
-  await electCanonicalUsage(conn);
-  // Refresh code-impact rows for the touched sessions, then re-elect the
-  // canonical edit per (uuid, tool_use_id) globally (fork copies dedup).
-  await refreshFileEdits(conn, editSessions);
-  await electCanonicalEdits(conn);
-  await rebuildSessions(conn);
-  await rebuildFtsIndex(conn);
-
-  ready = true;
-  return { reindexed, durationMs: Date.now() - start };
 }

--- a/packages/server/src/routes/index.ts
+++ b/packages/server/src/routes/index.ts
@@ -7,7 +7,7 @@
 import type { FastifyInstance } from 'fastify';
 import type { HealthResponse, ReindexResponse } from '@claudescope/shared';
 import { APP_VERSION } from '../config.js';
-import { isIndexReady, reindex } from '../data/index.js';
+import { getIndexProgress, isIndexReady, reindex } from '../data/index.js';
 import { registerProjectsRoute } from './projects.js';
 import { registerSessionsRoutes } from './sessions.js';
 import { registerSearchRoute } from './search.js';
@@ -23,8 +23,14 @@ import { registerSourcesRoute } from './sources.js';
 import { registerMemoryRoute } from './memory.js';
 
 export async function registerRoutes(app: FastifyInstance): Promise<void> {
-  app.get('/api/health', async (): Promise<HealthResponse & { ready: boolean }> => {
-    return { status: 'ok', version: APP_VERSION, ready: isIndexReady() };
+  app.get('/api/health', async (): Promise<HealthResponse> => {
+    const indexing = getIndexProgress();
+    return {
+      status: 'ok',
+      version: APP_VERSION,
+      ready: isIndexReady(),
+      ...(indexing ? { indexing } : {}),
+    };
   });
 
   await registerProjectsRoute(app);

--- a/packages/server/test/index-progress.integration.test.ts
+++ b/packages/server/test/index-progress.integration.test.ts
@@ -1,0 +1,188 @@
+/**
+ * Indexing-progress integration tests — the /api/health `indexing` contract
+ * (data/index.ts): a pass with work exposes a live {processed, total} counter,
+ * skipped-unreadable files still advance it, the first build grows the derived
+ * `sessions` table mid-pass (so /api/projects fills in while indexing), and a
+ * no-change pass exposes no progress at all.
+ *
+ * The sampling pattern mirrors production: the HTTP routes query the same
+ * DuckDB connection while a reindex pass runs on it.
+ */
+
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { chmodSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import type { FastifyInstance } from 'fastify';
+
+// --- temp locations (decided before any server module is imported) ----------
+const work = mkdtempSync(join(tmpdir(), 'claudescope-progress-'));
+const projectsDir = join(work, 'projects');
+
+process.env.CLAUDE_PROJECTS_DIR = projectsDir;
+process.env.CODEX_SESSIONS_DIR = join(work, 'codex-empty');
+process.env.JUNIE_SESSIONS_DIR = join(work, 'junie-empty');
+process.env.PI_SESSIONS_DIR = join(work, 'pi-empty');
+process.env.OPENCODE_DATA_DIR = join(work, 'opencode-empty');
+process.env.COPILOT_SESSIONS_DIR = join(work, 'copilot-empty');
+process.env.ANTIGRAVITY_CLI_DIR = join(work, 'antigravity-empty');
+process.env.ANTIGRAVITY_DIR = join(work, 'antigravity-empty-desktop');
+process.env.DUCKDB_PATH = join(work, 'index.duckdb');
+process.env.CLAUDESCOPE_HOME = join(work, 'home');
+process.env.REINDEX_INTERVAL_MS = '0';
+// Force a partial `sessions` rebuild after every file so mid-pass growth is
+// observable without depending on wall-clock timing.
+process.env.PARTIAL_REBUILD_MS = '0';
+
+const jsonl = (events: unknown[]): string => events.map((e) => JSON.stringify(e)).join('\n') + '\n';
+
+const READABLE_COUNT = 10;
+
+/** chmod(000) only bites for a non-root POSIX user; skip the unreadable file
+ *  elsewhere so the expected totals stay exact. */
+const canMakeUnreadable =
+  process.platform !== 'win32' && typeof process.getuid === 'function' && process.getuid() !== 0;
+
+/** Ten tiny sessions in one project, plus (where possible) one file DuckDB
+ *  cannot open at all — the catch-path in the per-file loop. */
+function writeFixtures(): void {
+  const proj = join(projectsDir, 'enc-projP');
+  mkdirSync(proj, { recursive: true });
+  for (let i = 0; i < READABLE_COUNT; i++) {
+    const sid = `sessP${i}`;
+    const base = { sessionId: sid, cwd: '/tmp/projP', gitBranch: 'main', version: '2.1.0' };
+    writeFileSync(
+      join(proj, `${sid}.jsonl`),
+      jsonl([
+        { ...base, type: 'user', uuid: `p${i}-u1`, parentUuid: null, timestamp: '2026-01-01T10:00:00.000Z', isSidechain: false, message: { role: 'user', content: `hello ${i}` } },
+        { ...base, type: 'assistant', uuid: `p${i}-a1`, parentUuid: `p${i}-u1`, timestamp: '2026-01-01T10:00:05.000Z', isSidechain: false, message: { role: 'assistant', model: 'claude-opus-4-8', content: [{ type: 'text', text: 'hi' }], usage: { input_tokens: 10, output_tokens: 5 } } },
+      ]),
+    );
+  }
+  if (canMakeUnreadable) {
+    const bad = join(proj, 'sessP-unreadable.jsonl');
+    writeFileSync(bad, jsonl([{ type: 'user', sessionId: 'bad' }]));
+    chmodSync(bad, 0o000);
+  }
+}
+
+const expectedTotal = READABLE_COUNT + (canMakeUnreadable ? 1 : 0);
+
+let app: FastifyInstance;
+let reindex: typeof import('../src/data/index.js').reindex;
+let getIndexProgress: typeof import('../src/data/index.js').getIndexProgress;
+let getConnection: typeof import('../src/db/duckdb.js').getConnection;
+let queryRows: typeof import('../src/db/duckdb.js').queryRows;
+let closeConnection: () => Promise<void>;
+
+beforeAll(async () => {
+  writeFixtures();
+  const Fastify = (await import('fastify')).default;
+  const { registerRoutes } = await import('../src/routes/index.js');
+  ({ reindex, getIndexProgress } = await import('../src/data/index.js'));
+  ({ getConnection, closeConnection, queryRows } = await import('../src/db/duckdb.js'));
+  app = Fastify();
+  await registerRoutes(app);
+  await app.ready();
+});
+
+afterAll(async () => {
+  await app?.close();
+  await closeConnection?.();
+  rmSync(work, { recursive: true, force: true });
+});
+
+describe('first build', () => {
+  it('exposes monotonic progress, counts skipped files, and grows sessions mid-pass', async () => {
+    const conn = await getConnection();
+
+    const samples: { processed: number; total: number }[] = [];
+    const midPassSessionCounts: number[] = [];
+    let resolved = false;
+    const run = reindex().then((r) => {
+      resolved = true;
+      return r;
+    });
+
+    // Sample once per event-loop turn while the pass runs — progress from
+    // memory every turn, the derived sessions count every few turns (a live
+    // query on the same connection, exactly what /api/projects does).
+    let turn = 0;
+    while (!resolved) {
+      const p = getIndexProgress();
+      if (p) samples.push({ ...p });
+      if (turn % 5 === 0) {
+        const rows = await queryRows(conn, 'SELECT count(*) AS n FROM sessions');
+        if (!resolved) midPassSessionCounts.push(Number(rows[0]?.n ?? 0));
+      }
+      turn += 1;
+      await new Promise((r) => setImmediate(r));
+    }
+    const result = await run;
+
+    // The pass reported a stable total and a non-decreasing counter.
+    expect(samples.length).toBeGreaterThan(0);
+    expect(samples.every((s) => s.total === expectedTotal)).toBe(true);
+    let prev = 0;
+    for (const s of samples) {
+      expect(s.processed).toBeGreaterThanOrEqual(prev);
+      expect(s.processed).toBeLessThanOrEqual(s.total);
+      prev = s.processed;
+    }
+    // Progress stays visible through finalization at processed === total —
+    // which also proves the skipped unreadable file advanced the counter.
+    expect(samples.at(-1)?.processed).toBe(expectedTotal);
+    // Cleared once the pass ends; only readable files were indexed.
+    expect(getIndexProgress()).toBeNull();
+    expect(result.reindexed).toBe(READABLE_COUNT);
+
+    // The partial finalization made sessions visible before the pass finished.
+    expect(midPassSessionCounts.some((n) => n > 0)).toBe(true);
+
+    const rows = await queryRows(conn, 'SELECT count(*) AS n FROM sessions');
+    expect(Number(rows[0]?.n ?? 0)).toBe(READABLE_COUNT);
+  });
+});
+
+/** Run a pass while sampling progress; returns the samples and the result. */
+async function samplePass(): Promise<{ seen: unknown[]; reindexed: number }> {
+  let resolved = false;
+  const run = reindex().then((r) => {
+    resolved = true;
+    return r;
+  });
+  const seen: unknown[] = [];
+  while (!resolved) {
+    const p = getIndexProgress();
+    if (p) seen.push(p);
+    await new Promise((r) => setImmediate(r));
+  }
+  const result = await run;
+  return { seen, reindexed: result.reindexed };
+}
+
+describe('passes with nothing to load', () => {
+  it('removal-only and no-change passes expose no progress; /api/health carries no indexing key', async () => {
+    // The never-loaded unreadable file has no `files` row, so it stays in the
+    // changed set every pass (deliberate: a later edit retries it). Remove it
+    // to reach a stable state; the removal pass itself has an empty changed
+    // set, so it must not surface a "0 of 0" progress object either.
+    if (canMakeUnreadable) {
+      rmSync(join(projectsDir, 'enc-projP', 'sessP-unreadable.jsonl'), { force: true });
+      const removal = await samplePass();
+      expect(removal.seen).toEqual([]);
+      expect(removal.reindexed).toBe(0);
+    }
+
+    // Truly idle pass: nothing discovered as changed, nothing removed.
+    const idle = await samplePass();
+    expect(idle.seen).toEqual([]);
+    expect(idle.reindexed).toBe(0);
+
+    const res = await app.inject({ method: 'GET', url: '/api/health' });
+    expect(res.statusCode).toBe(200);
+    const json = res.json();
+    expect(json).toMatchObject({ status: 'ok', ready: true });
+    expect(json.indexing).toBeUndefined();
+  });
+});

--- a/packages/shared/src/api.ts
+++ b/packages/shared/src/api.ts
@@ -408,10 +408,20 @@ export interface ReindexResponse {
   durationMs: number;
 }
 
+/** Live per-pass indexing progress: changed files loaded vs. total to load. */
+export interface IndexingProgress {
+  processed: number;
+  total: number;
+}
+
 /** GET /api/health */
 export interface HealthResponse {
   status: 'ok';
   version: string;
+  /** True once the initial index build (or a post-rebuild pass) has finished. */
+  ready: boolean;
+  /** Present while a reindex pass is loading changed files. */
+  indexing?: IndexingProgress;
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/web/src/main.tsx
+++ b/packages/web/src/main.tsx
@@ -3,6 +3,7 @@ import { createRoot } from 'react-dom/client';
 import { BrowserRouter } from 'react-router-dom';
 import { App } from './App.js';
 import { ThemeProvider } from './theme/ThemeProvider.js';
+import { StatusProvider } from './status/StatusProvider.js';
 import './styles/global.css';
 
 const root = document.getElementById('root');
@@ -11,9 +12,11 @@ if (!root) throw new Error('Root element #root not found');
 createRoot(root).render(
   <StrictMode>
     <ThemeProvider>
-      <BrowserRouter>
-        <App />
-      </BrowserRouter>
+      <StatusProvider>
+        <BrowserRouter>
+          <App />
+        </BrowserRouter>
+      </StatusProvider>
     </ThemeProvider>
   </StrictMode>,
 );

--- a/packages/web/src/pages/browse/BrowsePage.tsx
+++ b/packages/web/src/pages/browse/BrowsePage.tsx
@@ -1,8 +1,9 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { Link } from 'react-router-dom';
-import type { ProjectMeta } from '@claudescope/shared';
+import type { ProjectMeta, SourceInfo } from '@claudescope/shared';
 import { api, ApiError } from '../../api/client.js';
 import { AgentBadge, ErrorBox, formatCost, formatCount, SearchField, Spinner, SummaryStrip } from '../../components';
+import { useServerStatus } from '../../status/StatusProvider.js';
 import { timeAgo } from './format.js';
 import './browse.css';
 
@@ -37,6 +38,9 @@ function sortProjects(projects: ProjectMeta[], sort: ProjectSort): ProjectMeta[]
  * Browse view. Lists all projects; each card links to `/projects/:id` (the
  * routed session list), so drill-down is URL-driven and deep-linkable.
  */
+/** Min interval between silent project refetches while the index builds. */
+const REFETCH_THROTTLE_MS = 2000;
+
 export function BrowsePage() {
   const [projects, setProjects] = useState<ProjectMeta[]>([]);
   const [loading, setLoading] = useState(true);
@@ -44,6 +48,8 @@ export function BrowsePage() {
   const [sort, setSort] = useState<ProjectSort>('recent');
   const [filter, setFilter] = useState('');
   const [reloadKey, setReloadKey] = useState(0);
+  const [sources, setSources] = useState<SourceInfo[] | null>(null);
+  const { ready, indexing, building, indexingTick } = useServerStatus();
 
   useEffect(() => {
     const controller = new AbortController();
@@ -63,6 +69,46 @@ export function BrowsePage() {
       });
     return () => controller.abort();
   }, [reloadKey]);
+
+  // While the index builds, silently refetch projects so cards appear as
+  // sessions get indexed (no setLoading — no spinner flash), plus one final
+  // refetch when building flips off to catch the last finalization.
+  const wasBuilding = useRef(false);
+  const lastRefetch = useRef(0);
+  useEffect(() => {
+    const buildEnded = wasBuilding.current && !building;
+    wasBuilding.current = building;
+    if (!building && !buildEnded) return;
+    if (building && Date.now() - lastRefetch.current < REFETCH_THROTTLE_MS) return;
+    lastRefetch.current = Date.now();
+    const controller = new AbortController();
+    api
+      .listProjects(controller.signal)
+      .then((data) => {
+        setProjects(data);
+        setLoading(false);
+      })
+      .catch(() => {
+        /* transient — the next tick retries */
+      });
+    return () => controller.abort();
+  }, [building, indexingTick]);
+
+  // The genuinely-empty state (ready, idle, zero projects) explains itself with
+  // the watched source directories; fetch them lazily only when it shows.
+  const genuinelyEmpty =
+    !building && ready === true && !loading && !error && projects.length === 0;
+  useEffect(() => {
+    if (!genuinelyEmpty || sources !== null) return;
+    const controller = new AbortController();
+    api
+      .sources(controller.signal)
+      .then(setSources)
+      .catch(() => {
+        /* best-effort — the fallback copy still renders */
+      });
+    return () => controller.abort();
+  }, [genuinelyEmpty, sources]);
 
   const visible = useMemo(() => {
     const q = filter.trim().toLowerCase();
@@ -87,6 +133,12 @@ export function BrowsePage() {
     }
     return { projects: projects.length, sessions, cost, agents: agents.size };
   }, [projects]);
+
+  const indexingLabel = indexing
+    ? indexing.processed < indexing.total
+      ? `Indexing ${indexing.processed} of ${indexing.total} transcripts…`
+      : 'Finishing up the index…'
+    : 'Building the transcript index…';
 
   return (
     <section>
@@ -132,17 +184,52 @@ export function BrowsePage() {
       ) : error ? (
         <ErrorBox error={error} onRetry={() => setReloadKey((k) => k + 1)} />
       ) : visible.length === 0 ? (
-        <p className="tv-muted">
-          {projects.length === 0 ? 'No projects indexed yet.' : 'No projects match the filter.'}
-        </p>
+        projects.length > 0 ? (
+          <p className="tv-muted">No projects match the filter.</p>
+        ) : building ? (
+          // First build (or a post-update rebuild) in progress and nothing
+          // indexed yet — show live progress instead of a misleading empty state.
+          <Spinner size="lg" label={indexingLabel} />
+        ) : ready === true ? (
+          <EmptyIndexNotice sources={sources} />
+        ) : (
+          <p className="tv-muted">No projects indexed yet.</p>
+        )
       ) : (
-        <div className="tv-project-grid">
-          {visible.map((p) => (
-            <ProjectCard key={p.id} project={p} />
-          ))}
-        </div>
+        <>
+          {building ? (
+            <div className="tv-browse__indexing tv-muted">
+              <Spinner label={indexingLabel} />
+            </div>
+          ) : null}
+          <div className="tv-project-grid">
+            {visible.map((p) => (
+              <ProjectCard key={p.id} project={p} />
+            ))}
+          </div>
+        </>
       )}
     </section>
+  );
+}
+
+/** Ready + idle + zero projects: explain whether any source dirs exist at all. */
+function EmptyIndexNotice({ sources }: { sources: SourceInfo[] | null }) {
+  if (sources === null) return <p className="tv-muted">No projects indexed yet.</p>;
+  if (sources.length === 0) {
+    return <p className="tv-muted">No agent transcript directories were found on this machine.</p>;
+  }
+  return (
+    <div className="tv-muted tv-browse__empty">
+      <p>No transcripts found yet. Watching:</p>
+      <ul className="tv-browse__sources">
+        {sources.map((s) => (
+          <li key={s.id}>
+            <span className="tv-mono">{s.path}</span> — {s.label}
+          </li>
+        ))}
+      </ul>
+    </div>
   );
 }
 

--- a/packages/web/src/pages/browse/browse.css
+++ b/packages/web/src/pages/browse/browse.css
@@ -24,6 +24,21 @@
   font-size: var(--tv-fs-md);
 }
 
+/* Inline "index still building" line above the grid while cards stream in. */
+.tv-browse__indexing {
+  margin-bottom: var(--tv-space-3);
+  font-size: var(--tv-fs-sm);
+}
+
+/* Genuinely-empty state: the watched source directories, one per line. */
+.tv-browse__sources {
+  margin: var(--tv-space-2) 0 0;
+  padding-left: var(--tv-space-4);
+}
+.tv-browse__sources li {
+  margin-bottom: var(--tv-space-1);
+}
+
 /* Shared form controls (input + select) */
 .tv-input,
 .tv-select {

--- a/packages/web/src/status/StatusProvider.tsx
+++ b/packages/web/src/status/StatusProvider.tsx
@@ -1,0 +1,73 @@
+/**
+ * Server status: a lightweight /api/health poller behind a context.
+ *
+ * Polls fast (1s) while the index is building — first start or a post-update
+ * schema rebuild — so pages can show live progress and refetch growing data,
+ * then stops entirely once the server is ready and idle: steady state costs a
+ * single health call per page load. Any fetch failure means "server
+ * unreachable" (startup or restart window; network errors throw TypeError, not
+ * ApiError) and is retried slowly until the server comes back.
+ */
+
+import { createContext, useContext, useEffect, useState, type ReactNode } from 'react';
+import type { IndexingProgress } from '@claudescope/shared';
+import { api } from '../api/client.js';
+
+export interface ServerStatus {
+  /** null until the first successful health response (server unreachable). */
+  ready: boolean | null;
+  /** Live per-pass progress, when the server reports one. */
+  indexing: IndexingProgress | null;
+  /** True while the index is building: not ready yet, or a pass is running. */
+  building: boolean;
+  /** Increments on every poll observed while building — key refetches off it. */
+  indexingTick: number;
+}
+
+const idleStatus: ServerStatus = { ready: null, indexing: null, building: false, indexingTick: 0 };
+
+const StatusContext = createContext<ServerStatus>(idleStatus);
+
+/** Poll intervals: fast while the index builds, slow while unreachable. */
+const BUILDING_POLL_MS = 1000;
+const UNREACHABLE_POLL_MS = 5000;
+
+export function StatusProvider({ children }: { children: ReactNode }) {
+  const [status, setStatus] = useState<ServerStatus>(idleStatus);
+
+  useEffect(() => {
+    let cancelled = false;
+    let timer: number | undefined;
+
+    const tick = async () => {
+      try {
+        const h = await api.health();
+        if (cancelled) return;
+        const building = !h.ready || h.indexing != null;
+        setStatus((s) => ({
+          ready: h.ready,
+          indexing: h.indexing ?? null,
+          building,
+          indexingTick: building ? s.indexingTick + 1 : s.indexingTick,
+        }));
+        // Ready and idle: stop polling entirely.
+        if (building) timer = window.setTimeout(() => void tick(), BUILDING_POLL_MS);
+      } catch {
+        if (cancelled) return;
+        timer = window.setTimeout(() => void tick(), UNREACHABLE_POLL_MS);
+      }
+    };
+    void tick();
+
+    return () => {
+      cancelled = true;
+      window.clearTimeout(timer);
+    };
+  }, []);
+
+  return <StatusContext.Provider value={status}>{children}</StatusContext.Provider>;
+}
+
+export function useServerStatus(): ServerStatus {
+  return useContext(StatusContext);
+}


### PR DESCRIPTION
## Problem

On first start the UI shows **"No projects indexed yet."** while the index is still building in the background — indistinguishable from a machine with no transcripts at all. The same blind spot hits after a schema-bump rebuild (exactly when indexing is slowest). The server already tracked readiness (`/api/health` → `ready`), but nothing in the web app read it, and there were no progress counts at all.

## What changed

**Server**
- `data/index.ts` tracks live per-pass progress: the changed set is precomputed so `total` is stable up front; skipped-unreadable files still advance `processed`; the counter stays visible through finalization ("finishing up") and clears in a `finally`.
- During the **first build only** (`!ready`), a throttled (3s) partial finalization (`electCanonicalUsage` + `rebuildSessions`) makes `/api/projects` grow mid-pass instead of staying empty until the end. The FTS rebuild + CHECKPOINT (WAL-hazardous) stay end-of-pass; steady-state incremental passes are byte-identical to before.
- `/api/health` now returns `indexing: { processed, total }` while a pass has work. The shared `HealthResponse` type gains the `ready` field the server already returned (removes the `& { ready: boolean }` patches).

**Web**
- New `StatusProvider` polls `/api/health` at 1s **only while building** (5s while unreachable, stops entirely once ready + idle — steady state costs one health call per page load).
- BrowsePage: "Indexing N of M transcripts…" with a live counter, silent throttled refetches so project cards stream in, one final refetch when the build ends, and a ready-but-empty state that lists the watched source directories (or says none were found).

## Tests

- New `index-progress.integration.test.ts`: monotonic counter with a stable total; a chmod-000 unreadable file still reaches `processed === total`; sessions become visible mid-first-build (`PARTIAL_REBUILD_MS=0`); removal-only and no-change passes expose no `indexing` key. Ran 4× locally — stable.
- Full suite: 383 passed, `npm run typecheck` clean.
- Runtime-verified against a real ~1,900-file corpus: live counter, 18 projects served mid-pass, "finishing up" window at 1928/1928, then `ready: true` with no `indexing` key.

## Plan

Part 1 of 3 of [docs/plans/0045](docs/plans/0045-indexing-ux-and-self-healing-updates.md) (indexing UX + post-update self-healing); PR 3 (daemon self-heal) is independent and in flight, PR 2 (update nudge) follows this PR.