### PR TITLE
fix: harden image URL handling, LIKE escaping, batch title updates

### DIFF
--- a/packages/server/src/data/index.ts
+++ b/packages/server/src/data/index.ts
@@ -360,12 +360,23 @@ async function applyFallbackTitles(conn: DuckDBConnection): Promise<void> {
     `,
   );
 
+  const updates: string[] = [];
   for (const r of rows) {
     const title = cleanFallbackTitle(r.raw != null ? String(r.raw) : null);
     if (title.length === 0) continue;
-    await conn.run(
-      `UPDATE sessions SET title = ${sqlString(title)}, title_derived = TRUE WHERE id = ${sqlString(String(r.session_id))}`,
-    );
+    updates.push(`(${sqlString(String(r.session_id))}, ${sqlString(title)})`);
+  }
+  if (updates.length === 0) return;
+
+  // One UPDATE per chunk instead of one per session — this reruns on every
+  // rebuild, so a per-row loop is N round-trips for what is a single join.
+  const CHUNK = 1000;
+  for (let i = 0; i < updates.length; i += CHUNK) {
+    await conn.run(`
+      UPDATE sessions SET title = v.title, title_derived = TRUE
+      FROM (VALUES ${updates.slice(i, i + CHUNK).join(', ')}) AS v(id, title)
+      WHERE sessions.id = v.id
+    `);
   }
 }
 

--- a/packages/server/src/db/duckdb.ts
+++ b/packages/server/src/db/duckdb.ts
@@ -168,3 +168,12 @@ function normalizeRow(row: Record<string, unknown>): Record<string, unknown> {
 export function sqlString(value: string): string {
   return `'${value.replace(/'/g, "''")}'`;
 }
+
+/**
+ * Backslash-escape LIKE wildcards (`%`, `_`) and `\` itself so a user-supplied
+ * string matches literally inside a LIKE pattern. The LIKE must carry
+ * `ESCAPE '\'` for the escapes to take effect.
+ */
+export function sqlLikeEscape(value: string): string {
+  return value.replace(/[\\%_]/g, (c) => `\\${c}`);
+}

--- a/packages/server/src/routes/sessions.ts
+++ b/packages/server/src/routes/sessions.ts
@@ -17,7 +17,7 @@ import type {
   SessionSort,
 } from '@claudescope/shared';
 import { isZeroRated } from '@claudescope/shared';
-import { getConnection, queryRows, sqlString } from '../db/duckdb.js';
+import { getConnection, queryRows, sqlLikeEscape, sqlString } from '../db/duckdb.js';
 import { readRow } from '../db/row.js';
 import { displayNameFromCwd, projectIdFromCwd } from '../data/project-id.js';
 import { toIso } from './projects.js';
@@ -106,7 +106,9 @@ export async function registerSessionsRoutes(app: FastifyInstance): Promise<void
       where.push(`project_cwd = ${match ? sqlString(match) : "'\\0'"}`);
     }
     if (q && q.trim()) {
-      where.push(`(lower(title) LIKE ${sqlString('%' + q.toLowerCase() + '%')})`);
+      where.push(
+        `(lower(title) LIKE ${sqlString('%' + sqlLikeEscape(q.toLowerCase()) + '%')} ESCAPE '\\')`,
+      );
     }
 
     const sortKey: SessionSort = (sort as SessionSort) in SORT_SQL ? (sort as SessionSort) : 'recent';

