### PR TITLE
feat: live session updates (fingerprint polling + stick-to-bottom)

### DIFF
--- a/docs/plans/0046-live-session-updates.md
+++ b/docs/plans/0046-live-session-updates.md
@@ -1,0 +1,96 @@
+# 0046 — Live session updates (fingerprint polling + stick-to-bottom)
+
+- **Status:** in-progress
+- **Date:** 2026-07-13
+- **PR:** <link, once opened>
+
+## Context
+
+While an agent is still writing a transcript, the open session page only updates
+on manual ⌘R. The session *content* is already served live — `GET
+/api/sessions/:id` re-reads the JSONL from disk on every request
+(`data/session-loader.ts`); only the header `meta` and the `session_id → [file
+paths]` mapping come from the DuckDB index (≤15s stale via the interval
+reindex). So "live updates" needs only a cheap change signal plus an automatic
+trigger for the existing scroll-safe soft `refresh()` in SessionPage.
+
+## Goal
+
+A session whose transcript is actively growing updates in the open session page
+within ~2s, silently (no spinner flash), keeping a bottom-pinned reader pinned —
+at near-zero cost when nothing is live.
+
+## Decisions
+
+- **Split design** — the 15s interval reindex stays untouched (index path); a
+  new read-only per-session fingerprint probe serves the view path. Rejected:
+  *reindex-driven UI* (a changes-pass rebuilds sessions/FTS/checkpoint — far too
+  heavy at 2s cadence, and ~9s median latency), *fs watchers* (much larger
+  cross-platform effort; can be layered on later feeding the same fingerprint),
+  *SSE* (new infra class, no real latency win over localhost polling).
+- **Hybrid fingerprint** — live `fs.stat` of the session's known files **plus**
+  the files-table row set. Growth shows up within one poll; a brand-new subagent
+  file rides the next reindex (documented ≤15s blind spot) and then joins the
+  live-stat set.
+- **Connector hook `statFile?`** — opencode's paths are synthetic
+  `<dbPath>#<sessionId>` keys that can't be `fs.stat`ed; it probes SQLite
+  instead. All six file-backed connectors use the caller's `fs.stat` default.
+- **Polling, not push** — mirrors the established StatusProvider pattern: ~2s
+  while the session looks live (last modification within 3min), 5s after a
+  transient error, stop when idle/hidden, revive on tab visibility/focus.
+- **Stick-to-bottom without a toggle** — pin only a reader already near the
+  bottom, via a short rAF hold (the `holdAnchor` pattern) because appended turns
+  mount progressively and Shiki swaps in async. No live badge/chip anywhere.
+
+## Approach
+
+1. Shared type `SessionFingerprintResponse { fingerprint, lastModifiedMs }`.
+2. Server: optional `statFile?` on `AgentConnector`; opencode `statSession`
+   (the `listSessions` change-signal expression targeted at one id);
+   `computeSessionFingerprint` (files rows → per-file live stat →
+   sha1 over row count + `path:mtime:size` parts); thin
+   `GET /api/sessions/:id/fingerprint` route (404 shape of the detail route).
+3. Web: `api.sessionFingerprint`; `refresh({silent}) → Promise<boolean>` in
+   SessionPage (spinner only for manual refresh; resolves true when the swap
+   landed); `useLiveSession` poller hook; `isNearBottom`/`holdBottom` helpers
+   wired into the refresh swap path.
+4. Integration tests for the probe's contracts.
+
+## Files affected
+
+- `packages/shared/src/api.ts` — `SessionFingerprintResponse`.
+- `packages/server/src/connectors/types.ts` — optional `statFile?`.
+- `packages/server/src/connectors/opencode/{db,opencode}.ts` — `statSession` +
+  hook implementation.
+- `packages/server/src/data/fingerprint.ts` — new; `computeSessionFingerprint`.
+- `packages/server/src/routes/sessions.ts` — fingerprint route.
+- `packages/web/src/api/client.ts` — `sessionFingerprint`.
+- `packages/web/src/pages/session/useLiveSession.ts` — new; poller +
+  stick-to-bottom helpers.
+- `packages/web/src/pages/session/SessionPage.tsx` — silent refresh, poller +
+  pin wiring.
+- `packages/server/test/session-fingerprint.integration.test.ts` — new.
+- `packages/server/test/opencode.integration.test.ts` — one fingerprint case.
+
+## Testing
+
+- `npm test` / `npm run typecheck`.
+- Integration: fingerprint flips on file growth **without** reindex; a new
+  subagent file flips it only **after** reindex (documents the blind spot);
+  unknown session 404s; opencode probe works via SQLite (synthetic path never
+  `fs.stat`ed) and flips on a new `part` row without reindex.
+- Manual: dev server + a fixture transcript appended every few seconds — new
+  turns appear within ~2s with no spinner; bottom-pinned reader follows; a
+  scrolled-up reader stays put; polling stops when the tab hides / the session
+  goes idle and revives on focus.
+
+## Risks / open questions
+
+- Blocks inside a turn are index-keyed (`ThreadView.tsx`), so a *mutating*
+  in-progress final turn could mis-bind expand state; pure turn appends (the
+  common case) are unaffected. Revisit if it bites.
+- A fingerprint 404 permanently stops the poller; during a schema-bump rebuild
+  an open page could go quiet until re-navigation. Accepted — manual refresh
+  still works.
+- fs watchers remain a possible future upgrade; they would feed the same
+  fingerprint/version and leave the client untouched.

