### PR TITLE
feat: xAI Grok CLI connector

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,7 +12,8 @@ analyze AI coding-agent transcripts in one place — [Claude Code](https://claud
 (`~/.copilot/session-state/**/events.jsonl`), and
 [Google Antigravity](https://antigravity.google)
 (`~/.gemini/antigravity-cli/**/transcript_full.jsonl`, plus the desktop app dir
-`~/.gemini/antigravity/`). Sessions are merged by working
+`~/.gemini/antigravity/`), and [xAI Grok CLI](https://x.ai)
+(`~/.grok/sessions/**/chat_history.jsonl`). Sessions are merged by working
 directory into one project per `cwd`, each session tagged with its agent.
 Distributed as a single npm CLI (`@vladar107/claudescope`). This file is the
 source of truth for both humans and agents working in this repo; `AGENTS.md`
@@ -41,7 +42,7 @@ npm-workspaces monorepo (`packages/*`):
 ## Runtime state — critical
 
 - **NEVER write to any agent source** (`~/.claude`, `~/.codex`, `~/.junie`,
-  `~/.pi`, `~/.copilot`, `~/.gemini`, opencode's `opencode.db`). They are read-only data sources — and that
+  `~/.pi`, `~/.copilot`, `~/.gemini`, `~/.grok`, opencode's `opencode.db`). They are read-only data sources — and that
   includes reading agent memory live from those home dirs.
 - All app-owned state lives in **`~/.claudescope/`** (override: `CLAUDESCOPE_HOME`):
   the DuckDB index, a user-editable `pricing.json` (seeded from a shipped
@@ -123,8 +124,10 @@ The CLI `update` command (`cli.ts`) detects the install method and defers to
 
 - **Thinking blocks render empty** — Claude Code stores only a signature (and
   Codex only encrypted reasoning), not the plaintext. Expected, not a bug.
-  **pi and Antigravity are the exceptions**: both store plaintext thinking (pi
-  also keeps an opaque `thinkingSignature`), so their reasoning renders in full.
+  **pi, Antigravity, and Grok are the exceptions**: pi and Antigravity store
+  plaintext thinking (pi also keeps an opaque `thinkingSignature`), and Grok
+  stores plaintext reasoning *summaries* next to its encrypted content, so
+  their reasoning renders in full.
 - **Codex sessions have no stored title** — the session title falls back to the
   first user message (see `first_user` in `data/index.ts`). Same for **pi**.
 - **Codex subagents & apply_patch** — subagent rollouts are separate files whose
@@ -190,6 +193,26 @@ The CLI `update` command (`cli.ts`) detects the install method and defers to
   session (`is_sidechain`) and nested via a canonical `Task` tool_use. **No token
   counts** in the transcripts (the per-conversation SQLite is opaque protobuf,
   ignored) → cost 0, tokens unavailable by design.
+- **xAI Grok CLI connector** (`connectors/grok/`) — a session is a DIRECTORY
+  (`~/.grok/sessions/<encoded-cwd>/<uuid>/`) spreading facts across three files:
+  `chat_history.jsonl` is the message spine (OpenAI-Responses style; no
+  timestamps/usage), `updates.jsonl` is a best-effort overlay carrying
+  timestamps and the ONLY token usage (`turn_completed`, once per user turn —
+  a missing/truncated updates file → summary-time timestamps and zero usage),
+  and `summary.json` carries `cwd`/`generated_title`. `prepare()` normalizes to
+  canonical NDJSON (pi pattern); discovery stats fold all three files so
+  late-written usage/titles trigger re-index. Grok's `cachedReadTokens` is a
+  SUBSET of `inputTokens` → split out at normalize time (`input − cachedRead`).
+  Real user prompts carry `prompt_index` (text wrapped in `<user_query>`,
+  stripped); user rows WITHOUT it are injected context (user_info/agents-md)
+  and are skipped. `write`/`search_replace` map to canonical `Write`/`Edit` so
+  the Files-changed tab works; images are inline data-URLs → `ImageBlock`.
+  Subagents are SIBLING session dirs (child `summary.json` has
+  `session_kind:"subagent"`, no parent pointer); the linkage lives only in the
+  parent's `subagents/<child-id>/meta.json` — children re-key to the parent
+  (`is_sidechain`) and nest via `spawn_subagent` → canonical `Task` (its
+  `subagent_type` comes from meta, matched by the shared `description`).
+  Experimental memory (`~/.grok/memory/`) is not surfaced (off by default).
 - **Junie transcripts read differently** — Junie stores an event-sourced UI
   stream (`events.jsonl`), not a chat log: no assistant prose and no thinking, so
   a session renders as tool/terminal/file blocks plus a final result. Expected,

--- a/README.md
+++ b/README.md
@@ -24,14 +24,15 @@ machine and only ever reads your transcripts.
 | [opencode](https://opencode.ai)                   | `~/.local/share/opencode/opencode.db` (SQLite) |
 | [GitHub Copilot CLI](https://github.com/features/copilot) | `~/.copilot/session-state/**/events.jsonl` |
 | [Google Antigravity](https://antigravity.google) | `~/.gemini/antigravity-cli/brain/**/transcript_full.jsonl` |
+| [xAI Grok CLI](https://x.ai) | `~/.grok/sessions/**/chat_history.jsonl` |
 
 Each source is optional — a directory that doesn't exist is simply skipped, so
-Claudescope works whether you use one agent or all seven. Adding another is just
+Claudescope works whether you use one agent or all eight. Adding another is just
 [adding another connector](./CONTRIBUTING.md#adding-an-agent-connector).
 
 ## What it can do
 
-- **Multi-agent** — Claude Code, Codex, Junie, pi, opencode, GitHub Copilot CLI, and Google Antigravity sessions side by side, each labeled with an **agent badge**. A project that several agents touched shows one card with all its agent tags; drill in and **filter the session list by agent**.
+- **Multi-agent** — Claude Code, Codex, Junie, pi, opencode, GitHub Copilot CLI, Google Antigravity, and xAI Grok CLI sessions side by side, each labeled with an **agent badge**. A project that several agents touched shows one card with all its agent tags; drill in and **filter the session list by agent**.
 - **Browse** every session grouped by project — titles, dates, message/tool counts, token totals, cost, git branch, PR links.
 - **Read** a session as a clean threaded conversation: markdown, syntax-highlighted code, collapsible thinking, paired tool calls + results, **syntax-highlighted red/green diffs** for edits, attachments, and sidechain/subagent turns. A built-in **find-in-session** bar (⌘/Ctrl+F) searches the whole transcript — including collapsed thinking, tool, and subagent content — auto-expanding and highlighting matches, with a user/assistant filter.
 - **Review changes** via a **Files changed** tab that aggregates every edit/write in the session by file, with per-file diffs and +/− counts (diffs load lazily per file).
@@ -43,7 +44,7 @@ Claudescope works whether you use one agent or all seven. Adding another is just
 
 > **Privacy:** Everything runs locally on `127.0.0.1`. The app **never** writes to
 > any agent's data — every source (`~/.claude`, `~/.codex`, `~/.junie`, `~/.pi`,
-> `~/.copilot`, `~/.gemini`, and opencode's database) is treated as strictly read-only. Its only persistent
+> `~/.copilot`, `~/.gemini`, `~/.grok`, and opencode's database) is treated as strictly read-only. Its only persistent
 > state lives in `~/.claudescope/` — a DuckDB index, a copy of the pricing file, and
 > a cached pricing snapshot (`pricing.fetched.json`), all safe to delete anytime. The
 > sole outbound requests are an optional daily check for a newer published version
@@ -239,11 +240,12 @@ All optional — set via environment variables.
 | `COPILOT_SESSIONS_DIR`| `~/.copilot/session-state` | Where to read GitHub Copilot CLI transcripts from. A leading `~` is expanded. |
 | `ANTIGRAVITY_CLI_DIR` | `~/.gemini/antigravity-cli` | Where to read Google Antigravity transcripts from. A leading `~` is expanded. |
 | `ANTIGRAVITY_DIR`     | `~/.gemini/antigravity` | Where to read Google Antigravity desktop-app transcripts from. A leading `~` is expanded. |
+| `GROK_SESSIONS_DIR`   | `~/.grok/sessions`     | Where to read xAI Grok CLI transcripts from. A leading `~` is expanded. |
 | `CLAUDESCOPE_HOME`    | `~/.claudescope`       | Where the app keeps its own state (index, pricing copy, logs, PID).    |
 | `REINDEX_INTERVAL_MS` | `15000`                | How often to auto-pick-up new/updated sessions. Set `0` to disable.    |
 
 Each agent source is optional — if a directory doesn't exist it's simply skipped,
-so the app works whether you use one agent or all seven.
+so the app works whether you use one agent or all eight.
 
 Examples:
 
@@ -256,6 +258,7 @@ PI_SESSIONS_DIR=/path/to/pi/sessions claudescope         # point at pi sessions 
 OPENCODE_DATA_DIR=/path/to/opencode claudescope          # point at an opencode data dir elsewhere
 COPILOT_SESSIONS_DIR=/path/to/copilot/session-state claudescope  # point at Copilot CLI sessions elsewhere
 ANTIGRAVITY_CLI_DIR=/path/to/antigravity-cli claudescope # point at Google Antigravity sessions elsewhere
+GROK_SESSIONS_DIR=/path/to/grok/sessions claudescope     # point at Grok CLI sessions elsewhere
 claudescope --no-open                                    # don't pop a browser tab
 ```
 
@@ -304,7 +307,7 @@ The family step means version- or date-suffixed ids (e.g. `claude-haiku-4-5-2025
 user-editable fallback and override layer for families and the default rate; the
 fetched snapshot provides exact per-model rates for all known models.
 
-Claude Code, Junie, Copilot CLI, and Antigravity record no model provider in
+Claude Code, Junie, Copilot CLI, Antigravity, and Grok CLI record no model provider in
 their transcripts, so a local run there can't be auto-detected via step 1 — the
 escape hatch is pinning the exact model id to a zero rate in `pricing.json`'s
 `models` section.
@@ -318,6 +321,7 @@ Shipped fallback rates (USD per 1M tokens):
 | Sonnet 4.x          | $3    | $15    | $3.75            | $0.30      |
 | Haiku 4.5           | $1    | $5     | $1.25            | $0.10      |
 | Gemini 2.5 Pro-class| $1.25 | $10    | —                | $0.31      |
+| Grok 4.5-class      | $2    | $6     | —                | $0.50      |
 | GPT-5               | $0.63 | $5     | —                | $0.13      |
 | GPT-5.4             | $2.50 | $15    | —                | $0.50      |
 | GPT-5.5             | $5    | $30    | —                | $0.50      |
@@ -399,6 +403,14 @@ served from cache (legitimately high for Claude Code, which re-reads cached cont
   cost are unavailable by design and show as zero / —. Reasoning renders in full —
   like pi, it stores the plaintext of its thinking blocks. Subagents run as
   separate conversations and are shown nested under the call that spawned them.
+- **xAI Grok CLI spreads a session across three files** (`chat_history.jsonl` +
+  `updates.jsonl` + `summary.json`). Timestamps and token usage come from
+  `updates.jsonl` (recorded once per user turn), so a session whose updates file
+  is missing or truncated still renders but reports zero tokens. Reasoning
+  **summaries** render in full (plaintext, like pi). File edits show in the
+  **Files changed** tab, pasted screenshots embed, and subagents run as sibling
+  sessions shown nested under the call that spawned them. Grok's experimental
+  memory is not surfaced.
 
 ---
 
@@ -416,7 +428,7 @@ local copy, see [Run from source](#run-from-source) above.
 ## Security & privacy
 
 Claudescope runs entirely on your machine. It treats every agent source
-(`~/.claude`, `~/.codex`, `~/.junie`, `~/.pi`, `~/.copilot`, `~/.gemini`, and opencode's database) as
+(`~/.claude`, `~/.codex`, `~/.junie`, `~/.pi`, `~/.copilot`, `~/.gemini`, `~/.grok`, and opencode's database) as
 **read-only**, **binds to `127.0.0.1` only**, and sends **no telemetry**. Its only
 outbound requests are a cached npm-registry version check for the update notice
 and a daily fetch of public model pricing rates from LiteLLM (disable with
@@ -429,7 +441,7 @@ shell, and self-update behavior — and how to report a vulnerability.
 ## Troubleshooting
 
 - **App is empty / "sessions directory not found"** — none of `CLAUDE_PROJECTS_DIR`,
-  `CODEX_SESSIONS_DIR`, `JUNIE_SESSIONS_DIR`, `PI_SESSIONS_DIR`, `OPENCODE_DATA_DIR`, `COPILOT_SESSIONS_DIR`, or `ANTIGRAVITY_CLI_DIR` points at real transcripts. Check
+  `CODEX_SESSIONS_DIR`, `JUNIE_SESSIONS_DIR`, `PI_SESSIONS_DIR`, `OPENCODE_DATA_DIR`, `COPILOT_SESSIONS_DIR`, `ANTIGRAVITY_CLI_DIR`, or `GROK_SESSIONS_DIR` points at real transcripts. Check
   the banner and set them correctly. Any source can be absent; only the present
   ones are indexed.
 - **`Error: listen EADDRINUSE :4317`** — the port is taken; run `claudescope --port <n>`.

--- a/docs/plans/0048-grok-connector.md
+++ b/docs/plans/0048-grok-connector.md
@@ -1,0 +1,133 @@
+# 0048 — xAI Grok CLI connector
+
+- **Status:** done
+- **Date:** 2026-07-16
+- **PR:** https://github.com/vladar107/claudescope/pull/65
+
+## Context
+
+Claudescope merges coding-agent transcripts from 7 sources into one viewer. The
+xAI Grok CLI (`grok`, probed at v0.2.101) stores sessions under
+`~/.grok/sessions/<url-encoded-cwd>/<session-uuid>/` and was not supported.
+Scope is **xAI Grok only** (not other "grok"-named tools).
+
+The on-disk format (verified against real local sessions, including a real
+parent+subagent pair, plus a scratch probe session for the edit tools):
+
+- **`chat_history.jsonl`** — message spine, OpenAI-Responses style rows:
+  `system` (string), `user` (content parts: `text` | `image` with an inline
+  base64 data-URL; real prompts carry `prompt_index` and `<user_query>`-wrapped
+  text; injected context rows — user_info, agents-md, system-reminders — have
+  no `prompt_index`), `reasoning` (**plaintext** `summary[].text` + opaque
+  `encrypted_content`), `assistant` (markdown string, `model_id`,
+  `tool_calls[]` with JSON-string `arguments`), `tool_result`
+  (`{tool_call_id, content}`, no error flag). No timestamps, no usage.
+- **`updates.jsonl`** — ACP-style overlay: per-event `agentTimestampMs`;
+  `tool_call` correlates by `toolCallId`; `turn_completed` carries the only
+  usage (`inputTokens`, `outputTokens`, `cachedReadTokens` — a **subset** of
+  input — `reasoningTokens` inside output). May be missing/truncated.
+- **`summary.json`** — `info.{id, cwd}` (plain cwd), ISO
+  `created_at`/`updated_at`, `generated_title`, `session_kind: "subagent"`.
+- **Subagents** — children are sibling top-level session dirs; the only
+  linkage is the parent's `subagents/<child-id>/meta.json`
+  (`subagent_type`, `description`, `prompt`). The parent spawns via
+  `spawn_subagent {description, prompt}`.
+- Edit tools (confirmed via probe): `write {file_path, content}`,
+  `search_replace {file_path, old_string, new_string}`.
+- Resume: `grok --resume <id>` (+ `--fork-session` to fork).
+- Memory: `~/.grok/memory/` — experimental, off by default.
+
+## Goal
+
+Grok sessions browse/read/search/cost like every other agent: badge + title in
+the list, threaded detail with rendered reasoning and Files-changed, subagents
+nested at their spawning call, per-turn tokens priced at real grok rates.
+
+## Decisions
+
+- **prepare() → canonical NDJSON** (pi/copilot pattern) — the three-file split
+  can't be projected per-row by DuckDB. Cache at `~/.claudescope/cache/grok/`.
+- **chat_history is the spine; updates.jsonl is a best-effort overlay** —
+  timestamps assign by a monotonic carry-forward walk (user prompt k anchors to
+  turn k's start, assistant rows to their earliest `tool_call` update, a final
+  no-tools assistant to the turn's end; everything else inherits, clamped
+  monotonic, seeded/fallback from `summary.json` times). A corrupt/missing
+  updates file degrades to summary timestamps and zero usage — never an error.
+- **Usage split**: `input_tokens = inputTokens − cachedReadTokens` (verified
+  subset relationship), attached once to each turn's last assistant row; NULL
+  `message_id` → every row usage-canonical (no dedup needed).
+- **Skip injected rows** (user rows without `prompt_index`, the system row) —
+  they'd render fake user bubbles and pollute FTS; strip the `<user_query>`
+  wrapper so titles/search show what the user typed.
+- **Subagent re-key via readdir scan** of sibling dirs' `subagents/` folders
+  (memoized per cwd-dir mtime) — the child carries no parent pointer. Children
+  emit `session_id = parent`, `is_sidechain: true`; `spawn_subagent` → `Task`
+  with `subagent_type` from meta.json matched by the shared `description`.
+  Orphans (no meta claims them) index standalone.
+- **Folded freshness**: discovery/statFile fold mtime/size of all three files —
+  usage and title are written after the last chat row, so chat mtime alone
+  would miss them.
+- **Pricing shipped, not fetched**: LiteLLM has no bare `grok-*` keys (all
+  `xai/`-prefixed, which `mapLiteLLM` skips), so shipped exact entries
+  (`grok-4.5`, `grok-4`, `grok-code-fast-1`) + a `grok` family carry the cost
+  path; `PRICING_SCHEMA_VERSION` bumped 3 → 4 to reconcile user copies.
+- **No memory in v1** — Grok memory is experimental and off by default;
+  follow-up if it graduates.
+
+## Approach
+
+1. Probe a scratch grok session to confirm `write`/`search_replace` arg shapes
+   (then delete it). Confirmed: 1:1 with canonical `Write`/`Edit`.
+2. `config.ts`: `GROK_SESSIONS_DIR`; pricing entries + schema bump.
+3. `connectors/grok/normalize.ts`: tolerant parser, updates overlay, tool
+   canonicalization, usage split, title threading.
+4. `connectors/grok/grok.ts`: discover/statFile (folded), prepare/cache,
+   projections (copilot shape), loadSession subagent attach, resumeSpec.
+5. Registry + web badge/CSS + analytics-agents granularity/notes.
+6. `test/grok.integration.test.ts` + `GROK_SESSIONS_DIR` isolation in all
+   existing integration tests (antigravity precedent).
+7. Docs: CLAUDE.md source list/gotchas/thinking exceptions, README.
+
+## Files affected
+
+- `packages/server/src/connectors/grok/{grok,normalize}.ts` — new connector.
+- `packages/server/src/connectors/registry.ts` — register it.
+- `packages/server/src/config.ts` — `GROK_SESSIONS_DIR`; schema version bump.
+- `packages/server/pricing.json` — grok family + exact model rates.
+- `packages/server/src/routes/analytics-agents.ts` — granularity + note.
+- `packages/web/src/components/AgentBadge.tsx`, `packages/web/src/pages/browse/browse.css` — badge label + neutral-slate chip colors.
+- `packages/server/test/grok.integration.test.ts` — new suite; all existing
+  integration tests gain the `GROK_SESSIONS_DIR` isolation line;
+  `memory-overview.test.ts` expects the new connector card.
+- `CLAUDE.md`, `README.md` — source lists, gotchas, env var docs.
+
+## Testing
+
+- `npm test` (441 tests) and `npm run typecheck` green.
+- Integration suite covers the weird stuff: sibling-dir subagent re-key +
+  `Task` nesting + tokens folded into the parent, orphan child standalone,
+  the input-minus-cachedRead split priced at the shipped `grok-4.5` rate
+  (proving family/model resolution), `search_replace`→`Edit` in the shape the
+  Files-changed extractor keys off, inline data-URL → ImageBlock (malformed
+  URL tolerated), plaintext reasoning rendered, injected rows excluded from
+  thread AND search, `<user_query>` strip feeding the fallback title, missing
+  `updates.jsonl` (zero usage, summary timestamps), corrupt trailing line.
+- Manual run against the real `~/.grok/sessions` with a throwaway
+  `CLAUDESCOPE_HOME`/`DUCKDB_PATH` and all other sources pointed at empty dirs.
+
+## Risks / open questions
+
+- Grok is pre-1.0; the three-file format may drift (the tolerant parser skips
+  unknown row/update types, so drift degrades rather than breaks).
+- `tool_error_count` is NULL — `tool_result` carries no error flag; deriving
+  errors from `tool_call_update.status` is a possible follow-up.
+- Memory (`~/.grok/memory/`) not surfaced; revisit if it leaves experimental.
+- LiteLLM rates for grok never overlay (prefix-keyed) — shipped rates must be
+  maintained by hand when xAI changes pricing.
+- `grok --fork-session` semantics are unverified: if a fork copies the source
+  session's `updates.jsonl` (with its `turn_completed` usage) into a new
+  session dir, the copied turns would double-count cost (grok rows have no
+  `message_id` to dedup on). Verify if forked grok sessions appear.
+- Nesting is one level (like pi): a subagent spawning a subagent would index
+  under its immediate parent's id, not the root. Grok's default agents can't
+  spawn nested subagents, so this shouldn't occur in practice.

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -72,3 +72,4 @@ decision, or a change worth explaining before doing. Skip it for one-line fixes.
 | 0045 | [Indexing UX + post-update self-healing](./0045-indexing-ux-and-self-healing-updates.md) | done |
 | 0046 | [Live session updates (fingerprint polling + stick-to-bottom)](./0046-live-session-updates.md) | done |
 | 0047 | [List freshness: dataVersion idle polling](./0047-list-freshness-dataversion.md) | done |
+| 0048 | [xAI Grok CLI connector](./0048-grok-connector.md) | done |

--- a/packages/server/pricing.json
+++ b/packages/server/pricing.json
@@ -1,5 +1,5 @@
 {
-  "schemaVersion": 3,
+  "schemaVersion": 4,
   "providers": {
     "ollama": { "input": 0, "output": 0, "cacheWrite": 0, "cacheRead": 0 },
     "lmstudio": { "input": 0, "output": 0, "cacheWrite": 0, "cacheRead": 0 },
@@ -58,6 +58,10 @@
 
     "codex-mini-latest": { "input": 1.5, "output": 6, "cacheWrite": 0, "cacheRead": 0.375 },
 
+    "grok-4.5": { "input": 2, "output": 6, "cacheWrite": 0, "cacheRead": 0.5 },
+    "grok-4": { "input": 3, "output": 15, "cacheWrite": 0, "cacheRead": 0.75 },
+    "grok-code-fast-1": { "input": 0.2, "output": 1.5, "cacheWrite": 0, "cacheRead": 0.02 },
+
     "o4-mini": { "input": 1.1, "output": 4.4, "cacheWrite": 0, "cacheRead": 0.275 },
     "o3": { "input": 2, "output": 8, "cacheWrite": 0, "cacheRead": 0.5 },
     "o3-mini": { "input": 1.1, "output": 4.4, "cacheWrite": 0, "cacheRead": 0.55 },
@@ -69,7 +73,8 @@
     "sonnet": { "input": 3, "output": 15, "cacheWrite": 3.75, "cacheRead": 0.3 },
     "haiku": { "input": 1, "output": 5, "cacheWrite": 1.25, "cacheRead": 0.1 },
     "gemini": { "input": 1.25, "output": 10, "cacheWrite": 0, "cacheRead": 0.31 },
-    "gpt": { "input": 2.5, "output": 15, "cacheWrite": 0, "cacheRead": 0.25 }
+    "gpt": { "input": 2.5, "output": 15, "cacheWrite": 0, "cacheRead": 0.25 },
+    "grok": { "input": 2, "output": 6, "cacheWrite": 0, "cacheRead": 0.5 }
   },
   "default": { "input": 3, "output": 15, "cacheWrite": 3.75, "cacheRead": 0.3 }
 }

--- a/packages/server/src/config.ts
+++ b/packages/server/src/config.ts
@@ -92,6 +92,16 @@ export const COPILOT_SESSIONS_DIR = expandHome(
 );
 
 /**
+ * READ-ONLY source of xAI Grok CLI sessions. The app MUST NEVER write here.
+ * Defaults to `~/.grok/sessions` (one `<session-uuid>/` dir per session under a
+ * per-cwd url-encoded directory, holding `chat_history.jsonl` + `updates.jsonl`
+ * + `summary.json`). Override with GROK_SESSIONS_DIR. A leading `~` is expanded.
+ */
+export const GROK_SESSIONS_DIR = expandHome(
+  process.env.GROK_SESSIONS_DIR ?? join(homedir(), '.grok', 'sessions'),
+);
+
+/**
  * READ-ONLY source of Google Antigravity sessions. The app MUST NEVER write here.
  * Antigravity 2.0 has two surfaces that share the same on-disk shape — the CLI
  * (`agy`) and the desktop app — each with its own appDataDir under `~/.gemini`.
@@ -250,7 +260,7 @@ export const APP_VERSION =
  * shadowing it. A monotonic integer (not a content hash): the user copy is meant
  * to be edited, so only a real shipped change should trigger a reconcile.
  */
-export const PRICING_SCHEMA_VERSION = 3;
+export const PRICING_SCHEMA_VERSION = 4;
 
 /**
  * Reconcile the user-editable pricing file with the shipped default.

--- a/packages/server/src/connectors/grok/grok.ts
+++ b/packages/server/src/connectors/grok/grok.ts
@@ -1,0 +1,196 @@
+/**
+ * xAI Grok CLI connector.
+ *
+ * Source layout: `~/.grok/sessions/<url-encoded-cwd>/<session-uuid>/` — a
+ * directory per session holding `chat_history.jsonl` (the message spine),
+ * `updates.jsonl` (timestamps + per-turn usage), and `summary.json` (cwd,
+ * title). The facts are spread across the three files, so `prepare()`
+ * normalizes a session to canonical NDJSON (in TS, via
+ * {@link parseGrokSession}/{@link toCanonicalRows}) and `eventsProjectionSql`
+ * reads that 1:1 — the indexer/FTS/cost stay native.
+ *
+ * Subagent children are SIBLING session dirs re-keyed to the parent at index
+ * time (linkage: the parent's `subagents/<child-id>/meta.json`) and embedded
+ * as SubagentSources at their spawning `spawn_subagent` call (→ canonical
+ * `Task`) in {@link loadSession}.
+ *
+ * Grok's cross-session memory (`~/.grok/memory/`) is experimental and off by
+ * default, so this connector contributes no memory (v1).
+ *
+ * STRICTLY READ-ONLY with respect to ~/.grok — files are only ever read.
+ */
+
+import { createHash } from 'node:crypto';
+import { existsSync, mkdirSync, readdirSync, statSync, writeFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { CLAUDESCOPE_HOME, GROK_SESSIONS_DIR } from '../../config.js';
+import { sqlString } from '../../db/duckdb.js';
+import type { SessionData, SubagentSource } from '../../data/session-loader.js';
+import type { AgentConnector, AuxProjections, DiscoveredFile } from '../types.js';
+import { parentSessionDirOf, parseGrokSession, subagentMetas, toCanonicalRows } from './normalize.js';
+
+const CACHE_DIR = join(CLAUDESCOPE_HOME, 'cache', 'grok');
+
+/** Deterministic temp NDJSON path for a given session file. */
+function cachePath(filePath: string): string {
+  const hash = createHash('sha1').update(filePath).digest('hex').slice(0, 16);
+  return join(CACHE_DIR, `${hash}.ndjson`);
+}
+
+/**
+ * Fold a session's three files into one change signal. The discovery unit is
+ * `chat_history.jsonl`, but usage arrives in `updates.jsonl` and the title in
+ * `summary.json` — both often written AFTER the last chat row — so mtime/size
+ * must cover all three or those late writes never trigger a re-index.
+ */
+function foldedStat(chatPath: string): Pick<DiscoveredFile, 'mtimeMs' | 'size'> | null {
+  const sessionDir = dirname(chatPath);
+  let mtimeMs = 0;
+  let size = 0;
+  try {
+    const st = statSync(chatPath);
+    mtimeMs = Math.floor(st.mtimeMs);
+    size = st.size;
+  } catch {
+    return null; // no chat_history — not a session (or it vanished)
+  }
+  for (const sibling of ['updates.jsonl', 'summary.json']) {
+    try {
+      const st = statSync(join(sessionDir, sibling));
+      mtimeMs = Math.max(mtimeMs, Math.floor(st.mtimeMs));
+      size += st.size;
+    } catch {
+      /* sibling missing — chat_history alone still indexes */
+    }
+  }
+  return { mtimeMs, size };
+}
+
+/**
+ * Collect every `<cwd-dir>/<session-uuid>/chat_history.jsonl` under the Grok
+ * sessions dir — including subagent children (re-keyed by normalize). The
+ * exact path shape skips `session_search.sqlite`, the per-cwd
+ * `prompt_history.jsonl`, and the session dir's other files by construction.
+ */
+function discover(): DiscoveredFile[] {
+  const out: DiscoveredFile[] = [];
+  let cwdDirs: import('node:fs').Dirent[];
+  try {
+    cwdDirs = readdirSync(GROK_SESSIONS_DIR, { withFileTypes: true });
+  } catch {
+    return out; // no Grok install
+  }
+  for (const cwdDir of cwdDirs) {
+    if (!cwdDir.isDirectory()) continue;
+    let sessionDirs: import('node:fs').Dirent[];
+    try {
+      sessionDirs = readdirSync(join(GROK_SESSIONS_DIR, cwdDir.name), { withFileTypes: true });
+    } catch {
+      continue;
+    }
+    for (const sessionDir of sessionDirs) {
+      if (!sessionDir.isDirectory()) continue;
+      const chatPath = join(GROK_SESSIONS_DIR, cwdDir.name, sessionDir.name, 'chat_history.jsonl');
+      const st = foldedStat(chatPath);
+      if (st) out.push({ path: chatPath, ...st });
+    }
+  }
+  return out;
+}
+
+/** Normalize a session to canonical NDJSON the projection will read. */
+async function prepare(filePath: string): Promise<void> {
+  const session = parseGrokSession(filePath);
+  mkdirSync(CACHE_DIR, { recursive: true });
+  const rows = session ? toCanonicalRows(session, filePath) : [];
+  writeFileSync(cachePath(filePath), rows.map((r) => JSON.stringify(r)).join('\n') + '\n');
+}
+
+function eventsProjectionSql(filePath: string): string {
+  const path = sqlString(cachePath(filePath));
+  return `
+    SELECT
+      file_path, session_id, uuid, parent_uuid, role, type, ts, cwd, git_branch,
+      model, CAST(NULL AS VARCHAR) AS provider, input_tokens, output_tokens, cache_read_tokens, cache_write_tokens,
+      service_tier, is_sidechain, tool_use_count, tool_names, tool_error_count, text_content,
+      CAST(NULL AS VARCHAR) AS message_id, CAST(NULL AS VARCHAR) AS forked_from_session_id
+    FROM read_ndjson(${path}, format='newline_delimited', maximum_object_size=268435456, ignore_errors=true, columns={
+      file_path:'VARCHAR', session_id:'VARCHAR', uuid:'VARCHAR', parent_uuid:'VARCHAR',
+      role:'VARCHAR', type:'VARCHAR', ts:'TIMESTAMP', cwd:'VARCHAR', git_branch:'VARCHAR',
+      model:'VARCHAR', input_tokens:'BIGINT', output_tokens:'BIGINT', cache_read_tokens:'BIGINT',
+      cache_write_tokens:'BIGINT', service_tier:'VARCHAR', is_sidechain:'BOOLEAN',
+      tool_use_count:'INTEGER', tool_names:'VARCHAR', tool_error_count:'INTEGER', text_content:'VARCHAR'
+    })`;
+}
+
+/** Grok carries a real session title (summary.json `generated_title`), threaded
+ *  through the cache NDJSON; the first-user-message fallback applies when empty. */
+function auxProjections(filePath: string): AuxProjections {
+  if (!existsSync(cachePath(filePath))) return {};
+  const path = sqlString(cachePath(filePath));
+  return {
+    titles: `
+      SELECT session_id, last(title) AS title
+      FROM read_ndjson(${path}, format='newline_delimited', maximum_object_size=268435456, ignore_errors=true,
+        columns={session_id:'VARCHAR', title:'VARCHAR'})
+      WHERE session_id IS NOT NULL AND title IS NOT NULL AND title <> ''
+      GROUP BY session_id`,
+  };
+}
+
+async function loadSession(_sessionId: string, paths: string[]): Promise<SessionData> {
+  // `paths` holds the top-level file(s) plus any subagent children the index
+  // re-keyed to this session. Only top-level files feed the main thread;
+  // children attach below at their spawning `Task` call. If NO path is
+  // top-level (parent dir vanished, so only children map here), promote
+  // everything rather than serve an empty session.
+  let mainPaths = paths.filter((p) => parentSessionDirOf(p) === null);
+  if (mainPaths.length === 0) mainPaths = paths;
+  const mainSet = new Set(mainPaths);
+  const mainEvents = mainPaths.flatMap((p) => parseGrokSession(p)?.events ?? []);
+
+  const subagents: SubagentSource[] = [];
+  const attached = new Set<string>();
+  for (const p of mainPaths) {
+    const cwdDir = dirname(dirname(p));
+    for (const meta of subagentMetas(dirname(p))) {
+      const childPath = join(cwdDir, meta.childId, 'chat_history.jsonl');
+      const child = parseGrokSession(childPath);
+      if (!child) continue; // child dir pruned since the session ran — tolerate
+      attached.add(childPath);
+      subagents.push({
+        agentId: child.ownId,
+        agentType: meta.agentType,
+        description: meta.description,
+        events: child.events,
+      });
+    }
+  }
+
+  // Children indexed under this session but never claimed by a meta record
+  // (unreadable meta.json): attach them detached — empty description ⇒ the
+  // thread assembler renders them unanchored — so their text stays reachable.
+  for (const p of paths) {
+    if (mainSet.has(p) || attached.has(p)) continue;
+    const child = parseGrokSession(p);
+    if (!child) continue;
+    subagents.push({ agentId: child.ownId, agentType: '', description: '', events: child.events });
+  }
+  return { mainEvents, subagents };
+}
+
+export const grokConnector: AgentConnector = {
+  id: 'grok',
+  label: 'Grok CLI',
+  sourceDir: GROK_SESSIONS_DIR,
+  discover,
+  prepare,
+  eventsProjectionSql,
+  auxProjections,
+  loadSession,
+  statFile: foldedStat,
+  resumeSpec: (id) => ({
+    resumeArgv: ['grok', '--resume', id],
+    forkArgv: ['grok', '--resume', id, '--fork-session'],
+  }),
+};

--- a/packages/server/src/connectors/grok/normalize.ts
+++ b/packages/server/src/connectors/grok/normalize.ts
@@ -1,0 +1,668 @@
+/**
+ * xAI Grok CLI session → canonical thread normalizer.
+ *
+ * A Grok session is a directory (`~/.grok/sessions/<encoded-cwd>/<uuid>/`)
+ * spreading facts across three files:
+ *   - `chat_history.jsonl` — the message spine (OpenAI-Responses style rows:
+ *     `system` / `user` / `reasoning` / `assistant` / `tool_result`). Carries
+ *     content, `model_id`, and tool calls — but NO timestamps and NO usage.
+ *   - `updates.jsonl` — an ACP-style event stream. Carries per-event
+ *     `agentTimestampMs` and the ONLY token usage (`turn_completed`, one per
+ *     user turn). Best-effort overlay: it may be missing or truncated, so the
+ *     parse never fails on it — rows then fall back to `summary.json` times
+ *     and the turn reports zero usage.
+ *   - `summary.json` — session id, plain `cwd`, `generated_title`,
+ *     `created_at`/`updated_at`, and `session_kind: "subagent"` for children.
+ *
+ * Reasoning rows carry PLAINTEXT summaries (`summary[].text`) next to the
+ * opaque `encrypted_content` — like pi/Antigravity, Grok thinking renders.
+ *
+ * Injected context (user_info, agents-md, system-reminder rows) arrives as
+ * standalone `user` rows WITHOUT `prompt_index`; only rows with `prompt_index`
+ * are real prompts (their text is wrapped in `<user_query>` tags, stripped
+ * here). Skipping the rest keeps fake user bubbles out of the thread and
+ * per-session boilerplate out of FTS.
+ *
+ * Subagents: a child run is a SEPARATE sibling session dir; the only linkage
+ * lives in the PARENT dir (`subagents/<child-id>/meta.json`). Children are
+ * re-keyed to the parent session id with `is_sidechain: true` (pi pattern) and
+ * the parent's `spawn_subagent` call becomes a canonical `Task`, so the child
+ * transcript anchors at its spawning call in the detail view.
+ *
+ * STRICTLY READ-ONLY with respect to ~/.grok — files are only ever read.
+ */
+
+import { existsSync, readdirSync, readFileSync, statSync } from 'node:fs';
+import { basename, dirname, join } from 'node:path';
+import type { AssistantEvent, ContentBlock, MessageUsage, UserEvent } from '@claudescope/shared';
+import { toolNamesCsv } from '../tool-names.js';
+
+export interface GrokSession {
+  /** Indexing key: the parent's session id for a subagent child, else the own id. */
+  sessionId: string;
+  /** The session dir's own uuid (uuid prefix; `SubagentSource.agentId`). */
+  ownId: string;
+  /** True for a subagent child transcript (re-keyed to the parent session). */
+  isSidechain: boolean;
+  cwd: string;
+  /** `summary.json.generated_title` — threaded into the titles aux projection. */
+  title: string;
+  events: (UserEvent | AssistantEvent)[];
+}
+
+const str = (v: unknown): string => (typeof v === 'string' ? v : '');
+const num = (v: unknown): number => (typeof v === 'number' && Number.isFinite(v) ? v : 0);
+const rec = (v: unknown): Record<string, unknown> =>
+  v && typeof v === 'object' && !Array.isArray(v) ? (v as Record<string, unknown>) : {};
+
+/** One raw line of `chat_history.jsonl` (fields we read; others ignored). */
+interface GrokChatLine {
+  type?: string;
+  content?: unknown;
+  /** Real user prompts only — injected context rows lack it. */
+  prompt_index?: unknown;
+  /** `reasoning` rows: `[{type:'summary_text', text}]` (plaintext). */
+  summary?: unknown;
+  /** `assistant` rows: `[{id, name, arguments: <json string>}]`. */
+  tool_calls?: unknown;
+  model_id?: unknown;
+  tool_call_id?: unknown;
+}
+
+/** Tolerantly read a JSONL file as objects, or null if unreadable. */
+function readJsonl(path: string): Record<string, unknown>[] | null {
+  let raw: string;
+  try {
+    raw = readFileSync(path, 'utf8');
+  } catch {
+    return null;
+  }
+  const lines: Record<string, unknown>[] = [];
+  for (const line of raw.split('\n')) {
+    const t = line.trim();
+    if (!t) continue;
+    try {
+      lines.push(JSON.parse(t) as Record<string, unknown>);
+    } catch {
+      /* tolerate a corrupt/partial trailing line */
+    }
+  }
+  return lines;
+}
+
+/** Parsed `summary.json` facts (all optional — the file may be missing). */
+interface GrokSummary {
+  id: string;
+  cwd: string;
+  title: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+function readSummary(sessionDir: string): GrokSummary {
+  let raw: Record<string, unknown> = {};
+  try {
+    raw = rec(JSON.parse(readFileSync(join(sessionDir, 'summary.json'), 'utf8')));
+  } catch {
+    /* missing/corrupt summary — fall back to dir-derived facts */
+  }
+  const info = rec(raw.info);
+  return {
+    id: str(info.id),
+    cwd: str(info.cwd),
+    title: str(raw.generated_title) || str(raw.session_summary),
+    createdAt: str(raw.created_at),
+    updatedAt: str(raw.updated_at),
+  };
+}
+
+/**
+ * Memo for {@link childParentMap}, keyed on the cwd dir's mtime: every child
+ * parse re-resolves its parent, so indexing N children would otherwise re-scan
+ * the sibling dirs N times. A spawn creates the child session dir (bumping the
+ * cwd dir's mtime) alongside the parent's `subagents/<id>/` entry, so the memo
+ * invalidates when new children appear.
+ */
+const parentMapMemo = new Map<string, { fp: string; map: Map<string, string> }>();
+
+/**
+ * Child-session-id → parent-session-dir map for one cwd dir, built purely from
+ * `readdir` of each sibling's `subagents/` folder (no JSON parsing).
+ */
+function childParentMap(cwdDir: string): Map<string, string> {
+  let fp = '';
+  try {
+    const st = statSync(cwdDir);
+    fp = `${Math.floor(st.mtimeMs)}`;
+    const hit = parentMapMemo.get(cwdDir);
+    if (hit && hit.fp === fp) return hit.map;
+  } catch {
+    return new Map();
+  }
+  const map = new Map<string, string>();
+  let entries: import('node:fs').Dirent[] = [];
+  try {
+    entries = readdirSync(cwdDir, { withFileTypes: true });
+  } catch {
+    /* cwd dir vanished — empty map */
+  }
+  for (const entry of entries) {
+    if (!entry.isDirectory()) continue;
+    const parentDir = join(cwdDir, entry.name);
+    let children: string[];
+    try {
+      children = readdirSync(join(parentDir, 'subagents'));
+    } catch {
+      continue; // no subagents dir — most sessions
+    }
+    for (const childId of children) {
+      if (childId !== entry.name) map.set(childId, parentDir);
+    }
+  }
+  parentMapMemo.set(cwdDir, { fp, map });
+  return map;
+}
+
+/**
+ * The parent session dir for a subagent child transcript, or null for a
+ * top-level session. `path` is the child's `chat_history.jsonl`. The linkage
+ * lives only in the parent (`subagents/<child-id>/`), so a vanished parent →
+ * null and the orphan indexes as its own top-level session.
+ */
+export function parentSessionDirOf(path: string): string | null {
+  const sessionDir = dirname(path);
+  const parent = childParentMap(dirname(sessionDir)).get(basename(sessionDir));
+  return parent && existsSync(parent) ? parent : null;
+}
+
+/** One `subagents/<child-id>/meta.json` — the parent-side spawn record. */
+export interface GrokSubagentMeta {
+  childId: string;
+  agentType: string;
+  /** Correlation key — equals the spawning call's `description` argument. */
+  description: string;
+}
+
+/** Read every subagent meta recorded in a (parent) session dir. */
+export function subagentMetas(sessionDir: string): GrokSubagentMeta[] {
+  const subDir = join(sessionDir, 'subagents');
+  let ids: string[];
+  try {
+    ids = readdirSync(subDir);
+  } catch {
+    return [];
+  }
+  const out: GrokSubagentMeta[] = [];
+  for (const id of ids) {
+    try {
+      const meta = rec(JSON.parse(readFileSync(join(subDir, id, 'meta.json'), 'utf8')));
+      out.push({
+        childId: str(meta.child_session_id) || id,
+        agentType: str(meta.subagent_type),
+        description: str(meta.description),
+      });
+    } catch {
+      /* unreadable meta — the child still indexes; it just attaches detached */
+    }
+  }
+  return out;
+}
+
+/** Usage already split into canonical fields (see {@link splitUsage}). */
+interface TurnOverlay {
+  startMs?: number;
+  endMs?: number;
+  usage?: MessageUsage;
+}
+
+/**
+ * Grok's `turn_completed.usage` → canonical usage. `cachedReadTokens` is a
+ * SUBSET of `inputTokens` (verified: input + output = total), while Claude
+ * semantics — which every session/analytics SUM assumes — keep them disjoint,
+ * so the cached part is subtracted out of input. `reasoningTokens` are already
+ * inside `outputTokens`. Grok reports no cache writes.
+ */
+export function splitUsage(raw: unknown): MessageUsage {
+  const u = rec(raw);
+  const cacheRead = num(u.cachedReadTokens);
+  return {
+    input_tokens: Math.max(0, num(u.inputTokens) - cacheRead),
+    output_tokens: num(u.outputTokens),
+    cache_read_input_tokens: cacheRead,
+    cache_creation_input_tokens: 0,
+  };
+}
+
+/** Timing/usage overlay extracted from `updates.jsonl` (best-effort). */
+interface UpdatesOverlay {
+  /** First `tool_call` update timestamp per toolCallId. */
+  toolCallTs: Map<string, number>;
+  /** Indexed by user turn (prompt_index order == turn_completed order). */
+  turns: TurnOverlay[];
+}
+
+/**
+ * Parse `updates.jsonl` into the overlay. Turn correlation is positional: the
+ * k-th `turn_completed` closes user turn k, and a `user_message_chunk` opens
+ * turn k either via its `promptIndex` meta or (when absent) in arrival order.
+ * A missing/corrupt file yields an empty overlay — never an error.
+ */
+function parseUpdates(path: string): UpdatesOverlay {
+  const overlay: UpdatesOverlay = { toolCallTs: new Map(), turns: [] };
+  const lines = readJsonl(path);
+  if (!lines) return overlay;
+
+  const turn = (i: number): TurnOverlay => (overlay.turns[i] ??= {});
+  let userChunks = 0;
+  let completed = 0;
+  let prevWasUserChunk = false;
+
+  for (const line of lines) {
+    const params = rec(line.params);
+    const update = rec(params.update);
+    const kind = str(update.sessionUpdate);
+    const ms = num(rec(params._meta).agentTimestampMs) || num(line.timestamp) * 1000;
+    if (kind !== 'user_message_chunk') prevWasUserChunk = false;
+
+    switch (kind) {
+      case 'user_message_chunk': {
+        // Chunks of one message arrive back-to-back; count groups, not chunks.
+        const metaIdx = rec(update._meta).promptIndex;
+        const idx = typeof metaIdx === 'number' ? metaIdx : prevWasUserChunk ? userChunks - 1 : userChunks;
+        if (!prevWasUserChunk) userChunks = idx + 1;
+        prevWasUserChunk = true;
+        if (ms) turn(idx).startMs ??= ms;
+        break;
+      }
+      case 'tool_call': {
+        const id = str(update.toolCallId);
+        if (id && ms && !overlay.toolCallTs.has(id)) overlay.toolCallTs.set(id, ms);
+        break;
+      }
+      case 'turn_completed': {
+        const t = turn(completed++);
+        if (ms) t.endMs = ms;
+        t.usage = splitUsage(update.usage);
+        break;
+      }
+      default:
+        break;
+    }
+  }
+  return overlay;
+}
+
+/**
+ * Strip Grok's prompt scaffolding so titles/search/copy show what the user
+ * typed: drop `<image_files>` blocks (paste-an-image injects one with
+ * saved-to-workspace paths — the image itself rides the sibling image part,
+ * so the scaffold is pure noise), then unwrap the `<user_query>` tag when it
+ * wraps the whole remainder. The inline `[Image #N]` marker stays (copilot
+ * precedent).
+ */
+export function stripUserQuery(text: string): string {
+  const cleaned = text.replace(/<image_files>[\s\S]*?<\/image_files>\s*/g, '');
+  const m = /^\s*<user_query>\n?([\s\S]*?)\n?<\/user_query>\s*$/.exec(cleaned);
+  return m?.[1] ?? cleaned;
+}
+
+/** Map a Grok `{type:'image', url:'data:…'}` part to a canonical ImageBlock. */
+function imageBlock(part: Record<string, unknown>): ContentBlock | null {
+  const m = /^data:([^;,]+);base64,(.+)$/.exec(str(part.url));
+  if (!m?.[1] || !m[2]) return null; // only inline base64 data-URLs are embeddable
+  return { type: 'image', source: { type: 'base64', media_type: m[1], data: m[2] } };
+}
+
+/** Map a user row's content parts to canonical blocks (text + inline images). */
+function userBlocks(content: unknown): ContentBlock[] {
+  if (typeof content === 'string') {
+    const text = stripUserQuery(content);
+    return text ? [{ type: 'text', text }] : [];
+  }
+  if (!Array.isArray(content)) return [];
+  const out: ContentBlock[] = [];
+  for (const c of content) {
+    const part = rec(c);
+    if (str(part.type) === 'text') {
+      const text = stripUserQuery(str(part.text));
+      if (text) out.push({ type: 'text', text });
+    } else if (str(part.type) === 'image') {
+      const img = imageBlock(part);
+      if (img) out.push(img);
+    }
+  }
+  return out;
+}
+
+/**
+ * Map a Grok tool call to a canonical `tool_use` block. Grok's built-in tools
+ * map 1:1 onto Claude's (the binary itself aliases `Read`→`read_file`,
+ * `Edit`→`search_replace`, …), so we translate names + input keys to the
+ * shapes the web renderer and the Files-changed changeset extractor recognize.
+ * Arg shapes verified against a real session: `write {file_path, content}`,
+ * `search_replace {file_path, old_string, new_string}`, `read_file
+ * {target_file}`, `list_dir {target_directory}`. Unknown tools (incl. MCP's
+ * `server__tool`) pass through with their native name.
+ */
+function toolUseBlock(
+  raw: Record<string, unknown>,
+  agentTypeByDescription: Map<string, string>,
+): ContentBlock {
+  const id = str(raw.id);
+  const name = str(raw.name);
+  let args: Record<string, unknown>;
+  try {
+    args = rec(JSON.parse(str(raw.arguments) || '{}'));
+  } catch {
+    // Unparseable arguments — keep the raw string visible under the native name.
+    return { type: 'tool_use', id, name, input: { arguments: str(raw.arguments) } };
+  }
+  switch (name) {
+    case 'read_file':
+    case 'hashline_read':
+      return {
+        type: 'tool_use',
+        id,
+        name: 'Read',
+        input: {
+          file_path: str(args.target_file) || str(args.file_path),
+          ...(args.offset !== undefined ? { offset: args.offset } : {}),
+          ...(args.limit !== undefined ? { limit: args.limit } : {}),
+        },
+      };
+    case 'write':
+      return {
+        type: 'tool_use',
+        id,
+        name: 'Write',
+        input: { file_path: str(args.file_path), content: str(args.content) },
+      };
+    case 'search_replace':
+    case 'hashline_edit':
+      return {
+        type: 'tool_use',
+        id,
+        name: 'Edit',
+        input: {
+          file_path: str(args.file_path) || str(args.target_file),
+          old_string: str(args.old_string),
+          new_string: str(args.new_string),
+          ...(args.replace_all !== undefined ? { replace_all: args.replace_all } : {}),
+        },
+      };
+    case 'run_terminal_command':
+      return {
+        type: 'tool_use',
+        id,
+        name: 'Bash',
+        input: {
+          command: str(args.command),
+          description: str(args.description),
+          ...(args.timeout !== undefined ? { timeout: args.timeout } : {}),
+        },
+      };
+    case 'grep':
+      return { type: 'tool_use', id, name: 'Grep', input: args };
+    case 'list_dir':
+      return {
+        type: 'tool_use',
+        id,
+        name: 'LS',
+        input: { path: str(args.target_directory) || str(args.path) },
+      };
+    case 'web_search':
+      return { type: 'tool_use', id, name: 'WebSearch', input: args };
+    case 'web_fetch':
+      return { type: 'tool_use', id, name: 'WebFetch', input: args };
+    case 'todo_write':
+      return { type: 'tool_use', id, name: 'TodoWrite', input: args };
+    case 'skill':
+      return { type: 'tool_use', id, name: 'Skill', input: args };
+    case 'spawn_subagent': {
+      // Spawns a sibling child session → canonical `Task` so the embedded
+      // transcript anchors here. `subagent_type` isn't in the call args — it
+      // comes from the parent's own `subagents/<id>/meta.json`, matched by the
+      // shared `description` (both derive from this call's argument).
+      const description = str(args.description);
+      return {
+        type: 'tool_use',
+        id,
+        name: 'Task',
+        input: {
+          description,
+          subagent_type: agentTypeByDescription.get(description) ?? '',
+          prompt: str(args.prompt),
+        },
+      };
+    }
+    default:
+      return { type: 'tool_use', id, name, input: args };
+  }
+}
+
+/** Parse a Grok session dir (via its `chat_history.jsonl` path), or null. */
+export function parseGrokSession(path: string): GrokSession | null {
+  const chat = readJsonl(path);
+  if (!chat) return null;
+  const sessionDir = dirname(path);
+  const summary = readSummary(sessionDir);
+  const ownId = basename(sessionDir) || summary.id || path;
+
+  // A subagent child indexes under its PARENT's session id (with is_sidechain),
+  // folding it into the parent session; the own id still prefixes the
+  // synthesized uuids to keep them unique across the merged files.
+  const parentDir = parentSessionDirOf(path);
+  const sessionId = parentDir ? basename(parentDir) : ownId;
+  const isSidechain = parentDir !== null;
+
+  const overlay = parseUpdates(join(sessionDir, 'updates.jsonl'));
+  const agentTypeByDescription = new Map<string, string>();
+  for (const meta of subagentMetas(sessionDir)) {
+    if (meta.description) agentTypeByDescription.set(meta.description, meta.agentType);
+  }
+
+  const cwd = summary.cwd;
+  const events: (UserEvent | AssistantEvent)[] = [];
+  let seq = 0;
+  let prevUuid: string | null = null;
+  const nextUuid = (): string => `${ownId}-${seq++}`;
+
+  // Monotonic carry-forward clock: rows anchor to overlay timestamps where a
+  // correlation exists and inherit the previous row's time otherwise, clamped
+  // so the sequence never runs backwards. Seeded from summary.created_at.
+  let clockMs = Date.parse(summary.createdAt) || 0;
+  const tick = (anchorMs?: number): string => {
+    if (anchorMs && anchorMs > clockMs) clockMs = anchorMs;
+    return clockMs ? new Date(clockMs).toISOString() : '';
+  };
+
+  // Reasoning rows precede their assistant row — buffer and prepend.
+  let thinking: ContentBlock[] = [];
+  // Track the last assistant event of each user turn for usage attachment.
+  let currentTurn = -1;
+  const lastAssistantIdxByTurn = new Map<number, number>();
+
+  // Consecutive `tool_result` rows coalesce into one user turn.
+  let toolResults: ContentBlock[] = [];
+  const flushToolResults = (): void => {
+    if (toolResults.length === 0) return;
+    const uuid = nextUuid();
+    events.push({
+      uuid,
+      parentUuid: prevUuid,
+      sessionId,
+      timestamp: tick(),
+      cwd,
+      isSidechain,
+      type: 'user',
+      message: { role: 'user', content: toolResults },
+    } as UserEvent);
+    prevUuid = uuid;
+    toolResults = [];
+  };
+
+  const pushAssistant = (content: ContentBlock[], model: string): void => {
+    const uuid = nextUuid();
+    // Anchor to the earliest known tool_call time of this row, else — for a
+    // final no-tools response — to the turn's completion time.
+    const callTimes = content
+      .map((b) => (b.type === 'tool_use' ? overlay.toolCallTs.get(b.id) : undefined))
+      .filter((t): t is number => typeof t === 'number');
+    const hasTools = content.some((b) => b.type === 'tool_use');
+    const anchor = callTimes.length
+      ? Math.min(...callTimes)
+      : !hasTools
+        ? overlay.turns[currentTurn]?.endMs
+        : undefined;
+    events.push({
+      uuid,
+      parentUuid: prevUuid,
+      sessionId,
+      timestamp: tick(anchor),
+      cwd,
+      isSidechain,
+      type: 'assistant',
+      message: { role: 'assistant', model, content },
+    } as AssistantEvent);
+    prevUuid = uuid;
+    lastAssistantIdxByTurn.set(currentTurn, events.length - 1);
+  };
+
+  let lastModel = '';
+  for (const raw of chat as GrokChatLine[]) {
+    switch (str(raw.type)) {
+      case 'user': {
+        if (typeof raw.prompt_index !== 'number') break; // injected context row
+        flushToolResults();
+        currentTurn = raw.prompt_index as number;
+        const uuid = nextUuid();
+        events.push({
+          uuid,
+          parentUuid: prevUuid,
+          sessionId,
+          timestamp: tick(overlay.turns[currentTurn]?.startMs),
+          cwd,
+          isSidechain,
+          type: 'user',
+          message: { role: 'user', content: userBlocks(raw.content) },
+        } as UserEvent);
+        prevUuid = uuid;
+        break;
+      }
+      case 'reasoning': {
+        const parts = Array.isArray(raw.summary) ? raw.summary : [];
+        for (const p of parts) {
+          const text = str(rec(p).text);
+          if (text) thinking.push({ type: 'thinking', thinking: text });
+        }
+        break;
+      }
+      case 'assistant': {
+        flushToolResults();
+        const content: ContentBlock[] = [...thinking];
+        thinking = [];
+        const text = str(raw.content);
+        if (text) content.push({ type: 'text', text });
+        const calls = Array.isArray(raw.tool_calls) ? raw.tool_calls : [];
+        for (const c of calls) content.push(toolUseBlock(rec(c), agentTypeByDescription));
+        lastModel = str(raw.model_id) || lastModel;
+        pushAssistant(content, str(raw.model_id));
+        break;
+      }
+      case 'tool_result': {
+        const text = str(raw.content);
+        toolResults.push({
+          type: 'tool_result',
+          tool_use_id: str(raw.tool_call_id),
+          content: text ? [{ type: 'text', text }] : [],
+        });
+        break;
+      }
+      default:
+        break; // system / unknown rows — tolerate and skip
+    }
+  }
+  flushToolResults();
+  // A trailing reasoning row with no assistant after it (truncated session).
+  if (thinking.length > 0) pushAssistant(thinking, lastModel);
+
+  // Advance the final row to updated_at when the overlay gave us nothing newer
+  // (degenerate-but-honest session duration for a missing updates.jsonl).
+  const last = events[events.length - 1];
+  const updatedMs = Date.parse(summary.updatedAt) || 0;
+  if (last && updatedMs > clockMs) last.timestamp = new Date(updatedMs).toISOString();
+
+  // Attach each turn's usage to that turn's last assistant row, exactly once.
+  for (const [turnIdx, eventIdx] of lastAssistantIdxByTurn) {
+    const usage = overlay.turns[turnIdx]?.usage;
+    if (usage) (events[eventIdx] as AssistantEvent).message.usage = usage;
+  }
+
+  return { sessionId, ownId, isSidechain, cwd, title: summary.title, events };
+}
+
+/** A canonical index row (matches the events NDJSON the projection reads). */
+export interface CanonicalRow {
+  file_path: string;
+  session_id: string;
+  uuid: string;
+  parent_uuid: string | null;
+  role: string;
+  type: string;
+  ts: string;
+  cwd: string;
+  git_branch: string | null;
+  model: string | null;
+  input_tokens: number;
+  output_tokens: number;
+  cache_read_tokens: number;
+  cache_write_tokens: number;
+  service_tier: string | null;
+  is_sidechain: boolean;
+  tool_use_count: number;
+  tool_names: string;
+  /** NULL — Grok tool results carry no error signal, so the count is unknown. */
+  tool_error_count: number | null;
+  text_content: string;
+  /** Session title (read by auxProjections; ignored by the events projection). */
+  title: string;
+}
+
+/** Flatten a parsed session into canonical index rows for one file. */
+export function toCanonicalRows(session: GrokSession, filePath: string): CanonicalRow[] {
+  return session.events.map((e) => {
+    const msg = e.message;
+    const content = Array.isArray(msg.content) ? msg.content : [];
+    const usage = (msg as { usage?: MessageUsage }).usage;
+    const text = content
+      .map((b) => (b.type === 'text' ? b.text : b.type === 'thinking' ? b.thinking : ''))
+      .filter(Boolean)
+      .join(' ');
+    return {
+      file_path: filePath,
+      session_id: session.sessionId,
+      uuid: e.uuid,
+      parent_uuid: e.parentUuid,
+      role: msg.role,
+      type: e.type,
+      ts: e.timestamp,
+      cwd: session.cwd,
+      git_branch: null,
+      model: (msg as { model?: string }).model || null,
+      input_tokens: num(usage?.input_tokens),
+      output_tokens: num(usage?.output_tokens),
+      cache_read_tokens: num(usage?.cache_read_input_tokens),
+      cache_write_tokens: num(usage?.cache_creation_input_tokens),
+      service_tier: null,
+      is_sidechain: session.isSidechain,
+      tool_use_count: content.filter((b) => b.type === 'tool_use').length,
+      tool_names: toolNamesCsv(content),
+      tool_error_count: null,
+      text_content: text,
+      // A sidechain file's rows carry the PARENT's session_id — emitting the
+      // child's own title there would overwrite the parent's in the titles
+      // aux projection (last(title) per session).
+      title: session.isSidechain ? '' : session.title,
+    };
+  });
+}

--- a/packages/server/src/connectors/registry.ts
+++ b/packages/server/src/connectors/registry.ts
@@ -11,6 +11,7 @@ import { piConnector } from './pi/pi.js';
 import { opencodeConnector } from './opencode/opencode.js';
 import { copilotConnector } from './copilot/copilot.js';
 import { antigravityConnector } from './antigravity/antigravity.js';
+import { grokConnector } from './grok/grok.js';
 
 export const connectors: AgentConnector[] = [
   claudeCodeConnector,
@@ -20,6 +21,7 @@ export const connectors: AgentConnector[] = [
   opencodeConnector,
   copilotConnector,
   antigravityConnector,
+  grokConnector,
 ];
 
 /** The connector with the given id, falling back to Claude Code if unknown. */

--- a/packages/server/src/routes/analytics-agents.ts
+++ b/packages/server/src/routes/analytics-agents.ts
@@ -48,6 +48,7 @@ const USAGE_GRANULARITY: Record<string, AgentUsageGranularity> = {
   junie: 'per-response',
   copilot: 'session-level',
   antigravity: 'none',
+  grok: 'per-response',
 };
 
 /** Human notes behind the n/a markers, keyed by connector id. */
@@ -57,6 +58,7 @@ const AVAILABILITY_NOTES: Record<string, string> = {
   antigravity:
     'Antigravity transcripts carry no token counts — tokens and cost are unavailable by design.',
   junie: 'Junie delegates via plain terminal commands, so subagent usage is invisible.',
+  grok: 'Grok records usage once per user turn (in updates.jsonl); a session whose updates file is missing or truncated reports zero tokens.',
 };
 
 /** Shared cache-hit denominator (see /api/analytics). */

--- a/packages/server/test/agent-comparison.integration.test.ts
+++ b/packages/server/test/agent-comparison.integration.test.ts
@@ -33,6 +33,7 @@ process.env.OPENCODE_DATA_DIR = join(work, 'opencode-empty');
 process.env.COPILOT_SESSIONS_DIR = copilotDir;
 process.env.ANTIGRAVITY_CLI_DIR = antigravityDir;
 process.env.ANTIGRAVITY_DIR = join(work, 'antigravity-desktop-empty');
+process.env.GROK_SESSIONS_DIR = join(work, 'grok-empty');
 process.env.DUCKDB_PATH = join(work, 'index.duckdb');
 process.env.CLAUDESCOPE_HOME = join(work, 'home');
 process.env.REINDEX_INTERVAL_MS = '0';

--- a/packages/server/test/analytics-activity.integration.test.ts
+++ b/packages/server/test/analytics-activity.integration.test.ts
@@ -14,6 +14,7 @@ process.env.OPENCODE_DATA_DIR = join(work, 'opencode-empty');
 process.env.COPILOT_SESSIONS_DIR = join(work, 'copilot-empty');
 process.env.ANTIGRAVITY_CLI_DIR = join(work, 'antigravity-empty');
 process.env.ANTIGRAVITY_DIR = join(work, 'antigravity-empty-desktop');
+process.env.GROK_SESSIONS_DIR = join(work, 'grok-empty');
 process.env.DUCKDB_PATH = join(work, 'index.duckdb');
 process.env.CLAUDESCOPE_HOME = join(work, 'home');
 process.env.REINDEX_INTERVAL_MS = '0';

--- a/packages/server/test/analytics-digest.integration.test.ts
+++ b/packages/server/test/analytics-digest.integration.test.ts
@@ -31,6 +31,7 @@ process.env.OPENCODE_DATA_DIR = join(work, 'opencode-empty');
 process.env.COPILOT_SESSIONS_DIR = join(work, 'copilot-empty');
 process.env.ANTIGRAVITY_CLI_DIR = join(work, 'antigravity-empty');
 process.env.ANTIGRAVITY_DIR = join(work, 'antigravity-empty-desktop');
+process.env.GROK_SESSIONS_DIR = join(work, 'grok-empty');
 process.env.DUCKDB_PATH = join(work, 'index.duckdb');
 process.env.CLAUDESCOPE_HOME = join(work, 'home');
 process.env.REINDEX_INTERVAL_MS = '0';

--- a/packages/server/test/analytics-errors.integration.test.ts
+++ b/packages/server/test/analytics-errors.integration.test.ts
@@ -30,6 +30,7 @@ process.env.OPENCODE_DATA_DIR = join(work, 'opencode-empty');
 process.env.COPILOT_SESSIONS_DIR = join(work, 'copilot-empty');
 process.env.ANTIGRAVITY_CLI_DIR = join(work, 'antigravity-empty');
 process.env.ANTIGRAVITY_DIR = join(work, 'antigravity-empty-desktop');
+process.env.GROK_SESSIONS_DIR = join(work, 'grok-empty');
 process.env.DUCKDB_PATH = join(work, 'index.duckdb');
 process.env.CLAUDESCOPE_HOME = join(work, 'home');
 process.env.REINDEX_INTERVAL_MS = '0';

--- a/packages/server/test/analytics-tools.integration.test.ts
+++ b/packages/server/test/analytics-tools.integration.test.ts
@@ -14,6 +14,7 @@ process.env.OPENCODE_DATA_DIR = join(work, 'opencode-empty');
 process.env.COPILOT_SESSIONS_DIR = join(work, 'copilot-empty');
 process.env.ANTIGRAVITY_CLI_DIR = join(work, 'antigravity-empty');
 process.env.ANTIGRAVITY_DIR = join(work, 'antigravity-empty-desktop');
+process.env.GROK_SESSIONS_DIR = join(work, 'grok-empty');
 process.env.DUCKDB_PATH = join(work, 'index.duckdb');
 process.env.CLAUDESCOPE_HOME = join(work, 'home');
 process.env.REINDEX_INTERVAL_MS = '0';

--- a/packages/server/test/antigravity.integration.test.ts
+++ b/packages/server/test/antigravity.integration.test.ts
@@ -39,6 +39,7 @@ process.env.OPENCODE_DATA_DIR = join(work, 'opencode-empty');
 process.env.COPILOT_SESSIONS_DIR = join(work, 'copilot-empty');
 process.env.ANTIGRAVITY_CLI_DIR = cliDir;
 process.env.ANTIGRAVITY_DIR = join(work, 'antigravity-desktop-empty');
+process.env.GROK_SESSIONS_DIR = join(work, 'grok-empty');
 process.env.DUCKDB_PATH = join(work, 'index.duckdb');
 process.env.CLAUDESCOPE_HOME = join(work, 'home');
 process.env.REINDEX_INTERVAL_MS = '0';

--- a/packages/server/test/api.integration.test.ts
+++ b/packages/server/test/api.integration.test.ts
@@ -29,6 +29,7 @@ process.env.OPENCODE_DATA_DIR = join(work, 'opencode-empty');
 process.env.COPILOT_SESSIONS_DIR = join(work, 'copilot-empty');
 process.env.ANTIGRAVITY_CLI_DIR = join(work, 'antigravity-empty');
 process.env.ANTIGRAVITY_DIR = join(work, 'antigravity-empty-desktop');
+process.env.GROK_SESSIONS_DIR = join(work, 'grok-empty');
 process.env.DUCKDB_PATH = dbPath;
 process.env.CLAUDESCOPE_HOME = join(work, 'home');
 process.env.REINDEX_INTERVAL_MS = '0';

--- a/packages/server/test/cli-query.test.ts
+++ b/packages/server/test/cli-query.test.ts
@@ -27,6 +27,7 @@ process.env.OPENCODE_DATA_DIR = join(work, 'opencode-empty');
 process.env.COPILOT_SESSIONS_DIR = join(work, 'copilot-empty');
 process.env.ANTIGRAVITY_CLI_DIR = join(work, 'antigravity-empty');
 process.env.ANTIGRAVITY_DIR = join(work, 'antigravity-empty-desktop');
+process.env.GROK_SESSIONS_DIR = join(work, 'grok-empty');
 process.env.DUCKDB_PATH = join(work, 'index.duckdb');
 process.env.CLAUDESCOPE_HOME = join(work, 'home');
 process.env.REINDEX_INTERVAL_MS = '0';

--- a/packages/server/test/codex.integration.test.ts
+++ b/packages/server/test/codex.integration.test.ts
@@ -27,6 +27,7 @@ process.env.OPENCODE_DATA_DIR = join(work, 'opencode-empty');
 process.env.COPILOT_SESSIONS_DIR = join(work, 'copilot-empty');
 process.env.ANTIGRAVITY_CLI_DIR = join(work, 'antigravity-empty');
 process.env.ANTIGRAVITY_DIR = join(work, 'antigravity-empty-desktop');
+process.env.GROK_SESSIONS_DIR = join(work, 'grok-empty');
 process.env.DUCKDB_PATH = join(work, 'index.duckdb');
 process.env.CLAUDESCOPE_HOME = join(work, 'home');
 process.env.REINDEX_INTERVAL_MS = '0';

--- a/packages/server/test/copilot.integration.test.ts
+++ b/packages/server/test/copilot.integration.test.ts
@@ -40,6 +40,7 @@ process.env.OPENCODE_DATA_DIR = join(work, 'opencode-empty');
 process.env.COPILOT_SESSIONS_DIR = sessionsDir;
 process.env.ANTIGRAVITY_CLI_DIR = join(work, 'antigravity-empty');
 process.env.ANTIGRAVITY_DIR = join(work, 'antigravity-empty-desktop');
+process.env.GROK_SESSIONS_DIR = join(work, 'grok-empty');
 process.env.DUCKDB_PATH = join(work, 'index.duckdb');
 process.env.CLAUDESCOPE_HOME = join(work, 'home');
 process.env.REINDEX_INTERVAL_MS = '0';

--- a/packages/server/test/dedup.integration.test.ts
+++ b/packages/server/test/dedup.integration.test.ts
@@ -46,6 +46,7 @@ process.env.OPENCODE_DATA_DIR = join(work, 'opencode-empty');
 process.env.COPILOT_SESSIONS_DIR = join(work, 'copilot-empty');
 process.env.ANTIGRAVITY_CLI_DIR = join(work, 'antigravity-empty');
 process.env.ANTIGRAVITY_DIR = join(work, 'antigravity-empty-desktop');
+process.env.GROK_SESSIONS_DIR = join(work, 'grok-empty');
 process.env.DUCKDB_PATH = dbPath;
 process.env.CLAUDESCOPE_HOME = join(work, 'home');
 process.env.REINDEX_INTERVAL_MS = '0';

--- a/packages/server/test/file-edits.integration.test.ts
+++ b/packages/server/test/file-edits.integration.test.ts
@@ -41,6 +41,7 @@ process.env.OPENCODE_DATA_DIR = join(work, 'opencode-empty');
 process.env.COPILOT_SESSIONS_DIR = copilotDir;
 process.env.ANTIGRAVITY_CLI_DIR = join(work, 'antigravity-empty');
 process.env.ANTIGRAVITY_DIR = join(work, 'antigravity-empty-desktop');
+process.env.GROK_SESSIONS_DIR = join(work, 'grok-empty');
 process.env.DUCKDB_PATH = join(work, 'index.duckdb');
 process.env.CLAUDESCOPE_HOME = join(work, 'home');
 process.env.REINDEX_INTERVAL_MS = '0';

--- a/packages/server/test/grok.integration.test.ts
+++ b/packages/server/test/grok.integration.test.ts
@@ -1,0 +1,455 @@
+/**
+ * xAI Grok CLI connector integration test.
+ *
+ * Builds the index from synthetic Grok session dirs (in an isolated temp
+ * GROK_SESSIONS_DIR, with the other agents empty) and exercises the routes,
+ * verifying the grok-specific normalization: the chat_history/updates/summary
+ * three-file split (timestamps + usage come from updates.jsonl, title from
+ * summary.json), the injected-row skip (system + prompt_index-less user rows),
+ * the `<user_query>` wrapper strip (visible in the fallback title), plaintext
+ * reasoning summaries (NOT blanked), tool canonicalization (search_replace →
+ * Edit reaching the Files-changed extractor shape), inline data-URL images,
+ * the input-minus-cachedRead usage split priced at the shipped grok-4.5 rate,
+ * and subagent embedding: a SIBLING child session dir folds into the parent
+ * (searchable, tokens counted, never top-level) via the parent's
+ * `subagents/<id>/meta.json`, anchoring at its `spawn_subagent` → `Task`,
+ * while an orphaned child (no parent claims it) indexes standalone. A missing
+ * updates.jsonl and a corrupt trailing chat line must degrade, not crash.
+ */
+
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import type { FastifyInstance } from 'fastify';
+
+const work = mkdtempSync(join(tmpdir(), 'claudescope-grok-'));
+const grokDir = join(work, 'grok');
+const claudeDir = join(work, 'claude-empty');
+
+process.env.CLAUDE_PROJECTS_DIR = claudeDir;
+process.env.CODEX_SESSIONS_DIR = join(work, 'codex-empty');
+process.env.JUNIE_SESSIONS_DIR = join(work, 'junie-empty');
+process.env.PI_SESSIONS_DIR = join(work, 'pi-empty');
+process.env.OPENCODE_DATA_DIR = join(work, 'opencode-empty');
+process.env.COPILOT_SESSIONS_DIR = join(work, 'copilot-empty');
+process.env.ANTIGRAVITY_CLI_DIR = join(work, 'antigravity-empty');
+process.env.ANTIGRAVITY_DIR = join(work, 'antigravity-empty-desktop');
+process.env.GROK_SESSIONS_DIR = grokDir;
+process.env.DUCKDB_PATH = join(work, 'index.duckdb');
+process.env.CLAUDESCOPE_HOME = join(work, 'home');
+process.env.REINDEX_INTERVAL_MS = '0';
+
+const jsonl = (events: unknown[]): string => events.map((e) => JSON.stringify(e)).join('\n') + '\n';
+const CWD_DIR = join(grokDir, '%2Ftmp%2Fgrokproj');
+const BASE_MS = Date.parse('2026-06-20T10:00:00.000Z');
+const iso = (s: number) => new Date(BASE_MS + s * 1000).toISOString();
+
+const CALL_READ = 'call-aaaa-0';
+const CALL_EDIT = 'call-aaaa-1';
+const CALL_BASH = 'call-aaaa-2';
+const CALL_MCP = 'call-aaaa-3';
+const CALL_SPAWN = 'call-bbbb-0';
+// 1x1 transparent PNG (base64) — stands in for a pasted screenshot.
+const PNG_B64 =
+  'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYPhfDwAChwGA60e6kgAAAABJRU5ErkJggg==';
+
+/** One ACP-style updates.jsonl line. */
+const update = (ms: number, sessionUpdate: Record<string, unknown>, meta?: Record<string, unknown>) => ({
+  timestamp: Math.floor(ms / 1000),
+  method: 'session/update',
+  params: {
+    sessionId: 'x',
+    update: sessionUpdate,
+    _meta: { eventId: `e-${ms}`, agentTimestampMs: ms, ...meta },
+  },
+});
+
+function writeSummary(dir: string, id: string, extra: Record<string, unknown> = {}): void {
+  writeFileSync(
+    join(dir, 'summary.json'),
+    JSON.stringify({
+      info: { id, cwd: '/tmp/grokproj' },
+      created_at: iso(0),
+      updated_at: iso(120),
+      current_model_id: 'grok-4.5',
+      ...extra,
+    }),
+  );
+}
+
+/**
+ * The full-feature main session: injected rows to skip, a wrapped + image user
+ * prompt, plaintext reasoning, canonical tool mapping, and a turn_completed
+ * whose cachedReadTokens must be split OUT of inputTokens.
+ */
+function writeMainSession(): void {
+  const dir = join(CWD_DIR, 'grok-sess-1');
+  mkdirSync(dir, { recursive: true });
+  writeSummary(dir, 'grok-sess-1', { generated_title: 'Needle hunt in the grok haystack' });
+  writeFileSync(
+    join(dir, 'chat_history.jsonl'),
+    jsonl([
+      { type: 'system', content: 'You are Grok. secret-system-marker' },
+      // Injected context rows: no prompt_index (with and without synthetic_reason).
+      { type: 'user', content: [{ type: 'text', text: '<user_info>\nOS: macos injected-info-marker\n</user_info>' }] },
+      { type: 'user', content: [{ type: 'text', text: 'project instructions injected-agents-marker' }], synthetic_reason: 'agents_md' },
+      {
+        type: 'user',
+        prompt_index: 0,
+        content: [
+          // A pasted image injects an <image_files> scaffold INSIDE the same
+          // text part, before the <user_query> tag — both must be stripped.
+          {
+            type: 'text',
+            text: '<image_files>\nThe following images were provided by the user and saved to the workspace for future use:\n1. /tmp/grokproj/assets/image-1.png scaffold-marker\n</image_files>\n\n<user_query>\nfind the needle in the grok haystack [Image #1] \n</user_query>',
+          },
+          { type: 'image', url: `data:image/png;base64,${PNG_B64}` },
+          { type: 'image', url: 'https://example.com/not-inline.png' }, // non-data URL → skipped
+        ],
+      },
+      {
+        type: 'reasoning',
+        id: 'rs_1',
+        summary: [{ type: 'summary_text', text: 'let me grep the grok haystack' }],
+        encrypted_content: 'OPAQUE',
+        status: 'completed',
+      },
+      {
+        type: 'assistant',
+        content: 'Searching now.',
+        model_id: 'grok-4.5',
+        tool_calls: [
+          { id: CALL_READ, name: 'read_file', arguments: JSON.stringify({ target_file: '/tmp/grokproj/hay.txt' }) },
+          { id: CALL_EDIT, name: 'search_replace', arguments: JSON.stringify({ file_path: '/tmp/grokproj/hay.txt', old_string: 'hay', new_string: 'needle' }) },
+          { id: CALL_BASH, name: 'run_terminal_command', arguments: JSON.stringify({ command: 'grep needle hay.txt', description: 'Search the haystack' }) },
+          { id: CALL_MCP, name: 'context7__query-docs', arguments: JSON.stringify({ query: 'needles' }) },
+        ],
+      },
+      { type: 'tool_result', tool_call_id: CALL_READ, content: '1→hay in the stack' },
+      { type: 'tool_result', tool_call_id: CALL_EDIT, content: 'The file hay.txt has been edited' },
+      { type: 'tool_result', tool_call_id: CALL_BASH, content: 'needle found at line 42' },
+      { type: 'tool_result', tool_call_id: CALL_MCP, content: 'docs about needles' },
+      { type: 'assistant', content: 'Found the needle.', model_id: 'grok-4.5' },
+    ]),
+  );
+  writeFileSync(
+    join(dir, 'updates.jsonl'),
+    jsonl([
+      update(BASE_MS + 1000, { sessionUpdate: 'user_message_chunk', content: { type: 'text', text: 'find the needle' }, _meta: { promptIndex: 0 } }),
+      update(BASE_MS + 5000, { sessionUpdate: 'tool_call', toolCallId: CALL_READ, title: 'read_file' }),
+      update(BASE_MS + 6000, { sessionUpdate: 'tool_call', toolCallId: CALL_EDIT, title: 'search_replace' }),
+      // cachedReadTokens is a SUBSET of inputTokens → indexed input must be 1000.
+      update(BASE_MS + 30000, {
+        sessionUpdate: 'turn_completed',
+        prompt_id: 'p-1',
+        stop_reason: 'end_turn',
+        usage: { inputTokens: 1200, outputTokens: 300, totalTokens: 1500, cachedReadTokens: 200, reasoningTokens: 40, modelCalls: 2 },
+      }),
+    ]),
+  );
+}
+
+/**
+ * A parent that spawns a subagent. The child is a SIBLING session dir; the only
+ * linkage is the parent's `subagents/<child-id>/meta.json`. Only the child and
+ * parent carry usage via their own updates.jsonl — the parent's session totals
+ * prove the re-keyed sidechain rows fold in.
+ */
+function writeSubagentPair(): void {
+  const parentDir = join(CWD_DIR, 'grok-sess-2');
+  mkdirSync(parentDir, { recursive: true });
+  writeSummary(parentDir, 'grok-sess-2', { generated_title: 'Dispatch a cave reviewer' });
+  writeFileSync(
+    join(parentDir, 'chat_history.jsonl'),
+    jsonl([
+      { type: 'user', prompt_index: 0, content: [{ type: 'text', text: '<user_query>\ndispatch a reviewer to the caves\n</user_query>' }] },
+      {
+        type: 'assistant',
+        content: 'Spawning a reviewer.',
+        model_id: 'grok-4.5',
+        tool_calls: [
+          { id: CALL_SPAWN, name: 'spawn_subagent', arguments: JSON.stringify({ description: 'Review the cave code', prompt: 'Review the caves\nthoroughly.' }) },
+        ],
+      },
+      { type: 'tool_result', tool_call_id: CALL_SPAWN, content: 'subagent_id: grok-child-1\nstatus: started' },
+      { type: 'assistant', content: 'The reviewer finished.', model_id: 'grok-4.5' },
+    ]),
+  );
+  writeFileSync(
+    join(parentDir, 'updates.jsonl'),
+    jsonl([
+      update(BASE_MS + 1000, {
+        sessionUpdate: 'turn_completed',
+        prompt_id: 'p-1',
+        usage: { inputTokens: 100, outputTokens: 10, totalTokens: 110, cachedReadTokens: 0 },
+      }),
+    ]),
+  );
+  const metaDir = join(parentDir, 'subagents', 'grok-child-1');
+  mkdirSync(metaDir, { recursive: true });
+  writeFileSync(
+    join(metaDir, 'meta.json'),
+    JSON.stringify({
+      subagent_id: 'grok-child-1',
+      parent_session_id: 'grok-sess-2',
+      child_session_id: 'grok-child-1',
+      subagent_type: 'general-purpose',
+      description: 'Review the cave code',
+      prompt: 'Review the caves\nthoroughly.',
+      status: 'completed',
+    }),
+  );
+
+  const childDir = join(CWD_DIR, 'grok-child-1');
+  mkdirSync(childDir, { recursive: true });
+  writeSummary(childDir, 'grok-child-1', {
+    session_kind: 'subagent',
+    agent_name: 'general-purpose',
+    // The child has its own title — it must NOT leak onto the parent session.
+    generated_title: 'Review the caves thoroughly',
+  });
+  writeFileSync(
+    join(childDir, 'chat_history.jsonl'),
+    jsonl([
+      { type: 'user', prompt_index: 0, content: [{ type: 'text', text: '<user_query>\nReview the caves\nthoroughly.\n</user_query>' }] },
+      { type: 'assistant', content: 'Cave review done: the glowworm grotto is sound.', model_id: 'grok-4.5' },
+    ]),
+  );
+  writeFileSync(
+    join(childDir, 'updates.jsonl'),
+    jsonl([
+      update(BASE_MS + 2000, {
+        sessionUpdate: 'turn_completed',
+        prompt_id: 'p-c1',
+        usage: { inputTokens: 50, outputTokens: 20, totalTokens: 70, cachedReadTokens: 0 },
+      }),
+    ]),
+  );
+}
+
+/**
+ * Degraded session: NO updates.jsonl (timestamps fall back to summary times,
+ * zero usage), no generated_title (fallback title = stripped first user
+ * message), and a corrupt trailing chat line to tolerate.
+ */
+function writeDegradedSession(): void {
+  const dir = join(CWD_DIR, 'grok-sess-3');
+  mkdirSync(dir, { recursive: true });
+  writeSummary(dir, 'grok-sess-3');
+  writeFileSync(
+    join(dir, 'chat_history.jsonl'),
+    jsonl([
+      { type: 'user', prompt_index: 0, content: [{ type: 'text', text: '<user_query>\nchart the abyssal trench\n</user_query>' }] },
+      { type: 'assistant', content: 'Trench charted.', model_id: 'grok-4.5' },
+    ]) + '{"type":"assis', // truncated mid-write
+  );
+}
+
+/** An orphaned subagent child: no parent's subagents/ dir claims it. */
+function writeOrphanChild(): void {
+  const dir = join(CWD_DIR, 'grok-orphan-1');
+  mkdirSync(dir, { recursive: true });
+  writeSummary(dir, 'grok-orphan-1', { session_kind: 'subagent' });
+  writeFileSync(
+    join(dir, 'chat_history.jsonl'),
+    jsonl([
+      { type: 'user', prompt_index: 0, content: [{ type: 'text', text: 'orphan child with no parent' }] },
+      { type: 'assistant', content: 'Standing alone.', model_id: 'grok-4.5' },
+    ]),
+  );
+}
+
+let app: FastifyInstance;
+let closeConnection: () => Promise<void>;
+
+beforeAll(async () => {
+  mkdirSync(claudeDir, { recursive: true });
+  // A stray non-session file at the sessions root (grok writes one) — must be skipped.
+  mkdirSync(grokDir, { recursive: true });
+  writeFileSync(join(grokDir, 'session_search.sqlite'), 'not jsonl');
+  writeMainSession();
+  writeSubagentPair();
+  writeDegradedSession();
+  writeOrphanChild();
+  // The per-cwd prompt_history.jsonl grok keeps next to session dirs — skipped by shape.
+  writeFileSync(join(CWD_DIR, 'prompt_history.jsonl'), jsonl([{ prompt: 'not a session' }]));
+
+  const Fastify = (await import('fastify')).default;
+  const { registerRoutes } = await import('../src/routes/index.js');
+  const { reindex } = await import('../src/data/index.js');
+  ({ closeConnection } = await import('../src/db/duckdb.js'));
+
+  app = Fastify();
+  await registerRoutes(app);
+  await reindex();
+  await app.ready();
+});
+
+afterAll(async () => {
+  await app?.close();
+  await closeConnection?.();
+  rmSync(work, { recursive: true, force: true });
+});
+
+const get = (url: string) => app.inject({ method: 'GET', url });
+
+describe('grok session indexing', () => {
+  it('lists the grok sessions (child folds into parent; orphan stays standalone)', async () => {
+    const sessions = (await get('/api/sessions')).json();
+    expect(sessions.map((s: { id: string }) => s.id).sort()).toEqual([
+      'grok-orphan-1',
+      'grok-sess-1',
+      'grok-sess-2',
+      'grok-sess-3',
+    ]);
+    const s1 = sessions.find((s: { id: string }) => s.id === 'grok-sess-1');
+    expect(s1.connectorId).toBe('grok');
+    expect(s1.models).toContain('grok-4.5');
+    // The real title comes from summary.json's generated_title.
+    expect(s1.title).toBe('Needle hunt in the grok haystack');
+  });
+
+  it('falls back to the stripped first user message when summary has no title', async () => {
+    const s3 = (await get('/api/sessions')).json().find((x: { id: string }) => x.id === 'grok-sess-3');
+    // No <user_query> wrapper — proves stripUserQuery feeds the title fallback.
+    expect(s3.title).toBe('chart the abyssal trench');
+  });
+
+  it('splits cachedReadTokens out of inputTokens and prices at the grok-4.5 rate', async () => {
+    const s1 = (await get('/api/sessions')).json().find((x: { id: string }) => x.id === 'grok-sess-1');
+    // input 1200 includes 200 cached reads → indexed as 1000 in + 300 out + 200 cacheRead.
+    expect(s1.totalTokens).toBe(1500);
+    // grok-4.5 @ 2/6 (cacheRead 0.5) per 1M: (1000*2 + 300*6 + 200*0.5)/1e6 = 0.0039.
+    // (The 3/15 default rate would give ~0.0076 — proves the shipped grok entry resolves.)
+    expect(s1.totalCostUsd).toBeCloseTo(0.0039, 6);
+  });
+
+  it('indexes a session with NO updates.jsonl (zero usage, summary timestamps)', async () => {
+    const s3 = (await get('/api/sessions')).json().find((x: { id: string }) => x.id === 'grok-sess-3');
+    expect(s3.totalTokens).toBe(0);
+    expect(s3.totalCostUsd).toBe(0);
+  });
+
+  it('keeps injected context rows out of the index and search', async () => {
+    for (const marker of ['injected-info-marker', 'injected-agents-marker', 'secret-system-marker']) {
+      const { sessions: hits } = (await get(`/api/search?q=${marker}`)).json();
+      expect(hits).toEqual([]);
+    }
+    // The real prompt IS searchable (with the wrapper stripped at index time).
+    const { sessions: hits } = (await get('/api/search?q=haystack')).json();
+    expect(hits.some((r: { sessionId: string }) => r.sessionId === 'grok-sess-1')).toBe(true);
+  });
+
+  it('exposes the grok source dir and groups analytics by agent', async () => {
+    const sources = (await get('/api/sources')).json();
+    expect(sources.some((s: { id: string }) => s.id === 'grok')).toBe(true);
+    const { rows } = (await get('/api/analytics?groupBy=agent')).json();
+    expect(rows.map((r: { key: string }) => r.key)).toContain('grok');
+  });
+});
+
+describe('grok session detail', () => {
+  it('renders plaintext reasoning, strips the user_query wrapper, embeds the image, maps tools', async () => {
+    const detail = (await get('/api/sessions/grok-sess-1')).json();
+    const flat = detail.thread.flatMap((t: { blocks: Record<string, unknown>[] }) => t.blocks);
+    const all = JSON.stringify(detail.thread);
+
+    // Injected rows never render as user turns.
+    expect(all).not.toContain('injected-info-marker');
+    expect(all).not.toContain('injected-agents-marker');
+    // The wrapper AND the pasted-image scaffold are stripped from the prompt;
+    // the inline [Image #N] marker the user's text carries survives.
+    expect(all).not.toContain('<user_query>');
+    expect(all).not.toContain('image_files');
+    expect(all).not.toContain('scaffold-marker');
+    expect(all).toContain('find the needle in the grok haystack [Image #1]');
+
+    // Grok reasoning summaries are PLAINTEXT — must survive, not render blank.
+    const thinking = flat.find((b: Record<string, unknown>) => b.type === 'thinking');
+    expect(thinking.thinking).toContain('let me grep the grok haystack');
+
+    // The pasted screenshot embeds as a canonical base64 ImageBlock (rendered
+    // as an attachment); the non-data URL part is dropped, not a crash.
+    const attachments = flat.filter((b: Record<string, unknown>) => b.kind === 'attachment');
+    expect(attachments).toHaveLength(1);
+    expect(attachments[0].attachment).toMatchObject({
+      type: 'image',
+      source: { type: 'base64', media_type: 'image/png', data: PNG_B64 },
+    });
+
+    const tools = flat.filter((b: Record<string, unknown>) => b.kind === 'tool');
+    // read_file → Read keyed by file_path (from target_file).
+    const read = tools.find((t: { name: string }) => t.name === 'Read');
+    expect(read.input).toMatchObject({ file_path: '/tmp/grokproj/hay.txt' });
+    expect(JSON.stringify(read.result.content)).toContain('hay in the stack');
+    // search_replace → Edit in the exact shape the Files-changed extractor keys off.
+    const edit = tools.find((t: { name: string }) => t.name === 'Edit');
+    expect(edit.input).toMatchObject({
+      file_path: '/tmp/grokproj/hay.txt',
+      old_string: 'hay',
+      new_string: 'needle',
+    });
+    expect(edit.result).toBeTruthy();
+    // run_terminal_command → Bash.
+    const bash = tools.find((t: { name: string }) => t.name === 'Bash');
+    expect(bash.input).toMatchObject({ command: 'grep needle hay.txt' });
+    expect(JSON.stringify(bash.result.content)).toContain('needle found at line 42');
+    // MCP tools stay passthrough under their namespaced native name.
+    const mcp = tools.find((t: { id: string }) => t.id === CALL_MCP);
+    expect(mcp.name).toBe('context7__query-docs');
+
+    expect(all).toContain('Found the needle.');
+  });
+
+  it('tolerates a corrupt trailing chat line', async () => {
+    const detail = (await get('/api/sessions/grok-sess-3')).json();
+    expect(JSON.stringify(detail.thread)).toContain('Trench charted.');
+  });
+});
+
+describe('grok subagent embedding', () => {
+  it('folds the sibling child into the parent (sidechain + tokens)', async () => {
+    const s2 = (await get('/api/sessions')).json().find((x: { id: string }) => x.id === 'grok-sess-2');
+    expect(s2.hasSidechain).toBe(true);
+    // parent 100+10 (+0 cached) + child 50+20 — child rows count under the parent.
+    expect(s2.totalTokens).toBe(180);
+    // The PARENT's generated_title must win — the child file's re-keyed rows
+    // (same session_id) must not overwrite it with the child's own title.
+    expect(s2.title).toBe('Dispatch a cave reviewer');
+  });
+
+  it('nests the child at its spawn_subagent call via the canonical Task block', async () => {
+    const detail = (await get('/api/sessions/grok-sess-2')).json();
+    const flat = detail.thread.flatMap((t: { blocks: Record<string, unknown>[] }) => t.blocks);
+
+    const task = flat.find((b: { name?: string }) => b.name === 'Task');
+    expect(task.id).toBe(CALL_SPAWN);
+    // subagent_type comes from the parent's meta.json, matched by description.
+    expect(task.input).toMatchObject({
+      description: 'Review the cave code',
+      subagent_type: 'general-purpose',
+      prompt: 'Review the caves\nthoroughly.',
+    });
+
+    expect(detail.subagents).toHaveLength(1);
+    const run = detail.subagents[0];
+    expect(run).toMatchObject({ agentType: 'general-purpose', description: 'Review the cave code' });
+    expect(run.toolUseId).toBe(CALL_SPAWN);
+    // The child transcript rides the run — not the main thread.
+    expect(JSON.stringify(run)).toContain('glowworm grotto');
+    expect(JSON.stringify(detail.thread)).not.toContain('glowworm');
+  });
+
+  it('finds child-transcript text under the PARENT session via search', async () => {
+    const { sessions: results } = (await get('/api/search?q=glowworm')).json();
+    expect(results.some((r: { sessionId: string }) => r.sessionId === 'grok-sess-2')).toBe(true);
+    expect(results.every((r: { sessionId: string }) => r.sessionId !== 'grok-child-1')).toBe(true);
+  });
+
+  it('indexes an orphaned child (no parent claims it) as its own session', async () => {
+    const detail = (await get('/api/sessions/grok-orphan-1')).json();
+    expect(JSON.stringify(detail.thread)).toContain('orphan child with no parent');
+    expect(detail.subagents).toEqual([]);
+  });
+});

--- a/packages/server/test/index-progress.integration.test.ts
+++ b/packages/server/test/index-progress.integration.test.ts
@@ -27,6 +27,7 @@ process.env.OPENCODE_DATA_DIR = join(work, 'opencode-empty');
 process.env.COPILOT_SESSIONS_DIR = join(work, 'copilot-empty');
 process.env.ANTIGRAVITY_CLI_DIR = join(work, 'antigravity-empty');
 process.env.ANTIGRAVITY_DIR = join(work, 'antigravity-empty-desktop');
+process.env.GROK_SESSIONS_DIR = join(work, 'grok-empty');
 process.env.DUCKDB_PATH = join(work, 'index.duckdb');
 process.env.CLAUDESCOPE_HOME = join(work, 'home');
 process.env.REINDEX_INTERVAL_MS = '0';

--- a/packages/server/test/index-recovery.integration.test.ts
+++ b/packages/server/test/index-recovery.integration.test.ts
@@ -32,6 +32,7 @@ process.env.OPENCODE_DATA_DIR = join(work, 'opencode-empty');
 process.env.COPILOT_SESSIONS_DIR = join(work, 'copilot-empty');
 process.env.ANTIGRAVITY_CLI_DIR = join(work, 'antigravity-empty');
 process.env.ANTIGRAVITY_DIR = join(work, 'antigravity-empty-desktop');
+process.env.GROK_SESSIONS_DIR = join(work, 'grok-empty');
 process.env.CLAUDESCOPE_HOME = join(work, 'home');
 process.env.REINDEX_INTERVAL_MS = '0';
 process.env.PRICING_REFRESH_INTERVAL_MS = '0';

--- a/packages/server/test/junie.integration.test.ts
+++ b/packages/server/test/junie.integration.test.ts
@@ -32,6 +32,7 @@ process.env.OPENCODE_DATA_DIR = join(work, 'opencode-empty');
 process.env.COPILOT_SESSIONS_DIR = join(work, 'copilot-empty');
 process.env.ANTIGRAVITY_CLI_DIR = join(work, 'antigravity-empty');
 process.env.ANTIGRAVITY_DIR = join(work, 'antigravity-empty-desktop');
+process.env.GROK_SESSIONS_DIR = join(work, 'grok-empty');
 process.env.DUCKDB_PATH = join(work, 'index.duckdb');
 process.env.CLAUDESCOPE_HOME = join(work, 'home');
 process.env.REINDEX_INTERVAL_MS = '0';

--- a/packages/server/test/mcp.integration.test.ts
+++ b/packages/server/test/mcp.integration.test.ts
@@ -29,6 +29,7 @@ process.env.OPENCODE_DATA_DIR = join(work, 'opencode-empty');
 process.env.COPILOT_SESSIONS_DIR = join(work, 'copilot-empty');
 process.env.ANTIGRAVITY_CLI_DIR = join(work, 'antigravity-empty');
 process.env.ANTIGRAVITY_DIR = join(work, 'antigravity-empty-desktop');
+process.env.GROK_SESSIONS_DIR = join(work, 'grok-empty');
 process.env.DUCKDB_PATH = join(work, 'index.duckdb');
 process.env.CLAUDESCOPE_HOME = join(work, 'home');
 process.env.REINDEX_INTERVAL_MS = '0';

--- a/packages/server/test/memory-overview.test.ts
+++ b/packages/server/test/memory-overview.test.ts
@@ -117,12 +117,12 @@ describe('buildConnectorOverviews', () => {
       // claude-code has content (a fact) → rank 0.
       fact({ connectorId: 'claude-code', title: 'f', updatedAt: '2026-01-01T00:00:00.000Z' }),
       // codex/junie/copilot are supported but empty here → rank 1.
-      // pi/opencode are unsupported → rank 2.
+      // pi/opencode/grok are unsupported → rank 2.
     ];
     const overviews = buildConnectorOverviews(items);
-    // Every registered agent appears (claude-code, codex, junie, pi, opencode, copilot, antigravity).
+    // Every registered agent appears (claude-code, codex, junie, pi, opencode, copilot, antigravity, grok).
     expect(overviews.map((o) => o.connectorId).sort()).toEqual(
-      ['claude-code', 'codex', 'copilot', 'junie', 'opencode', 'pi', 'antigravity'].sort(),
+      ['claude-code', 'codex', 'copilot', 'junie', 'opencode', 'pi', 'antigravity', 'grok'].sort(),
     );
     const rank = (o: { supported: boolean; preview?: unknown }) =>
       o.supported && o.preview ? 0 : o.supported ? 1 : 2;

--- a/packages/server/test/opencode.integration.test.ts
+++ b/packages/server/test/opencode.integration.test.ts
@@ -33,6 +33,7 @@ process.env.OPENCODE_DATA_DIR = ocDataDir;
 process.env.COPILOT_SESSIONS_DIR = join(work, 'copilot-empty');
 process.env.ANTIGRAVITY_CLI_DIR = join(work, 'antigravity-empty');
 process.env.ANTIGRAVITY_DIR = join(work, 'antigravity-empty-desktop');
+process.env.GROK_SESSIONS_DIR = join(work, 'grok-empty');
 process.env.DUCKDB_PATH = join(work, 'index.duckdb');
 process.env.CLAUDESCOPE_HOME = join(work, 'home');
 process.env.REINDEX_INTERVAL_MS = '0';

--- a/packages/server/test/pi.integration.test.ts
+++ b/packages/server/test/pi.integration.test.ts
@@ -33,6 +33,7 @@ process.env.OPENCODE_DATA_DIR = join(work, 'opencode-empty');
 process.env.COPILOT_SESSIONS_DIR = join(work, 'copilot-empty');
 process.env.ANTIGRAVITY_CLI_DIR = join(work, 'antigravity-empty');
 process.env.ANTIGRAVITY_DIR = join(work, 'antigravity-empty-desktop');
+process.env.GROK_SESSIONS_DIR = join(work, 'grok-empty');
 process.env.DUCKDB_PATH = join(work, 'index.duckdb');
 process.env.CLAUDESCOPE_HOME = join(work, 'home');
 process.env.REINDEX_INTERVAL_MS = '0';

--- a/packages/server/test/pricing.test.ts
+++ b/packages/server/test/pricing.test.ts
@@ -45,6 +45,7 @@ process.env.OPENCODE_DATA_DIR = join(work, 'opencode-empty');
 process.env.COPILOT_SESSIONS_DIR = join(work, 'copilot-empty');
 process.env.ANTIGRAVITY_CLI_DIR = join(work, 'antigravity-empty');
 process.env.ANTIGRAVITY_DIR = join(work, 'antigravity-empty-desktop');
+process.env.GROK_SESSIONS_DIR = join(work, 'grok-empty');
 process.env.DUCKDB_PATH = dbPath;
 process.env.CLAUDESCOPE_HOME = join(work, 'home');
 process.env.REINDEX_INTERVAL_MS = '0';

--- a/packages/server/test/session-efficiency.integration.test.ts
+++ b/packages/server/test/session-efficiency.integration.test.ts
@@ -24,6 +24,7 @@ process.env.OPENCODE_DATA_DIR = join(work, 'opencode-empty');
 process.env.COPILOT_SESSIONS_DIR = join(work, 'copilot-empty');
 process.env.ANTIGRAVITY_CLI_DIR = join(work, 'antigravity-empty');
 process.env.ANTIGRAVITY_DIR = join(work, 'antigravity-empty-desktop');
+process.env.GROK_SESSIONS_DIR = join(work, 'grok-empty');
 process.env.DUCKDB_PATH = join(work, 'index.duckdb');
 process.env.CLAUDESCOPE_HOME = join(work, 'home');
 process.env.REINDEX_INTERVAL_MS = '0';

--- a/packages/server/test/session-fingerprint.integration.test.ts
+++ b/packages/server/test/session-fingerprint.integration.test.ts
@@ -24,6 +24,7 @@ process.env.OPENCODE_DATA_DIR = join(work, 'opencode-empty');
 process.env.COPILOT_SESSIONS_DIR = join(work, 'copilot-empty');
 process.env.ANTIGRAVITY_CLI_DIR = join(work, 'antigravity-empty');
 process.env.ANTIGRAVITY_DIR = join(work, 'antigravity-empty-desktop');
+process.env.GROK_SESSIONS_DIR = join(work, 'grok-empty');
 process.env.DUCKDB_PATH = join(work, 'index.duckdb');
 process.env.CLAUDESCOPE_HOME = join(work, 'home');
 process.env.REINDEX_INTERVAL_MS = '0';

--- a/packages/server/test/tool-names.integration.test.ts
+++ b/packages/server/test/tool-names.integration.test.ts
@@ -14,6 +14,7 @@ process.env.OPENCODE_DATA_DIR = join(work, 'opencode-empty');
 process.env.COPILOT_SESSIONS_DIR = join(work, 'copilot-empty');
 process.env.ANTIGRAVITY_CLI_DIR = join(work, 'antigravity-empty');
 process.env.ANTIGRAVITY_DIR = join(work, 'antigravity-empty-desktop');
+process.env.GROK_SESSIONS_DIR = join(work, 'grok-empty');
 process.env.DUCKDB_PATH = join(work, 'index.duckdb');
 process.env.CLAUDESCOPE_HOME = join(work, 'home');
 process.env.REINDEX_INTERVAL_MS = '0';

--- a/packages/web/src/components/AgentBadge.tsx
+++ b/packages/web/src/components/AgentBadge.tsx
@@ -8,6 +8,7 @@ const AGENT_LABELS: Record<string, string> = {
   opencode: 'opencode',
   copilot: 'Copilot',
   antigravity: 'Antigravity',
+  grok: 'Grok',
 };
 
 /** Human-friendly short label for a connector id. */

--- a/packages/web/src/pages/browse/browse.css
+++ b/packages/web/src/pages/browse/browse.css
@@ -325,6 +325,12 @@
   background: #8ab4f81a;
   color: #8ab4f8;
 }
+/* Grok's brand is monochrome — a neutral slate keeps it distinct from the hues. */
+.tv-chip--agent.tv-agent--grok {
+  border-color: #9da7b366;
+  background: #9da7b31a;
+  color: #c4cdd6;
+}
 /* Light theme: keep the brand tints but darken the text so it stays legible on
    a light surface. */
 :root[data-theme='light'] .tv-chip--agent.tv-agent--claude-code {
@@ -347,4 +353,7 @@
 }
 :root[data-theme='light'] .tv-chip--agent.tv-agent--antigravity {
   color: #1a73e8;
+}
+:root[data-theme='light'] .tv-chip--agent.tv-agent--grok {
+  color: #40484f;
 }


### PR DESCRIPTION
Adds [xAI Grok CLI](https://x.ai) as the 8th agent source: `~/.grok/sessions/<encoded-cwd>/<uuid>/`.

Plan: [docs/plans/0048-grok-connector.md](./docs/plans/0048-grok-connector.md)

## Format (verified against real local sessions + a scratch probe)

A Grok session is a **directory** spreading facts across three files:
- `chat_history.jsonl` — OpenAI-Responses-style message spine (content, `model_id`, tool calls; **no timestamps/usage**)
- `updates.jsonl` — ACP-style overlay: per-event timestamps and the **only** token usage (`turn_completed`, once per user turn)
- `summary.json` — plain `cwd`, `generated_title`, created/updated times

## Highlights

- **prepare() → canonical NDJSON** (pi pattern); discovery mtime/size fold all three files so late-written usage/titles trigger re-index
- **Plaintext reasoning summaries render as thinking** (joins pi/Antigravity in the exceptions list)
- **Injected rows skipped**: user rows without `prompt_index` (user_info/agents-md/system-reminders) never render or hit FTS; `<user_query>` wrappers and pasted-image `<image_files>` scaffolding are stripped
- **Files-changed works**: `write`/`search_replace` → canonical `Write`/`Edit` (arg shapes confirmed via a scratch session, deleted after); inline data-URL screenshots → `ImageBlock`
- **Usage split**: Grok's `cachedReadTokens` is a subset of `inputTokens` → split out at normalize time; NULL `message_id` (one usage record per turn, no dedup needed)
- **Pricing**: shipped `grok-4.5`/`grok-4`/`grok-code-fast-1` entries + `grok` family; LiteLLM only carries `xai/`-prefixed ids which the fetched overlay skips, so shipped rates carry the cost path. Schema v3 → v4 (user copies reconcile on boot)
- **Subagents**: children are **sibling session dirs**; linkage lives only in the parent's `subagents/<id>/meta.json` — children re-key to the parent (`is_sidechain`) and nest at `spawn_subagent` → canonical `Task`. Sidechain files contribute no title (found on real data: the child's `generated_title` was overwriting the parent's)
- **Resume/fork**: `grok --resume <id>` / `--fork-session`
- Memory (`~/.grok/memory/`) is experimental/off-by-default — not surfaced (v1)

## Testing

- 12-test integration suite (sibling-dir subagent re-key + token folding, usage split + rate resolution, `search_replace`→Edit, image embedding, missing/truncated `updates.jsonl`, corrupt trailing lines, injected-row exclusion, orphan children, title precedence)
- `GROK_SESSIONS_DIR` isolation added to all 22 existing integration tests
- 441 tests + typecheck green; verified end-to-end against real `~/.grok` sessions (badge, thinking, nested code-review subagent, tokens/cost, resume commands)