### PR TITLE
feat: live list freshness via dataVersion idle polling

### DIFF
--- a/.claude/skills/verify/SKILL.md
+++ b/.claude/skills/verify/SKILL.md
@@ -1,0 +1,56 @@
+---
+name: verify
+description: Build, launch, and drive Claudescope against sandboxed fixtures to verify a change end-to-end without touching real agent sources or ~/.claudescope.
+---
+
+# Verifying Claudescope changes
+
+## Sandboxed launch (never touch real agent homes or ~/.claudescope)
+
+Every data source and state dir is env-overridable (`packages/server/src/config.ts`).
+Build, then run the server against a scratch dir:
+
+```bash
+npm run build    # shared → web → server; server serves the built SPA
+
+SB=$(mktemp -d)  # sandbox: fixtures + app state
+mkdir -p $SB/home $SB/projects/-tmp-demo $SB/empty
+# Claude Code fixture format: see writeFixtures() in packages/server/test/api.integration.test.ts
+
+cd packages/server
+CLAUDESCOPE_HOME=$SB/home CLAUDE_PROJECTS_DIR=$SB/projects \
+CODEX_SESSIONS_DIR=$SB/empty JUNIE_SESSIONS_DIR=$SB/empty PI_SESSIONS_DIR=$SB/empty \
+OPENCODE_DATA_DIR=$SB/empty COPILOT_SESSIONS_DIR=$SB/empty \
+ANTIGRAVITY_CLI_DIR=$SB/empty ANTIGRAVITY_DIR=$SB/empty \
+PORT=4390 REINDEX_INTERVAL_MS=3000 node dist/index.js &
+```
+
+- Use a non-default port (**not** 4317 — the user's real daemon may hold it).
+- `REINDEX_INTERVAL_MS=3000` makes auto-reindex fast enough to observe.
+- API surface: `curl http://127.0.0.1:4390/api/...` (health, sessions, search).
+- **Kill the server when done** (kill the PID you started).
+
+## Driving the UI
+
+Playwright is already a dev dependency (perf suite). From a script anywhere:
+
+```js
+import { chromium } from '<repo>/node_modules/playwright/index.mjs';
+```
+
+Gotchas learned the hard way:
+
+- Playwright fires `framenavigated` for SPA pushState too — to prove "no page
+  reload", set `window.__marker = 1` after load and check it survived.
+- Steady-state list updates arrive within reindex interval + 10s idle health
+  poll; wait up to ~30s for new rows.
+- Dropping a new `<cwd-slug>/sessN.jsonl` fixture while the app runs is the
+  way to simulate a live agent session landing.
+
+## Flows worth driving
+
+- Browse → project card → session list → session page (the core read path).
+- Drop a new session fixture mid-run: list + project header stats should
+  update without reload (dataVersion refetch).
+- Kill + restart the server with the page open: it must recover via the
+  unreachable poll and keep updating (dataVersion resets on restart).

--- a/docs/plans/0047-list-freshness-dataversion.md
+++ b/docs/plans/0047-list-freshness-dataversion.md
@@ -1,0 +1,85 @@
+# 0047 — List freshness: dataVersion idle polling
+
+- **Status:** done
+- **Date:** 2026-07-16
+- **PR:** [#64](https://github.com/vladar107/claudescope/pull/64)
+
+## Context
+
+After the initial index build, `StatusProvider` stopped polling `/api/health`
+entirely: `ready` never flips back to false, and a steady-state incremental
+reindex pass is transient (sub-second), so its `indexing` progress is
+practically unobservable by any poll. Consequence: sitting on the Browse page
+or a project's session list, new sessions landed by the ~15s auto-reindex never
+appeared without a manual reload — at odds with the live-monitoring direction
+of 0045/0046 (the single-session view already live-refreshes via fingerprint
+polling). A long-lived tab also never learned about `updateAvailable`, since
+that nudge rode the same stopped poll.
+
+## Goal
+
+Browse and session lists silently pick up newly indexed data while the app is
+open, at negligible steady-state cost, without a new transport.
+
+## Decisions
+
+- **Expose a monotonic `dataVersion` on `/api/health`** — bumped only when a
+  pass actually changed derived data (incl. mid-first-build partial rebuilds),
+  never on no-op passes. A durable signal is required because the transient
+  `indexing` field can't be caught by a slow poll.
+- **Slow idle poll (10s) instead of stopping** — rejected SSE/WebSocket push:
+  it adds connection lifecycle (reconnects, dev-proxy, daemon restarts) to a
+  plain request/response API, and with a 15s indexer cadence push buys ~7s of
+  latency over polling. Rejected focus-only refetch: it misses the "watching
+  the list while an agent works" case.
+- **Clients compare by inequality, not greater-than** — the counter resets on
+  daemon restart; a reset then triggers one harmless refetch.
+- **Refetches are silent** (no spinner, keep scroll) and skipped while
+  `building`, where the existing fast-poll refetch paths already run.
+
+## Approach
+
+1. `data/index.ts`: module-level `dataVersion` counter + `getDataVersion()`;
+   bump after the changed-pass finalize and after each mid-first-build partial
+   rebuild; leave the no-op early-return untouched.
+2. `/api/health` returns it; `HealthResponse` gains `dataVersion: number`.
+3. `StatusProvider`: replace "stop when ready+idle" with a 10s idle poll;
+   expose `dataVersion` (null until the first response).
+4. A shared `useDataVersionRefetch(refetch)` hook: refetch silently when the
+   observed `dataVersion` moves past the version last fetched at. It records
+   the first observation instead of fetching (the mount fetch covered it) and
+   holds recording while `building` (the fast-poll build paths own that
+   window), so build-end always triggers one catch-up refetch.
+5. Wire the hook into `BrowsePage`, `SessionList`, and `ProjectLayout` — the
+   last found by end-to-end verification: the list refreshed while the header
+   stats (sessions/tokens/cost) above it stayed stale.
+
+## Files affected
+
+- `packages/server/src/data/index.ts` — counter, getter, two bump sites.
+- `packages/server/src/routes/index.ts` — health payload.
+- `packages/shared/src/api.ts` — `HealthResponse.dataVersion`.
+- `packages/web/src/status/StatusProvider.tsx` — idle poll, expose field.
+- `packages/web/src/status/useDataVersionRefetch.ts` — the shared hook.
+- `packages/web/src/pages/browse/BrowsePage.tsx` — silent refetch on change.
+- `packages/web/src/pages/browse/SessionList.tsx` — same.
+- `packages/web/src/pages/browse/ProjectLayout.tsx` — header stats, same.
+
+## Testing
+
+- Integration test in `api.integration.test.ts`: a no-op reindex pass must NOT
+  bump `dataVersion` (else idle clients refetch every 15s for nothing); a pass
+  that reloads a touched fixture must bump it.
+- End-to-end (Playwright against a sandboxed server, see
+  `.claude/skills/verify/SKILL.md`): new sessions/projects appear on open list
+  pages within reindex + idle-poll latency with no page reload; header stats
+  update in step; the page recovers and keeps updating across a daemon restart
+  (dataVersion reset).
+- `npm test`, `npm run typecheck`.
+
+## Risks / open questions
+
+- Steady-state cost is one tiny health GET per 10s per open tab on loopback —
+  accepted.
+- The lists refetch wholesale (no delta); fine at current list sizes, and
+  consistent with how the build-time refetch already works.

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -71,3 +71,4 @@ decision, or a change worth explaining before doing. Skip it for one-line fixes.
 | 0044 | [Provider-aware cost: local vs remote model sessions](./0044-provider-aware-cost.md) | done |
 | 0045 | [Indexing UX + post-update self-healing](./0045-indexing-ux-and-self-healing-updates.md) | done |
 | 0046 | [Live session updates (fingerprint polling + stick-to-bottom)](./0046-live-session-updates.md) | done |
+| 0047 | [List freshness: dataVersion idle polling](./0047-list-freshness-dataversion.md) | done |

--- a/packages/server/src/data/index.ts
+++ b/packages/server/src/data/index.ts
@@ -31,6 +31,11 @@ let inFlight: Promise<ReindexResponse> | null = null;
 /** Live progress of the current pass (changed files loaded vs. total). Non-null
  *  only while a pass with work is running; surfaced on /api/health. */
 let progress: IndexingProgress | null = null;
+/** Monotonic counter bumped whenever a pass changed the derived tables. An
+ *  incremental pass is transient (sub-second), so idle clients can't observe
+ *  `progress` — they watch this on /api/health instead and refetch when it
+ *  moves. Resets on daemon restart, so clients compare by inequality. */
+let dataVersion = 0;
 
 /** Min interval between mid-first-build partial `sessions` rebuilds (ms).
  *  Env-overridable so tests can force a rebuild after every file. */
@@ -47,6 +52,10 @@ export function isReindexInFlight(): boolean {
 
 export function getIndexProgress(): IndexingProgress | null {
   return progress;
+}
+
+export function getDataVersion(): number {
+  return dataVersion;
 }
 
 /** The four rate fields, in canonical → SQL-column order. */
@@ -538,6 +547,7 @@ async function doReindex(): Promise<ReindexResponse> {
           await electCanonicalUsage(conn);
           await rebuildSessions(conn);
           lastPartialRebuild = Date.now();
+          dataVersion += 1;
         }
       } catch (err) {
         console.warn(`claudescope: skipping unreadable transcript ${file.path}:`, err);
@@ -566,6 +576,7 @@ async function doReindex(): Promise<ReindexResponse> {
     await rebuildFtsIndex(conn);
 
     ready = true;
+    dataVersion += 1;
     return { reindexed, durationMs: Date.now() - start };
   } finally {
     // Progress stays visible through finalization ("finishing up"), then clears.

--- a/packages/server/src/routes/index.ts
+++ b/packages/server/src/routes/index.ts
@@ -7,7 +7,7 @@
 import type { FastifyInstance } from 'fastify';
 import type { HealthResponse, ReindexResponse } from '@claudescope/shared';
 import { APP_VERSION } from '../config.js';
-import { getIndexProgress, isIndexReady, reindex } from '../data/index.js';
+import { getDataVersion, getIndexProgress, isIndexReady, reindex } from '../data/index.js';
 import { updateAvailable } from '../update-check.js';
 import { registerProjectsRoute } from './projects.js';
 import { registerSessionsRoutes } from './sessions.js';
@@ -31,6 +31,7 @@ export async function registerRoutes(app: FastifyInstance): Promise<void> {
       status: 'ok',
       version: APP_VERSION,
       ready: isIndexReady(),
+      dataVersion: getDataVersion(),
       ...(indexing ? { indexing } : {}),
       ...(latest ? { updateAvailable: latest } : {}),
     };

--- a/packages/server/test/api.integration.test.ts
+++ b/packages/server/test/api.integration.test.ts
@@ -9,7 +9,7 @@
  */
 
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
-import { mkdirSync, mkdtempSync, rmSync, statSync, writeFileSync } from 'node:fs';
+import { appendFileSync, mkdirSync, mkdtempSync, rmSync, statSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import type { FastifyInstance } from 'fastify';
@@ -378,6 +378,23 @@ describe('POST /api/reindex', () => {
     const res = await app.inject({ method: 'POST', url: '/api/reindex' });
     expect(res.statusCode).toBe(200);
     expect(res.json().reindexed).toBe(0);
+  });
+
+  // dataVersion is the only signal an idle client can observe (an incremental
+  // pass is transient), so its semantics matter: a no-op pass must NOT bump it
+  // (or clients would refetch every 15s for nothing), a changed pass must.
+  it('bumps health dataVersion only when a pass changed data', async () => {
+    const v0 = (await get('/api/health')).json().dataVersion;
+    expect(typeof v0).toBe('number');
+
+    await app.inject({ method: 'POST', url: '/api/reindex' });
+    expect((await get('/api/health')).json().dataVersion).toBe(v0);
+
+    // Touch a fixture so the (mtime,size) check reloads it (a trailing blank
+    // line is skipped by the parser but changes the size).
+    appendFileSync(fixtureFiles[0]!, '\n');
+    await app.inject({ method: 'POST', url: '/api/reindex' });
+    expect((await get('/api/health')).json().dataVersion).not.toBe(v0);
   });
 });
 

--- a/packages/shared/src/api.ts
+++ b/packages/shared/src/api.ts
@@ -431,6 +431,12 @@ export interface HealthResponse {
   version: string;
   /** True once the initial index build (or a post-rebuild pass) has finished. */
   ready: boolean;
+  /**
+   * Monotonic counter bumped whenever a reindex pass changed indexed data.
+   * Clients refetch when it differs from the last value they saw (inequality,
+   * not greater-than — the counter resets on daemon restart).
+   */
+  dataVersion: number;
   /** Present while a reindex pass is loading changed files. */
   indexing?: IndexingProgress;
   /** Latest published version, when the daemon knows it is newer than itself. */

--- a/packages/web/src/pages/browse/BrowsePage.tsx
+++ b/packages/web/src/pages/browse/BrowsePage.tsx
@@ -4,6 +4,7 @@ import type { ProjectMeta, SourceInfo } from '@claudescope/shared';
 import { api, ApiError } from '../../api/client.js';
 import { AgentBadge, ErrorBox, formatCost, formatCount, SearchField, Spinner, SummaryStrip } from '../../components';
 import { useServerStatus } from '../../status/StatusProvider.js';
+import { useDataVersionRefetch } from '../../status/useDataVersionRefetch.js';
 import { timeAgo } from './format.js';
 import './browse.css';
 
@@ -93,6 +94,17 @@ export function BrowsePage() {
       });
     return () => controller.abort();
   }, [building, indexingTick]);
+
+  // Steady-state freshness: silently refetch when a reindex pass lands new
+  // data, so project cards update without a manual reload.
+  useDataVersionRefetch((signal) => {
+    api
+      .listProjects(signal)
+      .then(setProjects)
+      .catch(() => {
+        /* transient — the next change retries */
+      });
+  });
 
   // The genuinely-empty state (ready, idle, zero projects) explains itself with
   // the watched source directories; fetch them lazily only when it shows.

--- a/packages/web/src/pages/browse/ProjectLayout.tsx
+++ b/packages/web/src/pages/browse/ProjectLayout.tsx
@@ -14,6 +14,7 @@ import { Link, NavLink, Outlet, useOutletContext, useParams } from 'react-router
 import type { ProjectMeta } from '@claudescope/shared';
 import { api, ApiError } from '../../api/client.js';
 import { formatCost, formatCount, SummaryStrip } from '../../components';
+import { useDataVersionRefetch } from '../../status/useDataVersionRefetch.js';
 import '../memory/memory.css';
 
 export interface ProjectOutletContext {
@@ -52,6 +53,17 @@ export function ProjectLayout() {
       });
     return () => controller.abort();
   }, [projectId]);