--- a/docs/plans/0046-live-session-updates.md
+++ b/docs/plans/0046-live-session-updates.md
@@ -1,8 +1,8 @@
 # 0046 — Live session updates (fingerprint polling + stick-to-bottom)
 
-- **Status:** in-progress
+- **Status:** done
 - **Date:** 2026-07-13
-- **PR:** <link, once opened>
+- **PR:** [#60](https://github.com/vladar107/claudescope/pull/60)
 
 ## Context
 

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -70,4 +70,4 @@ decision, or a change worth explaining before doing. Skip it for one-line fixes.
 | 0043 | [Retire the Activity tab: redistribute its pieces](./0043-activity-tab-redistribution.md) | done |
 | 0044 | [Provider-aware cost: local vs remote model sessions](./0044-provider-aware-cost.md) | done |
 | 0045 | [Indexing UX + post-update self-healing](./0045-indexing-ux-and-self-healing-updates.md) | done |
-| 0046 | [Live session updates (fingerprint polling + stick-to-bottom)](./0046-live-session-updates.md) | in-progress |
+| 0046 | [Live session updates (fingerprint polling + stick-to-bottom)](./0046-live-session-updates.md) | done |

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -70,3 +70,4 @@ decision, or a change worth explaining before doing. Skip it for one-line fixes.
 | 0043 | [Retire the Activity tab: redistribute its pieces](./0043-activity-tab-redistribution.md) | done |
 | 0044 | [Provider-aware cost: local vs remote model sessions](./0044-provider-aware-cost.md) | done |
 | 0045 | [Indexing UX + post-update self-healing](./0045-indexing-ux-and-self-healing-updates.md) | done |
+| 0046 | [Live session updates (fingerprint polling + stick-to-bottom)](./0046-live-session-updates.md) | in-progress |

--- a/packages/server/src/connectors/opencode/db.ts
+++ b/packages/server/src/connectors/opencode/db.ts
@@ -80,6 +80,38 @@ export function listSessions(dbPath: string): OpencodeSessionMeta[] {
 }
 
 /**
+ * One session's change signal — the {@link listSessions} expression targeted at
+ * a single id, for the fingerprint route's live probe. Returns `null` when the
+ * DB file is absent or the session row is gone; an open/query failure on a
+ * present DB propagates (the fingerprint caller skips a throwing file — unlike
+ * the indexer's prune loop, a skipped probe can't wipe anything).
+ */
+export function statSession(dbPath: string, sessionId: string): { mtimeMs: number; size: number } | null {
+  if (!existsSync(dbPath)) return null;
+  const db = open(dbPath);
+  try {
+    const row = db
+      .prepare(
+        `SELECT max(
+             s.time_updated,
+             COALESCE((SELECT max(time_updated) FROM message m WHERE m.session_id = s.id), 0),
+             COALESCE((SELECT max(time_updated) FROM part    p WHERE p.session_id = s.id), 0)
+           ) AS mtime,
+           (
+             (SELECT count(*) FROM message m WHERE m.session_id = s.id) +
+             (SELECT count(*) FROM part    p WHERE p.session_id = s.id)
+           ) AS size
+         FROM session s WHERE s.id = ?`,
+      )
+      .get(sessionId) as { mtime: number; size: number } | undefined;
+    if (!row) return null;
+    return { mtimeMs: Math.floor(Number(row.mtime)), size: Number(row.size) };
+  } finally {
+    db.close();
+  }
+}
+
+/**
  * Follow `parent_id` up to the top-level ancestor. Stops at a dangling link (the
  * parent row is gone — the walked-to session is then the root) and degrades to
  * the session's own id on a cycle (corrupt data must not re-key anything).

--- a/packages/server/src/connectors/opencode/opencode.ts
+++ b/packages/server/src/connectors/opencode/opencode.ts
@@ -20,7 +20,7 @@ import { CLAUDESCOPE_HOME, OPENCODE_DATA_DIR, OPENCODE_DB_PATH } from '../../con
 import { sqlString } from '../../db/duckdb.js';
 import type { SessionData, SubagentSource } from '../../data/session-loader.js';
 import type { AgentConnector, AuxProjections, DiscoveredFile } from '../types.js';
-import { listSessions, readSession } from './db.js';
+import { listSessions, readSession, statSession } from './db.js';
 import { buildEvents, taskSpawns, toCanonicalRows } from './normalize.js';
 
 const CACHE_DIR = join(CLAUDESCOPE_HOME, 'cache', 'opencode');
@@ -145,6 +145,11 @@ export const opencodeConnector: AgentConnector = {
   eventsProjectionSql,
   auxProjections,
   loadSession,
+  // Synthetic `<dbPath>#<id>` paths can't be fs.stat'ed — probe the DB instead.
+  statFile: (filePath) => {
+    const { dbPath, sessionId } = parseKey(filePath);
+    return sessionId ? statSession(dbPath, sessionId) : null;
+  },
   resumeSpec: (id) => ({
     resumeArgv: ['opencode', '--session', id],
     forkArgv: ['opencode', '--session', id, '--fork'],

--- a/packages/server/src/connectors/types.ts
+++ b/packages/server/src/connectors/types.ts
@@ -104,6 +104,17 @@ export interface AgentConnector {
   loadSession(sessionId: string, paths: string[]): Promise<SessionData>;
 
   /**
+   * Optional: live-stat ONE of this connector's discovered files — the same
+   * change signal as {@link discover}, but targeted. Used by the session
+   * fingerprint route to detect growth between reindex passes. Absent → the
+   * caller `fs.stat`s the path directly, which is correct for every file-backed
+   * connector; opencode overrides it because its paths are synthetic
+   * `<dbPath>#<sessionId>` keys. Return `null` when the file/session is gone;
+   * throwing is treated the same (the file is skipped).
+   */
+  statFile?(path: string): Pick<DiscoveredFile, 'mtimeMs' | 'size'> | null;
+
+  /**
    * Optional: the agent's global, cross-project memory — user-authored
    * instruction file(s) and/or agent-distilled global memory. Read live (NOT
    * indexed). Returns `[]` when the agent has none.

--- a/packages/server/src/data/fingerprint.ts
+++ b/packages/server/src/data/fingerprint.ts
@@ -1,0 +1,59 @@
+/**
+ * Live change token for a single session, powering the session page's
+ * auto-refresh poller. Resolves the session's files from the index (same
+ * source of truth as the session loader), then live-stats each one via the
+ * owning connector — so growth shows up within one poll, with no reindex.
+ * Read-only: never triggers a reindex and never touches the `sessions` table.
+ */
+
+import { createHash } from 'node:crypto';
+import { statSync } from 'node:fs';
+import type { SessionFingerprintResponse } from '@claudescope/shared';
+import { getConnection, queryRows, sqlString } from '../db/duckdb.js';
+import { connectorById } from '../connectors/registry.js';
+
+/** fs.stat default for file-backed connectors; `Math.floor` matches `discover()`. */
+function defaultStat(path: string): { mtimeMs: number; size: number } {
+  const st = statSync(path);
+  return { mtimeMs: Math.floor(st.mtimeMs), size: st.size };
+}
+
+/**
+ * Hash the session's per-file (path, mtime, size) plus the files-table row
+ * count, so both a live append and a reindex-discovered new file (e.g. a
+ * subagent transcript, recorded ≤ one reindex interval later) flip the token.
+ * Deleted/unreadable files are skipped from the stat parts but still counted by
+ * the row-count prefix, so newly failing files flip it too. Returns `null` for
+ * a session with no indexed files (→ 404).
+ */
+export async function computeSessionFingerprint(
+  sessionId: string,
+): Promise<SessionFingerprintResponse | null> {
+  const conn = await getConnection();
+  const rows = await queryRows(
+    conn,
+    `SELECT path, connector_id FROM files WHERE session_id = ${sqlString(sessionId)} ORDER BY path`,
+  );
+  if (rows.length === 0) return null;
+
+  // One connector per session — the same assumption the session loader makes.
+  const connector = connectorById(rows[0]?.connector_id != null ? String(rows[0].connector_id) : null);
+
+  const parts: string[] = [];
+  let lastModifiedMs = 0;
+  for (const r of rows) {
+    const path = String(r.path);
+    let st: { mtimeMs: number; size: number } | null = null;
+    try {
+      st = connector.statFile ? connector.statFile(path) : defaultStat(path);
+    } catch {
+      // Gone or unreadable — skip; the row-count prefix still reflects it.
+    }
+    if (!st) continue;
+    parts.push(`${path}:${st.mtimeMs}:${st.size}`);
+    if (st.mtimeMs > lastModifiedMs) lastModifiedMs = st.mtimeMs;
+  }
+
+  const fingerprint = createHash('sha1').update(`${rows.length}|${parts.join('|')}`).digest('hex');
+  return { fingerprint, lastModifiedMs };
+}

--- a/packages/server/src/routes/sessions.ts
+++ b/packages/server/src/routes/sessions.ts
@@ -4,11 +4,15 @@
  *
  * GET /api/sessions/:id — full session detail: derived meta + the assembled
  * thread (parsed directly from the session's JSONL on disk).
+ *
+ * GET /api/sessions/:id/fingerprint — live change probe for the session page's
+ * auto-refresh poller (stats the session's files; never triggers a reindex).
  */
 
 import type { FastifyInstance } from 'fastify';
 import type {
   SessionDetailResponse,
+  SessionFingerprintResponse,
   SessionMeta,
   SessionSort,
 } from '@claudescope/shared';
@@ -19,6 +23,7 @@ import { displayNameFromCwd, projectIdFromCwd } from '../data/project-id.js';
 import { toIso } from './projects.js';
 import { assembleThread, buildSubagentRuns } from '../data/parser.js';
 import { loadSessionData } from '../data/session-loader.js';
+import { computeSessionFingerprint } from '../data/fingerprint.js';
 import { loadPricing } from '../data/pricing.js';
 import { connectorById } from '../connectors/registry.js';
 import { buildResumeInfo } from '../connectors/resume.js';
@@ -114,6 +119,20 @@ export async function registerSessionsRoutes(app: FastifyInstance): Promise<void
     );
     return rows.map(rowToSessionMeta);
   });
