### PR TITLE
fix: resolve Dependabot brace-expansion alert

### DIFF
--- a/docs/plans/0049-dependabot-brace-expansion.md
+++ b/docs/plans/0049-dependabot-brace-expansion.md
@@ -18,23 +18,27 @@ changing direct dependency ranges or application code.
 
 ## Decisions
 
-- **Update only `package-lock.json`** — the vulnerable package is transitive;
-  its parent range (`^5.0.5`) already permits `5.0.7`, so a direct override or
-  unrelated dependency upgrade is unnecessary.
+- **Do not add a direct dependency or override** — the vulnerable package is
+  transitive; its parent range (`^5.0.5`) already permits `5.0.7`.
+- **Refresh the Nix dependency hash** — `fetchNpmDeps` hashes the lockfile's
+  dependency set, so the patched tarball requires the corresponding hash update.
 
 ## Approach
 
 1. Regenerate the lockfile's `brace-expansion` resolution at `5.0.7`.
-2. Confirm the installed tree has no vulnerable `brace-expansion` release.
-3. Run the repository test suite and TypeScript check, then review the diff.
+2. Update the flake's `fetchNpmDeps` hash to match the patched lockfile.
+3. Confirm the installed tree has no vulnerable `brace-expansion` release.
+4. Run the repository tests, TypeScript check, and Nix build; then review the diff.
 
 ## Files affected
 
 - `package-lock.json` — resolve the patched transitive dependency.
+- `flake.nix` — refresh the fixed-output hash for the changed dependency set.
 
 ## Testing
 
-Run `npm ls brace-expansion`, `npm test`, and `npm run typecheck`.
+Run `npm ls brace-expansion`, `npm test`, `npm run typecheck`, and
+`nix build .#claudescope --no-link`.
 
 ## Risks / open questions
 

--- a/docs/plans/0049-dependabot-brace-expansion.md
+++ b/docs/plans/0049-dependabot-brace-expansion.md
@@ -1,0 +1,42 @@
+# 0049 — Dependabot #6: brace-expansion DoS remediation
+
+- **Status:** done
+- **Date:** 2026-07-22
+- **PR:** —
+
+## Context
+
+Dependabot alert #6 reports CVE-2026-13149 / GHSA-3jxr-9vmj-r5cp: an
+exponential-time denial of service in `brace-expansion`. The lockfile resolves
+the vulnerable `5.0.6` transitively through `@fastify/static` → `glob` →
+`minimatch`.
+
+## Goal
+
+Resolve `brace-expansion` to the minimal patched release, `5.0.7`, without
+changing direct dependency ranges or application code.
+
+## Decisions
+
+- **Update only `package-lock.json`** — the vulnerable package is transitive;
+  its parent range (`^5.0.5`) already permits `5.0.7`, so a direct override or
+  unrelated dependency upgrade is unnecessary.
+
+## Approach
+
+1. Regenerate the lockfile's `brace-expansion` resolution at `5.0.7`.
+2. Confirm the installed tree has no vulnerable `brace-expansion` release.
+3. Run the repository test suite and TypeScript check, then review the diff.
+
+## Files affected
+
+- `package-lock.json` — resolve the patched transitive dependency.
+
+## Testing
+
+Run `npm ls brace-expansion`, `npm test`, and `npm run typecheck`.
+
+## Risks / open questions
+
+The patch version is within the existing semver range. No behavior change is
+expected beyond the advisory's denial-of-service fix.

--- a/docs/plans/0049-dependabot-brace-expansion.md
+++ b/docs/plans/0049-dependabot-brace-expansion.md
@@ -2,7 +2,7 @@
 
 - **Status:** done
 - **Date:** 2026-07-22
-- **PR:** —
+- **PR:** https://github.com/vladar107/claudescope/pull/67
 
 ## Context
 

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -73,3 +73,4 @@ decision, or a change worth explaining before doing. Skip it for one-line fixes.
 | 0046 | [Live session updates (fingerprint polling + stick-to-bottom)](./0046-live-session-updates.md) | done |
 | 0047 | [List freshness: dataVersion idle polling](./0047-list-freshness-dataversion.md) | done |
 | 0048 | [xAI Grok CLI connector](./0048-grok-connector.md) | done |
+| 0049 | [Dependabot #6: brace-expansion DoS remediation](./0049-dependabot-brace-expansion.md) | done |

--- a/flake.nix
+++ b/flake.nix
@@ -55,7 +55,7 @@
           # `nix build .#claudescope` and the mismatch error prints the new value.
           npmDeps = pkgs.fetchNpmDeps {
             src = depsLock;
-            hash = "sha256-1nN4N+WTsMLZg7MY4u0PCdUmJu129t8v1lZyRmtP6H4=";
+            hash = "sha256-dwxF6rNahR99jt4JV8t4sdLfX1Z6LvkhzFZF4Dc2Cik=";
           };
 
           nodejs = node;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1799,9 +1799,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
+      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"


### PR DESCRIPTION
## Summary

Updates the transitive `brace-expansion` lockfile resolution from 5.0.6 to the patched 5.0.7 release and refreshes the Nix fixed-output dependency hash.

## Root cause

Dependabot alert #6 (CVE-2026-13149 / GHSA-3jxr-9vmj-r5cp) identified an exponential-time denial-of-service vulnerability in `brace-expansion`. It was brought in through `@fastify/static → glob → minimatch`.

Changing the lockfile dependency set also changes the `fetchNpmDeps` hash used by the Nix build.

## Impact

No application code or direct dependency ranges change. The existing `^5.0.5` range permits the patched version.

## Validation

- `npm ls brace-expansion --all` resolves 5.0.7
- `npm test` (441 passing)
- `npm run typecheck`
- Linux and macOS Nix jobs queued with the refreshed dependency hash

Includes the repository plan required for non-trivial changes.

Supersedes #66, which GitHub closed during the branch rename.