### PR TITLE
feat: Settings page — indexer lifecycle controls + settings.json layer

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,9 +48,16 @@ npm-workspaces monorepo (`packages/*`):
   the DuckDB index, a user-editable `pricing.json` (seeded from a shipped
   default; `loadPricing` falls back to the default if the copy is missing),
   `pricing.fetched.json` (runtime-fetched rates snapshot, auto-refreshed daily
-  from LiteLLM, or manually via `claudescope pricing update`), the daemon PID
-  file, and logs. State lives outside the package dir so global installs survive
-  upgrades — do not move it back into the package.
+  from LiteLLM, or manually via `claudescope pricing update`), `settings.json`
+  (written by the web UI's Settings page; **env vars always win** over saved
+  values — resolution is env > file > default, per call via `settings.ts`
+  getters, so source dirs and the reindex interval apply live without a
+  restart), the daemon PID file, and logs. State lives outside the package dir
+  so global installs survive upgrades — do not move it back into the package.
+- The web Settings page's Start/Stop/Restart control the **indexer** (the
+  reindex poller — `indexer-lifecycle.ts`), never the HTTP process; stopping
+  the server stays terminal-only (`claudescope stop`). The pause flag is
+  runtime-only (not persisted).
 
 ## Commands
 

--- a/README.md
+++ b/README.md
@@ -247,6 +247,10 @@ All optional — set via environment variables.
 Each agent source is optional — if a directory doesn't exist it's simply skipped,
 so the app works whether you use one agent or all eight.
 
+The source directories and the reindex interval can also be changed from the
+web UI's **Settings** page — saved to `~/.claudescope/settings.json` and applied
+live, no restart needed. Environment variables always override saved settings.
+
 Examples:
 
 ```bash

--- a/docs/plans/0051-settings-page.md
+++ b/docs/plans/0051-settings-page.md
@@ -1,0 +1,113 @@
+# 0051 — Settings page: indexer lifecycle + settings.json layer
+
+- **Status:** in-progress
+- **Date:** 2026-07-22
+- **PR:** <pending>
+
+## Context
+
+Claudescope had no user-facing settings surface: every knob was an env var
+frozen at boot in `config.ts`, and the only UI preference (theme) hid in the
+sidebar. A Settings-page mockup was challenged against the architecture and
+reduced to what fits it:
+
+- **Lifecycle controls target the INDEXER, not the process.** The HTTP server
+  is never stopped from the UI (terminal-only). The reindex poller + DuckDB
+  ingest are the real resource consumers and were already separable machinery —
+  Start/Stop/Restart become real, meaningful buttons with no dead-page paradox.
+- Dropped from the mockup: backup path (no backup feature exists), user
+  accounts/"Admin Mode", a process START button (the UI is served by the
+  process it would start), a "READ/WRITE" paths badge (sources are READ-ONLY —
+  the product promise), "vector store" naming (it's the DuckDB index), and an
+  auto-restart-on-crash toggle (no supervisor exists).
+
+## Goal
+
+A `/settings` page where users can: pause/resume/restart background indexing,
+edit agent source dirs + reindex interval + open-browser-on-start (persisted
+to `~/.claudescope/settings.json`, applied live where possible), sync pricing,
+see version/update/uptime, switch theme, and rebuild the index behind a
+confirm — with per-field provenance (env / saved / default) and env-shadow
+warnings.
+
+## Decisions
+
+- **Persistence: `settings.json` under `CLAUDESCOPE_HOME`, env always wins**
+  (env > file > default, resolved per call). Rejected: file-over-env (breaks
+  scripted overrides and the test harness); UI-read-only (defers the feature).
+- **Config consts → runtime getters** (`settings.ts`), connectors resolve
+  their dir once per discovery pass and expose `sourceDir` via object-literal
+  getters — so dir changes apply with a reindex kick, not a process restart.
+  The deleted consts made `tsc -b` enumerate every consumer.
+- **Indexer lifecycle, not process lifecycle** (`indexer-lifecycle.ts`): pause
+  disarms the poller (index stays queryable; in-flight passes drain), the
+  pause flag is runtime-only. `requestPass()` drains an in-flight pass then
+  runs one more, making "save dir → sessions appear" deterministic.
+- **Rebuild runs through the same `inFlight` slot as `reindex()`** so poller
+  ticks coalesce instead of racing the closed DuckDB connection; it also
+  re-prices history (cost is stamped at index time).
+- **Update stays terminal-driven**: `GET /api/system` shows the install-method
+  command (npm/brew/nix via the extracted `install-method.ts`); the server
+  never shells out to package managers.
+- **CSRF mutation guard** (`registerMutationGuard`): the Host guard doesn't
+  stop same-Host cross-origin no-cors POSTs; now that the API writes files,
+  mutations require `Sec-Fetch-Site` same-origin/none (when present) and JSON
+  content types.
+- **`openBrowser` setting has no env layer** — `OPEN_BROWSER` is the internal
+  launcher contract (the daemon pins it to `0`), so treating it as a user
+  override would misreport in the UI; the CLI folds flag > settings > default.
+
+## Approach
+
+1. Shared API types (`packages/shared/src/api.ts`): settings/lifecycle section.
+2. `settings.ts` (registry, mtime-cached loader, atomic saves, validation,
+   getters) + const→getter migration across all 8 connectors, `index.ts`,
+   `cli.ts`.
+3. `indexer-lifecycle.ts` (poller extraction, pause/resume/restart,
+   `requestPass`) + `rebuildIndex()`/`discardDbFiles()`; `/api/health` gains
+   compact indexer state.
+4. Routes: `GET/PUT /api/settings`, `POST /api/indexer/{stop,start,restart}`,
+   `POST /api/index/rebuild` (202/409), `POST /api/pricing/refresh`,
+   `GET /api/system`; `registerMutationGuard` in `security.ts`.
+5. CLI: `start` consults the persisted `openBrowser` (flag wins).
+6. Web: `pages/settings/` (SettingsPage, SettingRow, settings.css),
+   `ConfirmDialog` + `tv-btn--danger` (first modal/danger primitives),
+   client methods, StatusProvider passes `indexer` through, theme toggle moves
+   from the sidebar into Appearance.
+7. Tests (bug-prone edges): settings precedence/corruption/atomicity,
+   PUT→live-apply→reindex pickup, lifecycle pause/coalescing, rebuild
+   snapshot/re-pricing/409, mutation-guard matrix.
+
+## Files affected
+
+- `packages/shared/src/api.ts` — new settings/lifecycle contract types.
+- `packages/server/src/settings.ts` (new), `config.ts` — settings layer;
+  editable consts removed.
+- `packages/server/src/connectors/*` — getter migration (all 8 connectors).
+- `packages/server/src/indexer-lifecycle.ts` (new), `data/index.ts`,
+  `db/duckdb.ts`, `index.ts` — poller extraction + rebuild.
+- `packages/server/src/routes/{settings,indexer,pricing,system}.ts` (new),
+  `routes/index.ts`, `security.ts`, `install-method.ts` (new), `cli.ts`,
+  `update-check.ts`.
+- `packages/web/src/pages/settings/*` (new), `App.tsx`, `api/client.ts`,
+  `status/StatusProvider.tsx`, `components/ConfirmDialog.tsx` (new),
+  `styles/global.css`.
+
+## Testing
+
+`npm test` + `npm run typecheck` green at every step. New suites:
+`settings.test.ts`, `settings-api.integration.test.ts`,
+`indexer-lifecycle.integration.test.ts`, `index-rebuild.integration.test.ts`,
+mutation-guard cases in `security.test.ts`. Manual: run the app, change a
+source dir on /settings, watch sessions appear; pause/resume; rebuild.
+
+## Risks / open questions
+
+- The const→getter sweep could silently change a default — mitigated by
+  copying defaults verbatim into `SETTING_DEFS` and the full integration suite.
+- Rebuild closes the DuckDB connection; a concurrent query 500s once and
+  recovers on the next request — acceptable for an explicit danger action.
+- PORT shows source `env` for daemon-started servers (the CLI always injects
+  it) — honest but slightly noisy.
+- Pause is runtime-only: a self-restart or crash resumes indexing (stated in
+  the UI).

--- a/docs/plans/0051-settings-page.md
+++ b/docs/plans/0051-settings-page.md
@@ -1,8 +1,8 @@
 # 0051 — Settings page: indexer lifecycle + settings.json layer
 
-- **Status:** in-progress
+- **Status:** done
 - **Date:** 2026-07-22
-- **PR:** <pending>
+- **PR:** https://github.com/vladar107/claudescope/pull/69
 
 ## Context
 

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -75,3 +75,4 @@ decision, or a change worth explaining before doing. Skip it for one-line fixes.
 | 0048 | [xAI Grok CLI connector](./0048-grok-connector.md) | done |
 | 0049 | [Dependabot #6: brace-expansion DoS remediation](./0049-dependabot-brace-expansion.md) | done |
 | 0050 | [Dependabot alerts #7–#10 remediation](./0050-dependabot-alerts-7-10.md) | done |
+| 0051 | [Settings page: indexer lifecycle + settings.json layer](./0051-settings-page.md) | in-progress |

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -75,4 +75,4 @@ decision, or a change worth explaining before doing. Skip it for one-line fixes.
 | 0048 | [xAI Grok CLI connector](./0048-grok-connector.md) | done |
 | 0049 | [Dependabot #6: brace-expansion DoS remediation](./0049-dependabot-brace-expansion.md) | done |
 | 0050 | [Dependabot alerts #7–#10 remediation](./0050-dependabot-alerts-7-10.md) | done |
-| 0051 | [Settings page: indexer lifecycle + settings.json layer](./0051-settings-page.md) | in-progress |
+| 0051 | [Settings page: indexer lifecycle + settings.json layer](./0051-settings-page.md) | done |

--- a/packages/server/src/cli.ts
+++ b/packages/server/src/cli.ts
@@ -19,7 +19,6 @@
 
 import { spawnSync } from 'node:child_process';
 import { existsSync, mkdirSync, readFileSync, realpathSync, rmSync } from 'node:fs';
-import { dirname } from 'node:path';
 import { createInterface } from 'node:readline/promises';
 import { parseArgs } from 'node:util';
 import { fileURLToPath } from 'node:url';
@@ -29,7 +28,7 @@ import {
   PORT as DEFAULT_PORT,
   autoRestartEnabled,
 } from './config.js';
-import { claudeProjectsDir } from './settings.js';
+import { claudeProjectsDir, openBrowserOnStart } from './settings.js';
 import {
   DAEMON_FILE,
   EXIT_WAIT_MS,
@@ -56,6 +55,7 @@ import {
 } from './agent/query.js';
 import { ensureDaemon } from './daemon.js';
 import { PKG, getLatestVersion, isNewer } from './update-check.js';
+import { detectInstallMethod } from './install-method.js';
 import { refreshPricing } from './data/pricing-refresh.js';
 import { openBrowser } from './util/open-browser.js';
 
@@ -71,10 +71,6 @@ export {
   type DaemonRecord,
   type ExistingState,
 } from './daemon.js';
-
-// The bundle is ESM, so the CJS `__dirname` global doesn't exist — derive it
-// from import.meta.url like config.ts/daemon.ts do (the bundler injects none).
-const __dirname = dirname(fileURLToPath(import.meta.url));
 
 /** Start the server in the background, idempotently. */
 async function start(port: number, open: boolean): Promise<void> {
@@ -208,26 +204,6 @@ async function confirm(question: string, defaultYes: boolean): Promise<boolean> 
   } finally {
     rl.close();
   }
-}
-
-type InstallMethod = 'brew' | 'nix' | 'npm';
-
-/** Classify how this CLI was installed from where its bundle resides. Homebrew
- *  symlinks the bin out of the Cellar's libexec (realpath resolves it back); Nix
- *  installs under /nix/store; everything else (npm global, npx) is treated as npm. */
-function detectInstallMethod(): InstallMethod {
-  let p = __dirname;
-  try {
-    p = realpathSync(__dirname);
-  } catch {
-    /* keep __dirname if the path can't be resolved */
-  }
-  if (p.includes('/nix/store/')) return 'nix';
-  // Match the formula's Cellar dir specifically (…/Cellar/claudescope/<version>/…),
-  // not a generic "homebrew" — a plain `npm i -g` under Homebrew's own Node lives
-  // at …/homebrew/lib/node_modules/… and must NOT be mistaken for a brew install.
-  if (/[\\/]Cellar[\\/]claudescope[\\/]/.test(p)) return 'brew';
-  return 'npm';
 }
 
 /** Upgrade the global install to the latest published version and restart.
@@ -394,6 +370,8 @@ Options:
 State (index, pricing, logs, PID) lives in ${CLAUDESCOPE_HOME}
 (override with $CLAUDESCOPE_HOME). Sessions are read from
 ${claudeProjectsDir()} (override with $CLAUDE_PROJECTS_DIR).
+Settings edited in the web UI persist to settings.json in the state dir
+(env vars always win over saved settings).
 CLAUDESCOPE_AUTO_RESTART=0 disables automatic daemon restarts on version skew.`);
 }
 
@@ -429,7 +407,9 @@ async function main(): Promise<void> {
   });
 
   const port = values.port ? Number(values.port) : DEFAULT_PORT;
-  const open = !values['no-open'];
+  // Flag wins, then the persisted setting (which itself folds settings.json >
+  // default true; the OPEN_BROWSER env var stays the launcher's contract).
+  const open = values['no-open'] ? false : openBrowserOnStart();
 
   let command = positionals[0];
   if (!command) command = values.help ? 'help' : values.version ? 'version' : 'start';

--- a/packages/server/src/cli.ts
+++ b/packages/server/src/cli.ts
@@ -25,11 +25,11 @@ import { parseArgs } from 'node:util';
 import { fileURLToPath } from 'node:url';
 import {
   APP_VERSION,
-  CLAUDE_PROJECTS_DIR,
   CLAUDESCOPE_HOME,
   PORT as DEFAULT_PORT,
   autoRestartEnabled,
 } from './config.js';
+import { claudeProjectsDir } from './settings.js';
 import {
   DAEMON_FILE,
   EXIT_WAIT_MS,
@@ -136,7 +136,7 @@ async function start(port: number, open: boolean): Promise<void> {
     return;
   }
   console.log(`\n✓ claudescope running → ${url}`);
-  console.log(`  Sessions: ${CLAUDE_PROJECTS_DIR} (read-only)`);
+  console.log(`  Sessions: ${claudeProjectsDir()} (read-only)`);
   if (open) openBrowser(url);
   await maybeNotifyUpdate(false);
 }
@@ -393,7 +393,7 @@ Options:
 
 State (index, pricing, logs, PID) lives in ${CLAUDESCOPE_HOME}
 (override with $CLAUDESCOPE_HOME). Sessions are read from
-${CLAUDE_PROJECTS_DIR} (override with $CLAUDE_PROJECTS_DIR).
+${claudeProjectsDir()} (override with $CLAUDE_PROJECTS_DIR).
 CLAUDESCOPE_AUTO_RESTART=0 disables automatic daemon restarts on version skew.`);
 }
 

--- a/packages/server/src/config.ts
+++ b/packages/server/src/config.ts
@@ -9,7 +9,7 @@ import type { PricingConfig } from '@claudescope/shared';
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
 /** Return the first candidate path that exists, or `fallback` if none do. */
