### PR TITLE
fix: make a failed index load non-destructive and visible

### DIFF
--- a/docs/plans/0052-indexer-durability-and-state-perms.md
+++ b/docs/plans/0052-indexer-durability-and-state-perms.md
@@ -1,8 +1,8 @@
 # 0052 — Indexer durability + state-dir permissions
 
-- **Status:** in-progress <!-- proposed | in-progress | done | superseded | abandoned -->
+- **Status:** in-progress <!-- awaiting review on #72 --> <!-- proposed | in-progress | done | superseded | abandoned -->
 - **Date:** 2026-07-29
-- **PR:** <link, once opened>
+- **PR:** https://github.com/vladar107/claudescope/pull/72
 
 ## Context
 
@@ -56,11 +56,16 @@ deterministic for tied cwds.
 
 ## Decisions
 
-- **Wrap `loadFile`'s mutations in a DuckDB transaction** — rather than
-  reordering statements so the interpolation failure happens earlier. Ordering
-  luck is what makes the current behaviour inconsistent; a transaction makes
-  *any* mid-load failure a no-op regardless of which statement throws. Verified
-  `BEGIN`/`ROLLBACK` work through `conn.run` on `@duckdb/node-api`.
+- **Stage the projection into temp tables, then swap** — so every realistic
+  failure happens before a single existing row is touched.
+  A DuckDB transaction around the mutations was tried FIRST and rejected:
+  `index-progress.integration.test.ts` failed deterministically because the
+  indexer shares its connection with every HTTP route, so a `BEGIN` encloses
+  concurrent route queries and aborts them along with a failed load (the test
+  polls `SELECT count(*) FROM sessions` mid-pass precisely to mirror that).
+  Isolating the indexer on its own connection would also work, but that is an
+  architectural change to `db/duckdb.ts` and every `getConnection()` caller —
+  out of scope here. Staging needs no transaction to be non-destructive.
 - **Validate pricing rates in `loadPricing`, don't throw** — an unusable rate is
   dropped so the chain falls through (`models` entry → family → default), which
   is the philosophy `pricing-refresh.ts:mapLiteLLM` already applies to fetched
@@ -71,10 +76,10 @@ deterministic for tied cwds.
   design and `POST /api/reindex` both depend on `reindex()` resolving.
   `IndexerStatus.lastPass` is already `ReindexResponse | null`, so the count
   surfaces on `/api/indexer/*` with no new API surface.
-- **Keep the early return, but gate it on `failed === 0`** — with the
-  transaction in place a failed file changes nothing, so skipping the derived
-  rebuild is now *correct*; the gate is belt-and-braces so a future non-atomic
-  failure path can't silently reintroduce the inconsistency.
+- **Keep the early return, but gate it on `failed === 0`** — with staging in
+  place a failed file changes nothing, so skipping the derived rebuild is now
+  *correct*; the gate is belt-and-braces so a future destructive failure path
+  can't silently reintroduce the inconsistency.
 - **One `ensureDir` helper for the state dir** — the mode has to be right at all
   five `mkdirSync(CLAUDESCOPE_HOME)` sites, and a sixth will be added eventually.
   Existing installs are migrated on boot (`chmod` when the mode is looser).
@@ -119,12 +124,15 @@ deterministic for tied cwds.
 
 ## Risks / open questions
 
-- Per-file transactions add two statements per changed file. Measured cold-build
-  cost is expected to be noise against the ~300 ms/pass baseline; the perf job
-  gates it.
-- `PRAGMA create_fts_index` and `CHECKPOINT` must stay **outside** the
-  transaction. They already run after the per-file loop, so no change — but a
-  future refactor that moves them inside would break.
+- Staging costs one extra materialization per changed file: cold build 4951 →
+  5279 ms (+6.6%) on a 26k-event corpus; incremental passes unchanged. The perf
+  job gates further drift.
+- The staged temp tables use a constant name suffix, which is only safe because
+  one pass runs at a time (`inFlight`) and loads files sequentially. A future
+  parallel loader must key them per file.
+- The residual destructive window is between the deletes and the insert-from-temp
+  — table-to-table copies with no source file or interpolated input, so nothing
+  realistic is left to fail on.
 - Zeroing an invalid `default` field makes affected costs read 0. The warning
   names the field; the alternative (crash) is what this plan removes.
 - The mode migration only tightens `CLAUDESCOPE_HOME` itself, not pre-existing