--- a/packages/web/src/components/image.ts
+++ b/packages/web/src/components/image.ts
@@ -4,10 +4,25 @@
  */
 
 /**
+ * Restrict a url-source image to same-origin/relative or `data:image/` URLs.
+ * Transcript image blocks are untrusted content (tool results, pasted
+ * attachments); a remote URL would otherwise make the browser fetch it
+ * (tracking pixel / intranet probe). The CSP already blocks this at the
+ * network layer — this closes it at the source so no request is even
+ * attempted. Mirrors the markdown `urlTransform` in Markdown.tsx.
+ */
+function safeImageUrl(url: string): string | null {
+  if (/^data:image\//i.test(url)) return url; // inlined image — safe
+  if (/^\/\//.test(url) || /^[a-z][a-z0-9+.-]*:/i.test(url)) return null; // protocol-relative or schemed → remote
+  return url; // relative / same-origin path
+}
+
+/**
  * Pull a renderable `<img src>` string out of an Anthropic-style image block.
  *
  * Handles two source types:
- * - `url`: returns the URL directly.
+ * - `url`: returns the URL if it is a `data:image/` or same-origin URL
+ *   (remote/schemed URLs are rejected — see {@link safeImageUrl}).
  * - `base64`: returns a `data:<media_type>;base64,<data>` URI.
  *
  * Returns `null` when the value is not a valid image block or has no
@@ -23,7 +38,7 @@ export function extractImage(value: unknown): string | null {
     data?: string;
     url?: string;
   };
-  if (source.type === 'url' && source.url) return source.url;
+  if (source.type === 'url' && source.url) return safeImageUrl(source.url);
   if (source.type === 'base64' && source.data && source.media_type) {
     return `data:${source.media_type};base64,${source.data}`;
   }

--- a/packages/web/test/image.test.ts
+++ b/packages/web/test/image.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest';
+import { extractImage } from '../src/components/image.js';
+
+const urlBlock = (url: string) => ({ type: 'image', source: { type: 'url', url } });
+
+describe('extractImage', () => {
+  it('builds a data URI from a base64 source', () => {
+    expect(
+      extractImage({ type: 'image', source: { type: 'base64', media_type: 'image/png', data: 'abc' } }),
+    ).toBe('data:image/png;base64,abc');
+  });
+
+  it('keeps data:image/ and same-origin url sources', () => {
+    expect(extractImage(urlBlock('data:image/png;base64,abc'))).toBe('data:image/png;base64,abc');
+    expect(extractImage(urlBlock('/api/img/1'))).toBe('/api/img/1');
+  });
+
+  it('rejects remote and schemed url sources (transcripts are untrusted)', () => {
+    expect(extractImage(urlBlock('http://attacker.example/x.png'))).toBeNull();
+    expect(extractImage(urlBlock('https://attacker.example/x.png'))).toBeNull();
+    expect(extractImage(urlBlock('//attacker.example/x.png'))).toBeNull();
+    expect(extractImage(urlBlock('file:///etc/passwd'))).toBeNull();
+    expect(extractImage(urlBlock('data:text/html,<script>'))).toBeNull();
+  });
+
+  it('returns null for non-image or malformed blocks', () => {
+    expect(extractImage(null)).toBeNull();
+    expect(extractImage({ type: 'text', text: 'hi' })).toBeNull();
+    expect(extractImage({ type: 'image', source: { type: 'base64' } })).toBeNull();
+  });
+});


### PR DESCRIPTION
Three small fixes that came out of an external code review, each verified against the code before implementing.

## Changes

- **Reject remote URLs in structured image blocks** (`packages/web`): `extractImage` passed `url`-source values verbatim into `<img src>`, so a poisoned transcript (tool results, pasted attachments) could inject a remote image with only the CSP blocking the fetch. URL sources are now gated to `data:image/…` and same-origin paths, mirroring the markdown `urlTransform`, so no request is even attempted. Both render sites already null-check, so rejected URLs degrade gracefully. New `image.test.ts` covers the accept/reject matrix.
- **Escape LIKE wildcards in the session title search** (`packages/server`): the `q` filter on `/api/sessions` treated `%` and `_` in user input as wildcards. New `sqlLikeEscape` helper + `ESCAPE` clause make them match literally. Semantics verified against a real DuckDB instance (literal `%`, `_`, and `\` all match correctly).
- **Batch fallback-title updates** (`packages/server`): `applyFallbackTitles` issued one `UPDATE` per untitled session on every rebuild — now chunked `UPDATE … FROM (VALUES …)` statements. Exercised end-to-end by the existing integration tests, which assert derived titles against a real index.

## Notes

- Deliberately skipped from the same review: analytics `groupBy` (already whitelisted via `groupSource()`), snippet quote-escaping (escaping is correct for element-content position), and reindex auth (loopback bind + Host guard cover the local threat model).
- `npm test` (428 passed) and `npm run typecheck` are green.