### PR TITLE
fix(analytics): categorize misfiled tools in tool-usage chart

### DIFF
--- a/packages/shared/src/categories.ts
+++ b/packages/shared/src/categories.ts
@@ -10,11 +10,11 @@ export type ToolCategory =
   | 'Other';
 
 const EDIT = new Set(['edit', 'write', 'multiedit', 'notebookedit', 'apply_patch', 'str_replace', 'str_replace_editor', 'create_file']);
-const READ = new Set(['read', 'view', 'read_file']);
-const SEARCH = new Set(['grep', 'glob', 'search', 'codebase_search', 'file_search', 'find', 'list_dir', 'ls']);
-const SHELL = new Set(['bash', 'shell', 'exec_command', 'run_terminal_cmd', 'terminal', 'execute_command']);
+const READ = new Set(['read', 'view', 'read_file', 'view_image']);
+const SEARCH = new Set(['grep', 'glob', 'search', 'codebase_search', 'file_search', 'find', 'list_dir', 'ls', 'toolsearch', 'tool_search']);
+const SHELL = new Set(['bash', 'shell', 'exec_command', 'run_terminal_cmd', 'terminal', 'execute_command', 'write_stdin', 'background-start', 'background-stop']);
 const WEB = new Set(['webfetch', 'websearch', 'web_search', 'fetch', 'browser']);
-const SUBAGENT = new Set(['task', 'agent', 'subagent', 'dispatch_agent']);
+const SUBAGENT = new Set(['task', 'agent', 'subagent', 'dispatch_agent', 'sendmessage', 'workflow', 'wait_agent', 'close_agent']);
 
 /** Map a raw (already connector-canonicalized) tool name to a category. */
 export function toolCategory(name: string): ToolCategory {


### PR DESCRIPTION
## What

Recategorizes tools that were landing in the `Other` bucket of the analytics Tool-usage chart. Audited all 53 distinct tool names currently mapping to `Other` against a live index and fixed the misfiles in `packages/shared/src/categories.ts`:

| Tool | Agent | New category |
|---|---|---|
| `ToolSearch` / `tool_search` | claude-code / codex | Search |
| `SendMessage`, `Workflow` | claude-code | Subagent |
| `wait_agent`, `close_agent` | codex | Subagent |
| `view_image` | codex | Read |
| `write_stdin` | codex | Shell |
| `background-start`, `background-stop` | pi | Shell |

The rest of `Other` is legitimately meta (StructuredOutput, TaskCreate/Update/List todo tools, Skill, AskUserQuestion, plan-mode tools, MCP tools, …).

## Notes

- The mapping is applied at render time (maintained in `shared`, not stamped into the index), so no re-index is needed — categories update on the next page load.
- `npm test` (424 passed) and `npm run typecheck` are green.