--- a/docs/plans/0052-indexer-durability-and-state-perms.md
+++ b/docs/plans/0052-indexer-durability-and-state-perms.md
@@ -1,0 +1,132 @@
+# 0052 — Indexer durability + state-dir permissions
+
+- **Status:** in-progress <!-- proposed | in-progress | done | superseded | abandoned -->
+- **Date:** 2026-07-29
+- **PR:** <link, once opened>
+
+## Context
+
+A repo-wide review turned up two problems that lose or expose data. Both were
+reproduced against a real DuckDB index before this plan was written.
+
+**1. A pricing typo silently destroys indexed events.** `loadFile` deletes a
+file's `titles`/`pr_links`/`events` rows and then re-inserts them. The cost
+expression is built by string interpolation from `pricing.json`, and
+`loadPricing` does a bare `JSON.parse(...) as PricingConfig` with no validation
+— so a rate typed as a string (`"3.00 USD"`, a plausible hand-edit of a file the
+docs invite you to edit) produces invalid SQL. Which half of the pass fails
+depends on *where* the typo is:
+
+- in `models` → fails in `syncPricingTable`, **before** the deletes → data frozen;
+- in `families`/`default` → those are inlined into the cost expression by
+  `buildCostExpr`, so it fails in `INSERT INTO events`, **after** the deletes →
+  **data destroyed** (measured: 3 events → 0, `sessions` still advertising
+  `message_count: 3`).
+
+Same user action, opposite outcomes, decided by statement order. It compounds:
+another changed file is wiped on every subsequent pass.
+
+**2. The failure is invisible.** The per-file `catch` in `doReindex` warns to
+`console` and continues without incrementing `reindexed`, so the pass hits the
+`reindexed === 0 && removed === 0` early return and reports
+`{reindexed: 0, durationMs: 5}` — byte-identical to a genuinely idle pass. The
+poller's `if (res.reindexed > 0)` guard means it does not even log; `dataVersion`
+never moves so the web UI never refetches; `/api/health` reports a healthy
+`watching` indexer. Ingestion stops permanently while the app looks fine. This is
+generic — *any* per-file load failure is laundered into "nothing changed".
+
+**3. Two smaller defects in the same pass.** `modal_cwd`'s `row_number()` has no
+tie-break column, so a session whose two most-frequent cwds tie flips between
+projects (both values observed across 20 evaluations of identical data).
+`editBearing` builds one unchunked `IN (...)` list — 147 KB of SQL at 5k
+sessions — directly below a `DELETE` that chunks at 500 for exactly that reason.
+
+**4. The state dir downgrades source protection.** `~/.claude/projects` is
+`0700`; Claudescope re-materializes its content into `~/.claudescope/` at `0755`
+with `index.duckdb` at `0644` — 157 MB of transcript text plus a full FTS index,
+world-readable, on the reviewer's own machine. The index aggregates every
+connector, so it inherits the loosest posture of any source rather than the
+strictest.
+
+## Goal
+
+A per-file load failure can no longer lose data, can no longer masquerade as an
+idle pass, and app-owned state is owner-only. Derived-table output becomes
+deterministic for tied cwds.
+
+## Decisions
+
+- **Wrap `loadFile`'s mutations in a DuckDB transaction** — rather than
+  reordering statements so the interpolation failure happens earlier. Ordering
+  luck is what makes the current behaviour inconsistent; a transaction makes
+  *any* mid-load failure a no-op regardless of which statement throws. Verified
+  `BEGIN`/`ROLLBACK` work through `conn.run` on `@duckdb/node-api`.
+- **Validate pricing rates in `loadPricing`, don't throw** — an unusable rate is
+  dropped so the chain falls through (`models` entry → family → default), which
+  is the philosophy `pricing-refresh.ts:mapLiteLLM` already applies to fetched
+  rates. Rejected: throwing (turns a typo into a dead app) and repairing values
+  (guessing at intent). `default` cannot be dropped, so invalid fields there are
+  zeroed with a loud warning — visibly wrong beats invisibly wrong.
+- **`failed` on `ReindexResponse`, not an exception** — the poller's non-fatal
+  design and `POST /api/reindex` both depend on `reindex()` resolving.
+  `IndexerStatus.lastPass` is already `ReindexResponse | null`, so the count
+  surfaces on `/api/indexer/*` with no new API surface.
+- **Keep the early return, but gate it on `failed === 0`** — with the
+  transaction in place a failed file changes nothing, so skipping the derived
+  rebuild is now *correct*; the gate is belt-and-braces so a future non-atomic
+  failure path can't silently reintroduce the inconsistency.
+- **One `ensureDir` helper for the state dir** — the mode has to be right at all
+  five `mkdirSync(CLAUDESCOPE_HOME)` sites, and a sixth will be added eventually.
+  Existing installs are migrated on boot (`chmod` when the mode is looser).
+
+## Approach
+
+1. `shared`: add `failed: number` to `ReindexResponse`.
+2. `data/pricing.ts`: coerce every `ModelRates` through a validator on the
+   cache-miss path; drop unusable `models`/`families`/`providers` entries, zero
+   unusable `default` fields, warn once per file change.
+3. `data/index.ts`: transaction around `loadFile`'s mutations; count and return
+   `failed`; gate the early return on it; add `, cwd` to the `modal_cwd`
+   tie-break.
+4. `data/file-edits.ts`: chunk `editBearing` at the existing `INSERT_CHUNK`.
+5. `indexer-lifecycle.ts`: log at warn level when a pass reports failures.
+6. `config.ts`: `ensureDir` (mode `0700`) + `STATE_FILE_MODE` (`0600`); route the
+   other four `mkdirSync` sites through it; tighten an existing looser dir on boot.
+7. Regression tests for the two data-safety paths and the tie-break.
+
+## Files affected
+
+- `packages/shared/src/api.ts` — `ReindexResponse.failed`.
+- `packages/server/src/data/pricing.ts` — rate validation on load.
+- `packages/server/src/data/index.ts` — `loadFile` transaction, `failed`
+  accounting, `modal_cwd` tie-break.
+- `packages/server/src/data/file-edits.ts` — chunk `editBearing`.
+- `packages/server/src/indexer-lifecycle.ts` — surface `failed` in the poll log.
+- `packages/server/src/config.ts` — `ensureDir` / `STATE_FILE_MODE`, mode migration.
+- `packages/server/src/{daemon,cli,update-check,settings}.ts` — use `ensureDir`.
+- `packages/server/src/data/pricing-refresh.ts` — write the snapshot `0600`.
+- `packages/server/test/index-durability.integration.test.ts` — new.
+- `packages/server/test/pricing.test.ts` — validation cases.
+
+## Testing
+
+- `npm test` and `npm run typecheck` (baseline: 484 tests / 55 files green).
+- New integration test asserts a `default`-block typo leaves `events` intact,
+  reports `failed: 1`, and that a later valid pass recovers the data.
+- New test asserts a tied-cwd session resolves to the same project across
+  repeated evaluations.
+- Manual: `stat` the state dir after boot to confirm `0700`/`0600`.
+
+## Risks / open questions
+
+- Per-file transactions add two statements per changed file. Measured cold-build
+  cost is expected to be noise against the ~300 ms/pass baseline; the perf job
+  gates it.
+- `PRAGMA create_fts_index` and `CHECKPOINT` must stay **outside** the
+  transaction. They already run after the per-file loop, so no change — but a
+  future refactor that moves them inside would break.
+- Zeroing an invalid `default` field makes affected costs read 0. The warning
+  names the field; the alternative (crash) is what this plan removes.
+- The mode migration only tightens `CLAUDESCOPE_HOME` itself, not pre-existing
+  files inside it. `index.duckdb` is recreated on the next rebuild; a paranoid
+  user can `chmod -R go-rwx ~/.claudescope`. Called out in the PR body.

--- a/docs/plans/0052-indexer-durability-and-state-perms.md
+++ b/docs/plans/0052-indexer-durability-and-state-perms.md
@@ -90,9 +90,9 @@ deterministic for tied cwds.
 2. `data/pricing.ts`: coerce every `ModelRates` through a validator on the
    cache-miss path; drop unusable `models`/`families`/`providers` entries, zero
    unusable `default` fields, warn once per file change.
-3. `data/index.ts`: transaction around `loadFile`'s mutations; count and return
-   `failed`; gate the early return on it; add `, cwd` to the `modal_cwd`
-   tie-break.
+3. `data/index.ts`: stage `loadFile`'s projection (events + aux) into temp
+   tables, then delete-and-swap; count and return `failed`; gate the early
+   return on it; add the `cwd` tie-break to `modal_cwd`.
 4. `data/file-edits.ts`: chunk `editBearing` at the existing `INSERT_CHUNK`.
 5. `indexer-lifecycle.ts`: log at warn level when a pass reports failures.
 6. `config.ts`: `ensureDir` (mode `0700`) + `STATE_FILE_MODE` (`0600`); route the
@@ -103,24 +103,30 @@ deterministic for tied cwds.
 
 - `packages/shared/src/api.ts` — `ReindexResponse.failed`.
 - `packages/server/src/data/pricing.ts` — rate validation on load.
-- `packages/server/src/data/index.ts` — `loadFile` transaction, `failed`
+- `packages/server/src/data/index.ts` — `loadFile` stage-then-swap, `failed`
   accounting, `modal_cwd` tie-break.
 - `packages/server/src/data/file-edits.ts` — chunk `editBearing`.
 - `packages/server/src/indexer-lifecycle.ts` — surface `failed` in the poll log.
-- `packages/server/src/config.ts` — `ensureDir` / `STATE_FILE_MODE`, mode migration.
-- `packages/server/src/{daemon,cli,update-check,settings}.ts` — use `ensureDir`.
-- `packages/server/src/data/pricing-refresh.ts` — write the snapshot `0600`.
+- `packages/server/src/config.ts` — `ensureStateDir` / `STATE_FILE_MODE`, mode
+  migration; the old `ensureStateDir` boot helper becomes `initStateDir`.
+- `packages/server/src/{daemon,cli,update-check,settings}.ts`,
+  `src/db/duckdb.ts`, `src/data/pricing-refresh.ts` — use `ensureStateDir`.
 - `packages/server/test/index-durability.integration.test.ts` — new.
-- `packages/server/test/pricing.test.ts` — validation cases.
 
 ## Testing
 