+
+  // Keep the header stats (sessions/tokens/cost) in step with the session list
+  // below, which silently refetches when a reindex pass lands new data.
+  useDataVersionRefetch((signal) => {
+    api
+      .listProjects(signal)
+      .then((projects) => setProject(projects.find((p) => p.id === projectId) ?? null))
+      .catch(() => {
+        /* transient — the next change retries */
+      });
+  });
 
   const displayName = project?.displayName ?? projectId;
 

--- a/packages/web/src/pages/browse/SessionList.tsx
+++ b/packages/web/src/pages/browse/SessionList.tsx
@@ -5,6 +5,7 @@ import { api, ApiError } from '../../api/client.js';
 import { AgentBadge, agentLabel, ErrorBox, formatCost, formatCount, LocalBadge, ModelChips, SearchField, Spinner } from '../../components';
 import { formatBytes, formatDateTime, timeAgo } from './format.js';
 import { useProjectContext } from './ProjectLayout.js';
+import { useDataVersionRefetch } from '../../status/useDataVersionRefetch.js';
 
 const SORT_OPTIONS: { value: SessionSort; label: string }[] = [
   { value: 'recent', label: 'Most recent' },
@@ -56,6 +57,18 @@ export function SessionListPage() {
       });
     return () => controller.abort();
   }, [projectId, sort, agent, reloadKey]);
