### PR TITLE
feat(update): surface update availability on /api/health and in the sidebar

### DIFF
--- a/docs/plans/0045-indexing-ux-and-self-healing-updates.md
+++ b/docs/plans/0045-indexing-ux-and-self-healing-updates.md
@@ -1,8 +1,8 @@
 # 0045 — Indexing UX + post-update self-healing
 
-- **Status:** in-progress
+- **Status:** done
 - **Date:** 2026-07-13
-- **PR:** PR 1 (indexing visibility): [#58](https://github.com/vladar107/claudescope/pull/58) · PR 2 (update nudge): TBD · PR 3 (self-healing): [#57](https://github.com/vladar107/claudescope/pull/57)
+- **PR:** PR 1 (indexing visibility): [#58](https://github.com/vladar107/claudescope/pull/58) · PR 2 (update nudge): [#59](https://github.com/vladar107/claudescope/pull/59) · PR 3 (self-healing): [#57](https://github.com/vladar107/claudescope/pull/57)
 
 ## Context
 

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -69,4 +69,4 @@ decision, or a change worth explaining before doing. Skip it for one-line fixes.
 | 0042 | [Week-in-review digest (page + copy-md + CLI)](./0042-digest.md) | done |
 | 0043 | [Retire the Activity tab: redistribute its pieces](./0043-activity-tab-redistribution.md) | done |
 | 0044 | [Provider-aware cost: local vs remote model sessions](./0044-provider-aware-cost.md) | done |
-| 0045 | [Indexing UX + post-update self-healing](./0045-indexing-ux-and-self-healing-updates.md) | in-progress |
+| 0045 | [Indexing UX + post-update self-healing](./0045-indexing-ux-and-self-healing-updates.md) | done |

--- a/packages/server/src/cli.ts
+++ b/packages/server/src/cli.ts
@@ -18,8 +18,7 @@
  */
 
 import { spawnSync } from 'node:child_process';
-import { existsSync, mkdirSync, readFileSync, realpathSync, rmSync, writeFileSync } from 'node:fs';
-import { join } from 'node:path';
+import { existsSync, mkdirSync, readFileSync, realpathSync, rmSync } from 'node:fs';
 import { createInterface } from 'node:readline/promises';
 import { parseArgs } from 'node:util';
 import { fileURLToPath } from 'node:url';
@@ -55,6 +54,7 @@ import {
   querySessions,
 } from './agent/query.js';
 import { ensureDaemon } from './daemon.js';
+import { PKG, getLatestVersion, isNewer } from './update-check.js';
 import { refreshPricing } from './data/pricing-refresh.js';
 import { openBrowser } from './util/open-browser.js';
 
@@ -70,10 +70,6 @@ export {
   type DaemonRecord,
   type ExistingState,
 } from './daemon.js';
-
-const UPDATE_CHECK_FILE = join(CLAUDESCOPE_HOME, 'update-check.json');
-const PKG = '@vladar107/claudescope';
-const UPDATE_CHECK_TTL_MS = 24 * 60 * 60 * 1000;
 
 /** Start the server in the background, idempotently. */
 async function start(port: number, open: boolean): Promise<void> {
@@ -281,41 +277,6 @@ async function update(skipConfirm: boolean): Promise<void> {
     stdio: 'inherit',
     shell: process.platform === 'win32',
   });
-}
-
-/** Compare two `x.y.z` versions; true if `a` is strictly newer than `b`. */
-function isNewer(a: string, b: string): boolean {
-  const pa = a.split('.').map((n) => Number.parseInt(n, 10) || 0);
-  const pb = b.split('.').map((n) => Number.parseInt(n, 10) || 0);
-  for (let i = 0; i < 3; i++) {
-    if ((pa[i] ?? 0) > (pb[i] ?? 0)) return true;
-    if ((pa[i] ?? 0) < (pb[i] ?? 0)) return false;
-  }
-  return false;
-}
-
-/** Latest published version, cached for 24h. Null on any failure (offline). */
-async function getLatestVersion(force: boolean): Promise<string | null> {
-  const now = Date.now();
-  if (!force && existsSync(UPDATE_CHECK_FILE)) {
-    try {
-      const cached = JSON.parse(readFileSync(UPDATE_CHECK_FILE, 'utf8')) as {
-        lastCheck: number;
-        latest: string;
-      };
-      if (now - cached.lastCheck < UPDATE_CHECK_TTL_MS) return cached.latest;
-    } catch {
-      /* fall through to a fresh fetch */
-    }
-  }
-  const url = `https://registry.npmjs.org/${PKG.replaceAll('/', '%2f')}/latest`;
-  const res = await fetch(url, { signal: AbortSignal.timeout(2500) });
-  if (!res.ok) return null;
-  const json = (await res.json()) as { version?: string };
-  if (!json.version) return null;
-  mkdirSync(CLAUDESCOPE_HOME, { recursive: true });
-  writeFileSync(UPDATE_CHECK_FILE, JSON.stringify({ lastCheck: now, latest: json.version }));
-  return json.version;
 }
 
 /** Print an update notice if a newer version exists. Never throws. */

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -24,6 +24,7 @@ import { registerHostGuard, registerSecurityHeaders } from './security.js';
 import { reindex } from './data/index.js';
 import { refreshPricing } from './data/pricing-refresh.js';
 import { maybeSelfRestart } from './self-restart.js';
+import { refreshLatestVersion } from './update-check.js';
 import { openBrowser } from './util/open-browser.js';
 
 /** How old a fetched-pricing snapshot may be before a boot refresh fires. */
@@ -115,6 +116,18 @@ async function main(): Promise<void> {
     const pricingTimer = setInterval(runPricingRefresh, PRICING_REFRESH_INTERVAL_MS);
     pricingTimer.unref();
     app.addHook('onClose', async () => clearInterval(pricingTimer));
+  }
+
+  // Update-availability check: refresh the daemon-side "latest published
+  // version" cache so /api/health can carry `updateAvailable` for the web UI's
+  // sidebar nudge. Cheap — getLatestVersion caches on disk for 24h, so the
+  // hourly tick mostly re-reads the file and the network is hit ≤ once a day.
+  // Dev builds skip it (nothing meaningful to compare against).
+  if (APP_VERSION !== '0.0.0-dev') {
+    void refreshLatestVersion();
+    const updateTimer = setInterval(() => void refreshLatestVersion(), 60 * 60 * 1000);
+    updateTimer.unref();
+    app.addHook('onClose', async () => clearInterval(updateTimer));
   }
 
   // Post-update self-heal: periodically check whether the installed

--- a/packages/server/src/routes/index.ts
+++ b/packages/server/src/routes/index.ts
@@ -8,6 +8,7 @@ import type { FastifyInstance } from 'fastify';
 import type { HealthResponse, ReindexResponse } from '@claudescope/shared';
 import { APP_VERSION } from '../config.js';
 import { getIndexProgress, isIndexReady, reindex } from '../data/index.js';
+import { updateAvailable } from '../update-check.js';
 import { registerProjectsRoute } from './projects.js';
 import { registerSessionsRoutes } from './sessions.js';
 import { registerSearchRoute } from './search.js';
@@ -25,11 +26,13 @@ import { registerMemoryRoute } from './memory.js';
 export async function registerRoutes(app: FastifyInstance): Promise<void> {
   app.get('/api/health', async (): Promise<HealthResponse> => {
     const indexing = getIndexProgress();
+    const latest = updateAvailable();
     return {
       status: 'ok',
       version: APP_VERSION,
       ready: isIndexReady(),
       ...(indexing ? { indexing } : {}),
+      ...(latest ? { updateAvailable: latest } : {}),
     };
   });
 

--- a/packages/server/src/update-check.ts
+++ b/packages/server/src/update-check.ts
@@ -1,0 +1,70 @@
+/**
+ * Update-availability check against the npm registry, shared by the CLI
+ * (start/status notices, the `update` command) and the daemon (which surfaces
+ * `updateAvailable` on /api/health for the web UI's sidebar nudge).
+ *
+ * The registry lookup is cached on disk for 24h (update-check.json in the
+ * state dir), so however often callers ask, the network is hit at most once a
+ * day. Everything degrades to "no info" (null) offline — never throws.
+ */
+
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { APP_VERSION, CLAUDESCOPE_HOME } from './config.js';
+
+export const PKG = '@vladar107/claudescope';
+const UPDATE_CHECK_FILE = join(CLAUDESCOPE_HOME, 'update-check.json');
+const UPDATE_CHECK_TTL_MS = 24 * 60 * 60 * 1000;
+
+/** Compare two `x.y.z` versions; true if `a` is strictly newer than `b`. */
+export function isNewer(a: string, b: string): boolean {
+  const pa = a.split('.').map((n) => Number.parseInt(n, 10) || 0);
+  const pb = b.split('.').map((n) => Number.parseInt(n, 10) || 0);
+  for (let i = 0; i < 3; i++) {
+    if ((pa[i] ?? 0) > (pb[i] ?? 0)) return true;
+    if ((pa[i] ?? 0) < (pb[i] ?? 0)) return false;
+  }
+  return false;
+}
+
+/** Latest published version, cached for 24h. Null on any failure (offline). */
+export async function getLatestVersion(force: boolean): Promise<string | null> {
+  const now = Date.now();
+  if (!force && existsSync(UPDATE_CHECK_FILE)) {
+    try {
+      const cached = JSON.parse(readFileSync(UPDATE_CHECK_FILE, 'utf8')) as {
+        lastCheck: number;
+        latest: string;
+      };
+      if (now - cached.lastCheck < UPDATE_CHECK_TTL_MS) return cached.latest;
+    } catch {
+      /* fall through to a fresh fetch */
+    }
+  }
+  const url = `https://registry.npmjs.org/${PKG.replaceAll('/', '%2f')}/latest`;
+  const res = await fetch(url, { signal: AbortSignal.timeout(2500) });
+  if (!res.ok) return null;
+  const json = (await res.json()) as { version?: string };
+  if (!json.version) return null;
+  mkdirSync(CLAUDESCOPE_HOME, { recursive: true });
+  writeFileSync(UPDATE_CHECK_FILE, JSON.stringify({ lastCheck: now, latest: json.version }));
+  return json.version;
+}
+
+/** Last version seen by {@link refreshLatestVersion} (daemon-side cache). */
+let cachedLatest: string | null = null;
+
+/** The newer published version the daemon knows about, or null. */
+export function updateAvailable(): string | null {
+  return cachedLatest && isNewer(cachedLatest, APP_VERSION) ? cachedLatest : null;
+}
+
+/** Refresh the daemon-side cache from the (file-cached) registry lookup.
+ *  Never throws — offline just leaves the last-known value in place. */
+export async function refreshLatestVersion(): Promise<void> {
+  try {
+    cachedLatest = (await getLatestVersion(false)) ?? cachedLatest;
+  } catch {
+    /* offline or registry hiccup — keep the last-known value */
+  }
+}

--- a/packages/server/test/update-check.test.ts
+++ b/packages/server/test/update-check.test.ts
@@ -1,0 +1,129 @@
+/**
+ * Unit tests for update-check.ts: the x.y.z comparison that gates both the CLI
+ * update notice and the daemon's `updateAvailable` nudge (pinning its
+ * coercion of short/garbage/prerelease inputs), the 24h file-cache behavior of
+ * the registry lookup, and the daemon-side cache exposed on /api/health.
+ *
+ * CLAUDESCOPE_HOME is set before importing the module (config.ts reads env at
+ * import time). fetch is always stubbed — no test touches the network.
+ */
+
+import { afterAll, afterEach, describe, expect, it, vi } from 'vitest';
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+const home = mkdtempSync(join(tmpdir(), 'claudescope-update-'));
+process.env.CLAUDESCOPE_HOME = home;
+
+const uc = await import('../src/update-check.js');
+const CACHE = join(home, 'update-check.json');
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  rmSync(CACHE, { force: true });
+});
+
+afterAll(() => rmSync(home, { recursive: true, force: true }));
+
+describe('isNewer', () => {
+  it('orders plain x.y.z versions', () => {
+    expect(uc.isNewer('0.12.0', '0.11.9')).toBe(true);
+    expect(uc.isNewer('1.0.0', '0.99.99')).toBe(true);
+    expect(uc.isNewer('0.11.0', '0.11.0')).toBe(false);
+    expect(uc.isNewer('0.11.0', '0.12.0')).toBe(false);
+  });
+
+  it('coerces short, garbage, and prerelease segments to numbers (pinned)', () => {
+    // Missing segments read as 0 …
+    expect(uc.isNewer('0.12', '0.11.5')).toBe(true);
+    // … garbage reads as 0.0.0 (never "newer" than a real release) …
+    expect(uc.isNewer('abc', '0.0.1')).toBe(false);
+    // … and a prerelease tail is ignored: parseInt('0-beta') === 0.
+    expect(uc.isNewer('0.12.0-beta.2', '0.12.0')).toBe(false);
+    expect(uc.isNewer('9.9.9', '0.0.0-dev')).toBe(true);
+  });
+});
+
+describe('getLatestVersion', () => {
+  it('serves a fresh cache without touching the network', async () => {
+    writeFileSync(CACHE, JSON.stringify({ lastCheck: Date.now(), latest: '1.2.3' }));
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(() => {
+        throw new Error('network must not be touched');
+      }),
+    );
+    expect(await uc.getLatestVersion(false)).toBe('1.2.3');
+  });
+
+  it('refetches past the 24h TTL and rewrites the cache', async () => {
+    writeFileSync(
+      CACHE,
+      JSON.stringify({ lastCheck: Date.now() - 25 * 60 * 60 * 1000, latest: '1.2.3' }),
+    );
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => ({ ok: true, json: async () => ({ version: '1.3.0' }) })),
+    );
+    expect(await uc.getLatestVersion(false)).toBe('1.3.0');
+    expect(JSON.parse(readFileSync(CACHE, 'utf8')).latest).toBe('1.3.0');
+  });
+
+  it('force bypasses even a fresh cache', async () => {
+    writeFileSync(CACHE, JSON.stringify({ lastCheck: Date.now(), latest: '1.2.3' }));
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => ({ ok: true, json: async () => ({ version: '1.4.0' }) })),
+    );
+    expect(await uc.getLatestVersion(true)).toBe('1.4.0');
+  });
+
+  it('a corrupt cache file falls through to a fresh fetch', async () => {
+    writeFileSync(CACHE, 'not json');
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => ({ ok: true, json: async () => ({ version: '2.0.0' }) })),
+    );
+    expect(await uc.getLatestVersion(false)).toBe('2.0.0');
+  });
+
+  it('a non-ok registry response yields null and writes no cache', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => ({ ok: false })));
+    expect(await uc.getLatestVersion(false)).toBeNull();
+    expect(() => readFileSync(CACHE, 'utf8')).toThrow();
+  });
+});
+
+// These run in order on purpose: cachedLatest is module-level daemon state.
+describe('updateAvailable / refreshLatestVersion', () => {
+  it('is null before any refresh', () => {
+    expect(uc.updateAvailable()).toBeNull();
+  });
+
+  it('reports a newer published version after a refresh', async () => {
+    writeFileSync(CACHE, JSON.stringify({ lastCheck: Date.now(), latest: '9.9.9' }));
+    await uc.refreshLatestVersion();
+    // APP_VERSION is 0.0.0-dev under vitest, so 9.9.9 is newer.
+    expect(uc.updateAvailable()).toBe('9.9.9');
+  });
+
+  it('keeps the last-known value when the registry is unreachable', async () => {
+    // No cache file and fetch rejecting — refresh must neither throw nor
+    // clear the previously seen version.
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => {
+        throw new Error('offline');
+      }),
+    );
+    await uc.refreshLatestVersion();
+    expect(uc.updateAvailable()).toBe('9.9.9');
+  });
+
+  it('is null when the published version is not newer than this build', async () => {
+    writeFileSync(CACHE, JSON.stringify({ lastCheck: Date.now(), latest: '0.0.0-dev' }));
+    await uc.refreshLatestVersion();
+    expect(uc.updateAvailable()).toBeNull();
+  });
+});