-- `npm test` and `npm run typecheck` (baseline: 484 tests / 55 files green).
-- New integration test asserts a `default`-block typo leaves `events` intact,
-  reports `failed: 1`, and that a later valid pass recovers the data.
-- New test asserts a tied-cwd session resolves to the same project across
-  repeated evaluations.
-- Manual: `stat` the state dir after boot to confirm `0700`/`0600`.
+- `npm test` (484/55 baseline → 488/56), `npm run typecheck`, `npm run build`,
+  markdownlint. Suite run 3x, since the rejected transaction approach surfaced
+  as a first-run-only failure before it reproduced deterministically in isolation.
+- `index-durability.integration.test.ts` covers each layer separately, because
+  the two fixes overlap: validation neutralises the pricing trigger, so staging
+  has to be exercised by a failure validation CANNOT foresee (an unreadable
+  source file). It also asserts concurrent route-style queries survive a failing
+  load, and that the cwd tie-break is stable over 20 evaluations.
+- Both fixes were verified to be genuinely guarded: reverting the staging change
+  fails the suite with `expected +0 to be 2` (events destroyed), and disabling
+  validation fails all four new tests.
+- State-dir mode verified for a fresh dir and for migrating an existing 0755 one.
 
 ## Risks / open questions
 

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -76,3 +76,4 @@ decision, or a change worth explaining before doing. Skip it for one-line fixes.
 | 0049 | [Dependabot #6: brace-expansion DoS remediation](./0049-dependabot-brace-expansion.md) | done |
 | 0050 | [Dependabot alerts #7–#10 remediation](./0050-dependabot-alerts-7-10.md) | done |
 | 0051 | [Settings page: indexer lifecycle + settings.json layer](./0051-settings-page.md) | done |
+| 0052 | [Indexer durability + state-dir permissions](./0052-indexer-durability-and-state-perms.md) | in-progress |

--- a/packages/server/src/cli.ts
+++ b/packages/server/src/cli.ts
@@ -18,7 +18,7 @@
  */
 
 import { spawnSync } from 'node:child_process';
-import { existsSync, mkdirSync, readFileSync, realpathSync, rmSync } from 'node:fs';
+import { existsSync, readFileSync, realpathSync, rmSync } from 'node:fs';
 import { createInterface } from 'node:readline/promises';
 import { parseArgs } from 'node:util';
 import { fileURLToPath } from 'node:url';
@@ -27,6 +27,7 @@ import {
   CLAUDESCOPE_HOME,
   PORT as DEFAULT_PORT,
   autoRestartEnabled,
+  ensureStateDir,
 } from './config.js';
 import { claudeProjectsDir, openBrowserOnStart } from './settings.js';
 import {
@@ -74,7 +75,7 @@ export {
 
 /** Start the server in the background, idempotently. */
 async function start(port: number, open: boolean): Promise<void> {
-  mkdirSync(CLAUDESCOPE_HOME, { recursive: true });
+  ensureStateDir();
 
   const existing = readDaemon();
   const state = await classifyExisting(existing, isAlive, isHealthy);

--- a/packages/server/src/config.ts
+++ b/packages/server/src/config.ts
@@ -1,6 +1,15 @@
 /** Centralized server configuration constants. */
 
-import { copyFileSync, existsSync, mkdirSync, readFileSync, renameSync, writeFileSync } from 'node:fs';
+import {
+  chmodSync,
+  copyFileSync,
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  renameSync,
+  statSync,
+  writeFileSync,
+} from 'node:fs';
 import { homedir } from 'node:os';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -204,11 +213,40 @@ export function reconcilePricingConfig(
 }
 
 /**
- * Create the state directory and reconcile the user-editable pricing file with
- * the shipped default (seed on first run; non-destructively migrate a stale
- * copy). Idempotent; call once at boot.
+ * Mode for app-owned state files. The index is a searchable copy of every
+ * transcript we can read, so it must not be more permissive than the sources it
+ * derives from — `~/.claude/projects` is 0700, and a default-umask 0644
+ * `index.duckdb` would hand the whole corpus (plus its FTS index) to any local
+ * user. Same reasoning for the normalize cache, which holds transcript text
+ * verbatim.
  */
-export function ensureStateDir(): void {
-  mkdirSync(CLAUDESCOPE_HOME, { recursive: true });
+export const STATE_FILE_MODE = 0o600;
+
+/** Mode for app-owned state directories (see {@link STATE_FILE_MODE}). */
+export const STATE_DIR_MODE = 0o700;
+
+/**
+ * Create an app-owned state directory owner-only, tightening an existing dir
+ * that a previous version created with the default umask. Every writer of
+ * {@link CLAUDESCOPE_HOME} (and its subdirs) goes through this so the mode can't
+ * drift back at one of the call sites.
+ */
+export function ensureStateDir(dir: string = CLAUDESCOPE_HOME): void {
+  mkdirSync(dir, { recursive: true, mode: STATE_DIR_MODE });
+  try {
+    // Pre-existing dirs keep their old mode through mkdirSync — tighten in place.
+    if ((statSync(dir).mode & 0o777) !== STATE_DIR_MODE) chmodSync(dir, STATE_DIR_MODE);
+  } catch {
+    /* best-effort: a mode we can't read or set must not block startup */
+  }
+}
+
+/**
+ * Boot-time setup: create the state directory owner-only and reconcile the
+ * user-editable pricing file with the shipped default (seed on first run;
+ * non-destructively migrate a stale copy). Idempotent; call once at boot.
+ */
+export function initStateDir(): void {
+  ensureStateDir();
   reconcilePricingConfig();
 }

--- a/packages/server/src/daemon.ts
+++ b/packages/server/src/daemon.ts
@@ -11,7 +11,6 @@
 import { spawn } from 'node:child_process';
 import {
   existsSync,
-  mkdirSync,
   openSync,
   readFileSync,
   renameSync,
@@ -22,7 +21,14 @@ import {
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import type { HealthResponse } from '@claudescope/shared';
-import { APP_VERSION, CLAUDESCOPE_HOME, PORT as DEFAULT_PORT, autoRestartEnabled } from './config.js';
+import {
+  APP_VERSION,
+  CLAUDESCOPE_HOME,
+  PORT as DEFAULT_PORT,
+  STATE_FILE_MODE,
+  autoRestartEnabled,
+  ensureStateDir,
+} from './config.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 /** The server bundle, a sibling of the CLI in the published package. */
@@ -163,7 +169,7 @@ export function rotateLogIfLarge(): void {
 /** Spawn the server detached (stdio → daemon log) and record it in daemon.json.
  *  Fire-and-forget: callers wait for health themselves. */
 export function spawnDaemon(port: number): void {
-  mkdirSync(CLAUDESCOPE_HOME, { recursive: true });
+  ensureStateDir();
   rotateLogIfLarge();
   const logFd = openSync(LOG_FILE, 'a');
   // Detached + stdio→log + unref: the server keeps running after this CLI exits.
@@ -188,6 +194,7 @@ export function spawnDaemon(port: number): void {
       null,
       2,
     ),
+    { mode: STATE_FILE_MODE },
   );
 }
 

--- a/packages/server/src/data/file-edits.ts
+++ b/packages/server/src/data/file-edits.ts
@@ -33,14 +33,24 @@ const INSERT_CHUNK = 500;
  * finds no canonical edit blocks).
  */
 async function editBearing(conn: DuckDBConnection, sessionIds: string[]): Promise<string[]> {
-  const ids = sessionIds.map(sqlString).join(', ');
-  const rows = await queryRows(
-    conn,
-    `SELECT DISTINCT session_id FROM events
-     WHERE session_id IN (${ids})
-       AND (tool_names LIKE '%Edit%' OR tool_names LIKE '%Write%')`,
-  );
-  return rows.map((r) => String(r.session_id));
+  // Chunked for the same reason the DELETE in refreshFileEdits is: on a cold
+  // build EVERY session is touched, so an unchunked IN list is one statement
+  // carrying the whole corpus (~147 KB of SQL at 5k sessions).
+  const out: string[] = [];
+  for (let i = 0; i < sessionIds.length; i += INSERT_CHUNK) {
+    const ids = sessionIds
+      .slice(i, i + INSERT_CHUNK)
+      .map(sqlString)
+      .join(', ');
+    const rows = await queryRows(
+      conn,
+      `SELECT DISTINCT session_id FROM events
+       WHERE session_id IN (${ids})
+         AND (tool_names LIKE '%Edit%' OR tool_names LIKE '%Write%')`,
+    );
+    for (const r of rows) out.push(String(r.session_id));
+  }
+  return out;
 }
 
 /**

--- a/packages/server/src/data/index.ts
+++ b/packages/server/src/data/index.ts
@@ -94,6 +94,15 @@ const EVENTS_ALIAS = 'ev';
 const RATES_ALIAS = 'pr';
 
 /**
+ * Suffix for {@link loadFile}'s staging temp tables. Constant (not per-file):
+ * only one pass runs at a time (see {@link inFlight}) and it loads files
+ * sequentially, so `CREATE OR REPLACE` reuses the same three tables instead of
+ * leaking one set per indexed file. Temp tables are connection-scoped, so this
+ * can never collide with a route's query.
+ */
+const STAGE_SUFFIX = 'load';
+
+/**
  * (Re)create and populate the `pricing_rates` join table from the merged
  * pricing's exact-id model rates. At a few hundred rows this is cheap, so we
  * just recreate it once per reindex run (never per file). The cost expression
@@ -187,22 +196,34 @@ async function loadFile(
   costExpr: string,
 ): Promise<void> {
   const path = sqlString(file.path);
-  // Formats that can't be projected per-row normalize to a canonical NDJSON first.
+  // Formats that can't be projected per-row normalize to a canonical NDJSON
+  // first. Runs before anything is deleted, so a prepare failure is a no-op.
   await connector.prepare?.(file.path);
-  // Delete stale aux rows before clearing events: if an ai-title or pr-link line
-  // was removed from the transcript, the old row must not survive the reload and
-  // get LEFT JOINed back into the rebuilt session. The subquery reads events
-  // before they are deleted, so these must come first.
-  await conn.run(`DELETE FROM titles   WHERE session_id IN (SELECT DISTINCT session_id FROM events WHERE file_path = ${path})`);
-  await conn.run(`DELETE FROM pr_links WHERE session_id IN (SELECT DISTINCT session_id FROM events WHERE file_path = ${path})`);
-  await conn.run(`DELETE FROM events WHERE file_path = ${path}`);
+
+  // STAGE FIRST, THEN SWAP. The projection is materialized into temp tables
+  // before a single existing row is touched, because every realistic failure
+  // happens while projecting: an unreadable or unparseable source file and —
+  // critically — a bad rate in the user-editable pricing.json, which is
+  // string-interpolated into `costExpr` and so yields invalid SQL. Deleting
+  // first meant such a failure destroyed the file's indexed rows while the
+  // derived tables kept advertising them (one typo in pricing.json wiped a
+  // session's events, then another session's on every subsequent pass).
+  //
+  // Deliberately NOT an explicit transaction: the indexer shares its DuckDB
+  // connection with every HTTP route (see db/duckdb.ts), so a BEGIN here would
+  // enclose concurrent route queries and abort them along with a failed load.
+  // Staging is non-destructive without needing one.
+  const stagedEvents = `stage_events_${STAGE_SUFFIX}`;
+  const stagedTitles = `stage_titles_${STAGE_SUFFIX}`;
+  const stagedPrLinks = `stage_pr_links_${STAGE_SUFFIX}`;
 
   // The cost expression references the projected token/model columns plus the
   // pricing_rates join (aliased `pr` — see buildCostExpr). LEFT JOIN on the
   // model column so events whose model has no exact-id row fall through to the
   // family/default CASE; the table is recreated each reindex (syncPricingTable).
+  // This column order IS the `events` column order — the swap below relies on it.
   await conn.run(`
-    INSERT INTO events
+    CREATE OR REPLACE TEMP TABLE ${stagedEvents} AS
     SELECT
       ev.file_path, ev.session_id, ev.uuid, ev.parent_uuid, ev.role, ev.type, ev.ts, ev.cwd, ev.git_branch,
       ev.model, ev.provider, ev.input_tokens, ev.output_tokens, ev.cache_read_tokens, ev.cache_write_tokens,
@@ -217,13 +238,33 @@ async function loadFile(
     LEFT JOIN pricing_rates ${RATES_ALIAS} ON ${RATES_ALIAS}.model = ev.model
   `);
 
+  // Aux projections read the same source file, so stage them too — otherwise a
+  // malformed title record would fail after `events` had already been swapped.
   const aux = connector.auxProjections(file.path);
   if (aux.titles) {
-    await conn.run(`INSERT OR REPLACE INTO titles (session_id, title) ${aux.titles}`);
+    await conn.run(`CREATE OR REPLACE TEMP TABLE ${stagedTitles} AS ${aux.titles}`);
+  }
+  if (aux.prLinks) {
+    await conn.run(`CREATE OR REPLACE TEMP TABLE ${stagedPrLinks} AS ${aux.prLinks}`);
+  }
+
+  // Swap. From here the statements are table-to-table copies — no source file,
+  // no interpolated pricing, nothing left that can realistically fail.
+  //
+  // Delete stale aux rows before clearing events: if an ai-title or pr-link line
+  // was removed from the transcript, the old row must not survive the reload and
+  // get LEFT JOINed back into the rebuilt session. The subquery reads events
+  // before they are deleted, so these must come first.
+  await conn.run(`DELETE FROM titles   WHERE session_id IN (SELECT DISTINCT session_id FROM events WHERE file_path = ${path})`);
+  await conn.run(`DELETE FROM pr_links WHERE session_id IN (SELECT DISTINCT session_id FROM events WHERE file_path = ${path})`);
+  await conn.run(`DELETE FROM events WHERE file_path = ${path}`);
+  await conn.run(`INSERT INTO events SELECT * FROM ${stagedEvents}`);
+  if (aux.titles) {
+    await conn.run(`INSERT OR REPLACE INTO titles (session_id, title) SELECT * FROM ${stagedTitles}`);
   }
   if (aux.prLinks) {
     await conn.run(
-      `INSERT OR REPLACE INTO pr_links (session_id, pr_number, pr_repository, pr_url) ${aux.prLinks}`,
+      `INSERT OR REPLACE INTO pr_links (session_id, pr_number, pr_repository, pr_url) SELECT * FROM ${stagedPrLinks}`,
     );
   }
 }
@@ -295,7 +336,12 @@ async function rebuildSessions(conn: DuckDBConnection): Promise<void> {
     modal_cwd AS (
       SELECT session_id, cwd FROM (
         SELECT session_id, cwd,
-               row_number() OVER (PARTITION BY session_id ORDER BY count(*) DESC) AS rn
+               -- The trailing cwd is the tie-break, not decoration: on a count
+               -- tie DuckDB is free to order either way, and it does — a tied
+               -- session was observed flipping between projects across
+               -- evaluations of the SAME data, moving it (and its cost) between
+               -- projects from one pass to the next.
+               row_number() OVER (PARTITION BY session_id ORDER BY count(*) DESC, cwd) AS rn
         FROM events WHERE cwd IS NOT NULL GROUP BY session_id, cwd
       ) WHERE rn = 1
     ),
@@ -566,6 +612,11 @@ async function doReindex(): Promise<ReindexResponse> {
   });
 
   let reindexed = 0;
+  // Files this pass could not load. Reported on ReindexResponse so a pass that
+  // failed on everything is distinguishable from an idle one — otherwise both
+  // read as {reindexed: 0} and ingestion can stop permanently while /api/health
+  // still says "watching".
+  let failed = 0;
   if (changed.length > 0) progress = { processed: 0, total: changed.length };
   // Timestamp of the last mid-pass partial `sessions` rebuild (first build only).
   let lastPartialRebuild = start;
@@ -613,6 +664,7 @@ async function doReindex(): Promise<ReindexResponse> {
           dataVersion += 1;
         }
       } catch (err) {
+        failed += 1;
         console.warn(`claudescope: skipping unreadable transcript ${file.path}:`, err);
       } finally {
         // Skipped files still advance the counter so processed reaches total.
@@ -623,9 +675,14 @@ async function doReindex(): Promise<ReindexResponse> {
     // Nothing changed on disk: skip the (relatively expensive) derived-table and
     // FTS rebuild + CHECKPOINT entirely. This keeps periodic auto-reindex polls
     // cheap — they only stat files and bail when there's no new data.
-    if (reindexed === 0 && removed === 0) {
+    //
+    // `failed === 0` guard: loadFile is atomic, so a failed file leaves the
+    // tables untouched and skipping the rebuild is correct today. The guard is
+    // belt-and-braces — if a future non-atomic path ever half-applies a load,
+    // this must not report a clean idle pass over an inconsistent index.
+    if (reindexed === 0 && removed === 0 && failed === 0) {
       ready = true;
-      return { reindexed, durationMs: Date.now() - start };
+      return { reindexed, failed, durationMs: Date.now() - start };
     }
 
     // Something changed: re-elect the usage-canonical rows globally, then rebuild
@@ -640,7 +697,7 @@ async function doReindex(): Promise<ReindexResponse> {
 
     ready = true;
     dataVersion += 1;
-    return { reindexed, durationMs: Date.now() - start };
+    return { reindexed, failed, durationMs: Date.now() - start };
   } finally {
     // Progress stays visible through finalization ("finishing up"), then clears.
     progress = null;

--- a/packages/server/src/data/pricing-refresh.ts
+++ b/packages/server/src/data/pricing-refresh.ts
@@ -11,10 +11,15 @@
  * import-time side effects and never touches DuckDB.
  */
 
-import { mkdirSync, readFileSync, renameSync, writeFileSync } from 'node:fs';
+import { readFileSync, renameSync, writeFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import type { FetchedPricing, ModelRates } from '@claudescope/shared';
-import { FETCHED_PRICING_PATH, LITELLM_PRICING_URL } from '../config.js';
+import {
+  FETCHED_PRICING_PATH,
+  LITELLM_PRICING_URL,
+  STATE_FILE_MODE,
+  ensureStateDir,
+} from '../config.js';
 
 /**
  * Providers whose models we keep. Bare transcript model ids only ever match
@@ -189,9 +194,9 @@ export async function refreshPricing(): Promise<{
   const snapshot: FetchedPricing = { fetchedAt, models };
 
   // Atomic write: stage to a temp file in the same dir, then rename over target.
-  mkdirSync(dirname(FETCHED_PRICING_PATH), { recursive: true });
+  ensureStateDir(dirname(FETCHED_PRICING_PATH));
   const tmp = join(dirname(FETCHED_PRICING_PATH), `.pricing.fetched.${process.pid}.tmp`);
-  writeFileSync(tmp, `${JSON.stringify(snapshot, null, 2)}\n`);
+  writeFileSync(tmp, `${JSON.stringify(snapshot, null, 2)}\n`, { mode: STATE_FILE_MODE });
   renameSync(tmp, FETCHED_PRICING_PATH);
 
   return { fetchedAt, modelCount: Object.keys(models).length, changed, path: FETCHED_PRICING_PATH };

--- a/packages/server/src/data/pricing.ts
+++ b/packages/server/src/data/pricing.ts
@@ -15,8 +15,92 @@
  */
 
 import { existsSync, readFileSync, statSync } from 'node:fs';
-import type { FetchedPricing, PricingConfig } from '@claudescope/shared';
+import type { FetchedPricing, ModelRates, PricingConfig } from '@claudescope/shared';
 import { DEFAULT_PRICING_PATH, FETCHED_PRICING_PATH, PRICING_PATH } from '../config.js';
+
+/** The four rate fields every {@link ModelRates} must carry. */
+const RATE_FIELDS = ['input', 'output', 'cacheWrite', 'cacheRead'] as const;
+
+/**
+ * A finite, non-negative number, else `null`. Rates are interpolated straight
+ * into the SQL cost expression (see `data/index.ts:buildCostExpr`), so a value
+ * that isn't a real number is not merely wrong — it produces invalid SQL that
+ * fails the whole load. `pricing.json` is user-editable by design, so a typo
+ * like `"3.00 USD"` has to be survivable.
+ */
+function rateOrNull(value: unknown): number | null {
+  return typeof value === 'number' && Number.isFinite(value) && value >= 0 ? value : null;
+}
+
+/** A fully-valid {@link ModelRates}, or `null` if any field is unusable. */
+function ratesOrNull(value: unknown): ModelRates | null {
+  if (value === null || typeof value !== 'object') return null;
+  const raw = value as Record<string, unknown>;
+  const out = {} as ModelRates;
+  for (const field of RATE_FIELDS) {
+    const n = rateOrNull(raw[field]);
+    if (n === null) return null;
+    out[field] = n;
+  }
+  return out;
+}
+
+/**
+ * Drop every entry with an unusable rate from a keyed rate table. Dropping (not
+ * repairing) is deliberate: the cost chain is `models` → `families` → `default`,
+ * so a dropped entry falls through to the next layer — the same choice
+ * `pricing-refresh.ts:mapLiteLLM` makes for fetched rates.
+ */
+function sanitizeTable(
+  table: Record<string, unknown> | undefined,
+  label: string,
+  dropped: string[],
+): Record<string, ModelRates> {
+  const out: Record<string, ModelRates> = {};
+  for (const [key, value] of Object.entries(table ?? {})) {
+    const rates = ratesOrNull(value);
+    if (rates) out[key] = rates;
+    else dropped.push(`${label}.${key}`);
+  }
+  return out;
+}
+
+/**
+ * Validate a parsed config so no unusable rate can reach the SQL builder.
+ *
+ * `default` is the terminal fallback and cannot be dropped, so an unusable field
+ * there is zeroed — a visibly wrong 0 beats an invisible indexer failure. Every
+ * rejection is named in the warning, which fires only on a cache miss (i.e. once
+ * per edit, not once per reindex poll).
+ */
+function sanitizeConfig(raw: PricingConfig, sourcePath: string): PricingConfig {
+  const dropped: string[] = [];
+  const models = sanitizeTable(raw.models as unknown as Record<string, unknown>, 'models', dropped);
+  const families = sanitizeTable(raw.families as unknown as Record<string, unknown>, 'families', dropped);
+  const providers = sanitizeTable(raw.providers as unknown as Record<string, unknown>, 'providers', dropped);
+
+  const fallback = {} as ModelRates;
+  for (const field of RATE_FIELDS) {
+    const n = rateOrNull((raw.default as unknown as Record<string, unknown> | undefined)?.[field]);
+    if (n === null) dropped.push(`default.${field} (treated as 0)`);
+    fallback[field] = n ?? 0;
+  }
+
+  if (dropped.length > 0) {
+    console.warn(
+      `[pricing] ignoring unusable rate(s) in ${sourcePath}: ${dropped.join(', ')} — ` +
+        'rates must be finite non-negative numbers (USD per 1M tokens)',
+    );
+  }
+
+  return {
+    ...(raw.schemaVersion !== undefined ? { schemaVersion: raw.schemaVersion } : {}),
+    models,
+    families,
+    providers,
+    default: fallback,
+  };
+}
 
 /** Sentinel mtime for a file that does not exist. */
 const ABSENT = -1;
@@ -66,14 +150,26 @@ export function loadPricing(): PricingConfig {
     return cached.config;
   }
 
-  const base = JSON.parse(readFileSync(basePath, 'utf8')) as PricingConfig;
+  // Validate on the way in: rates are interpolated into SQL, so an unusable
+  // value would fail the load (and, pre-transaction, could destroy indexed rows).
+  const base = sanitizeConfig(
+    JSON.parse(readFileSync(basePath, 'utf8')) as PricingConfig,
+    basePath,
+  );
 
   // Overlay fetched rates per exact id; families/default stay from the base.
   let config = base;
   if (key.fetchedMtime !== ABSENT) {
     const fetched = readFetched(FETCHED_PRICING_PATH);
     if (fetched) {
-      config = { ...base, models: { ...base.models, ...fetched.models } };
+      // The snapshot is written by refreshPricing (already validated), but it's
+      // a plain file on disk and may have been hand-edited — validate it too.
+      const overlay = sanitizeTable(
+        fetched.models as unknown as Record<string, unknown>,
+        'fetched.models',
+        [],
+      );
+      config = { ...base, models: { ...base.models, ...overlay } };
     }
   }
 

--- a/packages/server/src/db/duckdb.ts
+++ b/packages/server/src/db/duckdb.ts
@@ -5,11 +5,11 @@
  */
 
 import { createHash } from 'node:crypto';
-import { mkdirSync, rmSync } from 'node:fs';
+import { rmSync } from 'node:fs';
 import { dirname } from 'node:path';
 import { DuckDBInstance } from '@duckdb/node-api';
 import type { DuckDBConnection } from '@duckdb/node-api';
-import { DUCKDB_PATH } from '../config.js';
+import { DUCKDB_PATH, ensureStateDir } from '../config.js';
 import { SCHEMA_DDL, SCHEMA_VERSION } from './schema.js';
 
 /**
@@ -56,7 +56,9 @@ async function isStaleSchema(conn: DuckDBConnection): Promise<boolean> {
 
 /** Open the DB file, load extensions, and apply the idempotent schema. */
 async function openAndPrepare(): Promise<{ conn: DuckDBConnection; inst: DuckDBInstance }> {
-  mkdirSync(dirname(DUCKDB_PATH), { recursive: true });
+  // Owner-only: DuckDB creates index.duckdb itself (we can't pass a mode), so
+  // the 0700 directory is what keeps the indexed transcript corpus private.
+  ensureStateDir(dirname(DUCKDB_PATH));
   const inst = await DuckDBInstance.create(DUCKDB_PATH);
   const conn = await inst.connect();
   await conn.run('INSTALL json; LOAD json;');

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -15,7 +15,7 @@ import {
   PRICING_REFRESH_INTERVAL_MS,
   SELF_RESTART_INTERVAL_MS,
   WEB_DIST_DIR,
-  ensureStateDir,
+  initStateDir,
 } from './config.js';
 import { claudeProjectsDir } from './settings.js';
 import { registerRoutes } from './routes/index.js';
@@ -47,7 +47,7 @@ function pricingSnapshotIsStale(): boolean {
 async function main(): Promise<void> {
   // Create ~/.claudescope and seed the user-editable pricing file before any
   // module touches the index or pricing.
-  ensureStateDir();
+  initStateDir();
 
   const app = Fastify({ logger: true });
 

--- a/packages/server/src/indexer-lifecycle.ts
+++ b/packages/server/src/indexer-lifecycle.ts
@@ -43,7 +43,15 @@ export function rearmTimer(): void {
   timer = setInterval(() => {
     reindex()
       .then((res) => {
-        if (res.reindexed > 0) {
+        // Failures are reported, not swallowed: a pass that could load nothing
+        // returns reindexed: 0 and would otherwise be silent, so the index could
+        // stop advancing indefinitely with no signal anywhere.
+        if (res.failed > 0) {
+          log.warn(
+            { reindexed: res.reindexed, failed: res.failed, durationMs: res.durationMs },
+            'auto-reindex could not load some files — the index is stale for them',
+          );
+        } else if (res.reindexed > 0) {
           log.info(
             { reindexed: res.reindexed, durationMs: res.durationMs },
             'auto-reindex picked up changes',
@@ -65,7 +73,7 @@ export function startIndexer(logger: FastifyBaseLogger): void {
   reindex()
     .then((res) =>
       log.info(
-        { reindexed: res.reindexed, durationMs: res.durationMs },
+        { reindexed: res.reindexed, failed: res.failed, durationMs: res.durationMs },
         'initial index build complete',
       ),
     )

--- a/packages/server/src/settings.ts
+++ b/packages/server/src/settings.ts
@@ -16,7 +16,6 @@
 import {
   copyFileSync,
   existsSync,
-  mkdirSync,
   readFileSync,
   renameSync,
   statSync,
@@ -25,7 +24,13 @@ import {
 import { homedir } from 'node:os';
 import { dirname, isAbsolute, join } from 'node:path';
 import type { SettingSource, SettingValue } from '@claudescope/shared';
-import { CLAUDESCOPE_HOME, expandHome, firstExisting } from './config.js';
+import {
+  CLAUDESCOPE_HOME,
+  STATE_FILE_MODE,
+  ensureStateDir,
+  expandHome,
+  firstExisting,
+} from './config.js';
 
 export const SETTINGS_SCHEMA_VERSION = 1;
 
@@ -318,10 +323,10 @@ export function saveSettings(patch: Partial<Record<SettingKey, SettingValue | nu
   }
   current.schemaVersion = SETTINGS_SCHEMA_VERSION;
 
-  // Self-sufficient: don't depend on ensureStateDir() having run at boot.
-  mkdirSync(CLAUDESCOPE_HOME, { recursive: true });
+  // Self-sufficient: don't depend on boot-time init having run.
+  ensureStateDir();
   const tmp = `${SETTINGS_PATH}.${process.pid}.tmp`;
-  writeFileSync(tmp, `${JSON.stringify(current, null, 2)}\n`);
+  writeFileSync(tmp, `${JSON.stringify(current, null, 2)}\n`, { mode: STATE_FILE_MODE });
   renameSync(tmp, SETTINGS_PATH);
   cached = null; // next read re-stats; rename bumps mtime but be explicit
 }

--- a/packages/server/src/update-check.ts
+++ b/packages/server/src/update-check.ts
@@ -8,9 +8,9 @@
  * day. Everything degrades to "no info" (null) offline — never throws.
  */
 
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { existsSync, readFileSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
-import { APP_VERSION, CLAUDESCOPE_HOME } from './config.js';
+import { APP_VERSION, CLAUDESCOPE_HOME, STATE_FILE_MODE, ensureStateDir } from './config.js';
 
 export const PKG = '@vladar107/claudescope';
 const UPDATE_CHECK_FILE = join(CLAUDESCOPE_HOME, 'update-check.json');
@@ -46,8 +46,10 @@ export async function getLatestVersion(force: boolean): Promise<string | null> {
   if (!res.ok) return null;
   const json = (await res.json()) as { version?: string };
   if (!json.version) return null;
-  mkdirSync(CLAUDESCOPE_HOME, { recursive: true });
-  writeFileSync(UPDATE_CHECK_FILE, JSON.stringify({ lastCheck: now, latest: json.version }));
+  ensureStateDir();
+  writeFileSync(UPDATE_CHECK_FILE, JSON.stringify({ lastCheck: now, latest: json.version }), {
+    mode: STATE_FILE_MODE,
+  });
   return json.version;
 }
 

--- a/packages/server/test/index-durability.integration.test.ts
+++ b/packages/server/test/index-durability.integration.test.ts
@@ -1,0 +1,255 @@
+/**
+ * Indexer durability — the failure paths that used to lose data silently.
+ *
+ * `loadFile` replaces a file's rows by delete-then-insert. Previously the insert
+ * came *after* the deletes, so anything that broke while projecting destroyed the
+ * file's indexed events — and the pass still returned `{reindexed: 0}`, which is
+ * exactly what an idle pass returns, so nothing reported a problem. Two layers
+ * now cover that, tested separately here:
+ *
+ *  - `loadPricing` validation, which stops the most likely trigger: a rate typed
+ *    as a string in the USER-EDITABLE `pricing.json` (it is string-interpolated
+ *    into the cost expression, so a bad value yields invalid SQL);
+ *  - staging in `loadFile`, which makes ANY projection failure non-destructive —
+ *    covering triggers validation can't foresee (here: an unreadable source
+ *    file) — plus the `failed` counter that stops a failing pass from passing
+ *    for an idle one.
+ *
+ * The concurrency case is a regression guard: an earlier attempt wrapped the
+ * load in an explicit transaction, which swept in — and aborted — queries the
+ * HTTP routes issue on the shared connection while a pass runs.
+ *
+ * Uses a throwaway projects dir + DuckDB in a temp dir; never touches any real
+ * agent source.
+ */
+
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { appendFileSync, chmodSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import type { DuckDBConnection } from '@duckdb/node-api';
+import type { PricingConfig, ReindexResponse } from '@claudescope/shared';
+
+// --- temp locations (decided before any server module is imported) ----------
+const work = mkdtempSync(join(tmpdir(), 'claudescope-durability-'));
+const projectsDir = join(work, 'projects');
+const pricingPath = join(work, 'pricing.json');
+
+process.env.CLAUDE_PROJECTS_DIR = projectsDir;
+for (const v of [
+  'CODEX_SESSIONS_DIR',
+  'JUNIE_SESSIONS_DIR',
+  'PI_SESSIONS_DIR',
+  'OPENCODE_DATA_DIR',
+  'COPILOT_SESSIONS_DIR',
+  'ANTIGRAVITY_CLI_DIR',
+  'ANTIGRAVITY_DIR',
+  'GROK_SESSIONS_DIR',
+]) {
+  process.env[v] = join(work, `${v.toLowerCase()}-empty`);
+}
+process.env.DUCKDB_PATH = join(work, 'index.duckdb');
+process.env.CLAUDESCOPE_HOME = join(work, 'home');
+process.env.PRICING_PATH = pricingPath;
+process.env.REINDEX_INTERVAL_MS = '0';
+
+/** chmod(000) only bites for a non-root POSIX user. */
+const canMakeUnreadable =
+  process.platform !== 'win32' && typeof process.getuid === 'function' && process.getuid() !== 0;
+
+const projDir = join(projectsDir, 'enc-projD');
+const keepFile = join(projDir, 'sessKeep.jsonl');
+
+/** One assistant turn. `model` is unlisted so it prices via `default`. */
+const row = (session: string, uuid: string, cwd = '/tmp/projD'): string =>
+  JSON.stringify({
+    sessionId: session,
+    cwd,
+    type: 'assistant',
+    uuid,
+    parentUuid: null,
+    timestamp: '2026-01-01T10:00:00.000Z',
+    isSidechain: false,
+    message: {
+      role: 'assistant',
+      id: `msg-${uuid}`,
+      model: 'some-unlisted-model',
+      content: [{ type: 'text', text: `turn ${uuid}` }],
+      usage: { input_tokens: 1_000_000, output_tokens: 0 },
+    },
+  }) + '\n';
+
+/** `default.input` is injectable so a test can make it unusable. */
+const pricingWith = (defaultInput: unknown): string =>
+  JSON.stringify(
+    {
+      schemaVersion: 4,
+      models: {},
+      families: {},
+      providers: {},
+      default: { input: defaultInput, output: 15, cacheWrite: 3.75, cacheRead: 0.3 },
+    } as unknown as PricingConfig,
+    null,
+    2,
+  );
+
+let reindex: () => Promise<ReindexResponse>;
+let conn: DuckDBConnection;
+let queryRows: typeof import('../src/db/duckdb.js').queryRows;
+let closeConnection: () => Promise<void>;
+
+const countEvents = async (file?: string): Promise<number> => {
+  const where = file ? ` WHERE file_path = '${file}'` : '';
+  return Number((await queryRows(conn, `SELECT count(*) AS n FROM events${where}`))[0]?.n ?? 0);
+};
+
+beforeAll(async () => {
+  mkdirSync(projDir, { recursive: true });
+  mkdirSync(join(work, 'home'), { recursive: true });
+  writeFileSync(pricingPath, pricingWith(3));
+  writeFileSync(keepFile, row('sessKeep', 'k1') + row('sessKeep', 'k2') + row('sessKeep', 'k3'));
+
+  ({ reindex } = await import('../src/data/index.js'));
+  const duck = await import('../src/db/duckdb.js');
+  ({ queryRows, closeConnection } = duck);
+  conn = await duck.getConnection();
+});
+
+afterAll(async () => {
+  await closeConnection?.();
+  rmSync(work, { recursive: true, force: true });
+});
+
+describe('an unusable rate in the user-editable pricing.json', () => {
+  it('is dropped rather than breaking the load', async () => {
+    const first = await reindex();
+    expect(first.reindexed).toBe(1);
+    expect(first.failed).toBe(0);
+    // 1M input tokens at $3/MTok.
+    const before = await queryRows(conn, "SELECT sum(cost_usd) AS c FROM events WHERE session_id = 'sessKeep'");
+    expect(Number(before[0]?.c ?? 0)).toBeCloseTo(9, 6);
+
+    // The plausible hand-edit: a rate with a unit suffix. Interpolated into the
+    // cost expression, this used to produce invalid SQL and destroy the rows.
+    writeFileSync(pricingPath, pricingWith('3.00 USD'));
+    appendFileSync(keepFile, row('sessKeep', 'k4'));
+
+    const pass = await reindex();
+    expect(pass.failed).toBe(0);
+    expect(pass.reindexed).toBe(1);
+    expect(await countEvents()).toBe(4);
+    // The unusable `default.input` is treated as 0 — visibly wrong, not fatal.
+    const after = await queryRows(conn, "SELECT sum(cost_usd) AS c FROM events WHERE session_id = 'sessKeep'");
+    expect(Number(after[0]?.c ?? 0)).toBe(0);
+
+    writeFileSync(pricingPath, pricingWith(3));
+    await reindex();
+  });
+});
+
+describe('a projection failure validation cannot foresee', () => {
+  it.skipIf(!canMakeUnreadable)(
+    'leaves the previously indexed rows intact and reports `failed`',
+    async () => {
+      const doomed = join(projDir, 'sessDoomed.jsonl');
+      writeFileSync(doomed, row('sessDoomed', 'x1') + row('sessDoomed', 'x2'));
+      const indexed = await reindex();
+      expect(indexed.failed).toBe(0);
+      expect(await countEvents(doomed)).toBe(2);
+
+      // Grow the file so it lands in the changed set, then make it unreadable —
+      // the projection now fails with an IO error mid-load.
+      appendFileSync(doomed, row('sessDoomed', 'x3'));
+      chmodSync(doomed, 0o000);
+
+      const failedPass = await reindex();
+
+      // The rows it could not re-read are still there (staging never deleted them).
+      expect(await countEvents(doomed)).toBe(2);
+      // Other files are untouched.
+      expect(await countEvents(keepFile)).toBe(4);
+      // And the pass is not reported as a clean idle one.
+      expect(failedPass.reindexed).toBe(0);
+      expect(failedPass.failed).toBe(1);
+
+      // Readable again → the pass recovers and picks up the appended turn.
+      chmodSync(doomed, 0o644);
+      const recovered = await reindex();
+      expect(recovered.failed).toBe(0);
+      expect(recovered.reindexed).toBe(1);
+      expect(await countEvents(doomed)).toBe(3);
+
+      rmSync(doomed, { force: true });
+      await reindex();
+    },
+  );
+
+  it.skipIf(!canMakeUnreadable)(
+    'does not disturb concurrent route-style queries on the shared connection',
+    async () => {
+      const doomed = join(projDir, 'sessConcurrent.jsonl');
+      writeFileSync(doomed, row('sessConcurrent', 'c1'));
+      await reindex();
+      appendFileSync(doomed, row('sessConcurrent', 'c2'));
+      chmodSync(doomed, 0o000);
+
+      let done = false;
+      const pass = reindex().then((r) => {
+        done = true;
+        return r;
+      });
+
+      // Exactly what /api/projects does while a pass runs, on the same connection.
+      const errors: unknown[] = [];
+      while (!done) {
+        try {
+          await queryRows(conn, 'SELECT count(*) AS n FROM sessions');
+        } catch (err) {
+          errors.push(err);
+        }
+        await new Promise((r) => setImmediate(r));
+      }
+      const result = await pass;
+
+      expect(result.failed).toBe(1);
+      expect(errors).toEqual([]);
+
+      chmodSync(doomed, 0o644);
+      rmSync(doomed, { force: true });
+      await reindex();
+    },
+  );
+});
+
+describe('modal project cwd', () => {
+  it('resolves a perfect cwd tie deterministically', async () => {
+    // Two cwds with an identical event count: without a tie-break column the
+    // window function is free to pick either, and it did flip between
+    // evaluations — moving the session (and its cost) between projects.
+    const tied = join(projDir, 'tie.jsonl');
+    writeFileSync(
+      tied,
+      ['t1', 't2', 't3'].map((u) => row('tie', u, '/tmp/aaa')).join('') +
+        ['t4', 't5', 't6'].map((u) => row('tie', u, '/tmp/bbb')).join(''),
+    );
+    await reindex();
+
+    const seen = new Set<string>();
+    for (let i = 0; i < 20; i++) {
+      const rows = await queryRows(
+        conn,
+        `SELECT session_id, cwd FROM (
+           SELECT session_id, cwd,
+                  row_number() OVER (PARTITION BY session_id ORDER BY count(*) DESC, cwd) AS rn
+           FROM events WHERE cwd IS NOT NULL GROUP BY session_id, cwd
+         ) WHERE rn = 1 AND session_id = 'tie'`,
+      );
+      seen.add(String(rows[0]?.cwd ?? 'none'));
+    }
+    expect([...seen]).toEqual(['/tmp/aaa']);
+
+    // The derived table agrees with the CTE.
+    const s = await queryRows(conn, "SELECT project_cwd FROM sessions WHERE id = 'tie'");
+    expect(String(s[0]?.project_cwd)).toBe('/tmp/aaa');
+  });
+});

--- a/packages/shared/src/api.ts
+++ b/packages/shared/src/api.ts
@@ -416,6 +416,12 @@ export interface ImpactResponse {
 /** POST /api/reindex */
 export interface ReindexResponse {
   reindexed: number;
+  /**
+   * Files the pass could not load (each isolated and skipped). Non-zero means
+   * the index is STALE for those files, not that nothing changed — without this
+   * a fully-failing pass is indistinguishable from a genuinely idle one.
+   */
+  failed: number;
   durationMs: number;
 }
 


### PR DESCRIPTION
Plan: [docs/plans/0052-indexer-durability-and-state-perms.md](./docs/plans/0052-indexer-durability-and-state-perms.md)

First of a series from a repo-wide review. Covers the two findings that lose or expose data; every claim below was reproduced against a real DuckDB index before the fix.

## 1. A pricing typo silently destroyed indexed events

`loadFile` replaced a file's rows by delete-then-insert, and the insert embeds a cost expression string-built from the **user-editable** `pricing.json`. A rate typed as a string — `"3.00 USD"`, a plausible hand-edit of a file the docs invite you to edit — produced invalid SQL *after* the deletes committed:

```text
BEFORE  events=3 sessions=1
AFTER   events=0 sessions=1
stale sessions row: [{"id":"s1","message_count":3,"total_cost_usd":0.001575}]
```

Which half failed depended purely on statement order: a typo in `models` failed in `syncPricingTable` (before the deletes → data merely frozen), one in `families`/`default` failed in the events insert (after → **data destroyed**). It compounded — another changed file wiped on every subsequent pass.

## 2. The failure reported itself as an idle pass

The per-file `catch` warned to `console` and left `reindexed` at 0, so the pass hit the `reindexed === 0 && removed === 0` early return and returned `{reindexed: 0, durationMs: 5}` — byte-identical to a genuinely idle pass. The poller's `if (res.reindexed > 0)` guard meant it did not even log; `dataVersion` never moved so the UI never refetched; `/api/health` reported a healthy `watching` indexer. Ingestion could stop permanently with no signal anywhere. Generic: *any* per-file load failure was laundered into "nothing changed".

## Fixes

- **Stage, then swap.** The projection is materialized into temp tables before a single existing row is touched, so a bad rate / unreadable source / projection error is a no-op.
  **Deliberately not a transaction.** My first attempt wrapped the load in `BEGIN`/`ROLLBACK`; `index-progress.integration.test.ts` caught it. The indexer shares its DuckDB connection with every HTTP route, so a `BEGIN` encloses concurrent route queries and aborts them along with a failed load. There is now a regression test for that.
- **Validate rates in `loadPricing`.** Unusable `models`/`families`/`providers` entries are dropped so the cost chain falls through; unusable `default` fields are zeroed with a warning naming each one. Mirrors `mapLiteLLM`'s existing handling of fetched rates. Rejected throwing (turns a typo into a dead app) and repairing values (guessing at intent).
- **`ReindexResponse.failed`.** Reported, not thrown — the poller's non-fatal design and `POST /api/reindex` both need `reindex()` to resolve. Surfaces through the existing `IndexerStatus.lastPass`, so no new API shape.
- **`modal_cwd` tie-break.** On a perfect cwd tie the session was observed flipping between projects across evaluations of *identical* data (both values seen in 20 runs) — moving it and its cost between projects from pass to pass.
- **Chunk `editBearing`**, which built one ~147 KB `IN` list on a cold build, directly below a `DELETE` chunked at 500 for exactly that reason.

## 3. State dir downgraded source protection

`~/.claude/projects` is `0700`; the index — a searchable copy of every readable transcript plus its FTS index — was landing at `0755`/`0644`:

```text
drwx------  ~/.claude/projects
drwxr-xr-x  ~/.claudescope/
-rw-r--r--  ~/.claudescope/index.duckdb   (157 MB here)
```

All five `mkdirSync(CLAUDESCOPE_HOME)` sites now go through one `ensureStateDir()` (0700, tightening an existing looser dir on boot); state writes use 0600. DuckDB creates `index.duckdb` itself, so the directory mode is what protects it.

## Testing

- `npm test` **488 passed / 56 files** (was 484/55), run 3× for stability; `npm run typecheck`, `npm run build`, markdownlint all clean.
- New `index-durability.integration.test.ts` covers each layer separately — validation neutralizing the pricing trigger, staging surviving a failure validation *can't* foresee (unreadable source file), concurrent route-style queries during a failing load, and the tie-break.
- Verified the tests genuinely guard the fixes: reverting the staging change fails them with `expected +0 to be 2` (events destroyed); disabling validation fails all four.
- Perf: cold build 4951 → 5279 ms (+6.6%) on a 26k-event corpus from the extra per-file materialization; incremental passes unchanged (332–359 ms vs 332–339 ms).

## Note for reviewers

The mode migration tightens `CLAUDESCOPE_HOME` itself, not files already inside it. `index.duckdb` is recreated on the next rebuild; to tighten an existing install immediately: `chmod -R go-rwx ~/.claudescope`.