+
+  // Steady-state freshness: silently refetch (no spinner, keep scroll) when a
+  // reindex pass lands new data — a live session's row updates and new
+  // sessions appear without a manual reload.
+  useDataVersionRefetch((signal) => {
+    api
+      .listSessions({ project: projectId, sort, agent }, signal)
+      .then(setSessions)
+      .catch(() => {
+        /* transient — the next change retries */
+      });
+  });
 
   const filtered = useMemo(() => {
     const q = filter.trim().toLowerCase();

--- a/packages/web/src/status/StatusProvider.tsx
+++ b/packages/web/src/status/StatusProvider.tsx
@@ -3,10 +3,13 @@
  *
  * Polls fast (1s) while the index is building — first start or a post-update
  * schema rebuild — so pages can show live progress and refetch growing data,
- * then stops entirely once the server is ready and idle: steady state costs a
- * single health call per page load. Any fetch failure means "server
- * unreachable" (startup or restart window; network errors throw TypeError, not
- * ApiError) and is retried slowly until the server comes back.
+ * then drops to a slow idle poll (10s) once the server is ready. The idle poll
+ * watches `dataVersion`: an incremental reindex pass is transient (sub-second),
+ * so it's the only signal an idle client can observe that new data landed —
+ * list pages refetch when it changes. It also keeps the update nudge live in
+ * long-lived tabs. Any fetch failure means "server unreachable" (startup or
+ * restart window; network errors throw TypeError, not ApiError) and is retried
+ * slowly until the server comes back.
  */
 
 import { createContext, useContext, useEffect, useState, type ReactNode } from 'react';
@@ -22,6 +25,12 @@ export interface ServerStatus {
   building: boolean;
   /** Increments on every poll observed while building — key refetches off it. */
   indexingTick: number;
+  /**
+   * The server's data-change counter (null until the first health response).
+   * Changes whenever a reindex pass landed new data — list pages key silent
+   * refetches off it. Compare by inequality: it resets on daemon restart.
+   */
+  dataVersion: number | null;
   /** Newer published version the daemon reported, for the sidebar nudge. */
   updateAvailable: string | null;
 }
@@ -31,14 +40,16 @@ const idleStatus: ServerStatus = {
   indexing: null,
   building: false,
   indexingTick: 0,
+  dataVersion: null,
   updateAvailable: null,
 };
 
 const StatusContext = createContext<ServerStatus>(idleStatus);
 
-/** Poll intervals: fast while the index builds, slow while unreachable. */
+/** Poll intervals: fast while the index builds, slow when idle or unreachable. */
 const BUILDING_POLL_MS = 1000;
 const UNREACHABLE_POLL_MS = 5000;
+const IDLE_POLL_MS = 10_000;
 
 export function StatusProvider({ children }: { children: ReactNode }) {
   const [status, setStatus] = useState<ServerStatus>(idleStatus);
@@ -57,10 +68,10 @@ export function StatusProvider({ children }: { children: ReactNode }) {
           indexing: h.indexing ?? null,
           building,
           indexingTick: building ? s.indexingTick + 1 : s.indexingTick,
+          dataVersion: h.dataVersion,
           updateAvailable: h.updateAvailable ?? null,
         }));
