### PR TITLE
fix: resolve Dependabot brace-expansion alert

### DIFF
--- a/docs/plans/0035-dependabot-brace-expansion.md
+++ b/docs/plans/0035-dependabot-brace-expansion.md
@@ -1,0 +1,42 @@
+# 0035 — Dependabot #6: brace-expansion DoS remediation
+
+- **Status:** done
+- **Date:** 2026-07-22
+- **PR:** —
+
+## Context
+
+Dependabot alert #6 reports CVE-2026-13149 / GHSA-3jxr-9vmj-r5cp: an
+exponential-time denial of service in `brace-expansion`. The lockfile resolves
+the vulnerable `5.0.6` transitively through `@fastify/static` → `glob` →
+`minimatch`.
+
+## Goal
+
+Resolve `brace-expansion` to the minimal patched release, `5.0.7`, without
+changing direct dependency ranges or application code.
+
+## Decisions
+
+- **Update only `package-lock.json`** — the vulnerable package is transitive;
+  its parent range (`^5.0.5`) already permits `5.0.7`, so a direct override or
+  unrelated dependency upgrade is unnecessary.
+
+## Approach
+
+1. Regenerate the lockfile's `brace-expansion` resolution at `5.0.7`.
+2. Confirm the installed tree has no vulnerable `brace-expansion` release.
+3. Run the repository test suite and TypeScript check, then review the diff.
+
+## Files affected
+
+- `package-lock.json` — resolve the patched transitive dependency.
+
+## Testing
+
+Run `npm ls brace-expansion`, `npm test`, and `npm run typecheck`.
+
+## Risks / open questions
+
+The patch version is within the existing semver range. No behavior change is
+expected beyond the advisory's denial-of-service fix.

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -59,3 +59,4 @@ decision, or a change worth explaining before doing. Skip it for one-line fixes.
 | 0032 | [Subagent embedding for Codex, pi, opencode, Copilot](./0032-subagent-embedding-connectors.md) | done |
 | 0033 | [Symlink-safe image resolution](./0033-symlink-safe-image-resolution.md) | done |
 | 0034 | [Restore reader's place after a full reload (Safari ⌘R)](./0034-safari-reload-scroll-restore.md) | done |
+| 0035 | [Dependabot #6: brace-expansion DoS remediation](./0035-dependabot-brace-expansion.md) | done |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1715,9 +1715,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
+      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"


### PR DESCRIPTION
## Summary

Updates the transitive `brace-expansion` lockfile resolution from 5.0.6 to the patched 5.0.7 release.

## Root cause

Dependabot alert #6 (CVE-2026-13149 / GHSA-3jxr-9vmj-r5cp) identified an exponential-time denial-of-service vulnerability in `brace-expansion`. It was brought in through `@fastify/static → glob → minimatch`.

## Impact

No application code or direct dependency ranges change. The existing `^5.0.5` range permits the patched version.

## Validation

- `npm ls brace-expansion --all` resolves 5.0.7
- `npm test` (311 passing)
- `npm run typecheck`

Includes the repository plan required for non-trivial changes.