+
+  // Lightweight live-change probe for the session page's auto-refresh poller.
+  // Stats the session's files per request (read-only; never triggers a reindex).
+  app.get<{ Params: { id: string } }>(
+    '/api/sessions/:id/fingerprint',
+    async (req, reply): Promise<SessionFingerprintResponse | void> => {
+      const fp = await computeSessionFingerprint(req.params.id);
+      if (!fp) {
+        reply.code(404).send({ error: 'Session not found' });
+        return;
+      }
+      return fp;
+    },
+  );
 
   app.get<{
     Params: { id: string };

--- a/packages/server/test/opencode.integration.test.ts
+++ b/packages/server/test/opencode.integration.test.ts
@@ -314,3 +314,28 @@ describe('opencode session detail', () => {
     expect(JSON.stringify(detail.thread)).toContain('orphaned child prompt');
   });
 });
+
+// Runs last: it writes to the fixture DB (never a real source), and mutating
+// `time_updated` rows would perturb the earlier assertions if it ran first.
+describe('opencode session fingerprint', () => {
+  it('probes synthetic <dbPath>#<id> paths via SQLite and flips on new rows without a reindex', async () => {
+    const before = (await get('/api/sessions/ses_test1/fingerprint')).json();
+    // A working fingerprint proves the probe never fs.stat'ed the synthetic
+    // path (which does not exist on disk) — it asked the DB instead.
+    expect(before.fingerprint).toMatch(/^[0-9a-f]{40}$/);
+    // max time_updated across the session's synthetic files (parent + folded child).
+    expect(before.lastModifiedMs).toBe(3000);
+
+    // A new part row with a later time_updated — the live change signal.
+    const db = new DatabaseSync(join(ocDataDir, 'opencode.db'));
+    db.prepare('INSERT INTO part VALUES (?,?,?,?,?,?)').run(
+      'p_live', 'a1', 'ses_test1', 9999, 9999,
+      JSON.stringify({ type: 'text', text: 'streamed in later' }),
+    );
+    db.close();
+
+    const after = (await get('/api/sessions/ses_test1/fingerprint')).json();
+    expect(after.fingerprint).not.toBe(before.fingerprint);
+    expect(after.lastModifiedMs).toBe(9999);
+  });
+});