-        // Ready and idle: stop polling entirely.
-        if (building) timer = window.setTimeout(() => void tick(), BUILDING_POLL_MS);
+        timer = window.setTimeout(() => void tick(), building ? BUILDING_POLL_MS : IDLE_POLL_MS);
       } catch {
         if (cancelled) return;
         timer = window.setTimeout(() => void tick(), UNREACHABLE_POLL_MS);

--- a/packages/web/src/status/useDataVersionRefetch.ts
+++ b/packages/web/src/status/useDataVersionRefetch.ts
@@ -1,0 +1,35 @@
+import { useEffect, useRef } from 'react';
+import { useServerStatus } from './StatusProvider.js';
+
+/**
+ * Steady-state freshness: run `refetch` whenever the server's dataVersion
+ * moves past the version we last fetched at — a reindex pass landed new data
+ * while the page is open. The callback should refetch silently (no spinner,
+ * keep scroll) and respect the abort signal.
+ *
+ * Semantics:
+ * - The first observed version is recorded, not fetched — the mount fetch
+ *   covered it.
+ * - While `building`, versions are NOT recorded or fetched (the fast-poll
+ *   build paths own that window); the first idle observation after a build
+ *   then differs from the recorded value and triggers one catch-up refetch.
+ */
+export function useDataVersionRefetch(refetch: (signal: AbortSignal) => void): void {
+  const { building, dataVersion } = useServerStatus();
+  const lastFetched = useRef<number | null>(null);
+
+  useEffect(() => {
+    if (dataVersion === null) return;
+    if (lastFetched.current === null) {
+      lastFetched.current = dataVersion;
+      return;
+    }
+    if (building || lastFetched.current === dataVersion) return;
+    lastFetched.current = dataVersion;
+    const controller = new AbortController();
+    refetch(controller.signal);
+    return () => controller.abort();
+    // `refetch` is deliberately omitted: effects always run the latest render's
+    // closure, and callers pass inline lambdas that change identity per render.
+  }, [dataVersion, building]);
+}


### PR DESCRIPTION
After the initial index build the web client stopped polling `/api/health` entirely, so new sessions landed by the ~15s auto-reindex never appeared on open Browse / session-list pages without a manual reload — at odds with the live-monitoring direction of #0045/#0046. Plan: [docs/plans/0047](docs/plans/0047-list-freshness-dataversion.md).

## Design

A slow poll of the current health shape can't work: an incremental pass is transient (sub-second) and `ready` never flips back, so an idle poll would always land between passes and learn nothing. Instead:

- **Server** exposes a monotonic `dataVersion` on `/api/health`, bumped only when a pass actually changed the derived tables (incl. mid-first-build partial rebuilds; never on no-op passes). Resets on restart → clients compare by inequality.
- **Web** keeps a 10s idle poll instead of stopping, and a shared `useDataVersionRefetch` hook silently refetches (no spinner, keep scroll) when the version moves — wired into `BrowsePage`, `SessionList`, and `ProjectLayout` (header stats stay in step with the list). Build-time fast-poll behavior is unchanged; the hook holds recording while building so build-end always triggers one catch-up refetch.
- SSE/push was considered and rejected: with a 15s indexer cadence it buys ~7s of latency for a whole new transport; focus-only refetch misses the "watching the list while an agent works" case.

## Verification

- Integration test: a no-op reindex pass must NOT bump `dataVersion` (else idle clients refetch every 15s for nothing); a changed pass must.
- End-to-end (Playwright against a sandboxed server, recipe now in `.claude/skills/verify/SKILL.md`): new sessions/projects appeared on open pages in ~10s with no reload (window-marker proof), header stats updated in step, no-op passes caused zero refetches, and the page recovered and kept updating across a daemon kill/restart (counter reset).
- `npm test` (429 passed) and `npm run typecheck` are green.

## Notes

- Steady-state cost: one tiny health GET per 10s per open tab on loopback.
- The idle poll also fixes a latent staleness: the `updateAvailable` nudge previously rode a poll that had stopped, so a long-lived tab never learned about new versions.