--- a/packages/shared/src/api.ts
+++ b/packages/shared/src/api.ts
@@ -422,6 +422,8 @@ export interface HealthResponse {
   ready: boolean;
   /** Present while a reindex pass is loading changed files. */
   indexing?: IndexingProgress;
+  /** Latest published version, when the daemon knows it is newer than itself. */
+  updateAvailable?: string;
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -5,6 +5,7 @@ import type { SourceInfo } from '@claudescope/shared';
 import { ErrorBoundary } from './components';
 import { api } from './api/client.js';
 import { useTheme, type ThemeChoice } from './theme/ThemeProvider.js';
+import { useServerStatus } from './status/StatusProvider.js';
 import { BrowsePage } from './pages/browse/BrowsePage.js';
 import { ProjectLayout } from './pages/browse/ProjectLayout.js';
 import { SessionListPage } from './pages/browse/SessionList.js';
@@ -63,6 +64,7 @@ function ThemeToggle() {
 
 /** Left navigation sidebar. */
 function Sidebar() {
+  const { updateAvailable } = useServerStatus();
   const [sources, setSources] = useState<SourceInfo[]>([]);
   useEffect(() => {
     const controller = new AbortController();
@@ -102,6 +104,11 @@ function Sidebar() {
       <div className="tv-nav__spacer" />
       <ThemeToggle />
       <div className="tv-nav__footer">
+        {updateAvailable ? (
+          <span className="tv-nav__update" title={`Update available: v${updateAvailable}`}>
+            v{updateAvailable} available — <code className="tv-mono">claudescope update</code>
+          </span>
+        ) : null}
         <span className="tv-nav__footer-label">Read-only sources</span>
         {sources.map((s) => (
           <span key={s.id} className="tv-nav__source tv-mono" title={`${s.label} · ${s.path}`}>

--- a/packages/web/src/status/StatusProvider.tsx
+++ b/packages/web/src/status/StatusProvider.tsx
@@ -22,9 +22,17 @@ export interface ServerStatus {
   building: boolean;
   /** Increments on every poll observed while building — key refetches off it. */
   indexingTick: number;
+  /** Newer published version the daemon reported, for the sidebar nudge. */
+  updateAvailable: string | null;
 }
 
-const idleStatus: ServerStatus = { ready: null, indexing: null, building: false, indexingTick: 0 };
+const idleStatus: ServerStatus = {
+  ready: null,
+  indexing: null,
+  building: false,
+  indexingTick: 0,
+  updateAvailable: null,
+};
 
 const StatusContext = createContext<ServerStatus>(idleStatus);
 
@@ -49,6 +57,7 @@ export function StatusProvider({ children }: { children: ReactNode }) {
           indexing: h.indexing ?? null,
           building,
           indexingTick: building ? s.indexingTick + 1 : s.indexingTick,
+          updateAvailable: h.updateAvailable ?? null,
         }));
         // Ready and idle: stop polling entirely.
         if (building) timer = window.setTimeout(() => void tick(), BUILDING_POLL_MS);

--- a/packages/web/src/styles/global.css
+++ b/packages/web/src/styles/global.css
@@ -234,6 +234,16 @@ button {
   overflow: hidden;
   text-overflow: ellipsis;
 }
+/* Update nudge above the sources — a hint, not an alert, so muted colors. */
+.tv-nav__update {
+  font-size: 11px;
+  color: var(--tv-fg-muted);
+  margin-bottom: var(--tv-space-2);
+}
+.tv-nav__update code {
+  font-size: 10px;
+  color: var(--tv-fg);
+}
 
 /* Theme toggle — segmented System / Light / Dark control in the nav footer. */
 .tv-theme-toggle {


### PR DESCRIPTION
Third and final PR of the indexing-UX / self-healing plan (docs/plans/0045; #58 indexing visibility, #57 self-healing).

## What

The daemon now knows when a newer version is published and the web UI says so — completing the loop: **notice the update (this PR) → run \`claudescope update\` → the daemon self-migrates (#57) with visible rebuild progress (#58)**.

- **\`packages/server/src/update-check.ts\` (new):** the 24h-file-cached npm-registry lookup (\`PKG\`, \`isNewer\`, \`getLatestVersion\`) moved verbatim out of \`cli.ts\`, plus a daemon-side in-memory cache: \`refreshLatestVersion()\` (never throws; offline keeps the last-known value) and \`updateAvailable()\` (non-null only when strictly newer than the running version).
- **Daemon:** refreshes at boot + hourly (\`unref\`'d, cleared on close; network hits ≤ 1/day thanks to the file cache; dev builds skip it). \`/api/health\` gains optional \`updateAvailable\`.
- **Web:** \`StatusProvider\` carries it; the sidebar footer shows a muted "v0.12.0 available — \`claudescope update\`" hint. Since the poller stops when ready+idle, steady state stays one health call per page load.
- CLI behavior unchanged — \`update\`/\`maybeNotifyUpdate\` just import from the new module.

## Tests

\`update-check.test.ts\` (11 tests): \`isNewer\` coercion edges (short/garbage/prerelease segments — it now gates the nudge *and* the #57 self-heal), cache TTL/force/corrupt-cache/non-ok behavior, and the daemon cache (null before refresh, set on refresh, survives offline, null when not newer). Full suite: 48 files, 420 tests, typecheck clean.

## Verified end-to-end

Bundled build (real version injected) + seeded warm cache (\`latest: 99.0.0\`): \`GET /api/health\` → \`{"status":"ok","version":"0.11.0","ready":true,"updateAvailable":"99.0.0"}\`.