--- a/packages/server/test/session-fingerprint.integration.test.ts
+++ b/packages/server/test/session-fingerprint.integration.test.ts
@@ -1,0 +1,130 @@
+/**
+ * Session-fingerprint integration tests — the GET /api/sessions/:id/fingerprint
+ * contract (data/fingerprint.ts): the probe live-stats the session's files, so
+ * transcript growth flips the token with NO reindex; a brand-new subagent file
+ * is invisible until a reindex pass records its `files` row (the documented
+ * ≤ REINDEX_INTERVAL_MS blind spot), then flips it; unknown sessions 404.
+ */
+
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { appendFileSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import type { FastifyInstance } from 'fastify';
+
+// --- temp locations (decided before any server module is imported) ----------
+const work = mkdtempSync(join(tmpdir(), 'claudescope-fingerprint-'));
+const projectsDir = join(work, 'projects');
+
+process.env.CLAUDE_PROJECTS_DIR = projectsDir;
+process.env.CODEX_SESSIONS_DIR = join(work, 'codex-empty');
+process.env.JUNIE_SESSIONS_DIR = join(work, 'junie-empty');
+process.env.PI_SESSIONS_DIR = join(work, 'pi-empty');
+process.env.OPENCODE_DATA_DIR = join(work, 'opencode-empty');
+process.env.COPILOT_SESSIONS_DIR = join(work, 'copilot-empty');
+process.env.ANTIGRAVITY_CLI_DIR = join(work, 'antigravity-empty');
+process.env.ANTIGRAVITY_DIR = join(work, 'antigravity-empty-desktop');
+process.env.DUCKDB_PATH = join(work, 'index.duckdb');
+process.env.CLAUDESCOPE_HOME = join(work, 'home');
+process.env.REINDEX_INTERVAL_MS = '0';
+
+const jsonl = (events: unknown[]): string => events.map((e) => JSON.stringify(e)).join('\n') + '\n';
+
+const proj = join(projectsDir, 'enc-projF');
+const sessFile = join(proj, 'sessF.jsonl');
+const subDir = join(proj, 'sessF', 'subagents');
+
+const base = { sessionId: 'sessF', cwd: '/tmp/projF', gitBranch: 'main', version: '2.1.0' };
+
+function writeFixtures(): void {
+  mkdirSync(subDir, { recursive: true });
+  writeFileSync(
+    sessFile,
+    jsonl([
+      { ...base, type: 'user', uuid: 'f-u1', parentUuid: null, timestamp: '2026-01-01T10:00:00.000Z', isSidechain: false, message: { role: 'user', content: 'start' } },
+      { ...base, type: 'assistant', uuid: 'f-a1', parentUuid: 'f-u1', timestamp: '2026-01-01T10:00:05.000Z', isSidechain: false, message: { role: 'assistant', model: 'claude-opus-4-8', content: [{ type: 'text', text: 'working' }], usage: { input_tokens: 10, output_tokens: 5 } } },
+    ]),
+  );
+}
+
+let app: FastifyInstance;
+let reindex: typeof import('../src/data/index.js').reindex;
+let closeConnection: () => Promise<void>;
+
+beforeAll(async () => {
+  writeFixtures();
+  const Fastify = (await import('fastify')).default;
+  const { registerRoutes } = await import('../src/routes/index.js');
+  ({ reindex } = await import('../src/data/index.js'));
+  ({ closeConnection } = await import('../src/db/duckdb.js'));
+  app = Fastify();
+  await registerRoutes(app);
+  await reindex();
+  await app.ready();
+});
+
+afterAll(async () => {
+  await app?.close();
+  await closeConnection?.();
+  rmSync(work, { recursive: true, force: true });
+});
+
+const getFingerprint = async (id: string) => {
+  const res = await app.inject({ method: 'GET', url: `/api/sessions/${id}/fingerprint` });
+  return { status: res.statusCode, body: res.json() as { fingerprint: string; lastModifiedMs: number } };
+};
+
+describe('GET /api/sessions/:id/fingerprint', () => {
+  it('is stable while nothing changes and flips on file growth WITHOUT a reindex', async () => {
+    const first = await getFingerprint('sessF');
+    expect(first.status).toBe(200);
+    expect(first.body.fingerprint).toMatch(/^[0-9a-f]{40}$/);
+    expect(first.body.lastModifiedMs).toBeGreaterThan(0);
+
+    const second = await getFingerprint('sessF');
+    expect(second.body.fingerprint).toBe(first.body.fingerprint);
+
+    // Append one event — size changes even when mtime lands in the same ms, so
+    // the assertion is timing-proof. Deliberately NO reindex() call here: the
+    // probe must see growth live, straight from disk.
+    appendFileSync(
+      sessFile,
+      jsonl([
+        { ...base, type: 'assistant', uuid: 'f-a2', parentUuid: 'f-a1', timestamp: '2026-01-01T10:00:10.000Z', isSidechain: false, message: { role: 'assistant', model: 'claude-opus-4-8', content: [{ type: 'text', text: 'more' }], usage: { input_tokens: 10, output_tokens: 5 } } },
+      ]),
+    );
+
+    const grown = await getFingerprint('sessF');
+    expect(grown.status).toBe(200);
+    expect(grown.body.fingerprint).not.toBe(first.body.fingerprint);
+    expect(grown.body.lastModifiedMs).toBeGreaterThanOrEqual(first.body.lastModifiedMs);
+  });
+
+  it('sees a brand-new subagent file only after a reindex records its files row', async () => {
+    const before = await getFingerprint('sessF');
+
+    // A subagent transcript spawned mid-session: a new file the `files` table
+    // doesn't know yet, so the probe can't include it — the documented
+    // ≤ REINDEX_INTERVAL_MS blind spot.
+    writeFileSync(
+      join(subDir, 'agent-bbbb.jsonl'),
+      jsonl([
+        { ...base, type: 'user', uuid: 'fs-u1', parentUuid: null, agentId: 'bbbb', isSidechain: true, timestamp: '2026-01-01T10:01:00.000Z', message: { role: 'user', content: 'subagent task' } },
+      ]),
+    );
+    const unchanged = await getFingerprint('sessF');
+    expect(unchanged.body.fingerprint).toBe(before.body.fingerprint);
+
+    // The reindex pass discovers the file and keys it to sessF (via the events'
+    // session_id), which flips the fingerprint through the row-count prefix.
+    await reindex();
+    const after = await getFingerprint('sessF');
+    expect(after.body.fingerprint).not.toBe(before.body.fingerprint);
+  });
+
+  it('404s for an unknown session, matching the detail route error shape', async () => {
+    const res = await app.inject({ method: 'GET', url: '/api/sessions/nope/fingerprint' });
+    expect(res.statusCode).toBe(404);
+    expect(res.json()).toEqual({ error: 'Session not found' });
+  });
+});

--- a/packages/shared/src/api.ts
+++ b/packages/shared/src/api.ts
@@ -325,6 +325,17 @@ export interface SessionDetailResponse {
   window?: SessionWindow;
 }
 
+/** GET /api/sessions/:id/fingerprint */
+export interface SessionFingerprintResponse {
+  /**
+   * Opaque change token over the session's files (live-statted per request).
+   * Compare-only — clients must not parse it.
+   */
+  fingerprint: string;
+  /** Max mtime (ms epoch) across the session's files; 0 when none could be statted. */
+  lastModifiedMs: number;
+}
+
 /** A full-text search hit in agent memory (instruction file or distilled fact). */
 export interface MemorySearchHit {
   connectorId: string;

--- a/packages/web/src/api/client.ts
+++ b/packages/web/src/api/client.ts
@@ -19,6 +19,7 @@ import type {
   SearchType,
   SessionDetailResponse,
   SessionEfficiencyResponse,
+  SessionFingerprintResponse,
   SessionEfficiencySort,
   SortDir,
   SessionSort,
@@ -137,6 +138,14 @@ export const api = {
   /** GET /api/sessions/:id */
   getSession(id: string, signal?: AbortSignal): Promise<SessionDetailResponse> {
     return request<SessionDetailResponse>(`/sessions/${encodeURIComponent(id)}`, { signal });
+  },
+
+  /** GET /api/sessions/:id/fingerprint */
+  sessionFingerprint(id: string, signal?: AbortSignal): Promise<SessionFingerprintResponse> {
+    return request<SessionFingerprintResponse>(
+      `/sessions/${encodeURIComponent(id)}/fingerprint`,
+      { signal },
+    );
   },
 
   /** GET /api/search?q=&project=&type= */

--- a/packages/web/src/pages/session/SessionPage.tsx
+++ b/packages/web/src/pages/session/SessionPage.tsx
@@ -9,6 +9,7 @@ import { hasRenderableContent } from './blocks.js';
 import { SubagentBlock, SubagentJumpMenu, ThreadList, useHashTarget } from './ThreadView.js';
 import { useProgressiveMount } from './useProgressiveMount.js';
 import { useScrollRestore } from './useScrollRestore.js';
+import { holdBottom, isNearBottom, useLiveSession } from './useLiveSession.js';
 import { ChangesetPanel } from './ChangesetPanel.js';
 import { buildChangeset } from './changeset.js';
 import { ExportMenu } from './ExportMenu.js';
@@ -64,29 +65,54 @@ export function SessionPage() {
   // Cancel any in-flight refresh when the session changes or the page unmounts.
   useEffect(() => () => refreshController.current?.abort(), [id]);
 
+  // Cancels a stick-to-bottom hold when the reader leaves the session mid-hold,
+  // so navigating away never keeps pinning the shared app scroller.
+  const stickCancelled = useRef(false);
+  useEffect(() => {
+    stickCancelled.current = false;
+    return () => {
+      stickCancelled.current = true;
+    };
+  }, [id]);
+
   // Soft refresh: re-fetch the thread and swap it in place without unmounting
   // the view, so the scroll position is preserved (turns are keyed by uuid and
   // new turns append at the end). Header `meta` stats may lag until a reindex.
-  const refresh = useCallback(() => {
-    if (!id || loading || refreshing) return;
-    refreshController.current?.abort();
-    const controller = new AbortController();
-    refreshController.current = controller;
-    setRefreshing(true);
-    api
-      .getSession(id, controller.signal)
-      .then((res) => {
+  // `silent` (the live poller) skips the `refreshing` spinner — auto-updates
+  // must not flash UI. Resolves true only when new data was swapped in.
+  const refresh = useCallback(
+    async (opts?: { silent?: boolean }): Promise<boolean> => {
+      if (!id || loading || refreshing) return false;
+      refreshController.current?.abort();
+      const controller = new AbortController();
+      refreshController.current = controller;
+      if (!opts?.silent) setRefreshing(true);
+      try {
+        const res = await api.getSession(id, controller.signal);
+        // Stick-to-bottom: a reader already at the bottom follows new turns; one
+        // scrolled up to read is left untouched (implicit scroll preservation).
+        const scroller = document.querySelector('main.tv-main');
+        const pin = scroller instanceof HTMLElement && isNearBottom(scroller);
         setData(res);
-        setRefreshing(false);
-      })
-      .catch((err: unknown) => {
-        if (err instanceof DOMException && err.name === 'AbortError') return;
-        if (err instanceof ApiError && err.status === 0) return;
-        // Keep the current content on a failed refresh; just stop the spinner.
-        console.error('Session refresh failed', err);
-        setRefreshing(false);
-      });
-  }, [id, loading, refreshing]);
+        if (pin && scroller instanceof HTMLElement) {
+          holdBottom(scroller, () => stickCancelled.current);
+        }
+        return true;
+      } catch (err: unknown) {
+        if (
+          !(err instanceof DOMException && err.name === 'AbortError') &&
+          !(err instanceof ApiError && err.status === 0)
+        ) {
+          // Keep the current content on a failed refresh; just stop the spinner.
+          console.error('Session refresh failed', err);
+        }
+        return false;
+      } finally {
+        if (!opts?.silent) setRefreshing(false);
+      }
+    },
+    [id, loading, refreshing],
+  );
 
   // ⌘R / Ctrl+R does an in-place soft refresh instead of a full browser reload
   // (which would lose scroll position). ⌘⇧R still falls through to the browser's
@@ -95,19 +121,24 @@ export function SessionPage() {
     const onKeyDown = (e: KeyboardEvent) => {
       if ((e.metaKey || e.ctrlKey) && !e.shiftKey && !e.altKey && e.key.toLowerCase() === 'r') {
         e.preventDefault();
-        refresh();
+        void refresh();
       }
     };
     window.addEventListener('keydown', onKeyDown);
     return () => window.removeEventListener('keydown', onKeyDown);
   }, [refresh]);
 
+  // Auto-refresh while the transcript is still being written: poll the cheap
+  // fingerprint probe and silently swap new turns in as they land.
+  const refreshSilently = useCallback(() => refresh({ silent: true }), [refresh]);
+  useLiveSession({ sessionId: id, active: data !== null && !loading, refreshSilently });
+
   if (!id) return <ErrorBox error="Missing session id" />;
   if (loading) return <Spinner size="lg" label="Loading session…" />;
   if (error) return <ErrorBox error={error} onRetry={() => setReloadKey((k) => k + 1)} />;
   if (!data) return null;
 
-  return <SessionView data={data} onRefresh={refresh} refreshing={refreshing} />;
+  return <SessionView data={data} onRefresh={() => void refresh()} refreshing={refreshing} />;
 }
 
 function SessionView({

--- a/packages/web/src/pages/session/useLiveSession.ts
+++ b/packages/web/src/pages/session/useLiveSession.ts
@@ -1,0 +1,133 @@
+/**
+ * Live-session auto-refresh: poll the lightweight per-session fingerprint
+ * endpoint while the transcript looks actively written, and trigger the page's
+ * silent soft refresh when it changes. Modeled on StatusProvider's
+ * self-rescheduling loop — fast while live, slower after a transient error,
+ * stopped entirely once the session goes idle (a visibility/focus re-check
+ * revives it). Also home to the stick-to-bottom helpers the refresh path uses
+ * so a reader tailing the session follows new turns.
+ */
+
+import { useEffect, useRef } from 'react';
+import { api, ApiError } from '../../api/client.js';
+
+/** Poll cadence while the session looks live. */
+const LIVE_POLL_MS = 2000;
+/** A session counts as live for this long after its last file modification. */
+const LIVE_WINDOW_MS = 3 * 60_000;
+/** Retry cadence after a transient fetch failure (server restart window etc.). */
+const LIVE_ERROR_POLL_MS = 5000;
+
+export function useLiveSession({
+  sessionId,
+  active,
+  refreshSilently,
+}: {
+  sessionId: string | undefined;
+  /** Gate: only poll once the page has data (the baseline matches what's shown). */
+  active: boolean;
+  /** Silent in-place data swap; resolves true when new data actually landed. */
+  refreshSilently: () => Promise<boolean>;
+}): void {
+  // Latest-callback ref so refresh identity churn doesn't tear the loop down.
+  const refreshRef = useRef(refreshSilently);
+  refreshRef.current = refreshSilently;
+
+  useEffect(() => {
+    if (!sessionId || !active) return;
+    let cancelled = false;
+    let timer: number | undefined;
+    let lastFingerprint: string | null = null; // baseline = first successful probe
+    let inFlight = false;
+
+    const schedule = (ms: number) => {
+      timer = window.setTimeout(() => void tick(), ms);
+    };
+
+    const tick = async () => {
+      if (cancelled || inFlight) return;
+      // Hidden tab: go idle without fetching — visibility/focus re-kicks.
+      if (document.hidden) return;
+      inFlight = true;
+      try {
+        const fp = await api.sessionFingerprint(sessionId);
+        if (cancelled) return;
+        if (lastFingerprint === null) {
+          // First probe: the page just fetched the data this baseline matches.
+          lastFingerprint = fp.fingerprint;
+        } else if (fp.fingerprint !== lastFingerprint) {
+          // Commit the baseline only when the swap landed — a skipped/failed
+          // refresh keeps the old one so the next tick retries.
+          if (await refreshRef.current()) lastFingerprint = fp.fingerprint;
+        }
+        if (cancelled) return;
+        // Keep polling only while the transcript was written to recently;
+        // otherwise go idle (a visibility/focus re-check revives the loop).
+        if (Date.now() - fp.lastModifiedMs <= LIVE_WINDOW_MS) schedule(LIVE_POLL_MS);
+      } catch (err) {
+        if (cancelled) return;
+        // Unknown session: stop for good. Anything else is transient (server
+        // restart window, brief network hiccup) — retry slowly.
+        if (err instanceof ApiError && err.status === 404) return;
+        schedule(LIVE_ERROR_POLL_MS);
+      } finally {
+        inFlight = false;
+      }
+    };
+
+    // Returning to the tab (or window) probes once, which catches up on any
+    // change made while away and revives polling if the session is live again.
+    const kick = () => {
+      if (cancelled || document.hidden || inFlight) return;
+      window.clearTimeout(timer);
+      void tick();
+    };
+    const onVisibility = () => {
+      if (!document.hidden) kick();
+    };
+    document.addEventListener('visibilitychange', onVisibility);
+    window.addEventListener('focus', kick);
+    void tick();
+
+    return () => {
+      cancelled = true;
+      window.clearTimeout(timer);
+      document.removeEventListener('visibilitychange', onVisibility);
+      window.removeEventListener('focus', kick);
+    };
+  }, [sessionId, active]);
+}
+
+/** "Near bottom" slack (px) below which a refresh keeps the reader pinned. */
+const STICK_BOTTOM_PX = 100;
+/**
+ * How long to keep re-pinning after a swap — appended turns mount over several
+ * frames (progressive mounting) and Shiki highlights swap in async, so a single
+ * post-commit scroll would undershoot. Same rationale as useScrollRestore's
+ * HOLD_MS.
+ */
+const BOTTOM_HOLD_MS = 1200;
+
+/** True when the scroller is within {@link STICK_BOTTOM_PX} of its bottom. */
+export function isNearBottom(scroller: HTMLElement): boolean {
+  return scroller.scrollHeight - scroller.scrollTop - scroller.clientHeight <= STICK_BOTTOM_PX;
+}
+
+/**
+ * Keep the scroller pinned to its (growing) bottom until layout settles. Any
+ * scroll the hold didn't make itself — user wheel/touch, a hash navigation —
+ * cancels it immediately (the holdAnchor pattern from useScrollRestore).
+ */
+export function holdBottom(scroller: HTMLElement, isCancelled: () => boolean): void {
+  const start = performance.now();
+  let expected: number | null = null;
+  const step = () => {
+    if (isCancelled()) return;
+    if (expected !== null && Math.abs(scroller.scrollTop - expected) > 1) return;
+    const target = scroller.scrollHeight - scroller.clientHeight;
+    if (Math.abs(scroller.scrollTop - target) > 1) scroller.scrollTop = target;
+    expected = scroller.scrollTop;
+    if (performance.now() - start < BOTTOM_HOLD_MS) requestAnimationFrame(step);
+  };
+  step();
+}


### PR DESCRIPTION
While an agent is still writing a transcript, the open session page now updates itself within ~2s instead of waiting for a manual ⌘R.

## How

**Split design** (plan [0046](docs/plans/0046-live-session-updates.md)): the session view already re-reads JSONL from disk per request, so live updates only need a cheap change signal — the 15s interval reindex stays untouched as the index path's freshness loop.

- **Server**: `GET /api/sessions/:id/fingerprint` — an opaque token from live-statting the session's files plus the files-table row set (a reindex-discovered new subagent file flips it too, ≤15s). Read-only, never triggers a reindex. New optional `AgentConnector.statFile` hook: opencode probes SQLite (its synthetic `<dbPath>#<id>` paths can't be `fs.stat`ed); all file-backed connectors use the `fs.stat` default.
- **Web**: `useLiveSession` polls the probe every 2s while the session looks live (last write < 3min), silently soft-refreshing on change — no spinner flash, scroll/expand state preserved. Stops when idle or the tab hides; revives on visibility/focus. A reader near the bottom stays pinned across the swap (rAF hold, since appended turns mount progressively); a reader scrolled up is never moved.

## Tests

- Fingerprint flips on file growth **without** reindex; a new subagent file flips it only **after** reindex (documents the blind spot); unknown session 404s; opencode probe flips on a new `part` row via SQLite, no reindex.
- Verified end-to-end against a running server with a temp fixture dir: stability, live flip on append, blind spot + auto-reindex pickup, 404.
- `npm test` (424 passed) and `npm run typecheck` clean.