### PR TITLE
fix(cli): derive __dirname in ESM bundle so update works

### DIFF
--- a/packages/server/src/cli.ts
+++ b/packages/server/src/cli.ts
@@ -19,6 +19,7 @@
 
 import { spawnSync } from 'node:child_process';
 import { existsSync, mkdirSync, readFileSync, realpathSync, rmSync } from 'node:fs';
+import { dirname } from 'node:path';
 import { createInterface } from 'node:readline/promises';
 import { parseArgs } from 'node:util';
 import { fileURLToPath } from 'node:url';
@@ -70,6 +71,10 @@ export {
   type DaemonRecord,
   type ExistingState,
 } from './daemon.js';
+
+// The bundle is ESM, so the CJS `__dirname` global doesn't exist — derive it
+// from import.meta.url like config.ts/daemon.ts do (the bundler injects none).
+const __dirname = dirname(fileURLToPath(import.meta.url));
 
 /** Start the server in the background, idempotently. */
 async function start(port: number, open: boolean): Promise<void> {


### PR DESCRIPTION
## Problem

`claudescope update` crashes on any installed version since the Homebrew/Nix channels landed (#6):

```
ReferenceError: __dirname is not defined
    at g4 (file:///…/@vladar107/claudescope/cli.js:150:1112)
```

The published bundles are ESM, where the CJS `__dirname` global doesn't exist. The bundle banner used to inject a shim, but b6792bc removed it (it collided with the entry modules' own declarations) on the assumption that every module derives its own from `import.meta.url` — `config.ts` and `daemon.ts` do, but `detectInstallMethod()` in `cli.ts` still used the bare global.

It shipped silently because `update` early-returns ("already on latest") unless a newer version exists, so the broken path first executed for real when 0.12.0 was published and older installs tried to update to it.

## Fix

Derive `__dirname` from `import.meta.url` at module scope in `cli.ts`, same pattern as `config.ts`/`daemon.ts`.

## Verification

- `npm run typecheck` + all 424 tests pass
- Rebuilt `dist/cli.js` contains zero bare `__dirname` references (one before — a minifier can't rename a free global)
- End-to-end on the bundled artifact: baked version lowered to 0.0.1, fake `npm` on PATH, scratch `CLAUDESCOPE_HOME` — `update` runs the full path (version check → install-method detection → npm spawn) without crashing

Note: the fix only helps once shipped — already-installed CLIs run the old bundle, so updating off a broken version needs one manual `npm install -g @vladar107/claudescope@latest`.