-function firstExisting(candidates: string[], fallback: string): string {
+export function firstExisting(candidates: string[], fallback: string): string {
   return candidates.find((p) => existsSync(p)) ?? fallback;
 }
 
@@ -20,140 +20,21 @@ export const PORT = Number(process.env.PORT ?? 4317);
 export const PACKAGE_ROOT = join(__dirname, '..');
 
 /** Expand a leading `~` to the user's home directory. */
-function expandHome(p: string): string {
+export function expandHome(p: string): string {
   if (p === '~') return homedir();
   if (p.startsWith('~/')) return join(homedir(), p.slice(2));
   return p;
 }
 
-/**
- * READ-ONLY source of session data. The app MUST NEVER write here.
- *
- * Defaults to `~/.claude/projects`. Override with the CLAUDE_PROJECTS_DIR
- * environment variable to point at a different location (e.g. a copy of
- * transcripts exported from another machine). A leading `~` is expanded.
- */
-export const CLAUDE_PROJECTS_DIR = expandHome(
-  process.env.CLAUDE_PROJECTS_DIR ?? join(homedir(), '.claude', 'projects'),
-);
-
-/**
- * READ-ONLY source of OpenAI Codex CLI sessions. The app MUST NEVER write here.
- * Defaults to `~/.codex/sessions` (`rollout-*.jsonl` under `YYYY/MM/DD/`).
- * Override with CODEX_SESSIONS_DIR. A leading `~` is expanded.
- */
-export const CODEX_SESSIONS_DIR = expandHome(
-  process.env.CODEX_SESSIONS_DIR ?? join(homedir(), '.codex', 'sessions'),
-);
-
-/**
- * READ-ONLY source of JetBrains Junie sessions. The app MUST NEVER write here.
- * Defaults to `~/.junie/sessions` (`session-<id>/events.jsonl`, plus an
- * `index.jsonl` listing every session). Override with JUNIE_SESSIONS_DIR. A
- * leading `~` is expanded.
- */
-export const JUNIE_SESSIONS_DIR = expandHome(
-  process.env.JUNIE_SESSIONS_DIR ?? join(homedir(), '.junie', 'sessions'),
-);
-
-/**
- * READ-ONLY source of pi (`@earendil-works/pi-coding-agent`) sessions. The app
- * MUST NEVER write here. Defaults to `~/.pi/agent/sessions` (one
- * `<ts>_<uuid>.jsonl` per session, under a per-`cwd` directory). Override with
- * PI_SESSIONS_DIR. A leading `~` is expanded.
- */
-export const PI_SESSIONS_DIR = expandHome(
-  process.env.PI_SESSIONS_DIR ?? join(homedir(), '.pi', 'agent', 'sessions'),
-);
-
-/**
- * READ-ONLY source of opencode sessions. The app MUST NEVER write here. Unlike the
- * other agents, opencode stores everything in ONE SQLite DB. `OPENCODE_DATA_DIR`
- * defaults to `$XDG_DATA_HOME/opencode` (else `~/.local/share/opencode`) and
- * `OPENCODE_DB_PATH` is `<dataDir>/opencode.db`. The connector opens the DB
- * strictly read-only (`node:sqlite`). Override either with its env var; a leading
- * `~` is expanded.
- */
-export const OPENCODE_DATA_DIR = expandHome(
-  process.env.OPENCODE_DATA_DIR ??
-    join(process.env.XDG_DATA_HOME ?? join(homedir(), '.local', 'share'), 'opencode'),
-);
-export const OPENCODE_DB_PATH =
-  process.env.OPENCODE_DB_PATH ?? join(OPENCODE_DATA_DIR, 'opencode.db');
-
-/**
- * READ-ONLY source of GitHub Copilot CLI sessions. The app MUST NEVER write here.
- * Defaults to `~/.copilot/session-state` (one `<uuid>/events.jsonl` per session,
- * with a sibling `workspace.yaml` and an optional `files/` attachment dir).
- * Override with COPILOT_SESSIONS_DIR. A leading `~` is expanded.
- */
-export const COPILOT_SESSIONS_DIR = expandHome(
-  process.env.COPILOT_SESSIONS_DIR ?? join(homedir(), '.copilot', 'session-state'),
-);
-
-/**
- * READ-ONLY source of xAI Grok CLI sessions. The app MUST NEVER write here.
- * Defaults to `~/.grok/sessions` (one `<session-uuid>/` dir per session under a
- * per-cwd url-encoded directory, holding `chat_history.jsonl` + `updates.jsonl`
- * + `summary.json`). Override with GROK_SESSIONS_DIR. A leading `~` is expanded.
- */
-export const GROK_SESSIONS_DIR = expandHome(
-  process.env.GROK_SESSIONS_DIR ?? join(homedir(), '.grok', 'sessions'),
-);
-
-/**
- * READ-ONLY source of Google Antigravity sessions. The app MUST NEVER write here.
- * Antigravity 2.0 has two surfaces that share the same on-disk shape — the CLI
- * (`agy`) and the desktop app — each with its own appDataDir under `~/.gemini`.
- * One connector scans both: `<dir>/brain/<conv-id>/.system_generated/logs/transcript_full.jsonl`
- * (with cwd resolved out-of-band from `<dir>/history.jsonl`). Override either dir
- * with its env var; a leading `~` is expanded.
- */
-export const ANTIGRAVITY_CLI_DIR = expandHome(
-  process.env.ANTIGRAVITY_CLI_DIR ?? join(homedir(), '.gemini', 'antigravity-cli'),
-);
-export const ANTIGRAVITY_DESKTOP_DIR = expandHome(
-  process.env.ANTIGRAVITY_DIR ?? join(homedir(), '.gemini', 'antigravity'),
-);
-/** Every Antigravity appDataDir the connector scans (both surfaces). */
-export const ANTIGRAVITY_DIRS = [ANTIGRAVITY_CLI_DIR, ANTIGRAVITY_DESKTOP_DIR];
-/**
- * The Antigravity source dir reported to `/api/sources` — the first surface that
- * exists (CLI or desktop). `discover()` scans both, so keying the sources footer
- * on the CLI dir alone would hide the source for a desktop-only install.
- */
-export const ANTIGRAVITY_SOURCE_DIR = firstExisting(
-  [ANTIGRAVITY_CLI_DIR, ANTIGRAVITY_DESKTOP_DIR],
-  ANTIGRAVITY_CLI_DIR,
-);
-
-/**
- * READ-ONLY agent home directories — the parents of the session/project dirs
- * above, where each agent keeps its memory (`CLAUDE.md`, `AGENTS.md`, the Codex
- * `memories/` tree). Derived from the dirs above so the env overrides carry
- * through. The app MUST NEVER write here. Memory is read **only** from these
- * home dirs — never from the user's project directories.
- */
-export const CLAUDE_HOME = dirname(CLAUDE_PROJECTS_DIR);
-export const CODEX_HOME = dirname(CODEX_SESSIONS_DIR);
-export const JUNIE_HOME = dirname(JUNIE_SESSIONS_DIR);
-/** `~/.copilot` — holds the global `copilot-instructions.md` memory file. */
-export const COPILOT_HOME = dirname(COPILOT_SESSIONS_DIR);
-/**
- * `~/.gemini` — the shared Gemini/Antigravity home, parent of the appDataDirs.
- * Holds Antigravity's global rules (`config/agents/AGENTS.md`) and `GEMINI.md`.
- */
-export const ANTIGRAVITY_HOME = dirname(ANTIGRAVITY_CLI_DIR);
+// NOTE: the READ-ONLY agent source dirs (CLAUDE_PROJECTS_DIR & co), the derived
+// *_HOME memory dirs, and REINDEX_INTERVAL_MS moved to settings.ts as runtime
+// getters — they resolve env > settings.json > default PER CALL, so the web
+// UI's Settings page can change them without a process restart. The consts
+// remaining here are infra frozen at boot (port, state paths, intervals wired
+// to boot-time timers).
 
 /** Whether to auto-open the default browser on startup (set by the launcher). */
 export const OPEN_BROWSER = process.env.OPEN_BROWSER === '1';
-
-/**
- * How often (ms) to auto-reindex so live/new sessions show up without a
- * restart. Each poll just stats files and bails when nothing changed, so the
- * cost is negligible. Set REINDEX_INTERVAL_MS=0 to disable. Default 15s.
- */
-export const REINDEX_INTERVAL_MS = Number(process.env.REINDEX_INTERVAL_MS ?? 15000);
 
 /**
  * Per-user state directory. Owns everything the app writes (the derived index,

--- a/packages/server/src/connectors/antigravity/antigravity.ts
+++ b/packages/server/src/connectors/antigravity/antigravity.ts
@@ -23,7 +23,8 @@ import { createHash } from 'node:crypto';
 import { existsSync, mkdirSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import type { MemorySource, RawEvent } from '@claudescope/shared';
-import { ANTIGRAVITY_DIRS, ANTIGRAVITY_SOURCE_DIR, CLAUDESCOPE_HOME } from '../../config.js';
+import { CLAUDESCOPE_HOME } from '../../config.js';
+import { antigravityDirs, antigravitySourceDir } from '../../settings.js';
 import { sqlString } from '../../db/duckdb.js';
 import type { SessionData, SubagentSource } from '../../data/session-loader.js';
 import type { AgentConnector, AuxProjections, DiscoveredFile } from '../types.js';
@@ -48,7 +49,7 @@ function cachePath(filePath: string): string {
 /** Every transcript across both Antigravity appDataDirs. */
 function discover(): DiscoveredFile[] {
   const out: DiscoveredFile[] = [];
-  for (const dir of ANTIGRAVITY_DIRS) {
+  for (const dir of antigravityDirs()) {
     const transcripts = listTranscripts(dir);
     if (transcripts.length === 0) continue;
     const { subagents } = getContext(dir);
@@ -138,7 +139,10 @@ function globalMemory(): MemorySource[] {
 export const antigravityConnector: AgentConnector = {
   id: 'antigravity',
   label: 'Antigravity',
-  sourceDir: ANTIGRAVITY_SOURCE_DIR,
+  // Resolved per access so a settings.json change applies without a restart.
+  get sourceDir() {
+    return antigravitySourceDir();
+  },
   discover,
   prepare,
   eventsProjectionSql,

--- a/packages/server/src/connectors/antigravity/memory.ts
+++ b/packages/server/src/connectors/antigravity/memory.ts
@@ -15,7 +15,7 @@
 import { readFileSync, statSync } from 'node:fs';
 import { join } from 'node:path';
 import type { MemorySource } from '@claudescope/shared';
-import { ANTIGRAVITY_HOME } from '../../config.js';
+import { antigravityHome } from '../../settings.js';
 import { contractHome } from '../../util/paths.js';
 
 /**
@@ -23,9 +23,10 @@ import { contractHome } from '../../util/paths.js';
  * an error.
  */
 export function antigravityGlobalMemory(): MemorySource[] {
+  const home = antigravityHome();
   const candidates: { path: string; title: string }[] = [
-    { path: join(ANTIGRAVITY_HOME, 'config', 'agents', 'AGENTS.md'), title: 'AGENTS.md (global)' },
-    { path: join(ANTIGRAVITY_HOME, 'GEMINI.md'), title: 'GEMINI.md (global)' },
+    { path: join(home, 'config', 'agents', 'AGENTS.md'), title: 'AGENTS.md (global)' },
+    { path: join(home, 'GEMINI.md'), title: 'GEMINI.md (global)' },
   ];
   const out: MemorySource[] = [];
   for (const c of candidates) {

--- a/packages/server/src/connectors/claude-code/claude-code.ts
+++ b/packages/server/src/connectors/claude-code/claude-code.ts
@@ -13,7 +13,7 @@
 import { existsSync, readdirSync, readFileSync, statSync } from 'node:fs';
 import { basename, join } from 'node:path';
 import type { RawEvent } from '@claudescope/shared';
-import { CLAUDE_PROJECTS_DIR } from '../../config.js';
+import { claudeProjectsDir } from '../../settings.js';
 import { sqlString } from '../../db/duckdb.js';
 import type { SessionData, SubagentSource } from '../../data/session-loader.js';
 import type { AgentConnector, AuxProjections, DiscoveredFile } from '../types.js';
@@ -133,7 +133,7 @@ function discover(): DiscoveredFile[] {
     }
   };
 
-  walk(CLAUDE_PROJECTS_DIR);
+  walk(claudeProjectsDir());
   return out;
 }
 
@@ -334,7 +334,10 @@ async function loadSession(sessionId: string, paths: string[]): Promise<SessionD
 export const claudeCodeConnector: AgentConnector = {
   id: 'claude-code',
   label: 'Claude Code',
-  sourceDir: CLAUDE_PROJECTS_DIR,
+  // Resolved per access so a settings.json change applies without a restart.
+  get sourceDir() {
+    return claudeProjectsDir();
+  },
   discover,
   eventsProjectionSql,
   auxProjections,

--- a/packages/server/src/connectors/claude-code/memory.ts
+++ b/packages/server/src/connectors/claude-code/memory.ts
@@ -21,7 +21,7 @@ import { readdirSync, readFileSync, statSync } from 'node:fs';
 import { join } from 'node:path';
 import type { MemorySource } from '@claudescope/shared';
 import type { AgentMemoryDir } from '../types.js';
-import { CLAUDE_HOME, CLAUDE_PROJECTS_DIR } from '../../config.js';
+import { claudeHome, claudeProjectsDir } from '../../settings.js';
 import { contractHome } from '../../util/paths.js';
 
 /**
@@ -120,7 +120,7 @@ function relatedNames(body: string): string[] {
  * `document` source. `[]` when absent, empty, or unreadable.
  */
 export function globalMemory(): MemorySource[] {
-  const path = join(CLAUDE_HOME, 'CLAUDE.md');
+  const path = join(claudeHome(), 'CLAUDE.md');
   try {
     const markdown = readFileSync(path, 'utf8');
     if (!markdown.trim()) return [];
@@ -170,9 +170,10 @@ function readFact(dir: string, fileName: string): MemorySource | null {
  * `originSessionId` (slug as the fallback). `[]` when none exist.
  */
 export function projectMemory(): AgentMemoryDir[] {
+  const projectsDir = claudeProjectsDir();
   let projectDirs: import('node:fs').Dirent[];
   try {
-    projectDirs = readdirSync(CLAUDE_PROJECTS_DIR, { withFileTypes: true });
+    projectDirs = readdirSync(projectsDir, { withFileTypes: true });
   } catch {
     return [];
   }
@@ -180,7 +181,7 @@ export function projectMemory(): AgentMemoryDir[] {
   const dirs: AgentMemoryDir[] = [];
   for (const projectDir of projectDirs) {
     if (!projectDir.isDirectory()) continue;
-    const memDir = join(CLAUDE_PROJECTS_DIR, projectDir.name, 'memory');
+    const memDir = join(projectsDir, projectDir.name, 'memory');
 
     let entries: import('node:fs').Dirent[];
     try {

--- a/packages/server/src/connectors/codex/codex.ts
+++ b/packages/server/src/connectors/codex/codex.ts
@@ -18,7 +18,8 @@
 import { createHash } from 'node:crypto';
 import { mkdirSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
-import { CLAUDESCOPE_HOME, CODEX_SESSIONS_DIR } from '../../config.js';
+import { CLAUDESCOPE_HOME } from '../../config.js';
+import { codexSessionsDir } from '../../settings.js';
 import { sqlString } from '../../db/duckdb.js';
 import type { SessionData, SubagentSource } from '../../data/session-loader.js';
 import type { AgentConnector, AuxProjections, DiscoveredFile } from '../types.js';
@@ -107,7 +108,10 @@ async function loadSession(sessionId: string, paths: string[]): Promise<SessionD
 export const codexConnector: AgentConnector = {
   id: 'codex',
   label: 'Codex',
-  sourceDir: CODEX_SESSIONS_DIR,
+  // Resolved per access so a settings.json change applies without a restart.
+  get sourceDir() {
+    return codexSessionsDir();
+  },
   discover,
   prepare,
   eventsProjectionSql,

--- a/packages/server/src/connectors/codex/memory.ts
+++ b/packages/server/src/connectors/codex/memory.ts
@@ -15,7 +15,7 @@
 import { readFileSync, statSync } from 'node:fs';
 import { join } from 'node:path';
 import type { MemorySource } from '@claudescope/shared';
-import { CODEX_HOME } from '../../config.js';
+import { codexHome } from '../../settings.js';
 import { contractHome } from '../../util/paths.js';
 
 /**
@@ -51,7 +51,7 @@ export function codexGlobalMemory(): MemorySource[] {
   const out: MemorySource[] = [];
 
   // Instruction file first: the user-authored global AGENTS.md.
-  const agents = readSource(join(CODEX_HOME, 'AGENTS.md'), {
+  const agents = readSource(join(codexHome(), 'AGENTS.md'), {
     provenance: 'user-authored',
     kind: 'document',
     title: 'AGENTS.md (global)',
@@ -59,7 +59,7 @@ export function codexGlobalMemory(): MemorySource[] {
   if (agents) out.push(agents);
 
   // Best-effort agent-authored handbook + summary; absent for almost everyone.
-  const memoriesDir = join(CODEX_HOME, 'memories');
+  const memoriesDir = join(codexHome(), 'memories');
   const handbook = readSource(join(memoriesDir, 'MEMORY.md'), {
     provenance: 'agent-authored',
     kind: 'document',

--- a/packages/server/src/connectors/codex/normalize.ts
+++ b/packages/server/src/connectors/codex/normalize.ts
@@ -30,7 +30,7 @@ import type {
   ToolUseBlock,
   UserEvent,
 } from '@claudescope/shared';
-import { CODEX_SESSIONS_DIR } from '../../config.js';
+import { codexSessionsDir } from '../../settings.js';
 import { toolNamesCsv } from '../tool-names.js';
 import { toolErrorCount } from '../tool-errors.js';
 
@@ -113,7 +113,7 @@ export function listRollouts(): RolloutFile[] {
       }
     }
   };
-  walk(CODEX_SESSIONS_DIR);
+  walk(codexSessionsDir());
   return out;
 }
 

--- a/packages/server/src/connectors/copilot/copilot.ts
+++ b/packages/server/src/connectors/copilot/copilot.ts
@@ -17,7 +17,8 @@
 import { createHash } from 'node:crypto';
 import { existsSync, mkdirSync, readdirSync, statSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
-import { CLAUDESCOPE_HOME, COPILOT_SESSIONS_DIR } from '../../config.js';
+import { CLAUDESCOPE_HOME } from '../../config.js';
+import { copilotSessionsDir } from '../../settings.js';
 import { sqlString } from '../../db/duckdb.js';
 import type { SessionData, SubagentSource } from '../../data/session-loader.js';
 import type { AgentConnector, AuxProjections, DiscoveredFile } from '../types.js';
@@ -34,16 +35,17 @@ function cachePath(filePath: string): string {
 
 /** Collect every `<uuid>/events.jsonl` under the Copilot session-state dir. */
 function discover(): DiscoveredFile[] {
+  const sessionsDir = copilotSessionsDir(); // resolve once per pass
   const out: DiscoveredFile[] = [];
   let dirs: import('node:fs').Dirent[];
   try {
-    dirs = readdirSync(COPILOT_SESSIONS_DIR, { withFileTypes: true });
+    dirs = readdirSync(sessionsDir, { withFileTypes: true });
   } catch {
     return out; // no Copilot install
   }
   for (const dir of dirs) {
     if (!dir.isDirectory()) continue;
-    const full = join(COPILOT_SESSIONS_DIR, dir.name, 'events.jsonl');
+    const full = join(sessionsDir, dir.name, 'events.jsonl');
     try {
       const st = statSync(full);
       out.push({ path: full, mtimeMs: Math.floor(st.mtimeMs), size: st.size });
@@ -116,7 +118,10 @@ async function loadSession(_sessionId: string, paths: string[]): Promise<Session
 export const copilotConnector: AgentConnector = {
   id: 'copilot',
   label: 'GitHub Copilot CLI',
-  sourceDir: COPILOT_SESSIONS_DIR,
+  // Resolved per access so a settings.json change applies without a restart.
+  get sourceDir() {
+    return copilotSessionsDir();
+  },
   discover,
   prepare,
   eventsProjectionSql,

--- a/packages/server/src/connectors/copilot/memory.ts
+++ b/packages/server/src/connectors/copilot/memory.ts
@@ -17,7 +17,7 @@
 import { readFileSync, statSync } from 'node:fs';
 import { join } from 'node:path';
 import type { MemorySource } from '@claudescope/shared';
-import { COPILOT_HOME } from '../../config.js';
+import { copilotHome } from '../../settings.js';
 import { contractHome } from '../../util/paths.js';
 
 /**
@@ -25,7 +25,7 @@ import { contractHome } from '../../util/paths.js';
  * Absent for most users → `[]`, never an error.
  */
 export function copilotGlobalMemory(): MemorySource[] {
-  const path = join(COPILOT_HOME, 'copilot-instructions.md');
+  const path = join(copilotHome(), 'copilot-instructions.md');
   try {
     const markdown = readFileSync(path, 'utf8');
     if (!markdown.trim()) return [];

--- a/packages/server/src/connectors/grok/grok.ts
+++ b/packages/server/src/connectors/grok/grok.ts
@@ -23,7 +23,8 @@
 import { createHash } from 'node:crypto';
 import { existsSync, mkdirSync, readdirSync, statSync, writeFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
-import { CLAUDESCOPE_HOME, GROK_SESSIONS_DIR } from '../../config.js';
+import { CLAUDESCOPE_HOME } from '../../config.js';
+import { grokSessionsDir } from '../../settings.js';
 import { sqlString } from '../../db/duckdb.js';
 import type { SessionData, SubagentSource } from '../../data/session-loader.js';
 import type { AgentConnector, AuxProjections, DiscoveredFile } from '../types.js';
@@ -73,10 +74,11 @@ function foldedStat(chatPath: string): Pick<DiscoveredFile, 'mtimeMs' | 'size'> 
  * `prompt_history.jsonl`, and the session dir's other files by construction.
  */
 function discover(): DiscoveredFile[] {
+  const sessionsDir = grokSessionsDir(); // resolve once per pass
   const out: DiscoveredFile[] = [];
   let cwdDirs: import('node:fs').Dirent[];
   try {
-    cwdDirs = readdirSync(GROK_SESSIONS_DIR, { withFileTypes: true });
+    cwdDirs = readdirSync(sessionsDir, { withFileTypes: true });
   } catch {
     return out; // no Grok install
   }
@@ -84,13 +86,13 @@ function discover(): DiscoveredFile[] {
     if (!cwdDir.isDirectory()) continue;
     let sessionDirs: import('node:fs').Dirent[];
     try {
-      sessionDirs = readdirSync(join(GROK_SESSIONS_DIR, cwdDir.name), { withFileTypes: true });
+      sessionDirs = readdirSync(join(sessionsDir, cwdDir.name), { withFileTypes: true });
     } catch {
       continue;
     }
     for (const sessionDir of sessionDirs) {
       if (!sessionDir.isDirectory()) continue;
-      const chatPath = join(GROK_SESSIONS_DIR, cwdDir.name, sessionDir.name, 'chat_history.jsonl');
+      const chatPath = join(sessionsDir, cwdDir.name, sessionDir.name, 'chat_history.jsonl');
       const st = foldedStat(chatPath);
       if (st) out.push({ path: chatPath, ...st });
     }
@@ -182,7 +184,10 @@ async function loadSession(_sessionId: string, paths: string[]): Promise<Session
 export const grokConnector: AgentConnector = {
   id: 'grok',
   label: 'Grok CLI',
-  sourceDir: GROK_SESSIONS_DIR,
+  // Resolved per access so a settings.json change applies without a restart.
+  get sourceDir() {
+    return grokSessionsDir();
+  },
   discover,
   prepare,
   eventsProjectionSql,

--- a/packages/server/src/connectors/junie/junie.ts
+++ b/packages/server/src/connectors/junie/junie.ts
@@ -15,7 +15,8 @@ import { createHash } from 'node:crypto';
 import { existsSync, mkdirSync, readFileSync, statSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import type { MemorySource } from '@claudescope/shared';
-import { CLAUDESCOPE_HOME, JUNIE_HOME, JUNIE_SESSIONS_DIR } from '../../config.js';
+import { CLAUDESCOPE_HOME } from '../../config.js';
+import { junieHome, junieSessionsDir } from '../../settings.js';
 import { contractHome } from '../../util/paths.js';
 import { sqlString } from '../../db/duckdb.js';
 import type { SessionData } from '../../data/session-loader.js';
@@ -36,7 +37,8 @@ function cachePath(filePath: string): string {
  * mirrors how Junie itself enumerates sessions and skips stray subdirectories.
  */
 function discover(): DiscoveredFile[] {
-  const indexPath = join(JUNIE_SESSIONS_DIR, 'index.jsonl');
+  const sessionsDir = junieSessionsDir(); // resolve once per pass
+  const indexPath = join(sessionsDir, 'index.jsonl');
   let raw: string;
   try {
     raw = readFileSync(indexPath, 'utf8');
@@ -54,10 +56,10 @@ function discover(): DiscoveredFile[] {
       continue;
     }
     // sessionId is used to build a filesystem path, so reject anything from a
-    // poisoned index.jsonl that could escape JUNIE_SESSIONS_DIR (separators or a
+    // poisoned index.jsonl that could escape the sessions dir (separators or a
     // traversal segment). Real Junie ids are a single plain `session-…` segment.
     if (!sessionId || /[/\\]/.test(sessionId) || sessionId === '.' || sessionId === '..') continue;
-    const full = join(JUNIE_SESSIONS_DIR, sessionId, 'events.jsonl');
+    const full = join(sessionsDir, sessionId, 'events.jsonl');
     try {
       const st = statSync(full);
       out.push({ path: full, mtimeMs: Math.floor(st.mtimeMs), size: st.size });
@@ -120,7 +122,7 @@ async function loadSession(_sessionId: string, paths: string[]): Promise<Session
  * `projectMemory`. Returns `[]` when the file is absent.
  */
 function globalMemory(): MemorySource[] {
-  const agentsPath = join(JUNIE_HOME, 'AGENTS.md');
+  const agentsPath = join(junieHome(), 'AGENTS.md');
   try {
     const markdown = readFileSync(agentsPath, 'utf8');
     if (!markdown.trim()) return []; // empty file → no memory
@@ -142,7 +144,10 @@ function globalMemory(): MemorySource[] {
 export const junieConnector: AgentConnector = {
   id: 'junie',
   label: 'Junie',
-  sourceDir: JUNIE_SESSIONS_DIR,
+  // Resolved per access so a settings.json change applies without a restart.
+  get sourceDir() {
+    return junieSessionsDir();
+  },
   discover,
   prepare,
   eventsProjectionSql,

--- a/packages/server/src/connectors/junie/normalize.ts
+++ b/packages/server/src/connectors/junie/normalize.ts
@@ -33,7 +33,7 @@ import type {
   MessageUsage,
   UserEvent,
 } from '@claudescope/shared';
-import { JUNIE_HOME } from '../../config.js';
+import { junieHome } from '../../settings.js';
 import { resolveImageWithin } from '../safe-image.js';
 import { toolNamesCsv } from '../tool-names.js';
 
@@ -90,7 +90,7 @@ interface StepAgg {
  * dir — the only tree this connector is ever allowed to read.
  */
 function imageBlockFromPath(path: string): ImageBlock | null {
-  return resolveImageWithin(JUNIE_HOME, path);
+  return resolveImageWithin(junieHome(), path);
 }
 
 /** Image blocks for a UserPromptEvent's string-path attachments (objects skipped). */

--- a/packages/server/src/connectors/opencode/opencode.ts
+++ b/packages/server/src/connectors/opencode/opencode.ts
@@ -16,7 +16,8 @@
 import { createHash } from 'node:crypto';
 import { existsSync, mkdirSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
-import { CLAUDESCOPE_HOME, OPENCODE_DATA_DIR, OPENCODE_DB_PATH } from '../../config.js';
+import { CLAUDESCOPE_HOME } from '../../config.js';
+import { opencodeDataDir, opencodeDbPath } from '../../settings.js';
 import { sqlString } from '../../db/duckdb.js';
 import type { SessionData, SubagentSource } from '../../data/session-loader.js';
 import type { AgentConnector, AuxProjections, DiscoveredFile } from '../types.js';
@@ -27,9 +28,6 @@ const CACHE_DIR = join(CLAUDESCOPE_HOME, 'cache', 'opencode');
 
 /** Synthetic per-session key → its DB path + session id. opencode ids are
  *  `ses_<base62>` (no `#`), so splitting on the first `#` is unambiguous. */
-function makeKey(sessionId: string): string {
-  return `${OPENCODE_DB_PATH}#${sessionId}`;
-}
 function parseKey(filePath: string): { dbPath: string; sessionId: string } {
   const i = filePath.indexOf('#');
   return i === -1
@@ -51,8 +49,9 @@ function cachePath(filePath: string): string {
  * connector and preserves its prior files — see `data/index.ts`).
  */
 function discover(): DiscoveredFile[] {
-  return listSessions(OPENCODE_DB_PATH).map((s) => ({
-    path: makeKey(s.id),
+  const dbPath = opencodeDbPath(); // resolve once per pass
+  return listSessions(dbPath).map((s) => ({
+    path: `${dbPath}#${s.id}`,
     mtimeMs: s.mtimeMs,
     size: s.size,
   }));
@@ -139,7 +138,10 @@ async function loadSession(sessionId: string, paths: string[]): Promise<SessionD
 export const opencodeConnector: AgentConnector = {
   id: 'opencode',
   label: 'opencode',
-  sourceDir: OPENCODE_DATA_DIR,
+  // Resolved per access so a settings.json change applies without a restart.
+  get sourceDir() {
+    return opencodeDataDir();
+  },
   discover,
   prepare,
   eventsProjectionSql,

--- a/packages/server/src/connectors/pi/pi.ts
+++ b/packages/server/src/connectors/pi/pi.ts
@@ -21,7 +21,8 @@
 import { createHash } from 'node:crypto';
 import { mkdirSync, readdirSync, statSync, writeFileSync } from 'node:fs';
 import { basename, dirname, join } from 'node:path';
-import { CLAUDESCOPE_HOME, PI_SESSIONS_DIR } from '../../config.js';
+import { CLAUDESCOPE_HOME } from '../../config.js';
+import { piSessionsDir } from '../../settings.js';
 import { sqlString } from '../../db/duckdb.js';
 import type { SessionData, SubagentSource } from '../../data/session-loader.js';
 import type { AgentConnector, AuxProjections, DiscoveredFile } from '../types.js';
@@ -66,7 +67,7 @@ function discover(): DiscoveredFile[] {
       }
     }
   };
-  walk(PI_SESSIONS_DIR);
+  walk(piSessionsDir());
   return out;
 }
 
@@ -146,7 +147,10 @@ async function loadSession(_sessionId: string, paths: string[]): Promise<Session
 export const piConnector: AgentConnector = {
   id: 'pi',
   label: 'pi',
-  sourceDir: PI_SESSIONS_DIR,
+  // Resolved per access so a settings.json change applies without a restart.
+  get sourceDir() {
+    return piSessionsDir();
+  },
   discover,
   prepare,
   eventsProjectionSql,

--- a/packages/server/src/data/index.ts
+++ b/packages/server/src/data/index.ts
@@ -17,7 +17,7 @@
 
 import type { DuckDBConnection } from '@duckdb/node-api';
 import type { IndexingProgress, PricingConfig, ReindexResponse } from '@claudescope/shared';
-import { getConnection, queryRows, sqlString } from '../db/duckdb.js';
+import { closeConnection, discardDbFiles, getConnection, queryRows, sqlString } from '../db/duckdb.js';
 import { connectors } from '../connectors/registry.js';
 import type { AgentConnector, DiscoveredFile } from '../connectors/types.js';
 import { loadPricing } from './pricing.js';
@@ -48,6 +48,27 @@ export function isIndexReady(): boolean {
 /** Whether a reindex pass is currently running (self-restart defers on it). */
 export function isReindexInFlight(): boolean {
   return inFlight !== null;
+}
+
+/** True while an explicit discard-and-rebuild is running (see {@link rebuildIndex}). */
+let rebuilding = false;
+export function isRebuildInFlight(): boolean {
+  return rebuilding;
+}
+
+/** Bookkeeping for the last completed pass (surfaced on the indexer status). */
+let lastPass: ReindexResponse | null = null;
+let lastPassAt: string | null = null;
+export function getLastPass(): ReindexResponse | null {
+  return lastPass;
+}
+export function getLastPassAt(): string | null {
+  return lastPassAt;
+}
+function stampLastPass(res: ReindexResponse): ReindexResponse {
+  lastPass = res;
+  lastPassAt = new Date().toISOString();
+  return res;
 }
 
 export function getIndexProgress(): IndexingProgress | null {
@@ -410,11 +431,50 @@ async function rebuildFtsIndex(conn: DuckDBConnection): Promise<void> {
  */
 export async function reindex(): Promise<ReindexResponse> {
   if (inFlight) return inFlight;
-  inFlight = doReindex();
+  const pass = doReindex().then(stampLastPass);
+  inFlight = pass;
   try {
-    return await inFlight;
+    return await pass;
   } finally {
-    inFlight = null;
+    // Only clear our own slot: rebuildIndex may have replaced it while this
+    // pass was still draining, and clobbering that would let a new pass run
+    // concurrently with the rebuild.
+    if (inFlight === pass) inFlight = null;
+  }
+}
+
+/**
+ * Discard the DuckDB file and rebuild the index from scratch (the danger-zone
+ * "Rebuild index" action). Runs through the same {@link inFlight} slot as
+ * {@link reindex}, so a poller tick during the rebuild coalesces onto it
+ * instead of racing the closed connection. Also re-prices all history at the
+ * current pricing, since every event is re-stamped at load time.
+ */
+export async function rebuildIndex(): Promise<ReindexResponse> {
+  // Already rebuilding → join the in-flight rebuild.
+  if (rebuilding && inFlight) return inFlight;
+  const prior = inFlight;
+  const run = (async (): Promise<ReindexResponse> => {
+    // Let any in-flight pass drain first — passes are uninterruptible and we
+    // must not close the connection underneath one.
+    if (prior) await prior.catch(() => {});
+    rebuilding = true;
+    ready = false; // health flips to "building"; the web building UX takes over
+    try {
+      await closeConnection();
+      discardDbFiles();
+      await getConnection();
+      // Empty `files` table ⇒ doReindex reloads everything from the sources.
+      return stampLastPass(await doReindex());
+    } finally {
+      rebuilding = false;
+    }
+  })();
+  inFlight = run;
+  try {
+    return await run;
+  } finally {
+    if (inFlight === run) inFlight = null;
   }
 }
 

--- a/packages/server/src/data/index.ts
+++ b/packages/server/src/data/index.ts
@@ -454,11 +454,14 @@ export async function rebuildIndex(): Promise<ReindexResponse> {
   // Already rebuilding → join the in-flight rebuild.
   if (rebuilding && inFlight) return inFlight;
   const prior = inFlight;
+  // Set synchronously — before the prior pass drains — so a second rebuild
+  // request during the drain window 409s instead of queueing a redundant
+  // second discard-and-rebuild.
+  rebuilding = true;
   const run = (async (): Promise<ReindexResponse> => {
     // Let any in-flight pass drain first — passes are uninterruptible and we
     // must not close the connection underneath one.
     if (prior) await prior.catch(() => {});
-    rebuilding = true;
     ready = false; // health flips to "building"; the web building UX takes over
     try {
       await closeConnection();

--- a/packages/server/src/db/duckdb.ts
+++ b/packages/server/src/db/duckdb.ts
@@ -79,8 +79,10 @@ async function openAndPrepare(): Promise<{ conn: DuckDBConnection; inst: DuckDBI
   return { conn, inst };
 }
 
-/** Delete the persistent DB file and its WAL/temp siblings. */
-function discardCorruptDb(): void {
+/** Delete the persistent DB file and its WAL/temp siblings. Used by the
+ *  corrupt-open recovery below and by the explicit rebuild-index action —
+ *  callers must {@link closeConnection} first to release the file lock. */
+export function discardDbFiles(): void {
   for (const suffix of ['', '.wal', '.tmp']) {
     rmSync(`${DUCKDB_PATH}${suffix}`, { force: true, recursive: true });
   }
@@ -110,7 +112,7 @@ export async function getConnection(): Promise<DuckDBConnection> {
         `[duckdb] failed to open index at ${DUCKDB_PATH}; discarding and rebuilding. Cause:`,
         err instanceof Error ? err.message : err,
       );
-      discardCorruptDb();
+      discardDbFiles();
       opened = await openAndPrepare();
     }
     connection = opened.conn;

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -9,16 +9,15 @@ import fastifyStatic from '@fastify/static';
 import type { FetchedPricing } from '@claudescope/shared';
 import {
   APP_VERSION,
-  CLAUDE_PROJECTS_DIR,
   FETCHED_PRICING_PATH,
   OPEN_BROWSER,
   PORT,
   PRICING_REFRESH_INTERVAL_MS,
-  REINDEX_INTERVAL_MS,
   SELF_RESTART_INTERVAL_MS,
   WEB_DIST_DIR,
   ensureStateDir,
 } from './config.js';
+import { claudeProjectsDir, reindexIntervalMs } from './settings.js';
 import { registerRoutes } from './routes/index.js';
 import { registerHostGuard, registerSecurityHeaders } from './security.js';
 import { reindex } from './data/index.js';
@@ -73,7 +72,7 @@ async function main(): Promise<void> {
   // Auto-reindex on an interval so live/new sessions appear without a restart.
   // Each poll stats files and returns immediately when nothing changed, so it's
   // cheap; only log when work was actually done.
-  if (REINDEX_INTERVAL_MS > 0) {
+  if (reindexIntervalMs() > 0) {
     const timer = setInterval(() => {
       reindex()
         .then((res) => {
@@ -88,7 +87,7 @@ async function main(): Promise<void> {
         // existing index — so warn rather than error (avoids error-level spam
         // every interval when, e.g., a single file is briefly unreadable).
         .catch((err) => app.log.warn({ err }, 'auto-reindex failed'));
-    }, REINDEX_INTERVAL_MS);
+    }, reindexIntervalMs());
     timer.unref(); // don't keep the process alive solely for the timer
     app.addHook('onClose', async () => clearInterval(timer));
   }
@@ -158,9 +157,9 @@ async function main(): Promise<void> {
   }
 
   const servesWeb = existsSync(WEB_DIST_DIR);
-  if (!existsSync(CLAUDE_PROJECTS_DIR)) {
+  if (!existsSync(claudeProjectsDir())) {
     app.log.warn(
-      `sessions directory not found: ${CLAUDE_PROJECTS_DIR} — the app will be empty. ` +
+      `sessions directory not found: ${claudeProjectsDir()} — the app will be empty. ` +
         'Set CLAUDE_PROJECTS_DIR to point at your Claude Code transcripts.',
     );
   }
@@ -173,7 +172,7 @@ async function main(): Promise<void> {
     '\n' +
       `  Claudescope v${APP_VERSION}\n` +
       `  ▸ URL:      ${url}\n` +
-      `  ▸ Sessions: ${CLAUDE_PROJECTS_DIR} (read-only)\n` +
+      `  ▸ Sessions: ${claudeProjectsDir()} (read-only)\n` +
       (servesWeb ? '' : '  ▸ Note:     web build not found — run `npm run build` to serve the UI\n'),
   );
 

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -17,10 +17,10 @@ import {
   WEB_DIST_DIR,
   ensureStateDir,
 } from './config.js';
-import { claudeProjectsDir, reindexIntervalMs } from './settings.js';
+import { claudeProjectsDir } from './settings.js';
 import { registerRoutes } from './routes/index.js';
 import { registerHostGuard, registerSecurityHeaders } from './security.js';
-import { reindex } from './data/index.js';
+import { startIndexer, stopIndexerTimer } from './indexer-lifecycle.js';
 import { refreshPricing } from './data/pricing-refresh.js';
 import { maybeSelfRestart } from './self-restart.js';
 import { refreshLatestVersion } from './update-check.js';
@@ -58,39 +58,11 @@ async function main(): Promise<void> {
 
   await registerRoutes(app);
 
-  // Kick off an initial (incremental) index build in the background so the
-  // server can accept connections immediately. /api/health reports readiness.
-  reindex()
-    .then((res) =>
-      app.log.info(
-        { reindexed: res.reindexed, durationMs: res.durationMs },
-        'initial index build complete',
-      ),
-    )
-    .catch((err) => app.log.error({ err }, 'initial index build failed'));
-
-  // Auto-reindex on an interval so live/new sessions appear without a restart.
-  // Each poll stats files and returns immediately when nothing changed, so it's
-  // cheap; only log when work was actually done.
-  if (reindexIntervalMs() > 0) {
-    const timer = setInterval(() => {
-      reindex()
-        .then((res) => {
-          if (res.reindexed > 0) {
-            app.log.info(
-              { reindexed: res.reindexed, durationMs: res.durationMs },
-              'auto-reindex picked up changes',
-            );
-          }
-        })
-        // A background poll failing is non-fatal — the server keeps serving the
-        // existing index — so warn rather than error (avoids error-level spam
-        // every interval when, e.g., a single file is briefly unreadable).
-        .catch((err) => app.log.warn({ err }, 'auto-reindex failed'));
-    }, reindexIntervalMs());
-    timer.unref(); // don't keep the process alive solely for the timer
-    app.addHook('onClose', async () => clearInterval(timer));
-  }
+  // Kick the initial background build and arm the auto-reindex poller. The
+  // indexer-lifecycle module owns both so the Settings page can pause/resume/
+  // restart indexing and re-arm the interval at runtime.
+  startIndexer(app.log);
+  app.addHook('onClose', async () => stopIndexerTimer());
 
   // Auto-refresh pricing from LiteLLM: once at boot when the snapshot is
   // missing/stale (>24h), then on an interval so long-running daemons track new

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -19,7 +19,7 @@ import {
 } from './config.js';
 import { claudeProjectsDir } from './settings.js';
 import { registerRoutes } from './routes/index.js';
-import { registerHostGuard, registerSecurityHeaders } from './security.js';
+import { registerHostGuard, registerMutationGuard, registerSecurityHeaders } from './security.js';
 import { startIndexer, stopIndexerTimer } from './indexer-lifecycle.js';
 import { refreshPricing } from './data/pricing-refresh.js';
 import { maybeSelfRestart } from './self-restart.js';
@@ -52,8 +52,10 @@ async function main(): Promise<void> {
   const app = Fastify({ logger: true });
 
   // Reject non-loopback Host headers (anti DNS-rebinding) before anything routes,
-  // and lock down what the served SPA may load (CSP). See security.ts.
+  // block cross-origin mutations (CSRF), and lock down what the served SPA may
+  // load (CSP). See security.ts.
   registerHostGuard(app);
+  registerMutationGuard(app);
   registerSecurityHeaders(app);
 
   await registerRoutes(app);

--- a/packages/server/src/indexer-lifecycle.ts
+++ b/packages/server/src/indexer-lifecycle.ts
@@ -1,0 +1,147 @@
+/**
+ * Indexer lifecycle: owns the auto-reindex poller and the runtime pause state.
+ *
+ * "Stop / Start / Restart" in the web UI control THIS — the background indexing
+ * engine — never the HTTP server (which stays terminal-only via `claudescope
+ * stop`). Pausing disarms the poller; the index stays fully queryable as a
+ * frozen snapshot, and an in-flight pass always drains (passes are
+ * uninterruptible by design). The pause flag is runtime-only — deliberately
+ * not persisted — so a fresh process always starts indexing.
+ */
+
+import type { FastifyBaseLogger } from 'fastify';
+import type { IndexerStatus, ReindexResponse } from '@claudescope/shared';
+import {
+  getLastPass,
+  getLastPassAt,
+  isIndexReady,
+  isRebuildInFlight,
+  isReindexInFlight,
+  reindex,
+} from './data/index.js';
+import { reindexIntervalMs } from './settings.js';
+
+let timer: NodeJS.Timeout | null = null;
+let paused = false;
+let log: FastifyBaseLogger | Console = console;
+
+function disarmTimer(): void {
+  if (timer) {
+    clearInterval(timer);
+    timer = null;
+  }
+}
+
+/** (Re-)arm the poller from the CURRENT effective interval. No-op while paused
+ *  or when the interval is 0 (auto-reindex disabled). */
+export function rearmTimer(): void {
+  disarmTimer();
+  const interval = reindexIntervalMs();
+  if (paused || interval <= 0) return;
+  timer = setInterval(() => {
+    reindex()
+      .then((res) => {
+        if (res.reindexed > 0) {
+          log.info(
+            { reindexed: res.reindexed, durationMs: res.durationMs },
+            'auto-reindex picked up changes',
+          );
+        }
+      })
+      // A background poll failing is non-fatal — the server keeps serving the
+      // existing index — so warn rather than error (avoids error-level spam
+      // every interval when, e.g., a single file is briefly unreadable).
+      .catch((err) => log.warn({ err }, 'auto-reindex failed'));
+  }, interval);
+  timer.unref(); // don't keep the process alive solely for the timer
+}
+
+/** Boot: kick the initial (incremental) build in the background so the server
+ *  accepts connections immediately, then arm the poller. */
+export function startIndexer(logger: FastifyBaseLogger): void {
+  log = logger;
+  reindex()
+    .then((res) =>
+      log.info(
+        { reindexed: res.reindexed, durationMs: res.durationMs },
+        'initial index build complete',
+      ),
+    )
+    .catch((err) => log.error({ err }, 'initial index build failed'));
+  rearmTimer();
+}
+
+/** Shutdown hook: stop the poller (in-flight passes drain on their own). */
+export function stopIndexerTimer(): void {
+  disarmTimer();
+}
+
+export function getIndexerStatus(): IndexerStatus {
+  const state = !isIndexReady()
+    ? 'building'
+    : isReindexInFlight()
+      ? 'indexing'
+      : paused
+        ? 'paused'
+        : 'watching';
+  return {
+    state,
+    paused,
+    intervalMs: reindexIntervalMs(),
+    lastPassAt: getLastPassAt(),
+    lastPass: getLastPass(),
+    rebuilding: isRebuildInFlight(),
+  };
+}
+
+/**
+ * Guarantee a pass STARTS after this call. A pass already in flight may have
+ * run discovery with pre-change settings, so joining it is not enough — drain
+ * it, then run one more. This is what makes "save new source dir → sessions
+ * appear" deterministic instead of next-poll-lucky.
+ */
+export async function requestPass(): Promise<ReindexResponse> {
+  if (isReindexInFlight()) await reindex().catch(() => {});
+  return reindex();
+}
+
+/** Stop auto-indexing (the UI's Stop). Takes effect after any in-flight pass. */
+export function pauseIndexing(): IndexerStatus {
+  paused = true;
+  disarmTimer();
+  return getIndexerStatus();
+}
+
+/** Resume auto-indexing (the UI's Start) and kick an immediate pass. */
+export async function resumeIndexing(): Promise<IndexerStatus> {
+  paused = false;
+  rearmTimer();
+  if (isIndexReady()) {
+    await requestPass();
+  } else {
+    // Initial build still running — it IS the immediate pass; don't block the
+    // response on a potentially long build.
+    void reindex().catch(() => {});
+  }
+  return getIndexerStatus();
+}
+
+/** Restart indexing: clear pause, run a fresh pass now, re-arm the poller. */
+export async function restartIndexing(): Promise<IndexerStatus> {
+  paused = false;
+  disarmTimer();
+  try {
+    if (isIndexReady()) await requestPass();
+    else void reindex().catch(() => {});
+  } finally {
+    rearmTimer();
+  }
+  return getIndexerStatus();
+}
+
+/** Test seam: reset runtime state between suites. */
+export function resetIndexerLifecycle(): void {
+  disarmTimer();
+  paused = false;
+  log = console;
+}

--- a/packages/server/src/indexer-lifecycle.ts
+++ b/packages/server/src/indexer-lifecycle.ts
@@ -36,7 +36,9 @@ function disarmTimer(): void {
  *  or when the interval is 0 (auto-reindex disabled). */
 export function rearmTimer(): void {
   disarmTimer();
-  const interval = reindexIntervalMs();
+  // Clamp defensively: Node treats setInterval delays over 2^31-1 as 1ms
+  // (validation rejects such values, but an env var can still carry one).
+  const interval = Math.min(reindexIntervalMs(), 2_147_483_647);
   if (paused || interval <= 0) return;
   timer = setInterval(() => {
     reindex()

--- a/packages/server/src/install-method.ts
+++ b/packages/server/src/install-method.ts
@@ -1,0 +1,47 @@
+/**
+ * Install-method detection, shared by the CLI (`update` defers to brew/nix)
+ * and the server (`GET /api/system` shows the right upgrade command). Both
+ * bundles (`cli.js`, `server.js`) are siblings in the published package, so
+ * resolving from this module's own dir classifies either identically.
+ */
+
+import { realpathSync } from 'node:fs';
+import { dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { PKG } from './update-check.js';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+export type InstallMethod = 'brew' | 'nix' | 'npm';
+
+/** Classify how this package was installed from where its bundle resides.
+ *  Homebrew symlinks the bin out of the Cellar's libexec (realpath resolves it
+ *  back); Nix installs under /nix/store; everything else (npm global, npx) is
+ *  treated as npm. */
+export function detectInstallMethod(): InstallMethod {
+  let p = __dirname;
+  try {
+    p = realpathSync(__dirname);
+  } catch {
+    /* keep __dirname if the path can't be resolved */
+  }
+  if (p.includes('/nix/store/')) return 'nix';
+  // Match the formula's Cellar dir specifically (…/Cellar/claudescope/<version>/…),
+  // not a generic "homebrew" — a plain `npm i -g` under Homebrew's own Node lives
+  // at …/homebrew/lib/node_modules/… and must NOT be mistaken for a brew install.
+  if (/[\\/]Cellar[\\/]claudescope[\\/]/.test(p)) return 'brew';
+  return 'npm';
+}
+
+/** The exact upgrade command for an install method (shown, never executed by
+ *  the server — updates stay terminal-driven). */
+export function updateCommandFor(method: InstallMethod): string {
+  switch (method) {
+    case 'brew':
+      return 'brew upgrade vladar107/tap/claudescope';
+    case 'nix':
+      return 'nix profile upgrade claudescope';
+    default:
+      return `npm install -g ${PKG}@latest`;
+  }
+}

--- a/packages/server/src/routes/index.ts
+++ b/packages/server/src/routes/index.ts
@@ -23,6 +23,10 @@ import { registerErrorsRoute } from './analytics-errors.js';
 import { registerDigestRoute } from './analytics-digest.js';
 import { registerSourcesRoute } from './sources.js';
 import { registerMemoryRoute } from './memory.js';
+import { registerSettingsRoute } from './settings.js';
+import { registerIndexerRoutes } from './indexer.js';
+import { registerPricingRoute } from './pricing.js';
+import { registerSystemRoute } from './system.js';
 
 export async function registerRoutes(app: FastifyInstance): Promise<void> {
   app.get('/api/health', async (): Promise<HealthResponse> => {
@@ -53,6 +57,10 @@ export async function registerRoutes(app: FastifyInstance): Promise<void> {
   await registerDigestRoute(app);
   await registerSourcesRoute(app);
   await registerMemoryRoute(app);
+  await registerSettingsRoute(app);
+  await registerIndexerRoutes(app);
+  await registerPricingRoute(app);
+  await registerSystemRoute(app);
 
   app.post('/api/reindex', async (): Promise<ReindexResponse> => {
     return reindex();

--- a/packages/server/src/routes/index.ts
+++ b/packages/server/src/routes/index.ts
@@ -8,6 +8,7 @@ import type { FastifyInstance } from 'fastify';
 import type { HealthResponse, ReindexResponse } from '@claudescope/shared';
 import { APP_VERSION } from '../config.js';
 import { getDataVersion, getIndexProgress, isIndexReady, reindex } from '../data/index.js';
+import { getIndexerStatus } from '../indexer-lifecycle.js';
 import { updateAvailable } from '../update-check.js';
 import { registerProjectsRoute } from './projects.js';
 import { registerSessionsRoutes } from './sessions.js';
@@ -27,6 +28,7 @@ export async function registerRoutes(app: FastifyInstance): Promise<void> {
   app.get('/api/health', async (): Promise<HealthResponse> => {
     const indexing = getIndexProgress();
     const latest = updateAvailable();
+    const { state, paused, intervalMs } = getIndexerStatus();
     return {
       status: 'ok',
       version: APP_VERSION,
@@ -34,6 +36,7 @@ export async function registerRoutes(app: FastifyInstance): Promise<void> {
       dataVersion: getDataVersion(),
       ...(indexing ? { indexing } : {}),
       ...(latest ? { updateAvailable: latest } : {}),
+      indexer: { state, paused, intervalMs },
     };
   });
 

--- a/packages/server/src/routes/indexer.ts
+++ b/packages/server/src/routes/indexer.ts
@@ -1,0 +1,32 @@
+/**
+ * Indexer lifecycle actions. These control the background indexing engine —
+ * the reindex poller + DuckDB ingest — never the HTTP process (which is
+ * stopped from the terminal only). All responses carry the fresh
+ * {@link IndexerStatus} so the UI updates without a second round-trip.
+ */
+
+import type { FastifyInstance } from 'fastify';
+import type { IndexerStatus, RebuildStartedResponse } from '@claudescope/shared';
+import { isRebuildInFlight, rebuildIndex } from '../data/index.js';
+import { pauseIndexing, restartIndexing, resumeIndexing } from '../indexer-lifecycle.js';
+
+export async function registerIndexerRoutes(app: FastifyInstance): Promise<void> {
+  app.post('/api/indexer/stop', async (): Promise<IndexerStatus> => pauseIndexing());
+
+  app.post('/api/indexer/start', async (): Promise<IndexerStatus> => resumeIndexing());
+
+  app.post('/api/indexer/restart', async (): Promise<IndexerStatus> => restartIndexing());
+
+  // Danger zone: discard the DuckDB file and rebuild from the sources. 202 —
+  // the rebuild runs in the background and progress rides the existing
+  // /api/health building UX (ready=false + indexing progress).
+  app.post('/api/index/rebuild', async (_req, reply): Promise<RebuildStartedResponse | undefined> => {
+    if (isRebuildInFlight()) {
+      void reply.code(409).send({ error: 'a rebuild is already in progress' });
+      return;
+    }
+    rebuildIndex().catch((err) => app.log.error({ err }, 'index rebuild failed'));
+    void reply.code(202);
+    return { started: true };
+  });
+}

--- a/packages/server/src/routes/indexer.ts
+++ b/packages/server/src/routes/indexer.ts
@@ -7,7 +7,7 @@
 
 import type { FastifyInstance } from 'fastify';
 import type { IndexerStatus, RebuildStartedResponse } from '@claudescope/shared';
-import { isRebuildInFlight, rebuildIndex } from '../data/index.js';
+import { isRebuildInFlight, rebuildIndex, reindex } from '../data/index.js';
 import { pauseIndexing, restartIndexing, resumeIndexing } from '../indexer-lifecycle.js';
 
 export async function registerIndexerRoutes(app: FastifyInstance): Promise<void> {
@@ -25,7 +25,14 @@ export async function registerIndexerRoutes(app: FastifyInstance): Promise<void>
       void reply.code(409).send({ error: 'a rebuild is already in progress' });
       return;
     }
-    rebuildIndex().catch((err) => app.log.error({ err }, 'index rebuild failed'));
+    rebuildIndex().catch((err) => {
+      app.log.error({ err }, 'index rebuild failed');
+      // Recover: a failed rebuild leaves ready=false, and with the poller
+      // disabled or paused nothing would retry — kick a pass so the app
+      // doesn't wedge in "building" (getConnection's corrupt-DB recovery
+      // handles a half-discarded index).
+      reindex().catch((err2) => app.log.error({ err: err2 }, 'post-rebuild recovery failed'));
+    });
     void reply.code(202);
     return { started: true };
   });

--- a/packages/server/src/routes/pricing.ts
+++ b/packages/server/src/routes/pricing.ts
@@ -1,0 +1,29 @@
+/**
+ * On-demand pricing refresh — the Settings page's "Sync prices now" button.
+ * Same code path as the daily timer and `claudescope pricing update`. New
+ * rates apply prospectively (next reindex); rebuilding the index re-prices
+ * history.
+ */
+
+import type { FastifyInstance } from 'fastify';
+import type { PricingRefreshResponse } from '@claudescope/shared';
+import { refreshPricing } from '../data/pricing-refresh.js';
+import { contractHome } from '../util/paths.js';
+
+export async function registerPricingRoute(app: FastifyInstance): Promise<void> {
+  app.post(
+    '/api/pricing/refresh',
+    async (_req, reply): Promise<PricingRefreshResponse | undefined> => {
+      try {
+        const res = await refreshPricing();
+        return { ...res, path: contractHome(res.path) };
+      } catch (err) {
+        app.log.warn({ err }, 'on-demand pricing refresh failed');
+        void reply
+          .code(502)
+          .send({ error: 'pricing refresh failed — check network access to LiteLLM' });
+        return;
+      }
+    },
+  );
+}

--- a/packages/server/src/routes/settings.ts
+++ b/packages/server/src/routes/settings.ts
@@ -1,0 +1,147 @@
+/**
+ * Settings API: read the effective configuration (with per-key provenance)
+ * and persist edits to `~/.claudescope/settings.json`. Live-applicable
+ * changes take effect immediately — a source-dir change kicks a reindex pass,
+ * an interval change re-arms the poller.
+ */
+
+import { existsSync } from 'node:fs';
+import type { FastifyInstance } from 'fastify';
+import type {
+  EditableSetting,
+  ReadOnlySetting,
+  SettingValue,
+  SettingsResponse,
+  SettingsUpdateRequest,
+  SettingsUpdateResponse,
+} from '@claudescope/shared';
+import {
+  CLAUDESCOPE_HOME,
+  DUCKDB_PATH,
+  FETCHED_PRICING_PATH,
+  PORT,
+  PRICING_PATH,
+} from '../config.js';
+import {
+  SETTING_DEFS,
+  SETTINGS_SCHEMA_VERSION,
+  fileValueOf,
+  resolveSetting,
+  saveSettings,
+  validateSettingsPatch,
+  type SettingKey,
+} from '../settings.js';
+import { rearmTimer, requestPass } from '../indexer-lifecycle.js';
+import { contractHome } from '../util/paths.js';
+
+/** Contract the home dir in path values for display; pass others through. */
+function displayValue(kind: 'path' | 'number' | 'boolean', v: SettingValue): SettingValue {
+  return kind === 'path' && typeof v === 'string' ? contractHome(v) : v;
+}
+
+function buildSettingsResponse(): SettingsResponse {
+  const editable: EditableSetting[] = SETTING_DEFS.map((def) => {
+    const { value, source } = resolveSetting(def.key);
+    const fileValue = fileValueOf(def.key);
+    const row: EditableSetting = {
+      key: def.key,
+      label: def.label,
+      group: def.group,
+      type: def.kind,
+      effective: displayValue(def.kind, value),
+      source,
+      defaultValue: displayValue(def.kind, def.defaultValue()),
+      live: def.live,
+    };
+    if (def.envVar) row.envVar = def.envVar;
+    if (fileValue !== undefined) row.fileValue = displayValue(def.kind, fileValue);
+    if (def.connectorId) row.connectorId = def.connectorId;
+    if (def.kind === 'path') row.exists = existsSync(value as string);
+    return row;
+  });
+
+  // Infra frozen at boot — shown for transparency, changed via env/CLI only.
+  const readOnlyDefs: { key: string; label: string; envVar?: string; value: string | number }[] = [
+    { key: 'port', label: 'Port', envVar: 'PORT', value: PORT },
+    {
+      key: 'claudescopeHome',
+      label: 'State directory',
+      envVar: 'CLAUDESCOPE_HOME',
+      value: contractHome(CLAUDESCOPE_HOME),
+    },
+    {
+      key: 'duckdbPath',
+      label: 'DuckDB index',
+      envVar: 'DUCKDB_PATH',
+      value: contractHome(DUCKDB_PATH),
+    },
+    {
+      key: 'pricingPath',
+      label: 'Pricing config',
+      envVar: 'PRICING_PATH',
+      value: contractHome(PRICING_PATH),
+    },
+    {
+      key: 'fetchedPricingPath',
+      label: 'Fetched pricing snapshot',
+      envVar: 'FETCHED_PRICING_PATH',
+      value: contractHome(FETCHED_PRICING_PATH),
+    },
+  ];
+  const readOnly: ReadOnlySetting[] = readOnlyDefs.map((d) => ({
+    ...d,
+    source: d.envVar && process.env[d.envVar] != null ? 'env' : 'default',
+  }));
+
+  return { schemaVersion: SETTINGS_SCHEMA_VERSION, editable, readOnly };
+}
+
+export async function registerSettingsRoute(app: FastifyInstance): Promise<void> {
+  app.get('/api/settings', async (): Promise<SettingsResponse> => buildSettingsResponse());
+
+  app.put('/api/settings', async (req, reply): Promise<SettingsUpdateResponse | undefined> => {
+    const set = (req.body as SettingsUpdateRequest | undefined)?.set;
+    if (!set || typeof set !== 'object' || Array.isArray(set) || Object.keys(set).length === 0) {
+      void reply.code(400).send({ error: 'body must be { set: { <key>: value | null } }' });
+      return;
+    }
+
+    // Normalize path strings before validating/saving.
+    const patch: Record<string, unknown> = {};
+    for (const [key, value] of Object.entries(set)) {
+      patch[key] = typeof value === 'string' ? value.trim() : value;
+    }
+
+    const { errors, warnings } = validateSettingsPatch(patch);
+    if (Object.keys(errors).length > 0) {
+      void reply.code(400).send({ error: 'invalid settings', fields: errors });
+      return;
+    }
+
+    // Snapshot the pre-save effective values so we only live-apply on REAL
+    // change (a save that is shadowed by an env var must not kick a reindex).
+    const before = new Map(SETTING_DEFS.map((d) => [d.key, resolveSetting(d.key).value]));
+    saveSettings(patch as Partial<Record<SettingKey, SettingValue | null>>);
+
+    const applied: SettingsUpdateResponse['applied'] = [];
+    let sourcesChanged = false;
+    let intervalChanged = false;
+    for (const key of Object.keys(patch)) {
+      const def = SETTING_DEFS.find((d) => d.key === key);
+      if (!def) continue;
+      applied.push({ key, live: def.live });
+      if (before.get(def.key) !== resolveSetting(def.key).value) {
+        if (def.group === 'sources') sourcesChanged = true;
+        if (def.key === 'reindexIntervalMs') intervalChanged = true;
+      }
+    }
+
+    if (intervalChanged) rearmTimer();
+    if (sourcesChanged) {
+      // Fire and forget: the pass surfaces through /api/health + dataVersion.
+      requestPass().catch((err) => app.log.warn({ err }, 'post-settings reindex failed'));
+    }
+
+    return { settings: buildSettingsResponse(), applied, warnings };
+  });
+}

--- a/packages/server/src/routes/system.ts
+++ b/packages/server/src/routes/system.ts
@@ -1,0 +1,30 @@
+/**
+ * Per-process system info for the Settings page's Status and Update cards:
+ * version vs latest, the install-method-specific upgrade command (shown,
+ * never executed server-side), process start time for uptime.
+ */
+
+import type { FastifyInstance } from 'fastify';
+import type { SystemInfoResponse } from '@claudescope/shared';
+import { APP_VERSION } from '../config.js';
+import { getDataVersion } from '../data/index.js';
+import { detectInstallMethod, updateCommandFor } from '../install-method.js';
+import { getCachedLatest, updateAvailable } from '../update-check.js';
+
+/** Stamped at module load ≈ process start; good enough for an uptime display. */
+const startedAt = new Date().toISOString();
+
+export async function registerSystemRoute(app: FastifyInstance): Promise<void> {
+  app.get('/api/system', async (): Promise<SystemInfoResponse> => {
+    const installMethod = detectInstallMethod();
+    return {
+      version: APP_VERSION,
+      latestVersion: getCachedLatest(),
+      updateAvailable: updateAvailable() !== null,
+      installMethod,
+      updateCommand: updateCommandFor(installMethod),
+      startedAt,
+      dataVersion: getDataVersion(),
+    };
+  });
+}

--- a/packages/server/src/security.ts
+++ b/packages/server/src/security.ts
@@ -120,10 +120,13 @@ const SAFE_METHODS = new Set(['GET', 'HEAD', 'OPTIONS']);
  *   `same-origin`/`none` (direct navigation) is rejected. curl / the CLI /
  *   `app.inject()` don't send it and pass. The Vite dev proxy forwards the
  *   browser's `same-origin` value.
+ * - `Origin`: browsers have sent it on cross-origin POSTs since ~2011, so it
+ *   covers legacy browsers that predate Fetch Metadata even for BODY-LESS
+ *   mutations (which the content-type check below can't see). A non-loopback
+ *   (or `null`) origin is rejected; curl/CLI omit the header and pass.
  * - Content type: a no-cors cross-origin request can only carry simple types
  *   (text/plain & co) — `application/json` forces a CORS preflight, which
- *   fails because this server serves no CORS headers. Requiring JSON bodies
- *   covers legacy browsers that predate `Sec-Fetch-Site`.
+ *   fails because this server serves no CORS headers.
  */
 export function registerMutationGuard(app: FastifyInstance): void {
   app.addHook('onRequest', async (req, reply) => {
@@ -133,10 +136,25 @@ export function registerMutationGuard(app: FastifyInstance): void {
       reply.code(403).send({ error: 'Forbidden: cross-site request' });
       return reply;
     }
+    const origin = req.headers.origin;
+    if (typeof origin === 'string' && !isAllowedOrigin(origin)) {
+      reply.code(403).send({ error: 'Forbidden: cross-origin request' });
+      return reply;
+    }
     const contentType = req.headers['content-type'];
     if (contentType !== undefined && !contentType.toLowerCase().startsWith('application/json')) {
       reply.code(415).send({ error: 'Unsupported content type — use application/json' });
       return reply;
     }
   });
+}
+
+/** True when an `Origin` header names a permitted loopback host. Opaque
+ *  (`null`) or unparsable origins fail — only real loopback pages pass. */
+export function isAllowedOrigin(origin: string): boolean {
+  try {
+    return ALLOWED_HOSTNAMES.has(new URL(origin).hostname.replace(/^\[|\]$/g, '').toLowerCase());
+  } catch {
+    return false;
+  }
 }

--- a/packages/server/src/security.ts
+++ b/packages/server/src/security.ts
@@ -104,3 +104,39 @@ export function registerHostGuard(app: FastifyInstance): void {
     }
   });
 }
+
+/** Request methods that can never mutate state and skip the mutation guard. */
+const SAFE_METHODS = new Set(['GET', 'HEAD', 'OPTIONS']);
+
+/**
+ * Guard every mutating request (POST/PUT/…) against cross-origin CSRF. The
+ * host guard stops DNS rebinding but NOT same-`Host` cross-origin side
+ * effects: any website can fire `fetch('http://localhost:4317/…', {method:
+ * 'POST', mode: 'no-cors'})` and it arrives with a loopback Host header. That
+ * was harmless while `/api/reindex` was the only mutation; not once settings
+ * writes and index rebuilds exist. Two independent checks:
+ *
+ * - `Sec-Fetch-Site`: every evergreen browser sends it; anything other than
+ *   `same-origin`/`none` (direct navigation) is rejected. curl / the CLI /
+ *   `app.inject()` don't send it and pass. The Vite dev proxy forwards the
+ *   browser's `same-origin` value.
+ * - Content type: a no-cors cross-origin request can only carry simple types
+ *   (text/plain & co) — `application/json` forces a CORS preflight, which
+ *   fails because this server serves no CORS headers. Requiring JSON bodies
+ *   covers legacy browsers that predate `Sec-Fetch-Site`.
+ */
+export function registerMutationGuard(app: FastifyInstance): void {
+  app.addHook('onRequest', async (req, reply) => {
+    if (SAFE_METHODS.has(req.method)) return;
+    const site = req.headers['sec-fetch-site'];
+    if (typeof site === 'string' && site !== 'same-origin' && site !== 'none') {
+      reply.code(403).send({ error: 'Forbidden: cross-site request' });
+      return reply;
+    }
+    const contentType = req.headers['content-type'];
+    if (contentType !== undefined && !contentType.toLowerCase().startsWith('application/json')) {
+      reply.code(415).send({ error: 'Unsupported content type — use application/json' });
+      return reply;
+    }
+  });
+}

--- a/packages/server/src/settings.ts
+++ b/packages/server/src/settings.ts
@@ -1,0 +1,483 @@
+/**
+ * User-editable runtime settings, persisted to `~/.claudescope/settings.json`.
+ *
+ * Precedence per key, computed at every call: **env var > settings.json >
+ * default**. Env vars keep winning so scripted overrides and the existing test
+ * harness (env set before import) behave exactly as before; the file is the
+ * layer the web UI writes. The file read is mtime-cached (same idiom as
+ * `loadPricing`), so hand edits are picked up on the next call without a
+ * restart, and getters stay cheap enough to call once per discovery pass or
+ * API request.
+ *
+ * Layering: `config.ts` (frozen infra consts) ← this module ← connectors /
+ * indexer / routes / CLI. Nothing here writes outside CLAUDESCOPE_HOME.
+ */
+
+import { existsSync, readFileSync, renameSync, statSync, writeFileSync, copyFileSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { dirname, isAbsolute, join } from 'node:path';
+import type { SettingSource, SettingValue } from '@claudescope/shared';
+import { CLAUDESCOPE_HOME, expandHome, firstExisting } from './config.js';
+
+export const SETTINGS_SCHEMA_VERSION = 1;
+
+/** The user-editable settings file (lives with the rest of the app state). */
+export const SETTINGS_PATH = join(CLAUDESCOPE_HOME, 'settings.json');
+
+export type SettingKey =
+  | 'claudeProjectsDir'
+  | 'codexSessionsDir'
+  | 'junieSessionsDir'
+  | 'piSessionsDir'
+  | 'opencodeDataDir'
+  | 'opencodeDbPath'
+  | 'copilotSessionsDir'
+  | 'grokSessionsDir'
+  | 'antigravityCliDir'
+  | 'antigravityDir'
+  | 'reindexIntervalMs'
+  | 'openBrowser';
+
+export interface SettingDef {
+  key: SettingKey;
+  /** Env var that overrides this setting; null = no env layer (openBrowser —
+   *  its OPEN_BROWSER var is the internal launcher contract, always pinned by
+   *  the daemon spawner, so reading it here would misreport user intent). */
+  envVar: string | null;
+  kind: 'path' | 'number' | 'boolean';
+  label: string;
+  group: 'sources' | 'indexing' | 'startup';
+  /** Connector fed by this dir (sources only), for UI labeling. */
+  connectorId?: string;
+  /** False → the change takes effect on the next `claudescope start`. */
+  live: boolean;
+  /** Lazy so derived defaults (opencodeDbPath) track their base setting live. */
+  defaultValue: () => SettingValue;
+}
+
+/**
+ * Single source of truth driving resolution, validation, and the settings API.
+ * Defaults are copied VERBATIM from the former config.ts consts — including
+ * opencode's XDG_DATA_HOME fallback chain — so the const→getter migration
+ * cannot silently change a default.
+ */
+export const SETTING_DEFS: readonly SettingDef[] = [
+  {
+    key: 'claudeProjectsDir',
+    envVar: 'CLAUDE_PROJECTS_DIR',
+    kind: 'path',
+    label: 'Claude Code projects',
+    group: 'sources',
+    connectorId: 'claude-code',
+    live: true,
+    defaultValue: () => join(homedir(), '.claude', 'projects'),
+  },
+  {
+    key: 'codexSessionsDir',
+    envVar: 'CODEX_SESSIONS_DIR',
+    kind: 'path',
+    label: 'Codex sessions',
+    group: 'sources',
+    connectorId: 'codex',
+    live: true,
+    defaultValue: () => join(homedir(), '.codex', 'sessions'),
+  },
+  {
+    key: 'junieSessionsDir',
+    envVar: 'JUNIE_SESSIONS_DIR',
+    kind: 'path',
+    label: 'Junie sessions',
+    group: 'sources',
+    connectorId: 'junie',
+    live: true,
+    defaultValue: () => join(homedir(), '.junie', 'sessions'),
+  },
+  {
+    key: 'piSessionsDir',
+    envVar: 'PI_SESSIONS_DIR',
+    kind: 'path',
+    label: 'pi sessions',
+    group: 'sources',
+    connectorId: 'pi',
+    live: true,
+    defaultValue: () => join(homedir(), '.pi', 'agent', 'sessions'),
+  },
+  {
+    key: 'opencodeDataDir',
+    envVar: 'OPENCODE_DATA_DIR',
+    kind: 'path',
+    label: 'opencode data dir',
+    group: 'sources',
+    connectorId: 'opencode',
+    live: true,
+    defaultValue: () =>
+      expandHome(
+        join(process.env.XDG_DATA_HOME ?? join(homedir(), '.local', 'share'), 'opencode'),
+      ),
+  },
+  {
+    key: 'opencodeDbPath',
+    envVar: 'OPENCODE_DB_PATH',
+    kind: 'path',
+    label: 'opencode database',
+    group: 'sources',
+    connectorId: 'opencode',
+    live: true,
+    // Derives from the EFFECTIVE data dir, so editing opencodeDataDir moves
+    // the default DB path along with it.
+    defaultValue: () => join(opencodeDataDir(), 'opencode.db'),
+  },
+  {
+    key: 'copilotSessionsDir',
+    envVar: 'COPILOT_SESSIONS_DIR',
+    kind: 'path',
+    label: 'Copilot sessions',
+    group: 'sources',
+    connectorId: 'copilot',
+    live: true,
+    defaultValue: () => join(homedir(), '.copilot', 'session-state'),
+  },
+  {
+    key: 'grokSessionsDir',
+    envVar: 'GROK_SESSIONS_DIR',
+    kind: 'path',
+    label: 'Grok sessions',
+    group: 'sources',
+    connectorId: 'grok',
+    live: true,
+    defaultValue: () => join(homedir(), '.grok', 'sessions'),
+  },
+  {
+    key: 'antigravityCliDir',
+    envVar: 'ANTIGRAVITY_CLI_DIR',
+    kind: 'path',
+    label: 'Antigravity (CLI)',
+    group: 'sources',
+    connectorId: 'antigravity',
+    live: true,
+    defaultValue: () => join(homedir(), '.gemini', 'antigravity-cli'),
+  },
+  {
+    key: 'antigravityDir',
+    envVar: 'ANTIGRAVITY_DIR',
+    kind: 'path',
+    label: 'Antigravity (desktop)',
+    group: 'sources',
+    connectorId: 'antigravity',
+    live: true,
+    defaultValue: () => join(homedir(), '.gemini', 'antigravity'),
+  },
+  {
+    key: 'reindexIntervalMs',
+    envVar: 'REINDEX_INTERVAL_MS',
+    kind: 'number',
+    label: 'Auto-reindex interval (ms)',
+    group: 'indexing',
+    live: true,
+    defaultValue: () => 15000,
+  },
+  {
+    key: 'openBrowser',
+    envVar: null,
+    kind: 'boolean',
+    label: 'Open browser on start',
+    group: 'startup',
+    live: false, // consumed by the CLI at the next `claudescope start`
+    defaultValue: () => true,
+  },
+] as const;
+
+const DEFS_BY_KEY = new Map(SETTING_DEFS.map((d) => [d.key, d]));
+
+// ---------------------------------------------------------------------------
+// File layer (mtime-cached read, atomic write)
+// ---------------------------------------------------------------------------
+
+/** Sentinel mtime for a file that does not exist. */
+const ABSENT = -1;
+
+let cached: { mtime: number; data: Record<string, unknown> } | null = null;
+/** mtime we last warned about, so a corrupt file logs once, not per call. */
+let warnedMtime: number | null = null;
+
+function mtimeOf(path: string): number {
+  try {
+    return statSync(path).mtimeMs;
+  } catch {
+    return ABSENT;
+  }
+}
+
+/** Raw parsed settings.json (mtime-cached). Corrupt/missing → `{}`. */
+function readSettingsFile(): Record<string, unknown> {
+  const mtime = mtimeOf(SETTINGS_PATH);
+  if (cached && cached.mtime === mtime) return cached.data;
+  let data: Record<string, unknown> = {};
+  if (mtime !== ABSENT) {
+    try {
+      const parsed: unknown = JSON.parse(readFileSync(SETTINGS_PATH, 'utf8'));
+      if (parsed !== null && typeof parsed === 'object' && !Array.isArray(parsed)) {
+        data = parsed as Record<string, unknown>;
+      }
+    } catch {
+      if (warnedMtime !== mtime) {
+        warnedMtime = mtime;
+        console.warn(`[settings] ${SETTINGS_PATH} is not valid JSON — using defaults`);
+      }
+    }
+  }
+  cached = { mtime, data };
+  return data;
+}
+
+/** Whether a raw file value has the right JS type for the setting's kind. */
+function typeOk(def: SettingDef, v: unknown): v is SettingValue {
+  if (def.kind === 'path') return typeof v === 'string';
+  if (def.kind === 'number') return typeof v === 'number' && Number.isFinite(v);
+  return typeof v === 'boolean';
+}
+
+/** The raw saved value for a key (unexpanded, for display), if present and valid. */
+export function fileValueOf(key: SettingKey): SettingValue | undefined {
+  const def = DEFS_BY_KEY.get(key);
+  if (!def) return undefined;
+  const v = readSettingsFile()[key];
+  return typeOk(def, v) ? v : undefined;
+}
+
+export interface ResolvedSetting {
+  value: SettingValue;
+  source: SettingSource;
+}
+
+/** Resolve a setting through env > file > default, computed per call. */
+export function resolveSetting(key: SettingKey): ResolvedSetting {
+  const def = DEFS_BY_KEY.get(key);
+  if (!def) throw new Error(`unknown setting: ${key}`);
+
+  if (def.envVar) {
+    const env = process.env[def.envVar];
+    if (env != null) {
+      if (def.kind === 'path') return { value: expandHome(env), source: 'env' };
+      if (def.kind === 'number') {
+        const n = Number(env);
+        // An unparsable number env var is ignored (validate at the boundary,
+        // fall through to the file/default) rather than poisoning the value.
+        if (Number.isFinite(n)) return { value: n, source: 'env' };
+      } else {
+        return { value: env === '1', source: 'env' };
+      }
+    }
+  }
+
+  const fileValue = fileValueOf(key);
+  if (fileValue !== undefined) {
+    return {
+      value: def.kind === 'path' ? expandHome(fileValue as string) : fileValue,
+      source: 'file',
+    };
+  }
+
+  return { value: def.defaultValue(), source: 'default' };
+}
+
+/**
+ * Persist a patch to settings.json. `null` clears a key back to its default;
+ * unknown keys already in the file are preserved (forward compatibility).
+ * Fully synchronous, so concurrent callers in this single-threaded process
+ * can never interleave a read-modify-write; last full call wins. Atomic on
+ * disk via tmp + rename (idiom of `reconcilePricingConfig`).
+ */
+export function saveSettings(patch: Partial<Record<SettingKey, SettingValue | null>>): void {
+  // Never silently destroy a hand-edited file we could not parse: keep a copy.
+  const raw = existsSync(SETTINGS_PATH) ? readFileSync(SETTINGS_PATH, 'utf8') : null;
+  let current: Record<string, unknown> = {};
+  if (raw !== null) {
+    try {
+      const parsed: unknown = JSON.parse(raw);
+      if (parsed !== null && typeof parsed === 'object' && !Array.isArray(parsed)) {
+        current = parsed as Record<string, unknown>;
+      }
+    } catch {
+      copyFileSync(SETTINGS_PATH, `${SETTINGS_PATH}.bak`);
+      console.warn(`[settings] backed up corrupt ${SETTINGS_PATH} to settings.json.bak`);
+    }
+  }
+
+  for (const [key, value] of Object.entries(patch)) {
+    if (value === null) delete current[key];
+    else if (value !== undefined) current[key] = value;
+  }
+  current.schemaVersion = SETTINGS_SCHEMA_VERSION;
+
+  const tmp = `${SETTINGS_PATH}.${process.pid}.tmp`;
+  writeFileSync(tmp, `${JSON.stringify(current, null, 2)}\n`);
+  renameSync(tmp, SETTINGS_PATH);
+  cached = null; // next read re-stats; rename bumps mtime but be explicit
+}
+
+// ---------------------------------------------------------------------------
+// Validation (used by PUT /api/settings)
+// ---------------------------------------------------------------------------
+
+export interface SettingsValidation {
+  /** Per-field hard errors; non-empty → reject the whole patch. */
+  errors: Record<string, string>;
+  /** Advisory only — the save proceeds (e.g. directory doesn't exist yet). */
+  warnings: { key: string; message: string }[];
+}
+
+/** Validate a raw PUT patch. Type errors hard-fail; existence soft-warns. */
+export function validateSettingsPatch(patch: Record<string, unknown>): SettingsValidation {
+  const errors: Record<string, string> = {};
+  const warnings: { key: string; message: string }[] = [];
+
+  for (const [key, value] of Object.entries(patch)) {
+    const def = DEFS_BY_KEY.get(key as SettingKey);
+    if (!def) {
+      errors[key] = 'unknown setting';
+      continue;
+    }
+    if (value === null) continue; // clear back to default — always valid
+
+    if (def.kind === 'path') {
+      if (typeof value !== 'string' || value.trim() === '') {
+        errors[key] = 'must be a non-empty path';
+        continue;
+      }
+      const expanded = expandHome(value.trim());
+      if (!isAbsolute(expanded)) {
+        errors[key] = 'must be an absolute path (a leading ~ is expanded)';
+        continue;
+      }
+      // A source dir may legitimately not exist yet (agent not installed) —
+      // warn, don't fail. opencodeDbPath points at a file, not a directory.
+      if (!existsSync(expanded)) {
+        warnings.push({ key, message: 'path does not exist — this source will index nothing' });
+      } else if (def.key !== 'opencodeDbPath' && !statSync(expanded).isDirectory()) {
+        warnings.push({ key, message: 'path is not a directory' });
+      }
+    } else if (def.kind === 'number') {
+      if (typeof value !== 'number' || !Number.isInteger(value)) {
+        errors[key] = 'must be an integer';
+        continue;
+      }
+      if (value !== 0 && value < 1000) {
+        errors[key] = 'must be 0 (disabled) or at least 1000 ms';
+        continue;
+      }
+    } else if (typeof value !== 'boolean') {
+      errors[key] = 'must be true or false';
+      continue;
+    }
+
+    if (def.envVar && process.env[def.envVar] != null) {
+      warnings.push({
+        key,
+        message: `saved, but $${def.envVar} currently overrides it`,
+      });
+    }
+  }
+
+  return { errors, warnings };
+}
+
+// ---------------------------------------------------------------------------
+// Effective-value getters (what connectors / the indexer / the CLI consume)
+// ---------------------------------------------------------------------------
+
+function pathOf(key: SettingKey): string {
+  return resolveSetting(key).value as string;
+}
+
+/** READ-ONLY source of Claude Code session data. */
+export function claudeProjectsDir(): string {
+  return pathOf('claudeProjectsDir');
+}
+/** READ-ONLY source of OpenAI Codex CLI sessions. */
+export function codexSessionsDir(): string {
+  return pathOf('codexSessionsDir');
+}
+/** READ-ONLY source of JetBrains Junie sessions. */
+export function junieSessionsDir(): string {
+  return pathOf('junieSessionsDir');
+}
+/** READ-ONLY source of pi sessions. */
+export function piSessionsDir(): string {
+  return pathOf('piSessionsDir');
+}
+/** READ-ONLY opencode data dir (holds the SQLite DB). */
+export function opencodeDataDir(): string {
+  return pathOf('opencodeDataDir');
+}
+/** READ-ONLY opencode SQLite database file. */
+export function opencodeDbPath(): string {
+  return pathOf('opencodeDbPath');
+}
+/** READ-ONLY source of GitHub Copilot CLI sessions. */
+export function copilotSessionsDir(): string {
+  return pathOf('copilotSessionsDir');
+}
+/** READ-ONLY source of xAI Grok CLI sessions. */
+export function grokSessionsDir(): string {
+  return pathOf('grokSessionsDir');
+}
+/** READ-ONLY Antigravity CLI appDataDir. */
+export function antigravityCliDir(): string {
+  return pathOf('antigravityCliDir');
+}
+/** READ-ONLY Antigravity desktop appDataDir. */
+export function antigravityDesktopDir(): string {
+  return pathOf('antigravityDir');
+}
+/** Every Antigravity appDataDir the connector scans (both surfaces). */
+export function antigravityDirs(): string[] {
+  return [antigravityCliDir(), antigravityDesktopDir()];
+}
+/**
+ * The Antigravity source dir reported to `/api/sources` — the first surface
+ * that exists (CLI or desktop), resolved per call.
+ */
+export function antigravitySourceDir(): string {
+  const cli = antigravityCliDir();
+  return firstExisting([cli, antigravityDesktopDir()], cli);
+}
+
+/**
+ * READ-ONLY agent home directories — parents of the session dirs above, where
+ * each agent keeps its memory. Derived from the effective dirs so env AND
+ * settings.json overrides carry through. The app MUST NEVER write here.
+ */
+export function claudeHome(): string {
+  return dirname(claudeProjectsDir());
+}
+export function codexHome(): string {
+  return dirname(codexSessionsDir());
+}
+export function junieHome(): string {
+  return dirname(junieSessionsDir());
+}
+/** `~/.copilot` — holds the global `copilot-instructions.md` memory file. */
+export function copilotHome(): string {
+  return dirname(copilotSessionsDir());
+}
+/** `~/.gemini` — shared Gemini/Antigravity home, parent of the appDataDirs. */
+export function antigravityHome(): string {
+  return dirname(antigravityCliDir());
+}
+
+/** Auto-reindex interval in ms (0 = disabled). */
+export function reindexIntervalMs(): number {
+  return resolveSetting('reindexIntervalMs').value as number;
+}
+
+/** Whether `claudescope start` should open the browser (CLI-consumed). */
+export function openBrowserOnStart(): boolean {
+  return resolveSetting('openBrowser').value as boolean;
+}
+
+/** Test seam: drop the mtime cache so a rewritten file is re-read immediately. */
+export function resetSettingsCache(): void {
+  cached = null;
+  warnedMtime = null;
+}

--- a/packages/server/src/settings.ts
+++ b/packages/server/src/settings.ts
@@ -13,7 +13,15 @@
  * indexer / routes / CLI. Nothing here writes outside CLAUDESCOPE_HOME.
  */
 
-import { existsSync, readFileSync, renameSync, statSync, writeFileSync, copyFileSync } from 'node:fs';
+import {
+  copyFileSync,
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  renameSync,
+  statSync,
+  writeFileSync,
+} from 'node:fs';
 import { homedir } from 'node:os';
 import { dirname, isAbsolute, join } from 'node:path';
 import type { SettingSource, SettingValue } from '@claudescope/shared';
@@ -310,6 +318,8 @@ export function saveSettings(patch: Partial<Record<SettingKey, SettingValue | nu
   }
   current.schemaVersion = SETTINGS_SCHEMA_VERSION;
 
+  // Self-sufficient: don't depend on ensureStateDir() having run at boot.
+  mkdirSync(CLAUDESCOPE_HOME, { recursive: true });
   const tmp = `${SETTINGS_PATH}.${process.pid}.tmp`;
   writeFileSync(tmp, `${JSON.stringify(current, null, 2)}\n`);
   renameSync(tmp, SETTINGS_PATH);

--- a/packages/server/src/settings.ts
+++ b/packages/server/src/settings.ts
@@ -376,6 +376,12 @@ export function validateSettingsPatch(patch: Record<string, unknown>): SettingsV
         errors[key] = 'must be 0 (disabled) or at least 1000 ms';
         continue;
       }
+      // Node clamps setInterval delays over 2^31-1 to 1ms — a "basically
+      // never" value would become a busy loop. Reject instead.
+      if (value > 2_147_483_647) {
+        errors[key] = 'must be at most 2147483647 ms (~24.8 days)';
+        continue;
+      }
     } else if (typeof value !== 'boolean') {
       errors[key] = 'must be true or false';
       continue;

--- a/packages/server/src/update-check.ts
+++ b/packages/server/src/update-check.ts
@@ -59,6 +59,12 @@ export function updateAvailable(): string | null {
   return cachedLatest && isNewer(cachedLatest, APP_VERSION) ? cachedLatest : null;
 }
 
+/** The last latest-version value the daemon fetched, newer or not (for the
+ *  Settings Update card, which also shows the "up to date" state). */
+export function getCachedLatest(): string | null {
+  return cachedLatest;
+}
+
 /** Refresh the daemon-side cache from the (file-cached) registry lookup.
  *  Never throws — offline just leaves the last-known value in place. */
 export async function refreshLatestVersion(): Promise<void> {

--- a/packages/server/test/index-rebuild.integration.test.ts
+++ b/packages/server/test/index-rebuild.integration.test.ts
@@ -1,0 +1,204 @@
+/**
+ * rebuildIndex() integration test — the danger-zone discard-and-rebuild path
+ * (data/index.ts) and its POST /api/index/rebuild endpoint.
+ *
+ * Covers the bug-prone edges: the rebuilt index must contain the SAME sessions
+ * (the DuckDB file is a derived cache), ready must flip false→true around the
+ * rebuild with dataVersion advanced, pricing must apply PROSPECTIVELY (a rate
+ * change re-prices history only on rebuild, never on an incremental pass), a
+ * reindex() during the rebuild must coalesce onto it (not race the closed
+ * connection), and the endpoint must 409 while a rebuild is in flight.
+ *
+ * Determinism: rebuildIndex() sets `rebuilding` and clears `ready`
+ * synchronously when nothing is in flight, so mid-flight states are asserted
+ * without sleeps; pricing rewrites bump mtime explicitly (loadPricing is
+ * mtime-cached).
+ */
+
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
+import { mkdirSync, mkdtempSync, rmSync, utimesSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import type { FastifyInstance } from 'fastify';
+
+// --- temp locations (decided before any server module is imported) ----------
+const work = mkdtempSync(join(tmpdir(), 'claudescope-rebuild-'));
+const projectsDir = join(work, 'projects');
+const pricingPath = join(work, 'pricing.json');
+
+process.env.CLAUDE_PROJECTS_DIR = projectsDir;
+process.env.CODEX_SESSIONS_DIR = join(work, 'codex-empty');
+process.env.JUNIE_SESSIONS_DIR = join(work, 'junie-empty');
+process.env.PI_SESSIONS_DIR = join(work, 'pi-empty');
+process.env.OPENCODE_DATA_DIR = join(work, 'opencode-empty');
+process.env.COPILOT_SESSIONS_DIR = join(work, 'copilot-empty');
+process.env.ANTIGRAVITY_CLI_DIR = join(work, 'antigravity-empty');
+process.env.ANTIGRAVITY_DIR = join(work, 'antigravity-empty-desktop');
+process.env.GROK_SESSIONS_DIR = join(work, 'grok-empty');
+process.env.DUCKDB_PATH = join(work, 'index.duckdb');
+process.env.CLAUDESCOPE_HOME = join(work, 'home');
+process.env.PRICING_PATH = pricingPath;
+process.env.FETCHED_PRICING_PATH = join(work, 'pricing.fetched.json'); // absent → base only
+process.env.REINDEX_INTERVAL_MS = '0';
+process.env.PRICING_REFRESH_INTERVAL_MS = '0';
+
+const jsonl = (events: unknown[]): string => events.map((e) => JSON.stringify(e)).join('\n') + '\n';
+
+/** Exact-id rates so the expected cost is a closed-form number. */
+const RATES_V1 = {
+  schemaVersion: 4,
+  models: { 'claude-opus-4-8': { input: 10, output: 20, cacheWrite: 0, cacheRead: 0 } },
+  default: { input: 0, output: 0, cacheWrite: 0, cacheRead: 0 },
+};
+/** 10x the v1 rates — a rebuild must re-price history to these. */
+const RATES_V2 = {
+  schemaVersion: 4,
+  models: { 'claude-opus-4-8': { input: 100, output: 200, cacheWrite: 0, cacheRead: 0 } },
+  default: { input: 0, output: 0, cacheWrite: 0, cacheRead: 0 },
+};
+// sessX: 1000 in + 500 out → v1 (1000*10 + 500*20)/1e6 = 0.02; v2 = 0.2.
+const COST_V1 = 0.02;
+const COST_V2 = 0.2;
+
+/**
+ * Force a strictly-increasing mtime so loadPricing's mtime-keyed cache busts
+ * even when two rewrites land in the same millisecond (pricing.test.ts idiom).
+ */
+let mtimeTick = Math.floor(Date.now() / 1000);
+const bumpMtime = (path: string): void => {
+  mtimeTick += 2;
+  utimesSync(path, mtimeTick, mtimeTick);
+};
+const writePricing = (config: unknown): void => {
+  writeFileSync(pricingPath, `${JSON.stringify(config, null, 2)}\n`);
+  bumpMtime(pricingPath);
+};
+
+/** Two small Claude sessions in one project (session-set snapshot fodder). */
+function writeFixtures(): void {
+  const proj = join(projectsDir, 'enc-rebuild');
+  mkdirSync(proj, { recursive: true });
+  const base = { cwd: '/tmp/rebuildproj', gitBranch: 'main', version: '2.1.0' };
+  writeFileSync(
+    join(proj, 'sessX.jsonl'),
+    jsonl([
+      { ...base, sessionId: 'sessX', type: 'user', uuid: 'x-u1', parentUuid: null, timestamp: '2026-01-01T10:00:00.000Z', isSidechain: false, message: { role: 'user', content: 'rebuild me' } },
+      { ...base, sessionId: 'sessX', type: 'assistant', uuid: 'x-a1', parentUuid: 'x-u1', timestamp: '2026-01-01T10:00:05.000Z', isSidechain: false, message: { role: 'assistant', model: 'claude-opus-4-8', content: [{ type: 'text', text: 'rebuilt' }], usage: { input_tokens: 1000, output_tokens: 500 } } },
+    ]),
+  );
+  writeFileSync(
+    join(proj, 'sessY.jsonl'),
+    jsonl([
+      { ...base, sessionId: 'sessY', type: 'user', uuid: 'y-u1', parentUuid: null, timestamp: '2026-01-02T10:00:00.000Z', isSidechain: false, message: { role: 'user', content: 'second session' } },
+      { ...base, sessionId: 'sessY', type: 'assistant', uuid: 'y-a1', parentUuid: 'y-u1', timestamp: '2026-01-02T10:00:05.000Z', isSidechain: false, message: { role: 'assistant', model: 'claude-opus-4-8', content: [{ type: 'text', text: 'ok' }], usage: { input_tokens: 100, output_tokens: 50 } } },
+    ]),
+  );
+}
+
+let app: FastifyInstance;
+let closeConnection: () => Promise<void>;
+let data: typeof import('../src/data/index.js');
+
+beforeAll(async () => {
+  writeFixtures();
+  writePricing(RATES_V1);
+
+  const Fastify = (await import('fastify')).default;
+  const { registerRoutes } = await import('../src/routes/index.js');
+  data = await import('../src/data/index.js');
+  ({ closeConnection } = await import('../src/db/duckdb.js'));
+
+  app = Fastify();
+  await registerRoutes(app);
+  await data.reindex();
+  await app.ready();
+});
+
+afterAll(async () => {
+  await app?.close();
+  await closeConnection?.();
+  rmSync(work, { recursive: true, force: true });
+});
+
+const get = (url: string) => app.inject({ method: 'GET', url });
+const sessionIds = async (): Promise<string[]> =>
+  ((await get('/api/sessions')).json() as { id: string }[]).map((s) => s.id).sort();
+const costOf = async (id: string): Promise<number> => {
+  const sessions = (await get('/api/sessions')).json() as { id: string; totalCostUsd: number }[];
+  return sessions.find((s) => s.id === id)!.totalCostUsd;
+};
+
+describe('rebuildIndex()', () => {
+  it('discards and rebuilds to the same sessions, flipping ready and advancing dataVersion', async () => {
+    const before = (await get('/api/health')).json();
+    expect(before.ready).toBe(true);
+    const idsBefore = await sessionIds();
+    expect(idsBefore).toEqual(['sessX', 'sessY']);
+
+    const p = data.rebuildIndex();
+    // With nothing in flight, the rebuild flags flip synchronously.
+    expect(data.isRebuildInFlight()).toBe(true);
+    expect(data.isIndexReady()).toBe(false);
+
+    const res = await p;
+    expect(res.reindexed).toBeGreaterThan(0); // an empty files table reloads everything
+    expect(data.isRebuildInFlight()).toBe(false);
+
+    const after = (await get('/api/health')).json();
+    expect(after.ready).toBe(true);
+    expect(after.dataVersion).not.toBe(before.dataVersion);
+    expect(await sessionIds()).toEqual(idsBefore); // derived cache — same content
+  });
+
+  it('re-prices history at the current rates on rebuild, but NOT on an incremental pass', async () => {
+    expect(await costOf('sessX')).toBeCloseTo(COST_V1, 6);
+
+    writePricing(RATES_V2);
+
+    // Incremental pass: no file changed, so no event rows are re-stamped —
+    // pricing changes are prospective.
+    const re = await app.inject({ method: 'POST', url: '/api/reindex' });
+    expect(re.statusCode).toBe(200);
+    expect(re.json().reindexed).toBe(0);
+    expect(await costOf('sessX')).toBeCloseTo(COST_V1, 6);
+
+    // Rebuild: every event reloads through the cost expression → new rates.
+    await data.rebuildIndex();
+    expect(await costOf('sessX')).toBeCloseTo(COST_V2, 6);
+  });
+
+  it('coalesces a reindex() called while the rebuild is in flight', async () => {
+    const p = data.rebuildIndex(); // occupies the shared in-flight slot synchronously
+    const r = data.reindex(); // must join the rebuild, not race the closed connection
+    const [rebuildRes, reindexRes] = await Promise.all([p, r]);
+    // Joining resolves to the SAME response object — proof of coalescing.
+    expect(reindexRes).toBe(rebuildRes);
+    expect(data.isIndexReady()).toBe(true);
+  });
+});
+
+describe('POST /api/index/rebuild', () => {
+  it('409s while a rebuild is in flight, 202s otherwise, and recovers to ready', async () => {
+    const p = data.rebuildIndex(); // rebuilding=true synchronously
+    const conflict = await app.inject({ method: 'POST', url: '/api/index/rebuild' });
+    expect(conflict.statusCode).toBe(409);
+    expect(conflict.json()).toMatchObject({ error: expect.stringContaining('progress') });
+    await p;
+
+    const accepted = await app.inject({ method: 'POST', url: '/api/index/rebuild' });
+    expect(accepted.statusCode).toBe(202);
+    expect(accepted.json()).toEqual({ started: true });
+
+    // The endpoint's rebuild runs in the background — drain it, then the index
+    // must be fully queryable again.
+    await vi.waitFor(
+      () => {
+        expect(data.isRebuildInFlight()).toBe(false);
+        expect(data.isReindexInFlight()).toBe(false);
+      },
+      { timeout: 25_000, interval: 50 },
+    );
+    expect((await get('/api/health')).json().ready).toBe(true);
+    expect(await sessionIds()).toEqual(['sessX', 'sessY']);
+  });
+});

--- a/packages/server/test/indexer-lifecycle.integration.test.ts
+++ b/packages/server/test/indexer-lifecycle.integration.test.ts
@@ -1,0 +1,161 @@
+/**
+ * Indexer lifecycle integration test — the pause/resume/restart runtime state,
+ * its surfacing on /api/health and the POST /api/indexer/* routes, and the
+ * requestPass coalescing guarantee (a pass STARTS after the call; joining an
+ * in-flight pass is not enough).
+ *
+ * Determinism notes: reindex() sets its in-flight slot synchronously, so
+ * "pass in flight" can be produced without sleeps; and each completed pass
+ * resolves to a DISTINCT response object, so "a second pass ran after the
+ * joined one" is observable by object identity, not timing.
+ */
+
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import type { FastifyInstance } from 'fastify';
+
+// --- temp locations (decided before any server module is imported) ----------
+const work = mkdtempSync(join(tmpdir(), 'claudescope-lifecycle-'));
+const projectsDir = join(work, 'projects');
+
+process.env.CLAUDE_PROJECTS_DIR = projectsDir;
+process.env.CODEX_SESSIONS_DIR = join(work, 'codex-empty');
+process.env.JUNIE_SESSIONS_DIR = join(work, 'junie-empty');
+process.env.PI_SESSIONS_DIR = join(work, 'pi-empty');
+process.env.OPENCODE_DATA_DIR = join(work, 'opencode-empty');
+process.env.COPILOT_SESSIONS_DIR = join(work, 'copilot-empty');
+process.env.ANTIGRAVITY_CLI_DIR = join(work, 'antigravity-empty');
+process.env.ANTIGRAVITY_DIR = join(work, 'antigravity-empty-desktop');
+process.env.GROK_SESSIONS_DIR = join(work, 'grok-empty');
+process.env.DUCKDB_PATH = join(work, 'index.duckdb');
+process.env.CLAUDESCOPE_HOME = join(work, 'home');
+process.env.REINDEX_INTERVAL_MS = '0'; // poller disabled — lifecycle only
+
+const jsonl = (events: unknown[]): string => events.map((e) => JSON.stringify(e)).join('\n') + '\n';
+
+/** One tiny Claude session, written mid-test to observe the coalesced pass. */
+function writeSessionFixture(): void {
+  const proj = join(projectsDir, 'enc-lc');
+  mkdirSync(proj, { recursive: true });
+  const base = { sessionId: 'sess-lc1', cwd: '/tmp/lcproj', gitBranch: 'main', version: '2.1.0' };
+  writeFileSync(
+    join(proj, 'sess-lc1.jsonl'),
+    jsonl([
+      { ...base, type: 'user', uuid: 'lc-u1', parentUuid: null, timestamp: '2026-01-01T10:00:00.000Z', isSidechain: false, message: { role: 'user', content: 'hello lifecycle' } },
+      { ...base, type: 'assistant', uuid: 'lc-a1', parentUuid: 'lc-u1', timestamp: '2026-01-01T10:00:05.000Z', isSidechain: false, message: { role: 'assistant', model: 'claude-opus-4-8', content: [{ type: 'text', text: 'hi' }], usage: { input_tokens: 10, output_tokens: 5 } } },
+    ]),
+  );
+}
+
+let app: FastifyInstance;
+let closeConnection: () => Promise<void>;
+let reindex: () => Promise<{ reindexed: number; durationMs: number }>;
+let isReindexInFlight: () => boolean;
+let lifecycle: typeof import('../src/indexer-lifecycle.js');
+
+beforeAll(async () => {
+  const Fastify = (await import('fastify')).default;
+  const { registerRoutes } = await import('../src/routes/index.js');
+  ({ reindex, isReindexInFlight } = await import('../src/data/index.js'));
+  lifecycle = await import('../src/indexer-lifecycle.js');
+  ({ closeConnection } = await import('../src/db/duckdb.js'));
+
+  app = Fastify();
+  await registerRoutes(app);
+  await reindex(); // initial (empty) build → ready
+  await app.ready();
+});
+
+afterAll(async () => {
+  lifecycle?.resetIndexerLifecycle();
+  await app?.close();
+  await closeConnection?.();
+  rmSync(work, { recursive: true, force: true });
+});
+
+const get = (url: string) => app.inject({ method: 'GET', url });
+const post = (url: string) => app.inject({ method: 'POST', url });
+
+describe('POST /api/indexer/{stop,start,restart}', () => {
+  it('stop pauses: IndexerStatus and health both report paused', async () => {
+    const res = await post('/api/indexer/stop');
+    expect(res.statusCode).toBe(200);
+    expect(res.json()).toMatchObject({
+      state: 'paused',
+      paused: true,
+      intervalMs: 0,
+      rebuilding: false,
+    });
+
+    const health = (await get('/api/health')).json();
+    expect(health.indexer).toEqual({ state: 'paused', paused: true, intervalMs: 0 });
+  });
+
+  it('start resumes, runs an immediate fresh pass, and reports watching', async () => {
+    // Object identity of lastPass distinguishes "a NEW pass completed" from
+    // "the pre-pause pass is still the latest" without timing assumptions.
+    const passBefore = lifecycle.getIndexerStatus().lastPass;
+
+    const res = await post('/api/indexer/start');
+    expect(res.statusCode).toBe(200);
+    const status = res.json();
+    expect(status).toMatchObject({ state: 'watching', paused: false, rebuilding: false });
+    expect(typeof status.lastPassAt).toBe('string');
+    expect(status.lastPass).toMatchObject({ reindexed: expect.any(Number) });
+
+    expect(lifecycle.getIndexerStatus().lastPass).not.toBe(passBefore);
+    expect((await get('/api/health')).json().indexer.state).toBe('watching');
+  });
+
+  it('restart clears pause and runs a fresh pass', async () => {
+    await post('/api/indexer/stop');
+    const passBefore = lifecycle.getIndexerStatus().lastPass;
+
+    const res = await post('/api/indexer/restart');
+    expect(res.statusCode).toBe(200);
+    expect(res.json()).toMatchObject({ state: 'watching', paused: false });
+    expect(lifecycle.getIndexerStatus().lastPass).not.toBe(passBefore);
+  });
+});
+
+describe('requestPass coalescing guarantee', () => {
+  it('drains an in-flight pass, then runs one MORE pass (never just joins)', async () => {
+    // Start a pass; the in-flight slot is set synchronously, so this is a
+    // deterministic "pass already running" state — no sleeps.
+    const p1 = reindex();
+    expect(isReindexInFlight()).toBe(true);
+
+    // The "settings changed under a running pass" scenario: new data lands
+    // between the pass start and the requestPass call.
+    writeSessionFixture();
+    const rp = lifecycle.requestPass();
+
+    const [r1, r2] = await Promise.all([p1, rp]);
+    // A joined pass resolves to the SAME response object; requestPass must
+    // resolve to a different one — proof a second pass started after the call.
+    expect(r2).not.toBe(r1);
+
+    // And the post-change data is queryable once requestPass resolves.
+    const sessions = (await get('/api/sessions')).json() as { id: string }[];
+    expect(sessions.map((s) => s.id)).toContain('sess-lc1');
+  });
+
+  it('two concurrent requestPass calls both resolve (second drains the first)', async () => {
+    const [a, b] = await Promise.all([lifecycle.requestPass(), lifecycle.requestPass()]);
+    expect(a).toMatchObject({ reindexed: expect.any(Number) });
+    expect(b).toMatchObject({ reindexed: expect.any(Number) });
+    expect(b).not.toBe(a); // the second call ran its own pass
+    expect(isReindexInFlight()).toBe(false);
+  });
+});
+
+describe('rearmTimer with interval 0', () => {
+  it('is a no-op (auto-reindex disabled): no timer, no throw, status intact', async () => {
+    expect(() => lifecycle.rearmTimer()).not.toThrow();
+    const status = lifecycle.getIndexerStatus();
+    expect(status).toMatchObject({ state: 'watching', paused: false, intervalMs: 0 });
+    expect((await get('/api/health')).json().indexer.intervalMs).toBe(0);
+  });
+});

--- a/packages/server/test/security.test.ts
+++ b/packages/server/test/security.test.ts
@@ -16,6 +16,7 @@ import {
   hostnameFromHeader,
   isAllowedHost,
   registerHostGuard,
+  registerMutationGuard,
   registerSecurityHeaders,
 } from '../src/security.js';
 
@@ -106,5 +107,92 @@ describe('host guard (anti DNS-rebinding)', () => {
     expect(isAllowedHost('localhost.evil.com')).toBe(false);
     expect(hostnameFromHeader('[::1]:4317')).toBe('::1');
     expect(hostnameFromHeader('LocalHost:5317')).toBe('localhost');
+  });
+});
+
+describe('mutation guard (anti-CSRF on mutating routes)', () => {
+  function appWithGuard() {
+    const app = Fastify();
+    registerMutationGuard(app);
+    app.post('/api/mutate', async () => ({ ok: true }));
+    app.get('/api/read', async () => ({ ok: true }));
+    return app;
+  }
+
+  // A cross-origin no-cors fetch from any website arrives with a loopback Host
+  // but a non-same-origin Sec-Fetch-Site — every such mutation must be refused.
+  // `same-site` covers the subdomain variant; both are attacker-reachable.
+  it.each(['cross-site', 'same-site'])(
+    'rejects a POST with Sec-Fetch-Site: %s (403)',
+    async (site) => {
+      const app = appWithGuard();
+      const res = await app.inject({
+        method: 'POST',
+        url: '/api/mutate',
+        headers: { 'sec-fetch-site': site },
+        payload: { a: 1 },
+      });
+      expect(res.statusCode).toBe(403);
+      await app.close();
+    },
+  );
+
+  // Legit callers: the SPA (same-origin), a direct navigation (none), and
+  // curl / the CLI / app.inject (no Sec-Fetch-Site at all).
+  it.each(['same-origin', 'none'])('allows a POST with Sec-Fetch-Site: %s', async (site) => {
+    const app = appWithGuard();
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/mutate',
+      headers: { 'sec-fetch-site': site },
+      payload: { a: 1 },
+    });
+    expect(res.statusCode).toBe(200);
+    expect(res.json()).toEqual({ ok: true });
+    await app.close();
+  });
+
+  it('allows a POST with no Sec-Fetch-Site header and a JSON body (curl / CLI)', async () => {
+    const app = appWithGuard();
+    const res = await app.inject({ method: 'POST', url: '/api/mutate', payload: { a: 1 } });
+    expect(res.statusCode).toBe(200);
+    await app.close();
+  });
+
+  // Legacy-browser fallback: a no-cors cross-origin POST can only carry simple
+  // content types (text/plain & co) — requiring JSON closes that path too.
+  it('rejects a non-JSON content type on a mutating request (415)', async () => {
+    const app = appWithGuard();
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/mutate',
+      headers: { 'content-type': 'text/plain' },
+      payload: 'a=1',
+    });
+    expect(res.statusCode).toBe(415);
+    await app.close();
+  });
+
+  it('accepts application/json with a charset parameter', async () => {
+    const app = appWithGuard();
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/mutate',
+      headers: { 'content-type': 'application/json; charset=utf-8' },
+      payload: JSON.stringify({ a: 1 }),
+    });
+    expect(res.statusCode).toBe(200);
+    await app.close();
+  });
+
+  it('skips safe methods: a GET passes even with Sec-Fetch-Site: cross-site', async () => {
+    const app = appWithGuard();
+    const res = await app.inject({
+      method: 'GET',
+      url: '/api/read',
+      headers: { 'sec-fetch-site': 'cross-site' },
+    });
+    expect(res.statusCode).toBe(200);
+    await app.close();
   });
 });

--- a/packages/server/test/settings-api.integration.test.ts
+++ b/packages/server/test/settings-api.integration.test.ts
@@ -1,0 +1,217 @@
+/**
+ * Settings API integration test — GET/PUT /api/settings against a real index,
+ * using the Grok connector as the guinea pig for the FILE layer: no
+ * GROK_SESSIONS_DIR env var is set; instead a pre-written settings.json in the
+ * temp CLAUDESCOPE_HOME points grokSessionsDir at a fixture dir. This exercises
+ * the whole runtime-settings chain: file-sourced resolution surfaces on GET,
+ * a PUT re-points the connector live (the next pass indexes the new dir and
+ * prunes the old), env-shadowed saves warn without changing the effective
+ * value, and invalid patches are rejected atomically (file untouched).
+ */
+
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import type { FastifyInstance } from 'fastify';
+
+// --- temp locations (decided before any server module is imported) ----------
+const work = mkdtempSync(join(tmpdir(), 'claudescope-settings-api-'));
+const home = join(work, 'home');
+const settingsPath = join(home, 'settings.json');
+const claudeDir = join(work, 'claude-empty');
+const grokDirA = join(work, 'grok-a');
+const grokDirB = join(work, 'grok-b');
+
+process.env.CLAUDE_PROJECTS_DIR = claudeDir; // env-sourced row + shadow-warning test
+process.env.CODEX_SESSIONS_DIR = join(work, 'codex-empty');
+process.env.JUNIE_SESSIONS_DIR = join(work, 'junie-empty');
+process.env.PI_SESSIONS_DIR = join(work, 'pi-empty');
+process.env.OPENCODE_DATA_DIR = join(work, 'opencode-empty');
+process.env.COPILOT_SESSIONS_DIR = join(work, 'copilot-empty');
+process.env.ANTIGRAVITY_CLI_DIR = join(work, 'antigravity-empty');
+process.env.ANTIGRAVITY_DIR = join(work, 'antigravity-empty-desktop');
+process.env.DUCKDB_PATH = join(work, 'index.duckdb');
+process.env.CLAUDESCOPE_HOME = home;
+process.env.REINDEX_INTERVAL_MS = '0';
+// The point of this suite: the grok dir comes from settings.json, NOT env.
+// resolveSetting reads env per call, so an inherited var would shadow the file.
+delete process.env.GROK_SESSIONS_DIR;
+
+const jsonl = (events: unknown[]): string => events.map((e) => JSON.stringify(e)).join('\n') + '\n';
+const BASE_MS = Date.parse('2026-06-20T10:00:00.000Z');
+const iso = (s: number) => new Date(BASE_MS + s * 1000).toISOString();
+
+/** Minimal Grok session dir: chat_history.jsonl + summary.json (no updates). */
+function writeGrokSession(sessionsDir: string, id: string, prompt: string): void {
+  const dir = join(sessionsDir, '%2Ftmp%2Fsettingsproj', id);
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(
+    join(dir, 'summary.json'),
+    JSON.stringify({
+      info: { id, cwd: '/tmp/settingsproj' },
+      created_at: iso(0),
+      updated_at: iso(60),
+      current_model_id: 'grok-4.5',
+      generated_title: `Session ${id}`,
+    }),
+  );
+  writeFileSync(
+    join(dir, 'chat_history.jsonl'),
+    jsonl([
+      { type: 'user', prompt_index: 0, content: [{ type: 'text', text: `<user_query>\n${prompt}\n</user_query>` }] },
+      { type: 'assistant', content: 'done', model_id: 'grok-4.5' },
+    ]),
+  );
+}
+
+let app: FastifyInstance;
+let closeConnection: () => Promise<void>;
+
+beforeAll(async () => {
+  mkdirSync(claudeDir, { recursive: true });
+  writeGrokSession(grokDirA, 'grok-sess-a', 'session living in dir A');
+  writeGrokSession(grokDirB, 'grok-sess-b', 'session living in dir B');
+  // Pre-write the settings file the server will read at the first resolve.
+  mkdirSync(home, { recursive: true });
+  writeFileSync(settingsPath, `${JSON.stringify({ schemaVersion: 1, grokSessionsDir: grokDirA }, null, 2)}\n`);
+
+  const Fastify = (await import('fastify')).default;
+  const { registerRoutes } = await import('../src/routes/index.js');
+  const { reindex } = await import('../src/data/index.js');
+  ({ closeConnection } = await import('../src/db/duckdb.js'));
+
+  app = Fastify();
+  await registerRoutes(app);
+  await reindex();
+  await app.ready();
+});
+
+afterAll(async () => {
+  await app?.close();
+  await closeConnection?.();
+  rmSync(work, { recursive: true, force: true });
+});
+
+const get = (url: string) => app.inject({ method: 'GET', url });
+const put = (set: Record<string, unknown>) =>
+  app.inject({ method: 'PUT', url: '/api/settings', payload: { set } });
+const sessionIds = async (): Promise<string[]> =>
+  ((await get('/api/sessions')).json() as { id: string }[]).map((s) => s.id).sort();
+
+type SettingsBody = {
+  schemaVersion: number;
+  editable: Record<string, unknown>[];
+  readOnly: Record<string, unknown>[];
+};
+const row = (body: SettingsBody, key: string) => body.editable.find((r) => r.key === key)!;
+
+describe('GET /api/settings', () => {
+  it('reports the file-sourced grok row and the env-sourced claude row with provenance', async () => {
+    const res = await get('/api/settings');
+    expect(res.statusCode).toBe(200);
+    const body = res.json() as SettingsBody;
+    expect(body.schemaVersion).toBe(1);
+
+    // File layer: value comes from settings.json (no env var set).
+    expect(row(body, 'grokSessionsDir')).toMatchObject({
+      source: 'file',
+      effective: grokDirA,
+      fileValue: grokDirA,
+      exists: true,
+      connectorId: 'grok',
+      type: 'path',
+      envVar: 'GROK_SESSIONS_DIR',
+      live: true,
+    });
+
+    // Env layer: the harness sets CLAUDE_PROJECTS_DIR, so env wins.
+    const claude = row(body, 'claudeProjectsDir');
+    expect(claude).toMatchObject({ source: 'env', effective: claudeDir, exists: true });
+    expect(claude.fileValue).toBeUndefined();
+
+    // Read-only infra rows ride along for transparency.
+    const homeRow = body.readOnly.find((r) => r.key === 'claudescopeHome');
+    expect(homeRow).toMatchObject({ source: 'env' });
+    expect(body.readOnly.some((r) => r.key === 'port')).toBe(true);
+  });
+
+  it('indexes sessions from the file-configured grok dir', async () => {
+    expect(await sessionIds()).toEqual(['grok-sess-a']);
+    const sessions = (await get('/api/sessions')).json() as { id: string; connectorId: string }[];
+    expect(sessions[0]!.connectorId).toBe('grok');
+  });
+});
+
+describe('PUT /api/settings', () => {
+  it('re-points the grok source dir live: dir B appears, dir A is pruned', async () => {
+    const res = await put({ grokSessionsDir: grokDirB });
+    expect(res.statusCode).toBe(200);
+    const body = res.json() as {
+      settings: SettingsBody;
+      applied: { key: string; live: boolean }[];
+      warnings: unknown[];
+    };
+    expect(body.applied).toContainEqual({ key: 'grokSessionsDir', live: true });
+    expect(body.warnings).toEqual([]);
+    expect(row(body.settings, 'grokSessionsDir')).toMatchObject({
+      source: 'file',
+      effective: grokDirB,
+      exists: true,
+    });
+
+    // The PUT kicks requestPass fire-and-forget; a POST /api/reindex serializes
+    // behind it (reindex coalesces on the in-flight pass), so after this await
+    // the post-save discovery has definitely completed.
+    const re = await app.inject({ method: 'POST', url: '/api/reindex' });
+    expect(re.statusCode).toBe(200);
+
+    expect(await sessionIds()).toEqual(['grok-sess-b']); // A's session pruned
+  });
+
+  it('saves an env-shadowed key with a warning; the effective value stays env', async () => {
+    const claudeAlt = join(work, 'claude-alt');
+    mkdirSync(claudeAlt, { recursive: true });
+
+    const res = await put({ claudeProjectsDir: claudeAlt });
+    expect(res.statusCode).toBe(200);
+    const body = res.json() as { settings: SettingsBody; warnings: { key: string; message: string }[] };
+    expect(body.warnings).toContainEqual({
+      key: 'claudeProjectsDir',
+      message: expect.stringContaining('$CLAUDE_PROJECTS_DIR'),
+    });
+
+    // Saved to the file, but env keeps winning until the var is unset.
+    expect(row(body.settings, 'claudeProjectsDir')).toMatchObject({
+      source: 'env',
+      effective: claudeDir,
+      fileValue: claudeAlt,
+    });
+    const onDisk = JSON.parse(readFileSync(settingsPath, 'utf8')) as Record<string, unknown>;
+    expect(onDisk.claudeProjectsDir).toBe(claudeAlt);
+  });
+
+  it('rejects an invalid interval with per-field errors and leaves the file untouched', async () => {
+    const before = readFileSync(settingsPath, 'utf8');
+    const res = await put({ reindexIntervalMs: 500 });
+    expect(res.statusCode).toBe(400);
+    const body = res.json() as { error: string; fields: Record<string, string> };
+    expect(body.fields.reindexIntervalMs).toMatch(/1000/);
+    expect(readFileSync(settingsPath, 'utf8')).toBe(before);
+  });
+
+  it('rejects an unknown key', async () => {
+    const res = await put({ nonsenseKey: '/x' });
+    expect(res.statusCode).toBe(400);
+    expect((res.json() as { fields: Record<string, string> }).fields.nonsenseKey).toBe(
+      'unknown setting',
+    );
+  });
+
+  it('rejects a malformed body (missing or empty set)', async () => {
+    const noSet = await app.inject({ method: 'PUT', url: '/api/settings', payload: {} });
+    expect(noSet.statusCode).toBe(400);
+    const emptySet = await put({});
+    expect(emptySet.statusCode).toBe(400);
+  });
+});

--- a/packages/server/test/settings.test.ts
+++ b/packages/server/test/settings.test.ts
@@ -1,0 +1,292 @@
+/**
+ * Unit tests for the settings.json layer (settings.ts): per-call env > file >
+ * default precedence, the mtime-cached file read, corruption handling (defaults
+ * + warn-once + .bak on save), null-clears / unknown-key preservation in
+ * saveSettings, the derived opencodeDbPath default, and validateSettingsPatch.
+ *
+ * CLAUDESCOPE_HOME is pointed at a temp dir BEFORE the module import (SETTINGS_PATH
+ * is computed at import time), and every setting's env var is deleted per test —
+ * the getters read env PER CALL, so an inherited var would silently win over the
+ * file layer under test.
+ */
+
+import { afterAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, utimesSync, writeFileSync } from 'node:fs';
+import { homedir, tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+// --- temp home (decided before the settings module is imported) -------------
+const work = mkdtempSync(join(tmpdir(), 'claudescope-settings-unit-'));
+const home = join(work, 'home');
+process.env.CLAUDESCOPE_HOME = home;
+mkdirSync(home, { recursive: true });
+
+const {
+  SETTINGS_PATH,
+  SETTINGS_SCHEMA_VERSION,
+  SETTING_DEFS,
+  fileValueOf,
+  grokSessionsDir,
+  opencodeDataDir,
+  openBrowserOnStart,
+  reindexIntervalMs,
+  resetSettingsCache,
+  resolveSetting,
+  saveSettings,
+  validateSettingsPatch,
+} = await import('../src/settings.js');
+
+/**
+ * Force a strictly-increasing mtime so the mtime-keyed cache busts even when
+ * two rewrites land in the same millisecond (same idiom as pricing.test.ts).
+ */
+let mtimeTick = Math.floor(Date.now() / 1000);
+const bumpMtime = (path: string): void => {
+  mtimeTick += 2;
+  utimesSync(path, mtimeTick, mtimeTick);
+};
+
+/** Write settings.json directly (bypassing saveSettings) with a fresh mtime. */
+const writeSettings = (data: Record<string, unknown>): void => {
+  writeFileSync(SETTINGS_PATH, `${JSON.stringify(data, null, 2)}\n`);
+  bumpMtime(SETTINGS_PATH);
+};
+
+const readSettingsRaw = (): string => readFileSync(SETTINGS_PATH, 'utf8');
+
+beforeEach(() => {
+  // The resolvers read env per call: strip every setting's env var so nothing
+  // inherited from the parent shell/vitest can shadow the layer under test.
+  for (const def of SETTING_DEFS) {
+    if (def.envVar) delete process.env[def.envVar];
+  }
+  delete process.env.OPEN_BROWSER;
+  rmSync(SETTINGS_PATH, { force: true });
+  rmSync(`${SETTINGS_PATH}.bak`, { force: true });
+  resetSettingsCache();
+});
+
+afterAll(() => rmSync(work, { recursive: true, force: true }));
+
+describe('resolveSetting precedence (env > file > default, per call)', () => {
+  it('path key: env wins over file, file over default, with ~ expanded on both layers', () => {
+    writeSettings({ grokSessionsDir: '~/file-grok' });
+    process.env.GROK_SESSIONS_DIR = '~/env-grok';
+
+    expect(resolveSetting('grokSessionsDir')).toEqual({
+      value: join(homedir(), 'env-grok'),
+      source: 'env',
+    });
+    expect(grokSessionsDir()).toBe(join(homedir(), 'env-grok'));
+
+    // Same process, same call site: dropping the env var flips to the file layer.
+    delete process.env.GROK_SESSIONS_DIR;
+    expect(resolveSetting('grokSessionsDir')).toEqual({
+      value: join(homedir(), 'file-grok'),
+      source: 'file',
+    });
+    // fileValueOf returns the RAW saved value (unexpanded, for display).
+    expect(fileValueOf('grokSessionsDir')).toBe('~/file-grok');
+
+    // Clearing the file value reverts to the default.
+    saveSettings({ grokSessionsDir: null });
+    expect(resolveSetting('grokSessionsDir')).toEqual({
+      value: join(homedir(), '.grok', 'sessions'),
+      source: 'default',
+    });
+  });
+
+  it('number key: a "0" env value resolves to 0 and still beats a file value', () => {
+    writeSettings({ reindexIntervalMs: 5000 });
+    process.env.REINDEX_INTERVAL_MS = '0';
+    expect(resolveSetting('reindexIntervalMs')).toEqual({ value: 0, source: 'env' });
+    expect(reindexIntervalMs()).toBe(0);
+  });
+
+  it('number key: an unparsable env value falls through to file, then default', () => {
+    process.env.REINDEX_INTERVAL_MS = 'abc';
+    writeSettings({ reindexIntervalMs: 5000 });
+    expect(resolveSetting('reindexIntervalMs')).toEqual({ value: 5000, source: 'file' });
+
+    saveSettings({ reindexIntervalMs: null });
+    expect(resolveSetting('reindexIntervalMs')).toEqual({ value: 15000, source: 'default' });
+  });
+
+  it('a wrong-typed file value is ignored (falls through to default)', () => {
+    writeSettings({ reindexIntervalMs: 'not-a-number', grokSessionsDir: 42 });
+    expect(fileValueOf('reindexIntervalMs')).toBeUndefined();
+    expect(resolveSetting('reindexIntervalMs')).toEqual({ value: 15000, source: 'default' });
+    expect(resolveSetting('grokSessionsDir').source).toBe('default');
+  });
+
+  it('openBrowser has NO env layer: OPEN_BROWSER never overrides file/default', () => {
+    // OPEN_BROWSER is the internal launcher contract, always pinned by the
+    // daemon spawner — reading it would misreport user intent.
+    process.env.OPEN_BROWSER = '1';
+    writeSettings({ openBrowser: false });
+    expect(openBrowserOnStart()).toBe(false);
+    expect(resolveSetting('openBrowser').source).toBe('file');
+
+    saveSettings({ openBrowser: null });
+    process.env.OPEN_BROWSER = '0';
+    expect(openBrowserOnStart()).toBe(true); // default, not the env var
+    expect(resolveSetting('openBrowser').source).toBe('default');
+  });
+});
+
+describe('corrupt settings.json', () => {
+  it('falls back to defaults, leaves the file untouched, and warns once (not per call)', () => {
+    writeFileSync(SETTINGS_PATH, '{ this is not json');
+    bumpMtime(SETTINGS_PATH);
+    const before = readSettingsRaw();
+
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    expect(resolveSetting('grokSessionsDir')).toEqual({
+      value: join(homedir(), '.grok', 'sessions'),
+      source: 'default',
+    });
+    expect(resolveSetting('reindexIntervalMs')).toEqual({ value: 15000, source: 'default' });
+    expect(warn).toHaveBeenCalledTimes(1);
+    warn.mockRestore();
+
+    // The read path never rewrites the user's file.
+    expect(readSettingsRaw()).toBe(before);
+  });
+
+  it('saveSettings backs a corrupt file up to .bak before overwriting it', () => {
+    writeFileSync(SETTINGS_PATH, '{ this is not json');
+    bumpMtime(SETTINGS_PATH);
+
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    saveSettings({ grokSessionsDir: '/abs/grok' });
+    warn.mockRestore();
+
+    // The corrupt bytes survive in the backup; the new file is valid JSON.
+    expect(readFileSync(`${SETTINGS_PATH}.bak`, 'utf8')).toBe('{ this is not json');
+    expect(JSON.parse(readSettingsRaw())).toEqual({
+      grokSessionsDir: '/abs/grok',
+      schemaVersion: SETTINGS_SCHEMA_VERSION,
+    });
+    expect(resolveSetting('grokSessionsDir')).toEqual({ value: '/abs/grok', source: 'file' });
+  });
+});
+
+describe('saveSettings', () => {
+  it('null clears a key, unknown file keys survive saves, schemaVersion is stamped', () => {
+    writeSettings({ grokSessionsDir: '/abs/a', futureKnob: 'kept' });
+
+    saveSettings({ grokSessionsDir: '/abs/b' });
+    let onDisk = JSON.parse(readSettingsRaw()) as Record<string, unknown>;
+    expect(onDisk.grokSessionsDir).toBe('/abs/b');
+    expect(onDisk.futureKnob).toBe('kept'); // forward compatibility
+    expect(onDisk.schemaVersion).toBe(SETTINGS_SCHEMA_VERSION);
+
+    saveSettings({ grokSessionsDir: null });
+    onDisk = JSON.parse(readSettingsRaw()) as Record<string, unknown>;
+    expect('grokSessionsDir' in onDisk).toBe(false);
+    expect(onDisk.futureKnob).toBe('kept');
+    expect(resolveSetting('grokSessionsDir').source).toBe('default');
+  });
+
+  it('opencodeDbPath default re-derives live from a saved opencodeDataDir', () => {
+    const dataDir = join(work, 'oc-data');
+    saveSettings({ opencodeDataDir: dataDir });
+    expect(opencodeDataDir()).toBe(dataDir);
+    // Still source 'default' — the DB path itself was never saved, its default
+    // just tracks the EFFECTIVE data dir.
+    expect(resolveSetting('opencodeDbPath')).toEqual({
+      value: join(dataDir, 'opencode.db'),
+      source: 'default',
+    });
+  });
+});
+
+describe('mtime-cached file read', () => {
+  it('picks up a hand-rewritten file on the next call once its mtime changes', () => {
+    writeSettings({ grokSessionsDir: '/abs/first' });
+    expect(grokSessionsDir()).toBe('/abs/first'); // warm the cache
+
+    // Rewrite behind the module's back — no saveSettings, no resetSettingsCache.
+    writeFileSync(SETTINGS_PATH, JSON.stringify({ grokSessionsDir: '/abs/second' }));
+    bumpMtime(SETTINGS_PATH); // guarantee a distinct mtime without sleeping
+    expect(grokSessionsDir()).toBe('/abs/second');
+  });
+});
+
+describe('validateSettingsPatch', () => {
+  it('rejects unknown keys', () => {
+    const v = validateSettingsPatch({ bogusKey: '/x' });
+    expect(v.errors).toEqual({ bogusKey: 'unknown setting' });
+  });
+
+  it('rejects relative, empty, and non-string paths', () => {
+    expect(validateSettingsPatch({ grokSessionsDir: 'rel/path' }).errors.grokSessionsDir).toMatch(
+      /absolute/,
+    );
+    expect(validateSettingsPatch({ grokSessionsDir: '   ' }).errors.grokSessionsDir).toMatch(
+      /non-empty/,
+    );
+    expect(validateSettingsPatch({ grokSessionsDir: 42 }).errors.grokSessionsDir).toMatch(
+      /non-empty/,
+    );
+  });
+
+  it('interval: 500 rejected, 0 and 1000 accepted, non-integers rejected', () => {
+    expect(validateSettingsPatch({ reindexIntervalMs: 500 }).errors.reindexIntervalMs).toMatch(
+      /1000/,
+    );
+    expect(validateSettingsPatch({ reindexIntervalMs: 0 }).errors).toEqual({});
+    expect(validateSettingsPatch({ reindexIntervalMs: 1000 }).errors).toEqual({});
+    expect(validateSettingsPatch({ reindexIntervalMs: 1500.5 }).errors.reindexIntervalMs).toMatch(
+      /integer/,
+    );
+    expect(validateSettingsPatch({ reindexIntervalMs: '5000' }).errors.reindexIntervalMs).toMatch(
+      /integer/,
+    );
+  });
+
+  it('rejects a boolean type mismatch', () => {
+    expect(validateSettingsPatch({ openBrowser: 'yes' }).errors.openBrowser).toMatch(
+      /true or false/,
+    );
+  });
+
+  it('a nonexistent dir (or a file where a dir is expected) warns, never errors', () => {
+    const missing = validateSettingsPatch({ grokSessionsDir: join(work, 'not-there') });
+    expect(missing.errors).toEqual({});
+    expect(missing.warnings).toEqual([
+      { key: 'grokSessionsDir', message: expect.stringContaining('does not exist') },
+    ]);
+
+    const filePath = join(work, 'plain-file');
+    writeFileSync(filePath, 'x');
+    const notDir = validateSettingsPatch({ grokSessionsDir: filePath });
+    expect(notDir.errors).toEqual({});
+    expect(notDir.warnings).toEqual([
+      { key: 'grokSessionsDir', message: expect.stringContaining('not a directory') },
+    ]);
+  });
+
+  it('warns when an env var currently shadows the saved key', () => {
+    process.env.CODEX_SESSIONS_DIR = '/somewhere-else';
+    const v = validateSettingsPatch({ codexSessionsDir: work }); // exists, is a dir
+    expect(v.errors).toEqual({});
+    expect(v.warnings).toContainEqual({
+      key: 'codexSessionsDir',
+      message: expect.stringContaining('$CODEX_SESSIONS_DIR'),
+    });
+  });
+
+  it('null clears are always valid', () => {
+    const v = validateSettingsPatch({ grokSessionsDir: null, reindexIntervalMs: null });
+    expect(v.errors).toEqual({});
+    expect(v.warnings).toEqual([]);
+  });
+});
+
+describe('read path never creates state', () => {
+  it('resolving with no settings.json neither throws nor writes one', () => {
+    expect(resolveSetting('claudeProjectsDir').source).toBe('default');
+    expect(existsSync(SETTINGS_PATH)).toBe(false);
+  });
+});

--- a/packages/shared/src/api.ts
+++ b/packages/shared/src/api.ts
@@ -441,6 +441,112 @@ export interface HealthResponse {
   indexing?: IndexingProgress;
   /** Latest published version, when the daemon knows it is newer than itself. */
   updateAvailable?: string;
+  /** Compact indexer lifecycle state (full status lives on the action responses). */
+  indexer?: Pick<IndexerStatus, 'state' | 'paused' | 'intervalMs'>;
+}
+
+// ---------------------------------------------------------------------------
+// Settings & lifecycle
+// ---------------------------------------------------------------------------
+
+/** Where an effective setting value came from (precedence: env > file > default). */
+export type SettingSource = 'env' | 'file' | 'default';
+
+export type SettingValue = string | number | boolean;
+
+/** One editable setting row, driven by the server-side registry. */
+export interface EditableSetting {
+  /** Registry key, e.g. `claudeProjectsDir`. */
+  key: string;
+  /** Human label, e.g. `Claude Code sessions`. */
+  label: string;
+  group: 'sources' | 'indexing' | 'startup';
+  type: 'path' | 'number' | 'boolean';
+  /** The env var that overrides this setting, e.g. `CLAUDE_PROJECTS_DIR`.
+   *  Absent for settings with no env layer (e.g. `openBrowser`, whose
+   *  `OPEN_BROWSER` env var is an internal launcher contract, not an override). */
+  envVar?: string;
+  /** The value currently in effect after precedence resolution. */
+  effective: SettingValue;
+  source: SettingSource;
+  /** Saved settings.json value, when present (may be shadowed by env). */
+  fileValue?: SettingValue;
+  defaultValue: SettingValue;
+  /** False → change takes effect on the next `claudescope start`. */
+  live: boolean;
+  /** Paths only: whether the effective path exists on disk. */
+  exists?: boolean;
+  /** Sources only: the connector this dir feeds, for UI labeling. */
+  connectorId?: string;
+}
+
+/** A config value shown for transparency but not editable from the UI. */
+export interface ReadOnlySetting {
+  key: string;
+  label: string;
+  envVar?: string;
+  value: string | number;
+  source: SettingSource;
+}
+
+/** GET /api/settings */
+export interface SettingsResponse {
+  schemaVersion: number;
+  editable: EditableSetting[];
+  readOnly: ReadOnlySetting[];
+}
+
+/** PUT /api/settings — `null` clears a key back to its default. */
+export interface SettingsUpdateRequest {
+  set: Record<string, SettingValue | null>;
+}
+
+export interface SettingsUpdateResponse {
+  /** Fresh post-save snapshot. */
+  settings: SettingsResponse;
+  applied: { key: string; live: boolean }[];
+  warnings: { key: string; message: string }[];
+}
+
+/** Indexer lifecycle state (the poller + reindex engine, not the process). */
+export interface IndexerStatus {
+  state: 'building' | 'watching' | 'paused' | 'indexing';
+  /** Runtime-only pause flag — not persisted; a restart resumes indexing. */
+  paused: boolean;
+  /** Effective auto-reindex interval (0 = disabled). */
+  intervalMs: number;
+  /** ISO timestamp of the last completed pass, if any. */
+  lastPassAt: string | null;
+  lastPass: ReindexResponse | null;
+  rebuilding: boolean;
+}
+
+/** POST /api/index/rebuild → 202 */
+export interface RebuildStartedResponse {
+  started: true;
+}
+
+/** POST /api/pricing/refresh */
+export interface PricingRefreshResponse {
+  fetchedAt: string;
+  modelCount: number;
+  changed: number;
+  /** Snapshot path, home dir contracted to `~`. */
+  path: string;
+}
+
+/** GET /api/system — per-process statics for the Status/Update cards. */
+export interface SystemInfoResponse {
+  version: string;
+  /** Latest published version, or null when offline / dev build. */
+  latestVersion: string | null;
+  updateAvailable: boolean;
+  installMethod: 'npm' | 'brew' | 'nix';
+  /** Exact upgrade command for the detected install method. */
+  updateCommand: string;
+  /** ISO timestamp of process start, for uptime display. */
+  startedAt: string;
+  dataVersion: number;
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -31,7 +31,7 @@ const NAV_ITEMS: NavItem[] = [
 
 /** Left navigation sidebar. */
 function Sidebar() {
-  const { updateAvailable } = useServerStatus();
+  const { updateAvailable, version } = useServerStatus();
 
   return (
     <nav className="tv-nav">
@@ -66,6 +66,7 @@ function Sidebar() {
         <Settings size={16} aria-hidden="true" />
         Settings
       </NavLink>
+      {version ? <span className="tv-nav__version tv-mono">v{version}</span> : null}
       {updateAvailable ? (
         <div className="tv-nav__footer">
           <span className="tv-nav__update" title={`Update available: v${updateAvailable}`}>

--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -1,10 +1,9 @@
 import { useEffect, useState } from 'react';
 import { NavLink, Route, Routes, useLocation } from 'react-router-dom';
-import { Cpu, FolderOpen, LineChart, Monitor, Moon, Search, Sun, type LucideIcon } from 'lucide-react';
+import { Cpu, FolderOpen, LineChart, Search, Settings, type LucideIcon } from 'lucide-react';
 import type { SourceInfo } from '@claudescope/shared';
 import { ErrorBoundary } from './components';
 import { api } from './api/client.js';
-import { useTheme, type ThemeChoice } from './theme/ThemeProvider.js';
 import { useServerStatus } from './status/StatusProvider.js';
 import { BrowsePage } from './pages/browse/BrowsePage.js';
 import { ProjectLayout } from './pages/browse/ProjectLayout.js';
@@ -16,6 +15,7 @@ import { MemoryPage } from './pages/memory/MemoryPage.js';
 import { AgentMemoryPage } from './pages/memory/AgentMemoryPage.js';
 import { AgentProjectMemoryPage } from './pages/memory/AgentProjectMemoryPage.js';
 import { ProjectMemoryPage } from './pages/memory/ProjectMemoryPage.js';
+import { SettingsPage } from './pages/settings/SettingsPage.js';
 
 interface NavItem {
   to: string;
@@ -30,37 +30,8 @@ const NAV_ITEMS: NavItem[] = [
   { to: '/memory', label: 'Memory', icon: Cpu },
   { to: '/search', label: 'Search', icon: Search },
   { to: '/analytics', label: 'Analytics', icon: LineChart },
+  { to: '/settings', label: 'Settings', icon: Settings },
 ];
-
-const THEME_OPTIONS: { value: ThemeChoice; label: string; icon: LucideIcon }[] = [
-  { value: 'system', label: 'System', icon: Monitor },
-  { value: 'light', label: 'Light', icon: Sun },
-  { value: 'dark', label: 'Dark', icon: Moon },
-];
-
-/** Segmented System / Light / Dark theme control. */
-function ThemeToggle() {
-  const { theme, setTheme } = useTheme();
-  return (
-    <div className="tv-theme-toggle" role="group" aria-label="Theme">
-      {THEME_OPTIONS.map((o) => {
-        const Icon = o.icon;
-        return (
-          <button
-            key={o.value}
-            type="button"
-            className={theme === o.value ? 'tv-theme-toggle__btn is-active' : 'tv-theme-toggle__btn'}
-            onClick={() => setTheme(o.value)}
-            title={`${o.label} theme`}
-            aria-pressed={theme === o.value}
-          >
-            <Icon size={15} aria-hidden="true" />
-          </button>
-        );
-      })}
-    </div>
-  );
-}
 
 /** Left navigation sidebar. */
 function Sidebar() {
@@ -102,7 +73,6 @@ function Sidebar() {
         </NavLink>
       ))}
       <div className="tv-nav__spacer" />
-      <ThemeToggle />
       <div className="tv-nav__footer">
         {updateAvailable ? (
           <span className="tv-nav__update" title={`Update available: v${updateAvailable}`}>
@@ -143,6 +113,7 @@ export function App() {
             <Route path="/memory" element={<MemoryPage />} />
             <Route path="/memory/:connectorId" element={<AgentMemoryPage />} />
             <Route path="/memory/:connectorId/:projectId" element={<AgentProjectMemoryPage />} />
+            <Route path="/settings" element={<SettingsPage />} />
             </Routes>
           </ErrorBoundary>
         </div>

--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -1,9 +1,6 @@
-import { useEffect, useState } from 'react';
 import { NavLink, Route, Routes, useLocation } from 'react-router-dom';
 import { Cpu, FolderOpen, LineChart, Search, Settings, type LucideIcon } from 'lucide-react';
-import type { SourceInfo } from '@claudescope/shared';
 import { ErrorBoundary } from './components';
-import { api } from './api/client.js';
 import { useServerStatus } from './status/StatusProvider.js';
 import { BrowsePage } from './pages/browse/BrowsePage.js';
 import { ProjectLayout } from './pages/browse/ProjectLayout.js';
@@ -30,23 +27,11 @@ const NAV_ITEMS: NavItem[] = [
   { to: '/memory', label: 'Memory', icon: Cpu },
   { to: '/search', label: 'Search', icon: Search },
   { to: '/analytics', label: 'Analytics', icon: LineChart },
-  { to: '/settings', label: 'Settings', icon: Settings },
 ];
 
 /** Left navigation sidebar. */
 function Sidebar() {
   const { updateAvailable } = useServerStatus();
-  const [sources, setSources] = useState<SourceInfo[]>([]);
-  useEffect(() => {
-    const controller = new AbortController();
-    api
-      .sources(controller.signal)
-      .then(setSources)
-      .catch(() => {
-        /* footer is best-effort */
-      });
-    return () => controller.abort();
-  }, []);
 
   return (
     <nav className="tv-nav">
@@ -73,19 +58,21 @@ function Sidebar() {
         </NavLink>
       ))}
       <div className="tv-nav__spacer" />
-      <div className="tv-nav__footer">
-        {updateAvailable ? (
+      {/* Settings anchors the bottom of the sidebar, apart from the main nav. */}
+      <NavLink
+        to="/settings"
+        className={({ isActive }) => (isActive ? 'tv-nav__link is-active' : 'tv-nav__link')}
+      >
+        <Settings size={16} aria-hidden="true" />
+        Settings
+      </NavLink>
+      {updateAvailable ? (
+        <div className="tv-nav__footer">
           <span className="tv-nav__update" title={`Update available: v${updateAvailable}`}>
             v{updateAvailable} available — <code className="tv-mono">claudescope update</code>
           </span>
-        ) : null}
-        <span className="tv-nav__footer-label">Read-only sources</span>
-        {sources.map((s) => (
-          <span key={s.id} className="tv-nav__source tv-mono" title={`${s.label} · ${s.path}`}>
-            {s.path}
-          </span>
-        ))}
-      </div>
+        </div>
+      ) : null}
     </nav>
   );
 }

--- a/packages/web/src/api/client.ts
+++ b/packages/web/src/api/client.ts
@@ -10,9 +10,12 @@ import type {
   AnalyticsGroupBy,
   AnalyticsResponse,
   HealthResponse,
+  IndexerStatus,
   MemoryResponse,
+  PricingRefreshResponse,
   ProjectMemoryResponse,
   ProjectsResponse,
+  RebuildStartedResponse,
   ReindexResponse,
   SearchResponse,
   SearchScope,
@@ -21,10 +24,14 @@ import type {
   SessionEfficiencyResponse,
   SessionFingerprintResponse,
   SessionEfficiencySort,
+  SettingsResponse,
+  SettingsUpdateRequest,
+  SettingsUpdateResponse,
   SortDir,
   SessionSort,
   SessionsResponse,
   SourcesResponse,
+  SystemInfoResponse,
   ToolUsageResponse,
   DigestResponse,
 } from '@claudescope/shared';
@@ -242,5 +249,48 @@ export const api = {
   /** POST /api/reindex */
   reindex(signal?: AbortSignal): Promise<ReindexResponse> {
     return request<ReindexResponse>('/reindex', { method: 'POST', body: {}, signal });
+  },
+
+  /** GET /api/settings */
+  getSettings(signal?: AbortSignal): Promise<SettingsResponse> {
+    return request<SettingsResponse>('/settings', { signal });
+  },
+
+  /** PUT /api/settings */
+  updateSettings(
+    set: SettingsUpdateRequest['set'],
+    signal?: AbortSignal,
+  ): Promise<SettingsUpdateResponse> {
+    return request<SettingsUpdateResponse>('/settings', { method: 'PUT', body: { set }, signal });
+  },
+
+  /** POST /api/indexer/stop — pause auto-indexing (the index stays queryable). */
+  indexerStop(signal?: AbortSignal): Promise<IndexerStatus> {
+    return request<IndexerStatus>('/indexer/stop', { method: 'POST', body: {}, signal });
+  },
+
+  /** POST /api/indexer/start — resume auto-indexing + kick a pass. */
+  indexerStart(signal?: AbortSignal): Promise<IndexerStatus> {
+    return request<IndexerStatus>('/indexer/start', { method: 'POST', body: {}, signal });
+  },
+
+  /** POST /api/indexer/restart — fresh pass now, poller re-armed. */
+  indexerRestart(signal?: AbortSignal): Promise<IndexerStatus> {
+    return request<IndexerStatus>('/indexer/restart', { method: 'POST', body: {}, signal });
+  },
+
+  /** POST /api/index/rebuild — discard the index and rebuild from sources. */
+  rebuildIndex(signal?: AbortSignal): Promise<RebuildStartedResponse> {
+    return request<RebuildStartedResponse>('/index/rebuild', { method: 'POST', body: {}, signal });
+  },
+
+  /** POST /api/pricing/refresh — sync rates from LiteLLM now. */
+  refreshPricing(signal?: AbortSignal): Promise<PricingRefreshResponse> {
+    return request<PricingRefreshResponse>('/pricing/refresh', { method: 'POST', body: {}, signal });
+  },
+
+  /** GET /api/system — version / update / uptime statics. */
+  systemInfo(signal?: AbortSignal): Promise<SystemInfoResponse> {
+    return request<SystemInfoResponse>('/system', { signal });
   },
 };

--- a/packages/web/src/components/ConfirmDialog.tsx
+++ b/packages/web/src/components/ConfirmDialog.tsx
@@ -1,0 +1,69 @@
+/**
+ * Minimal confirmation modal for destructive actions (the app's first — no
+ * dialog library). Renders a fixed overlay + a `tv-card` panel; Escape or an
+ * overlay click cancels; focus lands on Cancel so Enter never confirms by
+ * accident.
+ */
+
+import { useEffect, useRef } from 'react';
+
+interface ConfirmDialogProps {
+  title: string;
+  /** Body copy — spell out exactly what will happen. */
+  children: React.ReactNode;
+  confirmLabel: string;
+  /** Style the confirm button as destructive (danger) or primary. */
+  danger?: boolean;
+  busy?: boolean;
+  onConfirm: () => void;
+  onCancel: () => void;
+}
+
+export function ConfirmDialog({
+  title,
+  children,
+  confirmLabel,
+  danger = false,
+  busy = false,
+  onConfirm,
+  onCancel,
+}: ConfirmDialogProps) {
+  const cancelRef = useRef<HTMLButtonElement>(null);
+
+  useEffect(() => {
+    cancelRef.current?.focus();
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onCancel();
+    };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [onCancel]);
+
+  return (
+    <div className="tv-dialog-overlay" onClick={onCancel} role="presentation">
+      <div
+        className="tv-card tv-dialog"
+        role="dialog"
+        aria-modal="true"
+        aria-label={title}
+        onClick={(e) => e.stopPropagation()}
+      >
+        <h2 className="tv-dialog__title">{title}</h2>
+        <div className="tv-dialog__body">{children}</div>
+        <div className="tv-dialog__actions">
+          <button ref={cancelRef} type="button" className="tv-btn tv-btn--secondary" onClick={onCancel}>
+            Cancel
+          </button>
+          <button
+            type="button"
+            className={danger ? 'tv-btn tv-btn--danger' : 'tv-btn tv-btn--primary'}
+            onClick={onConfirm}
+            disabled={busy}
+          >
+            {busy ? 'Working…' : confirmLabel}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/packages/web/src/components/index.ts
+++ b/packages/web/src/components/index.ts
@@ -17,4 +17,5 @@ export { LocalBadge } from './LocalBadge.js';
 export { ModelChips, shortModel, type ModelChipsProps } from './ModelChips.js';
 export { SummaryStrip, type SummaryItem } from './SummaryStrip.js';
 export { SearchField, type SearchFieldProps } from './SearchField.js';
+export { ConfirmDialog } from './ConfirmDialog.js';
 export { extractImage } from './image.js';

--- a/packages/web/src/pages/settings/SettingRow.tsx
+++ b/packages/web/src/pages/settings/SettingRow.tsx
@@ -1,0 +1,91 @@
+/**
+ * One editable setting row: label, input (per type), provenance badge, and
+ * contextual hints — env-override warning, missing-path notice, per-field
+ * validation error, "applies on next start" for non-live settings.
+ */
+
+import type { EditableSetting, SettingValue } from '@claudescope/shared';
+
+export interface SettingRowProps {
+  setting: EditableSetting;
+  /** Current draft value (may be a string mid-edit for number fields). */
+  value: SettingValue;
+  /** Server-side validation error for this key, if the last save failed. */
+  error?: string;
+  dirty: boolean;
+  onChange: (value: SettingValue) => void;
+}
+
+/** Provenance chip: where the effective value comes from. */
+function SourceBadge({ setting }: { setting: EditableSetting }) {
+  const label =
+    setting.source === 'env' ? 'env' : setting.source === 'file' ? 'saved' : 'default';
+  return <span className={`tv-settings__badge tv-settings__badge--${setting.source}`}>{label}</span>;
+}
+
+export function SettingRow({ setting, value, error, dirty, onChange }: SettingRowProps) {
+  const envShadowed = setting.source === 'env' && setting.fileValue !== undefined;
+  const inputId = `tv-setting-${setting.key}`;
+
+  return (
+    <div className={dirty ? 'tv-settings__row is-dirty' : 'tv-settings__row'}>
+      <div className="tv-settings__row-head">
+        <label className="tv-settings__label" htmlFor={inputId}>
+          {setting.label}
+        </label>
+        <SourceBadge setting={setting} />
+        {setting.envVar ? (
+          <code className="tv-settings__envvar tv-mono" title={`Overriding env var`}>
+            ${setting.envVar}
+          </code>
+        ) : null}
+      </div>
+
+      {setting.type === 'boolean' ? (
+        <label className="tv-settings__toggle">
+          <input
+            id={inputId}
+            type="checkbox"
+            className="tv-switch__input"
+            checked={value === true}
+            onChange={(e) => onChange(e.target.checked)}
+          />
+          <span className="tv-switch" aria-hidden="true" />
+          <span className="tv-settings__toggle-text">{value === true ? 'On' : 'Off'}</span>
+        </label>
+      ) : (
+        <input
+          id={inputId}
+          type={setting.type === 'number' ? 'number' : 'text'}
+          className={
+            error
+              ? 'tv-settings__input tv-mono is-invalid'
+              : 'tv-settings__input tv-mono'
+          }
+          value={String(value)}
+          spellCheck={false}
+          onChange={(e) => onChange(e.target.value)}
+        />
+      )}
+
+      <div className="tv-settings__hints">
+        {error ? <span className="tv-settings__hint tv-settings__hint--error">{error}</span> : null}
+        {envShadowed ? (
+          <span className="tv-settings__hint tv-settings__hint--warn">
+            Saved value is overridden by ${setting.envVar} in this process
+          </span>
+        ) : null}
+        {setting.type === 'path' && setting.exists === false ? (
+          <span className="tv-settings__hint tv-settings__hint--warn">
+            Path not found — this source indexes nothing
+          </span>
+        ) : null}
+        {!setting.live ? (
+          <span className="tv-settings__hint">
+            Applies at the next <code className="tv-mono">claudescope start</code>
+          </span>
+        ) : null}
+      </div>
+    </div>
+  );
+}

--- a/packages/web/src/pages/settings/SettingsPage.tsx
+++ b/packages/web/src/pages/settings/SettingsPage.tsx
@@ -122,7 +122,12 @@ export function SettingsPage() {
 
   const editable = settings?.editable ?? [];
   const dirtyKeys = useMemo(
-    () => editable.filter((s) => draft[s.key] !== undefined && draft[s.key] !== baselineOf(s)),
+    // String-compare: number inputs hold strings mid-edit, so '15000' vs
+    // 15000 must not count as dirty when the user reverts an edit.
+    () =>
+      editable.filter(
+        (s) => draft[s.key] !== undefined && String(draft[s.key]) !== String(baselineOf(s)),
+      ),
     [editable, draft],
   );
 
@@ -142,9 +147,14 @@ export function SettingsPage() {
         const trimmed = String(v).trim();
         patch[s.key] = trimmed === '' ? null : trimmed; // empty clears to default
       } else if (s.type === 'number') {
-        const n = Number(v);
-        if (!Number.isFinite(n)) clientErrors[s.key] = 'must be a number';
-        else patch[s.key] = n;
+        const str = String(v).trim();
+        if (str === '') {
+          patch[s.key] = null; // empty clears to default, same as paths
+        } else {
+          const n = Number(str);
+          if (!Number.isFinite(n)) clientErrors[s.key] = 'must be a number';
+          else patch[s.key] = n;
+        }
       } else {
         patch[s.key] = v === true;
       }

--- a/packages/web/src/pages/settings/SettingsPage.tsx
+++ b/packages/web/src/pages/settings/SettingsPage.tsx
@@ -1,12 +1,24 @@
 /**
- * Settings page. Lifecycle controls target the INDEXER (the background
- * reindex engine) — the HTTP server is never stopped from here (terminal
- * only). Edits persist to ~/.claudescope/settings.json; env vars always win
- * and shadowed fields get a warning badge.
+ * Settings page, laid out after the design mockup: header with Save Changes,
+ * a Service Lifecycle tile row (controls the INDEXER — the HTTP server stays
+ * terminal-only), Global Configuration | Appearance side by side, a full-width
+ * Path Configuration card, and Advanced Runtime with the danger zone.
+ *
+ * Edits persist to ~/.claudescope/settings.json; env vars always win and
+ * shadowed fields get a warning.
  */
 
 import { useCallback, useEffect, useMemo, useState } from 'react';
-import { Moon, Monitor, Sun, type LucideIcon } from 'lucide-react';
+import {
+  DollarSign,
+  Moon,
+  Monitor,
+  Play,
+  RotateCcw,
+  Square,
+  Sun,
+  type LucideIcon,
+} from 'lucide-react';
 import type {
   EditableSetting,
   IndexerStatus,
@@ -23,41 +35,16 @@ import { SettingRow } from './SettingRow.js';
 import './settings.css';
 
 const THEME_OPTIONS: { value: ThemeChoice; label: string; icon: LucideIcon }[] = [
-  { value: 'system', label: 'System', icon: Monitor },
-  { value: 'light', label: 'Light', icon: Sun },
   { value: 'dark', label: 'Dark', icon: Moon },
+  { value: 'light', label: 'Light', icon: Sun },
+  { value: 'system', label: 'System', icon: Monitor },
 ];
 
-/** Segmented System / Light / Dark theme control (client-side, per browser). */
-function ThemeToggle() {
-  const { theme, setTheme } = useTheme();
-  return (
-    <div className="tv-theme-toggle" role="group" aria-label="Theme">
-      {THEME_OPTIONS.map((o) => {
-        const Icon = o.icon;
-        return (
-          <button
-            key={o.value}
-            type="button"
-            className={theme === o.value ? 'tv-theme-toggle__btn is-active' : 'tv-theme-toggle__btn'}
-            onClick={() => setTheme(o.value)}
-            title={`${o.label} theme`}
-            aria-pressed={theme === o.value}
-          >
-            <Icon size={15} aria-hidden="true" />
-            <span className="tv-settings__theme-label">{o.label}</span>
-          </button>
-        );
-      })}
-    </div>
-  );
-}
-
 const STATE_LABELS: Record<string, string> = {
-  building: 'Building index…',
-  indexing: 'Indexing now…',
-  watching: 'Watching for changes',
-  paused: 'Paused',
+  building: 'Building index',
+  indexing: 'Indexing',
+  watching: 'Indexer running',
+  paused: 'Indexer paused',
 };
 
 /** Baseline a draft compares against: the saved value, else what's in effect. */
@@ -73,6 +60,33 @@ function formatUptime(startedAt: string): string {
   const h = Math.floor(m / 60);
   if (h < 24) return `${h}h ${m % 60}m`;
   return `${Math.floor(h / 24)}d ${h % 24}h`;
+}
+
+/** One big square action tile (mockup's lifecycle buttons). */
+function ActionTile({
+  icon: Icon,
+  label,
+  disabled,
+  busy,
+  onClick,
+}: {
+  icon: LucideIcon;
+  label: string;
+  disabled?: boolean;
+  busy?: boolean;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      className={busy ? 'tv-settings__tile is-busy' : 'tv-settings__tile'}
+      disabled={disabled || busy}
+      onClick={onClick}
+    >
+      <Icon size={20} aria-hidden="true" />
+      <span>{label}</span>
+    </button>
+  );
 }
 
 export function SettingsPage() {
@@ -99,6 +113,8 @@ export function SettingsPage() {
 
   const [rebuildOpen, setRebuildOpen] = useState(false);
   const [rebuildBusy, setRebuildBusy] = useState(false);
+
+  const { theme, setTheme } = useTheme();
 
   const seedDraft = useCallback((res: SettingsResponse) => {
     const next: Record<string, SettingValue> = {};
@@ -130,6 +146,10 @@ export function SettingsPage() {
       ),
     [editable, draft],
   );
+
+  const setDraftValue = useCallback((key: string, v: SettingValue) => {
+    setDraft((d) => ({ ...d, [key]: v }));
+  }, []);
 
   const discard = useCallback(() => {
     if (settings) seedDraft(settings);
@@ -170,20 +190,18 @@ export function SettingsPage() {
       seedDraft(res.settings);
       setWarnings(res.warnings);
       setFieldErrors({});
-      const liveCount = res.applied.filter((a) => a.live).length;
-      const deferred = res.applied.length - liveCount;
+      const deferred = res.applied.filter((a) => !a.live).length;
       setNotice(
-        deferred > 0
-          ? `Saved. ${liveCount} setting${liveCount === 1 ? '' : 's'} applied live; ${deferred} take${deferred === 1 ? 's' : ''} effect on the next start.`
-          : 'Saved — changes applied live.',
+        deferred > 0 ? 'Saved — some changes take effect on the next start.' : 'Saved — applied live.',
       );
     } catch (err) {
       if (err instanceof ApiError && err.status === 400) {
         try {
           const body = JSON.parse(err.body) as { fields?: Record<string, string> };
           setFieldErrors(body.fields ?? {});
+          setNotice('Some fields are invalid.');
         } catch {
-          setLoadError(String(err));
+          setNotice(`Save failed: ${String(err)}`);
         }
       } else {
         setNotice(`Save failed: ${String(err)}`);
@@ -193,36 +211,31 @@ export function SettingsPage() {
     }
   }, [settings, dirtyKeys, draft, seedDraft]);
 
-  const runIndexerAction = useCallback(
-    async (action: 'stop' | 'start' | 'restart') => {
-      setActionBusy(action);
-      try {
-        const fn =
-          action === 'stop'
-            ? api.indexerStop
-            : action === 'start'
-              ? api.indexerStart
-              : api.indexerRestart;
-        setLocalIndexer(await fn());
-      } catch (err) {
-        setNotice(`Indexer ${action} failed: ${String(err)}`);
-      } finally {
-        setActionBusy(null);
-      }
-    },
-    [],
-  );
+  const runIndexerAction = useCallback(async (action: 'stop' | 'start' | 'restart') => {
+    setActionBusy(action);
+    try {
+      const fn =
+        action === 'stop'
+          ? api.indexerStop
+          : action === 'start'
+            ? api.indexerStart
+            : api.indexerRestart;
+      setLocalIndexer(await fn());
+    } catch (err) {
+      setNotice(`Indexer ${action} failed: ${String(err)}`);
+    } finally {
+      setActionBusy(null);
+    }
+  }, []);
 
   const syncPricing = useCallback(async () => {
     setPricingBusy(true);
     setPricingResult(null);
     try {
       const res = await api.refreshPricing();
-      setPricingResult(
-        `${res.modelCount} models fetched, ${res.changed} changed. New rates apply to newly indexed events.`,
-      );
+      setPricingResult(`Price sync: ${res.modelCount} models, ${res.changed} changed.`);
     } catch (err) {
-      setPricingResult(`Refresh failed: ${String(err)}`);
+      setPricingResult(`Price sync failed: ${String(err)}`);
     } finally {
       setPricingBusy(false);
     }
@@ -233,7 +246,7 @@ export function SettingsPage() {
     try {
       await api.rebuildIndex();
       setRebuildOpen(false);
-      setNotice('Rebuilding the index — progress shows in the status card.');
+      setNotice('Rebuilding the index — the status chip shows progress.');
     } catch (err) {
       setNotice(`Rebuild failed to start: ${String(err)}`);
     } finally {
@@ -247,226 +260,31 @@ export function SettingsPage() {
   const indexer = localIndexer ?? health.indexer;
   const state = indexer?.state ?? 'building';
   const paused = indexer?.paused ?? false;
-  const groups = {
-    sources: editable.filter((s) => s.group === 'sources'),
-    indexing: editable.filter((s) => s.group === 'indexing'),
-    startup: editable.filter((s) => s.group === 'startup'),
-  };
+  const building = state === 'building';
+
+  const sources = editable.filter((s) => s.group === 'sources');
+  const openBrowser = editable.find((s) => s.key === 'openBrowser');
+  const interval = editable.find((s) => s.key === 'reindexIntervalMs');
+  const port = settings.readOnly.find((r) => r.key === 'port');
+  const home = settings.readOnly.find((r) => r.key === 'claudescopeHome');
+
+  const intervalDraft = interval ? String(draft[interval.key] ?? baselineOf(interval)) : '15000';
+  const intervalNum = Number(intervalDraft) || 0;
 
   return (
     <div className="tv-settings">
-      <h1 className="tv-page-title">Settings</h1>
-
-      {/* ---- Status & indexing lifecycle -------------------------------- */}
-      <section className="tv-card tv-settings__card">
-        <div className="tv-settings__card-head">
-          <h2 className="tv-settings__card-title">Indexing</h2>
-          <span className={`tv-settings__state tv-settings__state--${state}`}>
-            {STATE_LABELS[state] ?? state}
-            {indexer?.intervalMs === 0 && state === 'watching' ? ' (auto-reindex off)' : ''}
-          </span>
-        </div>
-        <p className="tv-settings__desc">
-          Start, stop, or restart the background indexer. While paused, Claudescope stays fully
-          browsable on the existing index — it just stops picking up new sessions until resumed or
-          the app is restarted. The server itself is stopped from the terminal
-          (<code className="tv-mono">claudescope stop</code>).
-        </p>
-        <div className="tv-settings__actions">
-          {paused ? (
-            <button
-              type="button"
-              className="tv-btn tv-btn--primary"
-              disabled={actionBusy !== null}
-              onClick={() => void runIndexerAction('start')}
-            >
-              {actionBusy === 'start' ? 'Starting…' : 'Start indexing'}
-            </button>
-          ) : (
-            <button
-              type="button"
-              className="tv-btn tv-btn--secondary"
-              disabled={actionBusy !== null || state === 'building'}
-              onClick={() => void runIndexerAction('stop')}
-            >
-              {actionBusy === 'stop' ? 'Stopping…' : 'Stop indexing'}
-            </button>
-          )}
-          <button
-            type="button"
-            className="tv-btn tv-btn--secondary"
-            disabled={actionBusy !== null || state === 'building'}
-            onClick={() => void runIndexerAction('restart')}
-          >
-            {actionBusy === 'restart' ? 'Restarting…' : 'Restart indexing'}
-          </button>
-          {system ? (
-            <span className="tv-settings__meta">
-              v{system.version} · up {formatUptime(system.startedAt)}
-              {localIndexer?.lastPassAt
-                ? ` · last pass ${new Date(localIndexer.lastPassAt).toLocaleTimeString()}`
-                : ''}
-            </span>
+      {/* ---- Header: title + Save Changes (mockup top bar) ---------------- */}
+      <header className="tv-settings__header">
+        <h1 className="tv-page-title">Settings</h1>
+        <div className="tv-settings__header-actions">
+          {notice && dirtyKeys.length === 0 ? (
+            <span className="tv-settings__meta">{notice}</span>
           ) : null}
-        </div>
-        {paused ? (
-          <p className="tv-settings__hint tv-settings__hint--warn">
-            Paused until resumed here or the process restarts — the pause is not persisted.
-          </p>
-        ) : null}
-      </section>
-
-      {/* ---- Appearance -------------------------------------------------- */}
-      <section className="tv-card tv-settings__card">
-        <h2 className="tv-settings__card-title">Appearance</h2>
-        <p className="tv-settings__desc">Theme is stored per browser, not on the server.</p>
-        <ThemeToggle />
-      </section>
-
-      {/* ---- Sources ------------------------------------------------------ */}
-      <section className="tv-card tv-settings__card">
-        <div className="tv-settings__card-head">
-          <h2 className="tv-settings__card-title">Agent sources</h2>
-          <span className="tv-settings__badge tv-settings__badge--readonly">READ-ONLY sources</span>
-        </div>
-        <p className="tv-settings__desc">
-          Where each agent's transcripts are read from. Claudescope never writes to these
-          directories. Changes apply live — the index re-scans immediately; sessions from a
-          previous directory disappear from the index.
-        </p>
-        {groups.sources.map((s) => (
-          <SettingRow
-            key={s.key}
-            setting={s}
-            value={draft[s.key] ?? baselineOf(s)}
-            error={fieldErrors[s.key]}
-            dirty={dirtyKeys.some((d) => d.key === s.key)}
-            onChange={(v) => setDraft((d) => ({ ...d, [s.key]: v }))}
-          />
-        ))}
-      </section>
-
-      {/* ---- Indexing & startup ------------------------------------------ */}
-      <section className="tv-card tv-settings__card">
-        <h2 className="tv-settings__card-title">Indexing &amp; startup</h2>
-        {[...groups.indexing, ...groups.startup].map((s) => (
-          <SettingRow
-            key={s.key}
-            setting={s}
-            value={draft[s.key] ?? baselineOf(s)}
-            error={fieldErrors[s.key]}
-            dirty={dirtyKeys.some((d) => d.key === s.key)}
-            onChange={(v) => setDraft((d) => ({ ...d, [s.key]: v }))}
-          />
-        ))}
-        <p className="tv-settings__hint">Auto-reindex interval: 0 disables the background scan.</p>
-      </section>
-
-      {/* ---- Read-only paths ---------------------------------------------- */}
-      <section className="tv-card tv-settings__card">
-        <h2 className="tv-settings__card-title">App paths (read-only)</h2>
-        <p className="tv-settings__desc">
-          Infrastructure fixed at boot — change via env vars or CLI flags.
-        </p>
-        <table className="tv-settings__table">
-          <tbody>
-            {settings.readOnly.map((r) => (
-              <tr key={r.key}>
-                <td className="tv-settings__table-label">{r.label}</td>
-                <td className="tv-mono">{r.value}</td>
-                <td>
-                  <span className={`tv-settings__badge tv-settings__badge--${r.source}`}>
-                    {r.source === 'env' ? 'env' : 'default'}
-                  </span>
-                  {r.envVar ? <code className="tv-settings__envvar tv-mono">${r.envVar}</code> : null}
-                </td>
-              </tr>
-            ))}
-          </tbody>
-        </table>
-      </section>
-
-      {/* ---- Pricing ------------------------------------------------------- */}
-      <section className="tv-card tv-settings__card">
-        <h2 className="tv-settings__card-title">Pricing</h2>
-        <p className="tv-settings__desc">
-          Rates auto-refresh daily from LiteLLM; costs are local estimates. Edit{' '}
-          <code className="tv-mono">~/.claudescope/pricing.json</code> to override rates. Pricing
-          applies to newly indexed events — rebuild the index to re-price history.
-        </p>
-        <div className="tv-settings__actions">
-          <button
-            type="button"
-            className="tv-btn tv-btn--secondary"
-            disabled={pricingBusy}
-            onClick={() => void syncPricing()}
-          >
-            {pricingBusy ? 'Syncing…' : 'Sync prices now'}
-          </button>
-          {pricingResult ? <span className="tv-settings__meta">{pricingResult}</span> : null}
-        </div>
-      </section>
-
-      {/* ---- Update -------------------------------------------------------- */}
-      {system ? (
-        <section className="tv-card tv-settings__card">
-          <h2 className="tv-settings__card-title">Update</h2>
-          {system.updateAvailable && system.latestVersion ? (
+          {dirtyKeys.length > 0 ? (
             <>
-              <p className="tv-settings__desc">
-                v{system.version} → <strong>v{system.latestVersion}</strong> is available. Updates
-                run from the terminal ({system.installMethod} install):
-              </p>
-              <code className="tv-settings__cmd tv-mono">{system.updateCommand}</code>
-            </>
-          ) : (
-            <p className="tv-settings__desc">
-              v{system.version} — up to date
-              {system.latestVersion ? ` (latest: v${system.latestVersion})` : ''}.
-            </p>
-          )}
-        </section>
-      ) : null}
-
-      {/* ---- Danger zone ---------------------------------------------------- */}
-      <section className="tv-card tv-settings__card tv-settings__card--danger">
-        <h2 className="tv-settings__card-title">Danger zone</h2>
-        <p className="tv-settings__desc">
-          The index is a derived cache — rebuilding discards the local DuckDB file and re-indexes
-          every transcript from your sources. History is re-priced at current rates. The app stays
-          usable and shows build progress.
-        </p>
-        <div className="tv-settings__actions">
-          <button
-            type="button"
-            className="tv-btn tv-btn--danger"
-            disabled={state === 'building'}
-            onClick={() => setRebuildOpen(true)}
-          >
-            Rebuild index
-          </button>
-        </div>
-      </section>
-
-      {/* ---- Sticky save bar ------------------------------------------------ */}
-      {dirtyKeys.length > 0 || notice || warnings.length > 0 ? (
-        <div className="tv-settings__savebar">
-          <div className="tv-settings__savebar-text">
-            {dirtyKeys.length > 0 ? (
-              <span>
+              <span className="tv-settings__meta">
                 {dirtyKeys.length} unsaved change{dirtyKeys.length === 1 ? '' : 's'}
               </span>
-            ) : notice ? (
-              <span>{notice}</span>
-            ) : null}
-            {warnings.map((w) => (
-              <span key={`${w.key}:${w.message}`} className="tv-settings__hint--warn">
-                {settings.editable.find((s) => s.key === w.key)?.label ?? w.key}: {w.message}
-              </span>
-            ))}
-          </div>
-          {dirtyKeys.length > 0 ? (
-            <div className="tv-settings__savebar-actions">
               <button
                 type="button"
                 className="tv-btn tv-btn--secondary"
@@ -475,18 +293,262 @@ export function SettingsPage() {
               >
                 Discard
               </button>
-              <button
-                type="button"
-                className="tv-btn tv-btn--primary"
-                disabled={saving}
-                onClick={() => void save()}
-              >
-                {saving ? 'Saving…' : 'Save changes'}
-              </button>
-            </div>
+            </>
           ) : null}
+          <button
+            type="button"
+            className="tv-btn tv-btn--primary"
+            disabled={saving || dirtyKeys.length === 0}
+            onClick={() => void save()}
+          >
+            {saving ? 'Saving…' : 'Save Changes'}
+          </button>
+        </div>
+      </header>
+      {warnings.length > 0 ? (
+        <div className="tv-settings__warnings">
+          {warnings.map((w) => (
+            <span key={`${w.key}:${w.message}`} className="tv-settings__hint--warn">
+              {editable.find((s) => s.key === w.key)?.label ?? w.key}: {w.message}
+            </span>
+          ))}
         </div>
       ) : null}
+
+      {/* ---- Service lifecycle (indexer) ---------------------------------- */}
+      <section className="tv-settings__section">
+        <div className="tv-settings__section-head">
+          <div>
+            <h2 className="tv-settings__section-title">Service Lifecycle</h2>
+            <p className="tv-settings__desc">
+              Controls background indexing — the app stays browsable while paused. The server
+              itself is managed from the terminal (<code className="tv-mono">claudescope stop</code>).
+            </p>
+          </div>
+          <span className={`tv-settings__chip tv-settings__chip--${state}`}>
+            <span className="tv-settings__chip-dot" aria-hidden="true" />
+            {(STATE_LABELS[state] ?? state).toUpperCase()}
+          </span>
+        </div>
+        <div className="tv-settings__tiles">
+          <ActionTile
+            icon={Play}
+            label="Start"
+            disabled={!paused || actionBusy !== null}
+            busy={actionBusy === 'start'}
+            onClick={() => void runIndexerAction('start')}
+          />
+          <ActionTile
+            icon={Square}
+            label="Stop"
+            disabled={paused || building || actionBusy !== null}
+            busy={actionBusy === 'stop'}
+            onClick={() => void runIndexerAction('stop')}
+          />
+          <ActionTile
+            icon={RotateCcw}
+            label="Restart"
+            disabled={building || actionBusy !== null}
+            busy={actionBusy === 'restart'}
+            onClick={() => void runIndexerAction('restart')}
+          />
+          <ActionTile
+            icon={DollarSign}
+            label="Price Sync"
+            busy={pricingBusy}
+            onClick={() => void syncPricing()}
+          />
+        </div>
+        <div className="tv-settings__meta">
+          {system ? (
+            <>
+              v{system.version} · up {formatUptime(system.startedAt)}
+              {system.updateAvailable && system.latestVersion ? (
+                <>
+                  {' · '}
+                  <span className="tv-settings__hint--warn">
+                    v{system.latestVersion} available:{' '}
+                    <code className="tv-mono">{system.updateCommand}</code>
+                  </span>
+                </>
+              ) : (
+                ' · up to date'
+              )}
+            </>
+          ) : null}
+          {pricingResult ? <> · {pricingResult}</> : null}
+          {paused ? <> · paused until resumed or restart (not persisted)</> : null}
+        </div>
+      </section>
+
+      {/* ---- Global configuration | Appearance ---------------------------- */}
+      <div className="tv-settings__grid2">
+        <section className="tv-card tv-settings__card">
+          <h2 className="tv-settings__card-title">Global Configuration</h2>
+          <div className="tv-settings__row">
+            <div className="tv-settings__row-head">
+              <span className="tv-settings__label">Local Port</span>
+              <span className="tv-settings__badge tv-settings__badge--readonly">read-only</span>
+            </div>
+            <input
+              className="tv-settings__input tv-mono"
+              value={String(port?.value ?? '')}
+              disabled
+            />
+            <div className="tv-settings__hints">
+              <span className="tv-settings__hint">
+                Set with <code className="tv-mono">--port</code> or{' '}
+                <code className="tv-mono">$PORT</code>
+              </span>
+            </div>
+          </div>
+          {openBrowser ? (
+            <SettingRow
+              setting={openBrowser}
+              value={draft[openBrowser.key] ?? baselineOf(openBrowser)}
+              error={fieldErrors[openBrowser.key]}
+              dirty={dirtyKeys.some((d) => d.key === openBrowser.key)}
+              onChange={(v) => setDraftValue(openBrowser.key, v)}
+            />
+          ) : null}
+        </section>
+
+        <section className="tv-card tv-settings__card">
+          <h2 className="tv-settings__card-title">Appearance</h2>
+          <span className="tv-settings__label">Theme Preference</span>
+          <div className="tv-settings__theme-tiles" role="group" aria-label="Theme">
+            {THEME_OPTIONS.map((o) => {
+              const Icon = o.icon;
+              return (
+                <button
+                  key={o.value}
+                  type="button"
+                  className={
+                    theme === o.value
+                      ? 'tv-settings__theme-tile is-active'
+                      : 'tv-settings__theme-tile'
+                  }
+                  onClick={() => setTheme(o.value)}
+                  aria-pressed={theme === o.value}
+                >
+                  <Icon size={20} aria-hidden="true" />
+                  <span>{o.label}</span>
+                </button>
+              );
+            })}
+          </div>
+          <div className="tv-settings__hints">
+            <span className="tv-settings__hint">Stored per browser, not on the server.</span>
+          </div>
+        </section>
+      </div>
+
+      {/* ---- Path configuration ------------------------------------------- */}
+      <section className="tv-card tv-settings__card">
+        <div className="tv-settings__card-head">
+          <h2 className="tv-settings__card-title">Path Configuration</h2>
+        </div>
+        <p className="tv-settings__desc">
+          Agent transcript sources are read-only — Claudescope never writes to them. Path changes
+          apply live; sessions from a previous directory leave the index.
+        </p>
+        <div className="tv-settings__row">
+          <div className="tv-settings__row-head">
+            <span className="tv-settings__label">Claudescope home</span>
+            <span className="tv-settings__badge tv-settings__badge--readonly">read-only</span>
+            <code className="tv-settings__envvar tv-mono">$CLAUDESCOPE_HOME</code>
+          </div>
+          <input
+            className="tv-settings__input tv-mono"
+            value={String(home?.value ?? '')}
+            disabled
+          />
+        </div>
+        <div className="tv-settings__grid2 tv-settings__grid2--tight">
+          {sources.map((s) => (
+            <SettingRow
+              key={s.key}
+              setting={s}
+              value={draft[s.key] ?? baselineOf(s)}
+              error={fieldErrors[s.key]}
+              dirty={dirtyKeys.some((d) => d.key === s.key)}
+              onChange={(v) => setDraftValue(s.key, v)}
+            />
+          ))}
+        </div>
+      </section>
+
+      {/* ---- Advanced runtime + danger zone -------------------------------- */}
+      <section className="tv-card tv-settings__card">
+        <h2 className="tv-settings__card-title">Advanced Runtime</h2>
+        <div className="tv-settings__grid2">
+          <div>
+            {interval ? (
+              <div className="tv-settings__row">
+                <div className="tv-settings__row-head">
+                  <span className="tv-settings__label">Reindex Interval (ms)</span>
+                  {interval.source === 'env' ? (
+                    <span className="tv-settings__badge tv-settings__badge--env">env</span>
+                  ) : null}
+                </div>
+                <div className="tv-settings__slider-row">
+                  <input
+                    type="range"
+                    className="tv-settings__slider"
+                    min={0}
+                    max={60000}
+                    step={1000}
+                    value={Math.min(intervalNum, 60000)}
+                    onChange={(e) => setDraftValue(interval.key, e.target.value)}
+                    aria-label="Reindex interval"
+                  />
+                  <input
+                    type="number"
+                    className={
+                      fieldErrors[interval.key]
+                        ? 'tv-settings__input tv-settings__input--num tv-mono is-invalid'
+                        : 'tv-settings__input tv-settings__input--num tv-mono'
+                    }
+                    value={intervalDraft}
+                    onChange={(e) => setDraftValue(interval.key, e.target.value)}
+                  />
+                </div>
+                <div className="tv-settings__hints">
+                  {fieldErrors[interval.key] ? (
+                    <span className="tv-settings__hint tv-settings__hint--error">
+                      {fieldErrors[interval.key]}
+                    </span>
+                  ) : null}
+                  <span className="tv-settings__hint">
+                    How often the agent sources are scanned for new sessions. 0 disables.
+                  </span>
+                  {interval.source === 'env' && interval.fileValue !== undefined ? (
+                    <span className="tv-settings__hint tv-settings__hint--warn">
+                      Saved value is overridden by ${interval.envVar}
+                    </span>
+                  ) : null}
+                </div>
+              </div>
+            ) : null}
+          </div>
+
+          <div className="tv-settings__danger">
+            <h3 className="tv-settings__danger-title">⚠ Danger Zone</h3>
+            <p className="tv-settings__desc">
+              Discards the local index (a rebuildable cache) and re-indexes every transcript.
+              History is re-priced at current rates. Cannot be undone.
+            </p>
+            <button
+              type="button"
+              className="tv-btn tv-btn--danger"
+              disabled={building}
+              onClick={() => setRebuildOpen(true)}
+            >
+              Rebuild Index
+            </button>
+          </div>
+        </div>
+      </section>
 
       {rebuildOpen ? (
         <ConfirmDialog

--- a/packages/web/src/pages/settings/SettingsPage.tsx
+++ b/packages/web/src/pages/settings/SettingsPage.tsx
@@ -1,0 +1,497 @@
+/**
+ * Settings page. Lifecycle controls target the INDEXER (the background
+ * reindex engine) — the HTTP server is never stopped from here (terminal
+ * only). Edits persist to ~/.claudescope/settings.json; env vars always win
+ * and shadowed fields get a warning badge.
+ */
+
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { Moon, Monitor, Sun, type LucideIcon } from 'lucide-react';
+import type {
+  EditableSetting,
+  IndexerStatus,
+  SettingValue,
+  SettingsResponse,
+  SettingsUpdateResponse,
+  SystemInfoResponse,
+} from '@claudescope/shared';
+import { ApiError, api } from '../../api/client.js';
+import { ConfirmDialog, ErrorBox, Spinner } from '../../components';
+import { useServerStatus } from '../../status/StatusProvider.js';
+import { useTheme, type ThemeChoice } from '../../theme/ThemeProvider.js';
+import { SettingRow } from './SettingRow.js';
+import './settings.css';
+
+const THEME_OPTIONS: { value: ThemeChoice; label: string; icon: LucideIcon }[] = [
+  { value: 'system', label: 'System', icon: Monitor },
+  { value: 'light', label: 'Light', icon: Sun },
+  { value: 'dark', label: 'Dark', icon: Moon },
+];
+
+/** Segmented System / Light / Dark theme control (client-side, per browser). */
+function ThemeToggle() {
+  const { theme, setTheme } = useTheme();
+  return (
+    <div className="tv-theme-toggle" role="group" aria-label="Theme">
+      {THEME_OPTIONS.map((o) => {
+        const Icon = o.icon;
+        return (
+          <button
+            key={o.value}
+            type="button"
+            className={theme === o.value ? 'tv-theme-toggle__btn is-active' : 'tv-theme-toggle__btn'}
+            onClick={() => setTheme(o.value)}
+            title={`${o.label} theme`}
+            aria-pressed={theme === o.value}
+          >
+            <Icon size={15} aria-hidden="true" />
+            <span className="tv-settings__theme-label">{o.label}</span>
+          </button>
+        );
+      })}
+    </div>
+  );
+}
+
+const STATE_LABELS: Record<string, string> = {
+  building: 'Building index…',
+  indexing: 'Indexing now…',
+  watching: 'Watching for changes',
+  paused: 'Paused',
+};
+
+/** Baseline a draft compares against: the saved value, else what's in effect. */
+function baselineOf(s: EditableSetting): SettingValue {
+  return s.fileValue !== undefined ? s.fileValue : s.effective;
+}
+
+function formatUptime(startedAt: string): string {
+  const ms = Date.now() - Date.parse(startedAt);
+  if (!Number.isFinite(ms) || ms < 0) return '—';
+  const m = Math.floor(ms / 60_000);
+  if (m < 60) return `${m}m`;
+  const h = Math.floor(m / 60);
+  if (h < 24) return `${h}h ${m % 60}m`;
+  return `${Math.floor(h / 24)}d ${h % 24}h`;
+}
+
+export function SettingsPage() {
+  const health = useServerStatus();
+
+  const [settings, setSettings] = useState<SettingsResponse | null>(null);
+  const [system, setSystem] = useState<SystemInfoResponse | null>(null);
+  const [loadError, setLoadError] = useState<string | null>(null);
+
+  const [draft, setDraft] = useState<Record<string, SettingValue>>({});
+  const [fieldErrors, setFieldErrors] = useState<Record<string, string>>({});
+  const [warnings, setWarnings] = useState<SettingsUpdateResponse['warnings']>([]);
+  const [saving, setSaving] = useState(false);
+  const [notice, setNotice] = useState<string | null>(null);
+
+  // Fresh action response wins over the (up to 10s stale) health poll until
+  // the next poll lands.
+  const [localIndexer, setLocalIndexer] = useState<IndexerStatus | null>(null);
+  const [actionBusy, setActionBusy] = useState<string | null>(null);
+  useEffect(() => setLocalIndexer(null), [health.indexer]);
+
+  const [pricingBusy, setPricingBusy] = useState(false);
+  const [pricingResult, setPricingResult] = useState<string | null>(null);
+
+  const [rebuildOpen, setRebuildOpen] = useState(false);
+  const [rebuildBusy, setRebuildBusy] = useState(false);
+
+  const seedDraft = useCallback((res: SettingsResponse) => {
+    const next: Record<string, SettingValue> = {};
+    for (const s of res.editable) next[s.key] = baselineOf(s);
+    setDraft(next);
+  }, []);
+
+  useEffect(() => {
+    const controller = new AbortController();
+    Promise.all([api.getSettings(controller.signal), api.systemInfo(controller.signal)])
+      .then(([s, sys]) => {
+        setSettings(s);
+        setSystem(sys);
+        seedDraft(s);
+      })
+      .catch((err) => {
+        if (!controller.signal.aborted) setLoadError(String(err));
+      });
+    return () => controller.abort();
+  }, [seedDraft]);
+
+  const editable = settings?.editable ?? [];
+  const dirtyKeys = useMemo(
+    () => editable.filter((s) => draft[s.key] !== undefined && draft[s.key] !== baselineOf(s)),
+    [editable, draft],
+  );
+
+  const discard = useCallback(() => {
+    if (settings) seedDraft(settings);
+    setFieldErrors({});
+    setNotice(null);
+  }, [settings, seedDraft]);
+
+  const save = useCallback(async () => {
+    if (!settings || dirtyKeys.length === 0) return;
+    const patch: Record<string, SettingValue | null> = {};
+    const clientErrors: Record<string, string> = {};
+    for (const s of dirtyKeys) {
+      const v = draft[s.key];
+      if (s.type === 'path') {
+        const trimmed = String(v).trim();
+        patch[s.key] = trimmed === '' ? null : trimmed; // empty clears to default
+      } else if (s.type === 'number') {
+        const n = Number(v);
+        if (!Number.isFinite(n)) clientErrors[s.key] = 'must be a number';
+        else patch[s.key] = n;
+      } else {
+        patch[s.key] = v === true;
+      }
+    }
+    setFieldErrors(clientErrors);
+    if (Object.keys(clientErrors).length > 0) return;
+
+    setSaving(true);
+    setNotice(null);
+    try {
+      const res = await api.updateSettings(patch);
+      setSettings(res.settings);
+      seedDraft(res.settings);
+      setWarnings(res.warnings);
+      setFieldErrors({});
+      const liveCount = res.applied.filter((a) => a.live).length;
+      const deferred = res.applied.length - liveCount;
+      setNotice(
+        deferred > 0
+          ? `Saved. ${liveCount} setting${liveCount === 1 ? '' : 's'} applied live; ${deferred} take${deferred === 1 ? 's' : ''} effect on the next start.`
+          : 'Saved — changes applied live.',
+      );
+    } catch (err) {
+      if (err instanceof ApiError && err.status === 400) {
+        try {
+          const body = JSON.parse(err.body) as { fields?: Record<string, string> };
+          setFieldErrors(body.fields ?? {});
+        } catch {
+          setLoadError(String(err));
+        }
+      } else {
+        setNotice(`Save failed: ${String(err)}`);
+      }
+    } finally {
+      setSaving(false);
+    }
+  }, [settings, dirtyKeys, draft, seedDraft]);
+
+  const runIndexerAction = useCallback(
+    async (action: 'stop' | 'start' | 'restart') => {
+      setActionBusy(action);
+      try {
+        const fn =
+          action === 'stop'
+            ? api.indexerStop
+            : action === 'start'
+              ? api.indexerStart
+              : api.indexerRestart;
+        setLocalIndexer(await fn());
+      } catch (err) {
+        setNotice(`Indexer ${action} failed: ${String(err)}`);
+      } finally {
+        setActionBusy(null);
+      }
+    },
+    [],
+  );
+
+  const syncPricing = useCallback(async () => {
+    setPricingBusy(true);
+    setPricingResult(null);
+    try {
+      const res = await api.refreshPricing();
+      setPricingResult(
+        `${res.modelCount} models fetched, ${res.changed} changed. New rates apply to newly indexed events.`,
+      );
+    } catch (err) {
+      setPricingResult(`Refresh failed: ${String(err)}`);
+    } finally {
+      setPricingBusy(false);
+    }
+  }, []);
+
+  const rebuild = useCallback(async () => {
+    setRebuildBusy(true);
+    try {
+      await api.rebuildIndex();
+      setRebuildOpen(false);
+      setNotice('Rebuilding the index — progress shows in the status card.');
+    } catch (err) {
+      setNotice(`Rebuild failed to start: ${String(err)}`);
+    } finally {
+      setRebuildBusy(false);
+    }
+  }, []);
+
+  if (loadError) return <ErrorBox title="Failed to load settings" error={loadError} />;
+  if (!settings) return <Spinner label="Loading settings…" />;
+
+  const indexer = localIndexer ?? health.indexer;
+  const state = indexer?.state ?? 'building';
+  const paused = indexer?.paused ?? false;
+  const groups = {
+    sources: editable.filter((s) => s.group === 'sources'),
+    indexing: editable.filter((s) => s.group === 'indexing'),
+    startup: editable.filter((s) => s.group === 'startup'),
+  };
+
+  return (
+    <div className="tv-settings">
+      <h1 className="tv-page-title">Settings</h1>
+
+      {/* ---- Status & indexing lifecycle -------------------------------- */}
+      <section className="tv-card tv-settings__card">
+        <div className="tv-settings__card-head">
+          <h2 className="tv-settings__card-title">Indexing</h2>
+          <span className={`tv-settings__state tv-settings__state--${state}`}>
+            {STATE_LABELS[state] ?? state}
+            {indexer?.intervalMs === 0 && state === 'watching' ? ' (auto-reindex off)' : ''}
+          </span>
+        </div>
+        <p className="tv-settings__desc">
+          Start, stop, or restart the background indexer. While paused, Claudescope stays fully
+          browsable on the existing index — it just stops picking up new sessions until resumed or
+          the app is restarted. The server itself is stopped from the terminal
+          (<code className="tv-mono">claudescope stop</code>).
+        </p>
+        <div className="tv-settings__actions">
+          {paused ? (
+            <button
+              type="button"
+              className="tv-btn tv-btn--primary"
+              disabled={actionBusy !== null}
+              onClick={() => void runIndexerAction('start')}
+            >
+              {actionBusy === 'start' ? 'Starting…' : 'Start indexing'}
+            </button>
+          ) : (
+            <button
+              type="button"
+              className="tv-btn tv-btn--secondary"
+              disabled={actionBusy !== null || state === 'building'}
+              onClick={() => void runIndexerAction('stop')}
+            >
+              {actionBusy === 'stop' ? 'Stopping…' : 'Stop indexing'}
+            </button>
+          )}
+          <button
+            type="button"
+            className="tv-btn tv-btn--secondary"
+            disabled={actionBusy !== null || state === 'building'}
+            onClick={() => void runIndexerAction('restart')}
+          >
+            {actionBusy === 'restart' ? 'Restarting…' : 'Restart indexing'}
+          </button>
+          {system ? (
+            <span className="tv-settings__meta">
+              v{system.version} · up {formatUptime(system.startedAt)}
+              {localIndexer?.lastPassAt
+                ? ` · last pass ${new Date(localIndexer.lastPassAt).toLocaleTimeString()}`
+                : ''}
+            </span>
+          ) : null}
+        </div>
+        {paused ? (
+          <p className="tv-settings__hint tv-settings__hint--warn">
+            Paused until resumed here or the process restarts — the pause is not persisted.
+          </p>
+        ) : null}
+      </section>
+
+      {/* ---- Appearance -------------------------------------------------- */}
+      <section className="tv-card tv-settings__card">
+        <h2 className="tv-settings__card-title">Appearance</h2>
+        <p className="tv-settings__desc">Theme is stored per browser, not on the server.</p>
+        <ThemeToggle />
+      </section>
+
+      {/* ---- Sources ------------------------------------------------------ */}
+      <section className="tv-card tv-settings__card">
+        <div className="tv-settings__card-head">
+          <h2 className="tv-settings__card-title">Agent sources</h2>
+          <span className="tv-settings__badge tv-settings__badge--readonly">READ-ONLY sources</span>
+        </div>
+        <p className="tv-settings__desc">
+          Where each agent's transcripts are read from. Claudescope never writes to these
+          directories. Changes apply live — the index re-scans immediately; sessions from a
+          previous directory disappear from the index.
+        </p>
+        {groups.sources.map((s) => (
+          <SettingRow
+            key={s.key}
+            setting={s}
+            value={draft[s.key] ?? baselineOf(s)}
+            error={fieldErrors[s.key]}
+            dirty={dirtyKeys.some((d) => d.key === s.key)}
+            onChange={(v) => setDraft((d) => ({ ...d, [s.key]: v }))}
+          />
+        ))}
+      </section>
+
+      {/* ---- Indexing & startup ------------------------------------------ */}
+      <section className="tv-card tv-settings__card">
+        <h2 className="tv-settings__card-title">Indexing &amp; startup</h2>
+        {[...groups.indexing, ...groups.startup].map((s) => (
+          <SettingRow
+            key={s.key}
+            setting={s}
+            value={draft[s.key] ?? baselineOf(s)}
+            error={fieldErrors[s.key]}
+            dirty={dirtyKeys.some((d) => d.key === s.key)}
+            onChange={(v) => setDraft((d) => ({ ...d, [s.key]: v }))}
+          />
+        ))}
+        <p className="tv-settings__hint">Auto-reindex interval: 0 disables the background scan.</p>
+      </section>
+
+      {/* ---- Read-only paths ---------------------------------------------- */}
+      <section className="tv-card tv-settings__card">
+        <h2 className="tv-settings__card-title">App paths (read-only)</h2>
+        <p className="tv-settings__desc">
+          Infrastructure fixed at boot — change via env vars or CLI flags.
+        </p>
+        <table className="tv-settings__table">
+          <tbody>
+            {settings.readOnly.map((r) => (
+              <tr key={r.key}>
+                <td className="tv-settings__table-label">{r.label}</td>
+                <td className="tv-mono">{r.value}</td>
+                <td>
+                  <span className={`tv-settings__badge tv-settings__badge--${r.source}`}>
+                    {r.source === 'env' ? 'env' : 'default'}
+                  </span>
+                  {r.envVar ? <code className="tv-settings__envvar tv-mono">${r.envVar}</code> : null}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </section>
+
+      {/* ---- Pricing ------------------------------------------------------- */}
+      <section className="tv-card tv-settings__card">
+        <h2 className="tv-settings__card-title">Pricing</h2>
+        <p className="tv-settings__desc">
+          Rates auto-refresh daily from LiteLLM; costs are local estimates. Edit{' '}
+          <code className="tv-mono">~/.claudescope/pricing.json</code> to override rates. Pricing
+          applies to newly indexed events — rebuild the index to re-price history.
+        </p>
+        <div className="tv-settings__actions">
+          <button
+            type="button"
+            className="tv-btn tv-btn--secondary"
+            disabled={pricingBusy}
+            onClick={() => void syncPricing()}
+          >
+            {pricingBusy ? 'Syncing…' : 'Sync prices now'}
+          </button>
+          {pricingResult ? <span className="tv-settings__meta">{pricingResult}</span> : null}
+        </div>
+      </section>
+
+      {/* ---- Update -------------------------------------------------------- */}
+      {system ? (
+        <section className="tv-card tv-settings__card">
+          <h2 className="tv-settings__card-title">Update</h2>
+          {system.updateAvailable && system.latestVersion ? (
+            <>
+              <p className="tv-settings__desc">
+                v{system.version} → <strong>v{system.latestVersion}</strong> is available. Updates
+                run from the terminal ({system.installMethod} install):
+              </p>
+              <code className="tv-settings__cmd tv-mono">{system.updateCommand}</code>
+            </>
+          ) : (
+            <p className="tv-settings__desc">
+              v{system.version} — up to date
+              {system.latestVersion ? ` (latest: v${system.latestVersion})` : ''}.
+            </p>
+          )}
+        </section>
+      ) : null}
+
+      {/* ---- Danger zone ---------------------------------------------------- */}
+      <section className="tv-card tv-settings__card tv-settings__card--danger">
+        <h2 className="tv-settings__card-title">Danger zone</h2>
+        <p className="tv-settings__desc">
+          The index is a derived cache — rebuilding discards the local DuckDB file and re-indexes
+          every transcript from your sources. History is re-priced at current rates. The app stays
+          usable and shows build progress.
+        </p>
+        <div className="tv-settings__actions">
+          <button
+            type="button"
+            className="tv-btn tv-btn--danger"
+            disabled={state === 'building'}
+            onClick={() => setRebuildOpen(true)}
+          >
+            Rebuild index
+          </button>
+        </div>
+      </section>
+
+      {/* ---- Sticky save bar ------------------------------------------------ */}
+      {dirtyKeys.length > 0 || notice || warnings.length > 0 ? (
+        <div className="tv-settings__savebar">
+          <div className="tv-settings__savebar-text">
+            {dirtyKeys.length > 0 ? (
+              <span>
+                {dirtyKeys.length} unsaved change{dirtyKeys.length === 1 ? '' : 's'}
+              </span>
+            ) : notice ? (
+              <span>{notice}</span>
+            ) : null}
+            {warnings.map((w) => (
+              <span key={`${w.key}:${w.message}`} className="tv-settings__hint--warn">
+                {settings.editable.find((s) => s.key === w.key)?.label ?? w.key}: {w.message}
+              </span>
+            ))}
+          </div>
+          {dirtyKeys.length > 0 ? (
+            <div className="tv-settings__savebar-actions">
+              <button
+                type="button"
+                className="tv-btn tv-btn--secondary"
+                disabled={saving}
+                onClick={discard}
+              >
+                Discard
+              </button>
+              <button
+                type="button"
+                className="tv-btn tv-btn--primary"
+                disabled={saving}
+                onClick={() => void save()}
+              >
+                {saving ? 'Saving…' : 'Save changes'}
+              </button>
+            </div>
+          ) : null}
+        </div>
+      ) : null}
+
+      {rebuildOpen ? (
+        <ConfirmDialog
+          title="Rebuild the index?"
+          confirmLabel="Rebuild index"
+          danger
+          busy={rebuildBusy}
+          onConfirm={() => void rebuild()}
+          onCancel={() => setRebuildOpen(false)}
+        >
+          This discards the local index and rebuilds it from your transcripts. Nothing in your
+          agent directories is touched. History is re-priced at current rates. Browsing is limited
+          until the rebuild finishes.
+        </ConfirmDialog>
+      ) : null}
+    </div>
+  );
+}

--- a/packages/web/src/pages/settings/settings.css
+++ b/packages/web/src/pages/settings/settings.css
@@ -8,12 +8,21 @@
   max-width: 1040px;
 }
 
-/* Header: page title left, Save Changes right */
+/* Header: page title left, Save Changes right. Sticky so Save stays reachable
+   while scrolling; bleeds over the .tv-main__inner padding so scrolled content
+   never peeks above it. */
 .tv-settings__header {
+  position: sticky;
+  top: 0;
+  z-index: 20;
   display: flex;
   align-items: center;
   justify-content: space-between;
   gap: var(--tv-space-3);
+  background: var(--tv-bg);
+  margin: calc(-1 * var(--tv-space-5)) calc(-1 * var(--tv-space-5)) 0;
+  padding: var(--tv-space-4) var(--tv-space-5);
+  border-bottom: 1px solid var(--tv-border);
 }
 .tv-settings__header .tv-page-title {
   margin: 0;
@@ -70,12 +79,12 @@
   line-height: 1.5;
 }
 
-/* Two-column layout */
+/* Two-column layout. Cards stretch to equal height so a shorter card doesn't
+   leave a ragged gap next to its neighbor. */
 .tv-settings__grid2 {
   display: grid;
   grid-template-columns: 1fr 1fr;
   gap: var(--tv-space-4);
-  align-items: start;
 }
 .tv-settings__grid2--tight {
   gap: 0 var(--tv-space-4);

--- a/packages/web/src/pages/settings/settings.css
+++ b/packages/web/src/pages/settings/settings.css
@@ -1,37 +1,68 @@
-/* Settings page — cards of setting rows, provenance badges, sticky save bar. */
+/* Settings page — mockup layout: header w/ Save Changes, lifecycle tiles,
+   two-column config cards, path configuration, advanced runtime + danger. */
 
 .tv-settings {
   display: flex;
   flex-direction: column;
   gap: var(--tv-space-4);
-  /* Leave room so the sticky save bar never covers the danger zone. */
-  padding-bottom: 72px;
-  max-width: 860px;
+  max-width: 1040px;
 }
 
+/* Header: page title left, Save Changes right */
+.tv-settings__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--tv-space-3);
+}
+.tv-settings__header .tv-page-title {
+  margin: 0;
+}
+.tv-settings__header-actions {
+  display: flex;
+  align-items: center;
+  gap: var(--tv-space-2);
+}
+.tv-settings__warnings {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  font-size: var(--tv-fs-sm);
+}
+
+/* Sections & cards */
+.tv-settings__section {
+  display: flex;
+  flex-direction: column;
+  gap: var(--tv-space-3);
+}
+.tv-settings__section-head {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: var(--tv-space-3);
+}
+.tv-settings__section-title {
+  margin: 0 0 var(--tv-space-1);
+  font-size: var(--tv-fs-lg);
+  font-weight: 600;
+}
 .tv-settings__card {
   display: flex;
   flex-direction: column;
   gap: var(--tv-space-3);
 }
-
-.tv-settings__card--danger {
-  border-color: var(--tv-danger);
-}
-
 .tv-settings__card-head {
   display: flex;
   align-items: center;
   justify-content: space-between;
   gap: var(--tv-space-2);
 }
-
 .tv-settings__card-title {
   margin: 0;
   font-size: var(--tv-fs-lg);
   font-weight: 600;
 }
-
 .tv-settings__desc {
   margin: 0;
   color: var(--tv-fg-muted);
@@ -39,28 +70,89 @@
   line-height: 1.5;
 }
 
-/* Indexer state pill */
-.tv-settings__state {
-  padding: 2px var(--tv-space-2);
-  border-radius: 999px;
+/* Two-column layout */
+.tv-settings__grid2 {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: var(--tv-space-4);
+  align-items: start;
+}
+.tv-settings__grid2--tight {
+  gap: 0 var(--tv-space-4);
+}
+@media (max-width: 900px) {
+  .tv-settings__grid2 {
+    grid-template-columns: 1fr;
+  }
+}
+
+/* Status chip (● INDEXER RUNNING) */
+.tv-settings__chip {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--tv-space-2);
+  padding: var(--tv-space-1) var(--tv-space-3);
+  border: 1px solid var(--tv-border-strong);
+  border-radius: var(--tv-radius);
+  background: var(--tv-bg-elevated);
   font-size: var(--tv-fs-sm);
   font-weight: 600;
-  border: 1px solid var(--tv-border-strong);
-  color: var(--tv-fg-muted);
+  letter-spacing: 0.04em;
   white-space: nowrap;
 }
-.tv-settings__state--watching {
-  color: var(--tv-success);
-  border-color: var(--tv-success);
+.tv-settings__chip-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--tv-fg-faint);
 }
-.tv-settings__state--indexing,
-.tv-settings__state--building {
-  color: var(--tv-accent);
+.tv-settings__chip--watching .tv-settings__chip-dot {
+  background: var(--tv-success);
+}
+.tv-settings__chip--indexing .tv-settings__chip-dot,
+.tv-settings__chip--building .tv-settings__chip-dot {
+  background: var(--tv-accent);
+}
+.tv-settings__chip--paused .tv-settings__chip-dot {
+  background: var(--tv-warning);
+}
+
+/* Lifecycle action tiles */
+.tv-settings__tiles {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+  gap: var(--tv-space-3);
+}
+.tv-settings__tile {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: var(--tv-space-2);
+  padding: var(--tv-space-4) var(--tv-space-3);
+  border: 1px solid var(--tv-border-strong);
+  border-radius: var(--tv-radius);
+  background: var(--tv-bg-elevated);
+  color: var(--tv-fg-muted);
+  font-family: inherit;
+  font-size: var(--tv-fs-sm);
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  cursor: pointer;
+  transition: border-color 0.12s ease, color 0.12s ease, background 0.12s ease;
+}
+.tv-settings__tile:hover:not(:disabled) {
   border-color: var(--tv-accent);
+  color: var(--tv-fg);
 }
-.tv-settings__state--paused {
-  color: var(--tv-warning);
-  border-color: var(--tv-warning);
+.tv-settings__tile:disabled {
+  opacity: 0.4;
+  cursor: default;
+}
+.tv-settings__tile.is-busy {
+  border-color: var(--tv-accent);
+  color: var(--tv-accent);
 }
 
 /* Setting rows */
@@ -69,25 +161,22 @@
   flex-direction: column;
   gap: var(--tv-space-1);
   padding: var(--tv-space-2) 0;
-  border-top: 1px solid var(--tv-border);
 }
-.tv-settings__row.is-dirty {
-  border-left: 2px solid var(--tv-accent);
-  padding-left: var(--tv-space-2);
-  margin-left: calc(-1 * var(--tv-space-2));
+.tv-settings__row.is-dirty .tv-settings__input {
+  border-color: var(--tv-accent);
 }
-
 .tv-settings__row-head {
   display: flex;
   align-items: center;
   gap: var(--tv-space-2);
 }
-
 .tv-settings__label {
-  font-size: var(--tv-fs-md);
+  font-size: var(--tv-fs-sm);
   font-weight: 600;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: var(--tv-fg-muted);
 }
-
 .tv-settings__envvar {
   font-size: var(--tv-fs-sm);
   color: var(--tv-fg-faint);
@@ -95,7 +184,7 @@
 
 .tv-settings__input {
   width: 100%;
-  padding: var(--tv-space-2);
+  padding: var(--tv-space-2) var(--tv-space-3);
   border: 1px solid var(--tv-border-strong);
   border-radius: var(--tv-radius);
   background: var(--tv-bg-inset);
@@ -108,6 +197,13 @@
 }
 .tv-settings__input.is-invalid {
   border-color: var(--tv-danger);
+}
+.tv-settings__input:disabled {
+  color: var(--tv-fg-muted);
+}
+.tv-settings__input--num {
+  width: 110px;
+  flex: 0 0 auto;
 }
 
 .tv-settings__toggle {
@@ -127,7 +223,6 @@
   border-radius: 999px;
   font-size: var(--tv-fs-sm);
   font-weight: 600;
-  letter-spacing: 0.02em;
   border: 1px solid var(--tv-border-strong);
   color: var(--tv-fg-muted);
   white-space: nowrap;
@@ -140,12 +235,12 @@
   color: var(--tv-accent);
   border-color: var(--tv-accent);
 }
-.tv-settings__badge--readonly {
-  color: var(--tv-success);
-  border-color: var(--tv-success);
+.tv-settings__badge--readonly,
+.tv-settings__badge--default {
+  color: var(--tv-fg-faint);
 }
 
-/* Hints under a row */
+/* Hints */
 .tv-settings__hints {
   display: flex;
   flex-direction: column;
@@ -161,72 +256,67 @@
 .tv-settings__hint--error {
   color: var(--tv-danger);
 }
-
-/* Actions rows (lifecycle / pricing buttons) */
-.tv-settings__actions {
-  display: flex;
-  align-items: center;
-  gap: var(--tv-space-2);
-  flex-wrap: wrap;
-}
 .tv-settings__meta {
   font-size: var(--tv-fs-sm);
   color: var(--tv-fg-faint);
 }
 
-/* Read-only paths table */
-.tv-settings__table {
-  border-collapse: collapse;
-  font-size: var(--tv-fs-md);
-}
-.tv-settings__table td {
-  padding: var(--tv-space-1) var(--tv-space-3) var(--tv-space-1) 0;
-  vertical-align: baseline;
-}
-.tv-settings__table-label {
-  color: var(--tv-fg-muted);
-  white-space: nowrap;
-}
-
-/* Update command block */
-.tv-settings__cmd {
-  display: inline-block;
-  padding: var(--tv-space-2);
-  border: 1px solid var(--tv-border);
-  border-radius: var(--tv-radius);
-  background: var(--tv-bg-inset);
-  user-select: all;
-}
-
-/* Theme toggle: show labels next to icons on this page */
-.tv-settings__theme-label {
-  margin-left: var(--tv-space-1);
-  font-size: var(--tv-fs-sm);
-}
-
-/* Sticky save bar */
-.tv-settings__savebar {
-  position: sticky;
-  bottom: var(--tv-space-3);
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
+/* Theme tiles (Appearance card) */
+.tv-settings__theme-tiles {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
   gap: var(--tv-space-3);
-  padding: var(--tv-space-2) var(--tv-space-3);
-  border: 1px solid var(--tv-border-strong);
-  border-radius: var(--tv-radius);
-  background: var(--tv-bg-elevated);
-  box-shadow: 0 4px 16px rgb(0 0 0 / 25%);
 }
-.tv-settings__savebar-text {
+.tv-settings__theme-tile {
   display: flex;
   flex-direction: column;
-  gap: 2px;
-  font-size: var(--tv-fs-sm);
-  color: var(--tv-fg-muted);
-}
-.tv-settings__savebar-actions {
-  display: flex;
+  align-items: center;
   gap: var(--tv-space-2);
-  flex: 0 0 auto;
+  padding: var(--tv-space-4) var(--tv-space-2);
+  border: 1px solid var(--tv-border-strong);
+  border-radius: var(--tv-radius);
+  background: var(--tv-bg-inset);
+  color: var(--tv-fg-muted);
+  font-family: inherit;
+  font-size: var(--tv-fs-md);
+  cursor: pointer;
+  transition: border-color 0.12s ease, color 0.12s ease;
+}
+.tv-settings__theme-tile:hover {
+  color: var(--tv-fg);
+}
+.tv-settings__theme-tile.is-active {
+  border-color: var(--tv-accent);
+  color: var(--tv-fg);
+  box-shadow: 0 0 0 1px var(--tv-accent);
+}
+
+/* Reindex interval slider */
+.tv-settings__slider-row {
+  display: flex;
+  align-items: center;
+  gap: var(--tv-space-3);
+}
+.tv-settings__slider {
+  flex: 1;
+  accent-color: var(--tv-accent);
+}
+
+/* Danger zone */
+.tv-settings__danger {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: var(--tv-space-2);
+  padding: var(--tv-space-3);
+  border: 1px solid var(--tv-danger);
+  border-radius: var(--tv-radius);
+  background: var(--tv-danger-bg);
+}
+.tv-settings__danger-title {
+  margin: 0;
+  font-size: var(--tv-fs-md);
+  font-weight: 600;
+  color: var(--tv-danger);
+  letter-spacing: 0.03em;
 }

--- a/packages/web/src/pages/settings/settings.css
+++ b/packages/web/src/pages/settings/settings.css
@@ -1,0 +1,232 @@
+/* Settings page — cards of setting rows, provenance badges, sticky save bar. */
+
+.tv-settings {
+  display: flex;
+  flex-direction: column;
+  gap: var(--tv-space-4);
+  /* Leave room so the sticky save bar never covers the danger zone. */
+  padding-bottom: 72px;
+  max-width: 860px;
+}
+
+.tv-settings__card {
+  display: flex;
+  flex-direction: column;
+  gap: var(--tv-space-3);
+}
+
+.tv-settings__card--danger {
+  border-color: var(--tv-danger);
+}
+
+.tv-settings__card-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--tv-space-2);
+}
+
+.tv-settings__card-title {
+  margin: 0;
+  font-size: var(--tv-fs-lg);
+  font-weight: 600;
+}
+
+.tv-settings__desc {
+  margin: 0;
+  color: var(--tv-fg-muted);
+  font-size: var(--tv-fs-md);
+  line-height: 1.5;
+}
+
+/* Indexer state pill */
+.tv-settings__state {
+  padding: 2px var(--tv-space-2);
+  border-radius: 999px;
+  font-size: var(--tv-fs-sm);
+  font-weight: 600;
+  border: 1px solid var(--tv-border-strong);
+  color: var(--tv-fg-muted);
+  white-space: nowrap;
+}
+.tv-settings__state--watching {
+  color: var(--tv-success);
+  border-color: var(--tv-success);
+}
+.tv-settings__state--indexing,
+.tv-settings__state--building {
+  color: var(--tv-accent);
+  border-color: var(--tv-accent);
+}
+.tv-settings__state--paused {
+  color: var(--tv-warning);
+  border-color: var(--tv-warning);
+}
+
+/* Setting rows */
+.tv-settings__row {
+  display: flex;
+  flex-direction: column;
+  gap: var(--tv-space-1);
+  padding: var(--tv-space-2) 0;
+  border-top: 1px solid var(--tv-border);
+}
+.tv-settings__row.is-dirty {
+  border-left: 2px solid var(--tv-accent);
+  padding-left: var(--tv-space-2);
+  margin-left: calc(-1 * var(--tv-space-2));
+}
+
+.tv-settings__row-head {
+  display: flex;
+  align-items: center;
+  gap: var(--tv-space-2);
+}
+
+.tv-settings__label {
+  font-size: var(--tv-fs-md);
+  font-weight: 600;
+}
+
+.tv-settings__envvar {
+  font-size: var(--tv-fs-sm);
+  color: var(--tv-fg-faint);
+}
+
+.tv-settings__input {
+  width: 100%;
+  padding: var(--tv-space-2);
+  border: 1px solid var(--tv-border-strong);
+  border-radius: var(--tv-radius);
+  background: var(--tv-bg-inset);
+  color: var(--tv-fg);
+  font-size: var(--tv-fs-md);
+}
+.tv-settings__input:focus-visible {
+  outline: none;
+  border-color: var(--tv-accent);
+}
+.tv-settings__input.is-invalid {
+  border-color: var(--tv-danger);
+}
+
+.tv-settings__toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--tv-space-2);
+  cursor: pointer;
+  font-size: var(--tv-fs-md);
+}
+.tv-settings__toggle-text {
+  color: var(--tv-fg-muted);
+}
+
+/* Provenance badges */
+.tv-settings__badge {
+  padding: 1px var(--tv-space-2);
+  border-radius: 999px;
+  font-size: var(--tv-fs-sm);
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  border: 1px solid var(--tv-border-strong);
+  color: var(--tv-fg-muted);
+  white-space: nowrap;
+}
+.tv-settings__badge--env {
+  color: var(--tv-warning);
+  border-color: var(--tv-warning);
+}
+.tv-settings__badge--file {
+  color: var(--tv-accent);
+  border-color: var(--tv-accent);
+}
+.tv-settings__badge--readonly {
+  color: var(--tv-success);
+  border-color: var(--tv-success);
+}
+
+/* Hints under a row */
+.tv-settings__hints {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+.tv-settings__hint {
+  font-size: var(--tv-fs-sm);
+  color: var(--tv-fg-faint);
+}
+.tv-settings__hint--warn {
+  color: var(--tv-warning);
+}
+.tv-settings__hint--error {
+  color: var(--tv-danger);
+}
+
+/* Actions rows (lifecycle / pricing buttons) */
+.tv-settings__actions {
+  display: flex;
+  align-items: center;
+  gap: var(--tv-space-2);
+  flex-wrap: wrap;
+}
+.tv-settings__meta {
+  font-size: var(--tv-fs-sm);
+  color: var(--tv-fg-faint);
+}
+
+/* Read-only paths table */
+.tv-settings__table {
+  border-collapse: collapse;
+  font-size: var(--tv-fs-md);
+}
+.tv-settings__table td {
+  padding: var(--tv-space-1) var(--tv-space-3) var(--tv-space-1) 0;
+  vertical-align: baseline;
+}
+.tv-settings__table-label {
+  color: var(--tv-fg-muted);
+  white-space: nowrap;
+}
+
+/* Update command block */
+.tv-settings__cmd {
+  display: inline-block;
+  padding: var(--tv-space-2);
+  border: 1px solid var(--tv-border);
+  border-radius: var(--tv-radius);
+  background: var(--tv-bg-inset);
+  user-select: all;
+}
+
+/* Theme toggle: show labels next to icons on this page */
+.tv-settings__theme-label {
+  margin-left: var(--tv-space-1);
+  font-size: var(--tv-fs-sm);
+}
+
+/* Sticky save bar */
+.tv-settings__savebar {
+  position: sticky;
+  bottom: var(--tv-space-3);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--tv-space-3);
+  padding: var(--tv-space-2) var(--tv-space-3);
+  border: 1px solid var(--tv-border-strong);
+  border-radius: var(--tv-radius);
+  background: var(--tv-bg-elevated);
+  box-shadow: 0 4px 16px rgb(0 0 0 / 25%);
+}
+.tv-settings__savebar-text {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  font-size: var(--tv-fs-sm);
+  color: var(--tv-fg-muted);
+}
+.tv-settings__savebar-actions {
+  display: flex;
+  gap: var(--tv-space-2);
+  flex: 0 0 auto;
+}

--- a/packages/web/src/status/StatusProvider.tsx
+++ b/packages/web/src/status/StatusProvider.tsx
@@ -35,6 +35,8 @@ export interface ServerStatus {
   updateAvailable: string | null;
   /** Compact indexer lifecycle state (null until the first health response). */
   indexer: HealthResponse['indexer'] | null;
+  /** Running app version (null until the first health response). */
+  version: string | null;
 }
 
 const idleStatus: ServerStatus = {
@@ -45,6 +47,7 @@ const idleStatus: ServerStatus = {
   dataVersion: null,
   updateAvailable: null,
   indexer: null,
+  version: null,
 };
 
 const StatusContext = createContext<ServerStatus>(idleStatus);
@@ -74,6 +77,7 @@ export function StatusProvider({ children }: { children: ReactNode }) {
           dataVersion: h.dataVersion,
           updateAvailable: h.updateAvailable ?? null,
           indexer: h.indexer ?? null,
+          version: h.version,
         }));
         timer = window.setTimeout(() => void tick(), building ? BUILDING_POLL_MS : IDLE_POLL_MS);
       } catch {

--- a/packages/web/src/status/StatusProvider.tsx
+++ b/packages/web/src/status/StatusProvider.tsx
@@ -13,7 +13,7 @@
  */
 
 import { createContext, useContext, useEffect, useState, type ReactNode } from 'react';
-import type { IndexingProgress } from '@claudescope/shared';
+import type { HealthResponse, IndexingProgress } from '@claudescope/shared';
 import { api } from '../api/client.js';
 
 export interface ServerStatus {
@@ -33,6 +33,8 @@ export interface ServerStatus {
   dataVersion: number | null;
   /** Newer published version the daemon reported, for the sidebar nudge. */
   updateAvailable: string | null;
+  /** Compact indexer lifecycle state (null until the first health response). */
+  indexer: HealthResponse['indexer'] | null;
 }
 
 const idleStatus: ServerStatus = {
@@ -42,6 +44,7 @@ const idleStatus: ServerStatus = {
   indexingTick: 0,
   dataVersion: null,
   updateAvailable: null,
+  indexer: null,
 };
 
 const StatusContext = createContext<ServerStatus>(idleStatus);
@@ -70,6 +73,7 @@ export function StatusProvider({ children }: { children: ReactNode }) {
           indexingTick: building ? s.indexingTick + 1 : s.indexingTick,
           dataVersion: h.dataVersion,
           updateAvailable: h.updateAvailable ?? null,
+          indexer: h.indexer ?? null,
         }));
         timer = window.setTimeout(() => void tick(), building ? BUILDING_POLL_MS : IDLE_POLL_MS);
       } catch {

--- a/packages/web/src/styles/global.css
+++ b/packages/web/src/styles/global.css
@@ -858,6 +858,54 @@ mark {
   font-size: var(--tv-fs-sm);
   font-weight: 500;
 }
+.tv-btn--danger {
+  background: transparent;
+  border-color: var(--tv-danger);
+  color: var(--tv-danger);
+}
+.tv-btn--danger:hover {
+  background: var(--tv-danger-bg);
+  text-decoration: none;
+}
+.tv-btn:disabled {
+  opacity: 0.55;
+  cursor: default;
+  pointer-events: none;
+}
+
+/* --------------------------------------------------------------------------
+   Confirmation dialog — fixed overlay + a tv-card panel (see ConfirmDialog).
+   -------------------------------------------------------------------------- */
+.tv-dialog-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 100;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgb(0 0 0 / 50%);
+}
+.tv-dialog {
+  width: min(440px, calc(100vw - var(--tv-space-6)));
+  display: flex;
+  flex-direction: column;
+  gap: var(--tv-space-3);
+}
+.tv-dialog__title {
+  margin: 0;
+  font-size: var(--tv-fs-lg);
+  font-weight: 600;
+}
+.tv-dialog__body {
+  color: var(--tv-fg-muted);
+  font-size: var(--tv-fs-md);
+  line-height: 1.5;
+}
+.tv-dialog__actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: var(--tv-space-2);
+}
 
 /* Search/filter field — one shared control (magnifier in-field + clear ×). */
 .tv-field {

--- a/packages/web/src/styles/global.css
+++ b/packages/web/src/styles/global.css
@@ -235,6 +235,15 @@ button {
   text-overflow: ellipsis;
 }
 /* Update nudge above the sources — a hint, not an alert, so muted colors. */
+/* Running app version, tucked under the Settings link at the sidebar bottom. */
+.tv-nav__version {
+  padding: 2px var(--tv-space-3);
+  font-size: 10px;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: var(--tv-fg-faint);
+}
+
 .tv-nav__update {
   font-size: 11px;
   color: var(--tv-fg-muted);


### PR DESCRIPTION
Adds a **Settings page** (`/settings`, bottom of the sidebar) and the runtime plumbing behind it: a persisted `settings.json` layer and lifecycle controls that target the **indexer**, not the process.

Plan: [docs/plans/0051-settings-page.md](./docs/plans/0051-settings-page.md)

## Design decisions

- **Lifecycle = the indexer.** Start/Stop/Restart control the background reindex engine (`indexer-lifecycle.ts`); the app stays fully browsable on the frozen index while paused. The HTTP server is never stopped from the UI — terminal-only (`claudescope stop`), so there's no dead-page paradox and no START-button impossibility. Pause is runtime-only (not persisted).
- **`~/.claudescope/settings.json`, env always wins.** Precedence env > file > default, resolved **per call** via `settings.ts` getters (mtime-cached read, atomic tmp+rename writes, `.bak` before overwriting a corrupt file). The UI shows per-field provenance (`env`/`saved`/`default`) and warns when an env var shadows a saved value.
- **Live-apply.** All 8 connectors migrated from import-frozen consts to per-pass getters (`get sourceDir()` object literals keep every consumer compiling). Saving a source dir kicks `requestPass()` — drain any in-flight pass, then run one more — so "save → sessions appear" is deterministic; interval changes re-arm the poller.
- **Rebuild index** (danger zone) runs through the same `inFlight` slot as `reindex()` so poller ticks coalesce instead of racing the closed DuckDB connection; history is re-priced at current rates. A failed rebuild kicks a recovery pass so the app can't wedge in "building".
- **Update stays terminal-driven**: `GET /api/system` shows the install-method-specific command (`install-method.ts`, shared with the CLI); the server never shells out.
- **CSRF mutation guard**: now that the API writes files, mutations require `Sec-Fetch-Site` same-origin/none, a loopback `Origin` when present (covers pre-Fetch-Metadata browsers on body-less POSTs), and JSON content types.

## API

`GET/PUT /api/settings` · `POST /api/indexer/{stop,start,restart}` · `POST /api/index/rebuild` (202/409) · `POST /api/pricing/refresh` · `GET /api/system`; `/api/health` gains compact `indexer` state (`StatusProvider` passes it through — no new polling).

## UI

Mockup-faithful: sticky header with Save Changes, Service Lifecycle action tiles + live status chip, Global Configuration | Appearance (theme tiles — toggle moved out of the sidebar), Path Configuration with provenance badges, Advanced Runtime with interval slider next to the red danger zone. First `ConfirmDialog` + `tv-btn--danger` primitives. Version label under the sidebar Settings link.

## Testing

- 43 new tests (484 total, typecheck clean): settings precedence/`~`-expansion/corrupt-file/`.bak`/mtime-cache/validation matrix; PUT → live-apply → re-pointed Grok dir indexed and old sessions pruned; pause/resume/restart + the coalescing guarantee (object-identity assertions, no sleeps); rebuild snapshot identity, prospective-vs-rebuild pricing, mid-rebuild coalescing, 409; mutation-guard matrix
- Adversarial review pass: no criticals; all four warnings fixed in `770ae48`
- Verified end-to-end against the live app (settings CRUD, stop/start round-trip, cross-site POST → 403, screenshots vs the mockup)