### PR TITLE
fix: validate query params before they reach SQL

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,6 +38,11 @@ npm-workspaces monorepo (`packages/*`):
   Adding an agent = adding a connector; the index/FTS/cost paths stay shared.
 - The DuckDB index is a **derived cache** — fully rebuildable from the JSONL. If
   it's corrupt the app discards and rebuilds it.
+- **One DuckDB connection is shared by the indexer AND every HTTP route**
+  (`getConnection()` is a singleton). So indexer work must **never** open an
+  explicit transaction: a `BEGIN` there encloses whatever queries the routes
+  issue concurrently and aborts them along with a failed load. `loadFile`
+  therefore gets its atomicity by staging instead (see Gotchas).
 
 ## Runtime state — critical
 
@@ -54,6 +59,8 @@ npm-workspaces monorepo (`packages/*`):
   getters, so source dirs and the reindex interval apply live without a
   restart), the daemon PID file, and logs. State lives outside the package dir
   so global installs survive upgrades — do not move it back into the package.
+- App-owned state is created **owner-only** — always via `ensureStateDir()` from
+  `config.ts`, never a bare `mkdirSync`.
 - The web Settings page's Start/Stop/Restart control the **indexer** (the
   reindex poller — `indexer-lifecycle.ts`), never the HTTP process; stopping
   the server stays terminal-only (`claudescope stop`). The pause flag is
@@ -240,7 +247,13 @@ The CLI `update` command (`cli.ts`) detects the install method and defers to
   `providers` section overrides model rates for it entirely (shipped defaults
   zero-rate local runtimes like LM Studio/Ollama). Pricing changes apply
   **prospectively** — cost is stamped per event at index time, so only an index
-  rebuild re-prices already-indexed history.
+  rebuild re-prices already-indexed history. Rates are interpolated into SQL, so
+  `loadPricing` validates them — an unusable rate is dropped, not passed through.
+- **`loadFile` stages, then swaps — keep it that way.** It materializes the
+  projection into temp tables *before* deleting the file's existing rows, so a
+  failure while projecting (unreadable source, a bad rate reaching the
+  interpolated cost expression) can't destroy already-indexed events. A
+  transaction is not an option here — see the shared-connection note above.
 - **Release is maintainer-only** and tag-triggered (npm Trusted Publishing /
   OIDC). See `CONTRIBUTING.md`.
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -43,6 +43,10 @@ None of these are misused; they're listed here so you can verify that.
 - **Writes** only inside its own state dir `~/.claudescope/` (override:
   `$CLAUDESCOPE_HOME`): the DuckDB index (a rebuildable cache), a user-editable
   `pricing.json`, the daemon PID/port file, and logs.
+- **Creates that state dir owner-only** (`0700`, files `0600`) — the index is a
+  searchable copy of every transcript it can read. A directory an older version
+  created with the default umask is tightened at startup; files already written
+  keep their mode, so run `chmod -R go-rwx ~/.claudescope` to tighten those.
 
 ### Network
 

--- a/docs/plans/0052-indexer-durability-and-state-perms.md
+++ b/docs/plans/0052-indexer-durability-and-state-perms.md
@@ -1,6 +1,6 @@
 # 0052 — Indexer durability + state-dir permissions
 
-- **Status:** in-progress <!-- awaiting review on #72 --> <!-- proposed | in-progress | done | superseded | abandoned -->
+- **Status:** done <!-- proposed | in-progress | done | superseded | abandoned -->
 - **Date:** 2026-07-29
 - **PR:** https://github.com/vladar107/claudescope/pull/72
 

--- a/docs/plans/0053-validate-query-params.md
+++ b/docs/plans/0053-validate-query-params.md
@@ -1,0 +1,138 @@
+# 0053 — Validate query params before they reach SQL
+
+- **Status:** in-progress <!-- proposed | in-progress | done | superseded | abandoned -->
+- **Date:** 2026-07-29
+- **PR:** <link, once opened>
+
+## Context
+
+Second PR from the repo-wide review (after [0052](./0052-indexer-durability-and-state-perms.md)).
+Three query-param paths reach SQL without validation and 500 with the generated
+statement in the response body. All reproduced against a real index.
+
+**1. The sort allowlist is bypassed by the prototype chain.** Both sort gates
+test membership with `in`, which walks `Object.prototype`:
+
+```text
+GET /api/sessions?sort=toString
+→ 500  Parser Error: syntax error at or near "toString"
+   LINE 1: SELECT * FROM sessions ORDER BY function toString() { [native code] }
+
+GET /api/analytics/sessions?sort=constructor
+→ 500  ORDER BY function Object() { [native code] } DESC NULLS LAST…
+```
+
+Not injection — the value is a `Function`, not attacker-controlled text — but it
+defeats the allowlist `analytics-sessions.ts` documents as *"Never interpolate
+the raw param"*, and `?sort=__proto__` yields `ORDER BY [object Object]`.
+
+**2. Date bounds are interpolated unvalidated.** `sqlString` blocks injection but
+not a cast error:
+
+```text
+GET /api/analytics?from=not-a-date
+→ 500  Conversion Error: invalid timestamp field format: "not-a-date"
+   LINE 10: WHERE e.type = 'assistant' AND e.ts >= 'not-a-date'::TIMESTAMP
+```
+
+There are five `::TIMESTAMP` interpolation sites but **eight** affected
+endpoints, because `scopeFilters` is shared: `/api/analytics`,
+`/analytics/sessions`, `/analytics/agents`, `/analytics/activity`,
+`/analytics/tools`, `/analytics/impact`, `/analytics/errors`,
+`/analytics/digest`. The MCP `get_analytics` tool passes `from`/`to` straight
+through, so agents hit it too.
+
+This is also the duplication finding: the same two-line bound filter is written
+five times, which is *why* the validation gap is 5× instead of 1×. Notably
+`analytics-activity.ts` already regex-validates its `today` param — the
+discipline exists, it just was not applied to `from`/`to`.
+
+**3. 500 responses echo the SQL.** Fastify's default error handler serializes
+`err.message`, so a DuckDB parser/conversion error ships the generated statement
+(table and column names included) to the client. Low impact on a loopback-only
+viewer, but it is free to stop leaking.
+
+Ride-along: the CSP has no `form-action`. Unlike the fetch directives it does
+**not** inherit from `default-src`, so it is genuinely unrestricted.
+
+## Goal
+
+No query param can reach SQL unvalidated; a bad one returns 400 with a useful
+message instead of 500 with a statement dump. The five duplicated bound filters
+become one.
+
+## Decisions
+
+- **Validate inside `scopeFilters`, not per route** — it is the shared chokepoint,
+  so every current and future caller is covered by construction. Routes that
+  hand-rolled their own bound filters move onto it, which fixes the duplication
+  and the validation gap in one change.
+- **Invalid date → 400; unknown sort → silent fallback** — deliberately
+  asymmetric. An unparseable date is a caller mistake worth reporting, and today
+  it is a 500 either way. An unknown `sort` already falls back to the default and
+  real clients depend on that; `Object.hasOwn` closes the hole without changing
+  behaviour for anyone.
+- **A typed `BadRequestError` plus one `setErrorHandler`** — rather than each
+  route branching on validity. The handler is registered in `routes/index.ts`
+  (not `index.ts`'s `main`) so tests, which build a bare Fastify with
+  `registerRoutes`, exercise the same behaviour as production.
+- **Accept exactly what the callers send** — `YYYY-MM-DD` (the MCP/CLI contract)
+  and full ISO with optional time/fraction/offset (what the web sends via
+  `toISOString()`, and what the digest's own default range uses). Shape is
+  checked by regex and reality by `Date.parse`, so `2026-13-45` is rejected
+  rather than passed to DuckDB. `TIMESTAMP` (not `TIMESTAMPTZ`) semantics are
+  unchanged — the cast already ignored the offset and this must not alter
+  existing numbers.
+- **Generic 500 body, full detail to the log** — `{error: 'Internal Server
+  Error'}` to the client, `req.log.error` with the real error server-side, so
+  debuggability is unaffected.
+
+## Approach
+
+1. New `src/params.ts`: `BadRequestError`, `timestampParam()`, `isoDayParam()`.
+   Root-level so both `data/` and `routes/` may import it without inverting the
+   existing layering.
+2. `data/analytics-scope.ts`: validate `from`/`to` through `timestampParam`.
+3. Move `/api/analytics`, `/analytics/activity`, `/analytics/tools` and
+   `/analytics/digest` onto `scopeFilters` for their bounds, deleting the four
+   hand-rolled copies.
+4. `routes/sessions.ts` + `routes/analytics-sessions.ts`: `Object.hasOwn` gates.
+5. `routes/index.ts`: `setErrorHandler` mapping `BadRequestError` → 400,
+   preserving explicit 4xx, and collapsing everything else to a generic 500.
+6. `security.ts`: add `form-action 'self'`.
+7. Tests: prototype-chain sort keys, invalid dates on every affected endpoint,
+   no SQL in a 500 body, and that valid formats still produce identical results.
+
+## Files affected
+
+- `packages/server/src/params.ts` — new; validators + `BadRequestError`.
+- `packages/server/src/data/analytics-scope.ts` — validate bounds.
+- `packages/server/src/routes/analytics.ts`, `analytics-activity.ts`,
+  `analytics-tools.ts`, `analytics-digest.ts` — use `scopeFilters` for bounds.
+- `packages/server/src/routes/sessions.ts`,
+  `packages/server/src/routes/analytics-sessions.ts` — `Object.hasOwn`.
+- `packages/server/src/routes/index.ts` — error handler.
+- `packages/server/src/security.ts` — `form-action`.
+- `packages/server/test/query-params.integration.test.ts` — new.
+
+## Testing
+
+- `npm test`, `npm run typecheck`, `npm run build`, markdownlint.
+- New integration test covers each prototype key (`toString`, `constructor`,
+  `__proto__`) on both sort routes, an invalid date on all eight endpoints, and
+  asserts a 500 body carries no `SELECT`/table names.
+- Regression check: the same requests must fail (500) with the fixes reverted.
+- Equivalence check: `from`/`to` in both accepted formats return the same rows
+  before and after the `scopeFilters` consolidation, so moving four routes onto
+  the shared helper cannot silently change a bound.
+
+## Risks / open questions
+
+- Consolidating onto `scopeFilters` changes which column the bound applies to if
+  a `ts` override is missed: `/api/analytics`, `/analytics/activity` and
+  `/analytics/tools` filter the EVENT timestamp (`e.ts`), while the default is
+  the session start (`started_at`). The equivalence test above is what guards it.
+- `/api/analytics` gains no project filter — only the bounds move. Passing a
+  `project` there stays ignored, as today.
+- A 400 where clients previously got a 500 is a visible API change, but no client
+  can be relying on the 500.

--- a/docs/plans/0053-validate-query-params.md
+++ b/docs/plans/0053-validate-query-params.md
@@ -2,7 +2,7 @@
 
 - **Status:** in-progress <!-- proposed | in-progress | done | superseded | abandoned -->
 - **Date:** 2026-07-29
-- **PR:** <link, once opened>
+- **PR:** https://github.com/vladar107/claudescope/pull/73
 
 ## Context
 

--- a/docs/plans/0053-validate-query-params.md
+++ b/docs/plans/0053-validate-query-params.md
@@ -1,6 +1,6 @@
 # 0053 — Validate query params before they reach SQL
 
-- **Status:** in-progress <!-- proposed | in-progress | done | superseded | abandoned -->
+- **Status:** done <!-- proposed | in-progress | done | superseded | abandoned -->
 - **Date:** 2026-07-29
 - **PR:** https://github.com/vladar107/claudescope/pull/73
 

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -76,4 +76,5 @@ decision, or a change worth explaining before doing. Skip it for one-line fixes.
 | 0049 | [Dependabot #6: brace-expansion DoS remediation](./0049-dependabot-brace-expansion.md) | done |
 | 0050 | [Dependabot alerts #7–#10 remediation](./0050-dependabot-alerts-7-10.md) | done |
 | 0051 | [Settings page: indexer lifecycle + settings.json layer](./0051-settings-page.md) | done |
-| 0052 | [Indexer durability + state-dir permissions](./0052-indexer-durability-and-state-perms.md) | in-progress |
+| 0052 | [Indexer durability + state-dir permissions](./0052-indexer-durability-and-state-perms.md) | done |
+| 0053 | [Validate query params before they reach SQL](./0053-validate-query-params.md) | in-progress |

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -77,4 +77,4 @@ decision, or a change worth explaining before doing. Skip it for one-line fixes.
 | 0050 | [Dependabot alerts #7–#10 remediation](./0050-dependabot-alerts-7-10.md) | done |
 | 0051 | [Settings page: indexer lifecycle + settings.json layer](./0051-settings-page.md) | done |
 | 0052 | [Indexer durability + state-dir permissions](./0052-indexer-durability-and-state-perms.md) | done |
-| 0053 | [Validate query params before they reach SQL](./0053-validate-query-params.md) | in-progress |
+| 0053 | [Validate query params before they reach SQL](./0053-validate-query-params.md) | done |

--- a/packages/server/src/data/analytics-scope.ts
+++ b/packages/server/src/data/analytics-scope.ts
@@ -8,6 +8,7 @@
 
 import type { DuckDBConnection } from '@duckdb/node-api';
 import { queryRows, sqlString } from '../db/duckdb.js';
+import { timestampParam } from '../params.js';
 import { projectIdFromCwd } from './project-id.js';
 
 export interface AnalyticsScope {
@@ -31,6 +32,13 @@ export interface ScopeColumns {
  * cwd by scanning the distinct `project_cwd` values (same resolution
  * /api/sessions uses); an unknown slug yields a never-matching condition so
  * a bad param returns empty rather than everything.
+ *
+ * The date bounds are VALIDATED here rather than at each route. This is the one
+ * chokepoint every bounded endpoint passes through, so validating it covers all
+ * of them — /api/analytics{,/sessions,/agents,/activity,/tools,/impact,/errors,
+ * /digest} — and any future caller by construction. An unusable bound throws
+ * {@link BadRequestError}, which the route layer maps to 400; previously it
+ * reached DuckDB and surfaced as a 500 quoting the generated SQL.
  */
 export async function scopeFilters(
   conn: DuckDBConnection,
@@ -39,6 +47,8 @@ export async function scopeFilters(
 ): Promise<string[]> {
   const cwdCol = cols.cwd ?? 'project_cwd';
   const tsCol = cols.ts ?? 'started_at';
+  const from = timestampParam(scope.from, 'from');
+  const to = timestampParam(scope.to, 'to');
   const filters: string[] = [];
   if (scope.project) {
     const cwds = await queryRows(
@@ -50,7 +60,7 @@ export async function scopeFilters(
       .find((c) => projectIdFromCwd(c) === scope.project);
     filters.push(`${cwdCol} = ${match ? sqlString(match) : "'\\0'"}`);
   }
-  if (scope.from) filters.push(`${tsCol} >= ${sqlString(scope.from)}::TIMESTAMP`);
-  if (scope.to) filters.push(`${tsCol} <= ${sqlString(scope.to)}::TIMESTAMP`);
+  if (from) filters.push(`${tsCol} >= ${sqlString(from)}::TIMESTAMP`);
+  if (to) filters.push(`${tsCol} <= ${sqlString(to)}::TIMESTAMP`);
   return filters;
 }

--- a/packages/server/src/params.ts
+++ b/packages/server/src/params.ts
@@ -1,0 +1,73 @@
+/**
+ * Request-parameter validation for values that end up inside SQL.
+ *
+ * Every query string in this app is interpolated into a statement (there are no
+ * prepared statements — see `db/duckdb.ts`). `sqlString` makes that injection-safe,
+ * but it does NOT make it *valid*: a date bound that DuckDB cannot cast aborts
+ * the query, which surfaced as a 500 carrying the generated SQL. These helpers
+ * reject such values at the boundary instead, and {@link BadRequestError} lets the
+ * route layer map them to a 400 from one place (see `routes/index.ts`).
+ *
+ * Lives at the server root deliberately: both `data/` (analytics-scope) and
+ * `routes/` consume it, so putting it in either would invert the layering.
+ */
+
+/**
+ * A caller-supplied value was unusable. Mapped to `400` with `message` by the
+ * error handler in `routes/index.ts`; anything else becomes a generic 500.
+ */
+export class BadRequestError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'BadRequestError';
+  }
+}
+
+/**
+ * Timestamp shapes accepted for a date bound. Covers exactly what the callers
+ * send: `YYYY-MM-DD` (the MCP/CLI contract), and a full ISO timestamp with
+ * optional seconds, fraction, and `Z`/±offset (what the web sends via
+ * `toISOString()` and what the digest's default range builds). A space separator
+ * is allowed because that is DuckDB's own canonical form.
+ */
+const TIMESTAMP_RE =
+  /^\d{4}-\d{2}-\d{2}(?:[T ]\d{2}:\d{2}(?::\d{2}(?:\.\d{1,6})?)?(?:Z|[+-]\d{2}(?::?\d{2})?)?)?$/;
+
+/**
+ * Validate an inclusive date-bound param destined for `::TIMESTAMP`.
+ *
+ * Returns `undefined` for an absent/empty value (the bound is simply not
+ * applied) and throws {@link BadRequestError} for anything unusable. The regex
+ * checks shape; `Date.parse` then checks the calendar, so `2026-13-45` is
+ * rejected here rather than becoming a DuckDB conversion error.
+ *
+ * The value is returned unchanged — callers still wrap it in `sqlString` and the
+ * cast stays `TIMESTAMP` (not `TIMESTAMPTZ`), so any offset keeps being ignored
+ * exactly as before. This validates; it does not normalize.
+ */
+export function timestampParam(raw: string | undefined, field: string): string | undefined {
+  if (raw === undefined) return undefined;
+  const value = raw.trim();
+  if (value === '') return undefined;
+  if (!TIMESTAMP_RE.test(value) || Number.isNaN(Date.parse(value))) {
+    throw new BadRequestError(
+      `${field} must be YYYY-MM-DD or an ISO timestamp (got '${value}')`,
+    );
+  }
+  return value;
+}
+
+/** `YYYY-MM-DD` only — the shape the activity punchcard's `today` anchor uses. */
+const ISO_DAY_RE = /^\d{4}-\d{2}-\d{2}$/;
+
+/**
+ * Validate a calendar-day param. Unlike {@link timestampParam} an unusable value
+ * is IGNORED rather than rejected: `today` only anchors the streak display, and
+ * a bad clock on the client should not fail the whole analytics request.
+ */
+export function isoDayParam(raw: string | undefined): string | undefined {
+  if (raw === undefined) return undefined;
+  const value = raw.trim();
+  if (!ISO_DAY_RE.test(value) || Number.isNaN(Date.parse(value))) return undefined;
+  return value;
+}

--- a/packages/server/src/routes/analytics-activity.ts
+++ b/packages/server/src/routes/analytics-activity.ts
@@ -10,7 +10,9 @@
  */
 import type { FastifyInstance } from 'fastify';
 import type { ActivityCell, ActivityResponse, StreakInfo } from '@claudescope/shared';
-import { getConnection, queryRows, sqlString } from '../db/duckdb.js';
+import { getConnection, queryRows } from '../db/duckdb.js';
+import { scopeFilters } from '../data/analytics-scope.js';
+import { isoDayParam } from '../params.js';
 import { readRow } from '../db/row.js';
 
 const DAY_MS = 86_400_000;
@@ -50,24 +52,26 @@ function clampOffset(raw: string | undefined): number {
   return Math.max(-840, Math.min(840, n));
 }
 
-const ISO_DAY = /^\d{4}-\d{2}-\d{2}$/;
-
 export async function registerActivityRoute(app: FastifyInstance): Promise<void> {
   app.get<{
     Querystring: { from?: string; to?: string; tzOffsetMinutes?: string; today?: string };
   }>('/api/analytics/activity', async (req): Promise<ActivityResponse> => {
     const conn = await getConnection();
     const offset = clampOffset(req.query.tzOffsetMinutes);
-    const today = ISO_DAY.test(req.query.today ?? '') ? (req.query.today as string) : '';
+    const today = isoDayParam(req.query.today) ?? '';
     const localTs = `(e.ts + to_minutes(${offset}))`;
 
     // Heatmap: honors the date filter (matches the rest of the page).
     // Exclude sidechain rows (subagent-internal user turns) and fork-copy rows
     // (copied when a session is forked/resumed) so only genuine human prompts
     // are counted — sidechain + fork copies would otherwise inflate by ~2.6×.
-    const filters: string[] = ["e.type = 'user'", 'NOT e.is_sidechain', 'e.forked_from_session_id IS NULL'];
-    if (req.query.from) filters.push(`e.ts >= ${sqlString(req.query.from)}::TIMESTAMP`);
-    if (req.query.to) filters.push(`e.ts <= ${sqlString(req.query.to)}::TIMESTAMP`);
+    const filters: string[] = [
+      "e.type = 'user'",
+      'NOT e.is_sidechain',
+      'e.forked_from_session_id IS NULL',
+      // Shared (validated) bounds, on the event timestamp.
+      ...(await scopeFilters(conn, { from: req.query.from, to: req.query.to }, { ts: 'e.ts' })),
+    ];
     const heatmapRows = await queryRows(
       conn,
       `SELECT

--- a/packages/server/src/routes/analytics-digest.ts
+++ b/packages/server/src/routes/analytics-digest.ts
@@ -21,7 +21,8 @@ import type {
   DigestProjectRow,
   DigestResponse,
 } from '@claudescope/shared';
-import { getConnection, queryRows, sqlString } from '../db/duckdb.js';
+import { getConnection, queryRows } from '../db/duckdb.js';
+import { scopeFilters } from '../data/analytics-scope.js';
 import { readRow } from '../db/row.js';
 import { projectIdFromCwd } from '../data/project-id.js';
 import { errorSignalsByAgent } from './analytics-errors.js';
@@ -45,8 +46,11 @@ export async function registerDigestRoute(app: FastifyInstance): Promise<void> {
     const from = req.query.from || range.from;
     const to = req.query.to || range.to;
 
-    const where = `WHERE started_at >= ${sqlString(from)}::TIMESTAMP AND started_at <= ${sqlString(to)}::TIMESTAMP`;
-    const scopedCte = `WITH scoped AS (SELECT * FROM sessions ${where})`;
+    // Shared (validated) bounds on the session start — a session belongs to the
+    // range its START falls in. Both bounds are always present (defaultRange).
+    const filters = await scopeFilters(conn, { from, to });
+    const whereSql = filters.length > 0 ? `WHERE ${filters.join(' AND ')}` : '';
+    const scopedCte = `WITH scoped AS (SELECT * FROM sessions ${whereSql})`;
 
     // Totals — session-level sums, plus canonical assistant responses.
     const totalsRaw = await queryRows(

--- a/packages/server/src/routes/analytics-sessions.ts
+++ b/packages/server/src/routes/analytics-sessions.ts
@@ -57,10 +57,11 @@ export async function registerSessionEfficiencyRoute(app: FastifyInstance): Prom
   }>('/api/analytics/sessions', async (req): Promise<SessionEfficiencyResponse> => {
     const conn = await getConnection();
 
-    const sort: SessionEfficiencySort =
-      req.query.sort && req.query.sort in SORT_EXPR
-        ? (req.query.sort as SessionEfficiencySort)
-        : 'cost';
+    // Object.hasOwn, NOT `in`: `in` walks Object.prototype, so ?sort=constructor
+    // reached ORDER BY as a Function. Unknown values fall back to the default.
+    const sort: SessionEfficiencySort = Object.hasOwn(SORT_EXPR, req.query.sort ?? '')
+      ? (req.query.sort as SessionEfficiencySort)
+      : 'cost';
     // Whitelisted direction (never interpolate the raw param); default desc.
     const dir = req.query.dir === 'asc' ? 'ASC' : 'DESC';
     const limit = clampInt(req.query.limit, 50, 1, 500);

--- a/packages/server/src/routes/analytics-tools.ts
+++ b/packages/server/src/routes/analytics-tools.ts
@@ -8,7 +8,7 @@
  */
 import type { FastifyInstance } from 'fastify';
 import type { ToolUsageResponse, ToolUsageRow } from '@claudescope/shared';
-import { getConnection, queryRows, sqlString } from '../db/duckdb.js';
+import { getConnection, queryRows } from '../db/duckdb.js';
 import { readRow } from '../db/row.js';
 import { scopeFilters } from '../data/analytics-scope.js';
 
@@ -20,9 +20,7 @@ export async function registerToolsRoute(app: FastifyInstance): Promise<void> {
     const filters: string[] = ["e.type = 'assistant'", 'e.usage_canonical', "e.tool_names <> ''"];
     // Project scope resolves like every other analytics route; date bounds stay
     // on the event timestamp (a call belongs to the day it happened).
-    filters.push(...(await scopeFilters(conn, { project: req.query.project }, { cwd: 's.project_cwd' })));
-    if (req.query.from) filters.push(`e.ts >= ${sqlString(req.query.from)}::TIMESTAMP`);
-    if (req.query.to) filters.push(`e.ts <= ${sqlString(req.query.to)}::TIMESTAMP`);
+    filters.push(...(await scopeFilters(conn, req.query, { cwd: 's.project_cwd', ts: 'e.ts' })));
 
     const rows = await queryRows(
       conn,

--- a/packages/server/src/routes/analytics.ts
+++ b/packages/server/src/routes/analytics.ts
@@ -18,8 +18,9 @@ import type {
   AnalyticsRow,
   AnalyticsTotals,
 } from '@claudescope/shared';
-import { getConnection, queryRows, sqlString } from '../db/duckdb.js';
+import { getConnection, queryRows } from '../db/duckdb.js';
 import { readRow } from '../db/row.js';
+import { scopeFilters } from '../data/analytics-scope.js';
 import { projectIdFromCwd } from '../data/project-id.js';
 
 /**
@@ -67,9 +68,13 @@ export async function registerAnalyticsRoute(app: FastifyInstance): Promise<void
     const groupBy = (req.query.groupBy as AnalyticsGroupBy) ?? 'project';
     const { keyExpr, fromSql } = groupSource(groupBy);
 
-    const filters: string[] = ["e.type = 'assistant'"];
-    if (req.query.from) filters.push(`e.ts >= ${sqlString(req.query.from)}::TIMESTAMP`);
-    if (req.query.to) filters.push(`e.ts <= ${sqlString(req.query.to)}::TIMESTAMP`);
+    // Bounds go through the shared scope helper (which validates them); this
+    // route filters the EVENT timestamp, not the session start, hence the `ts`
+    // override. No project filter here — only the bounds are shared.
+    const filters: string[] = [
+      "e.type = 'assistant'",
+      ...(await scopeFilters(conn, { from: req.query.from, to: req.query.to }, { ts: 'e.ts' })),
+    ];
     const whereSql = `WHERE ${filters.join(' AND ')}`;
 
     const rows = await queryRows(

--- a/packages/server/src/routes/index.ts
+++ b/packages/server/src/routes/index.ts
@@ -8,6 +8,7 @@ import type { FastifyInstance } from 'fastify';
 import type { HealthResponse, ReindexResponse } from '@claudescope/shared';
 import { APP_VERSION } from '../config.js';
 import { getDataVersion, getIndexProgress, isIndexReady, reindex } from '../data/index.js';
+import { BadRequestError } from '../params.js';
 import { getIndexerStatus } from '../indexer-lifecycle.js';
 import { updateAvailable } from '../update-check.js';
 import { registerProjectsRoute } from './projects.js';
@@ -28,7 +29,43 @@ import { registerIndexerRoutes } from './indexer.js';
 import { registerPricingRoute } from './pricing.js';
 import { registerSystemRoute } from './system.js';
 
+/**
+ * Single error handler for the API.
+ *
+ * Two jobs. It maps {@link BadRequestError} — thrown by the param validators in
+ * `params.ts` — to a 400 carrying the reason, so a bad query param is a client
+ * error rather than a crash. And it stops leaking implementation detail: every
+ * query in this app is string-built, so Fastify's default handler was
+ * serializing DuckDB parser/conversion errors verbatim, shipping the generated
+ * statement (table and column names included) to the client. The full error
+ * still goes to the server log, so debuggability is unchanged.
+ *
+ * Registered here rather than in `index.ts`'s `main()` so the test harness —
+ * which builds a bare Fastify around `registerRoutes` — exercises the same
+ * behaviour as production.
+ */
+export function registerErrorHandler(app: FastifyInstance): void {
+  app.setErrorHandler((err, req, reply) => {
+    if (err instanceof BadRequestError) {
+      void reply.code(400).send({ error: err.message });
+      return;
+    }
+    // Preserve deliberate client errors (Fastify's own 4xx: unsupported media
+    // type, malformed JSON body, …) — those messages are about the request, not
+    // about our internals.
+    const status = (err as { statusCode?: number }).statusCode ?? 500;
+    if (status >= 400 && status < 500) {
+      void reply.code(status).send({ error: (err as Error).message });
+      return;
+    }
+    req.log.error({ err }, 'unhandled error serving request');
+    void reply.code(500).send({ error: 'Internal Server Error' });
+  });
+}
+
 export async function registerRoutes(app: FastifyInstance): Promise<void> {
+  registerErrorHandler(app);
+
   app.get('/api/health', async (): Promise<HealthResponse> => {
     const indexing = getIndexProgress();
     const latest = updateAvailable();

--- a/packages/server/src/routes/sessions.ts
+++ b/packages/server/src/routes/sessions.ts
@@ -111,7 +111,12 @@ export async function registerSessionsRoutes(app: FastifyInstance): Promise<void
       );
     }
 
-    const sortKey: SessionSort = (sort as SessionSort) in SORT_SQL ? (sort as SessionSort) : 'recent';
+    // Object.hasOwn, NOT `in`: `in` walks Object.prototype, so ?sort=toString
+    // passed the gate and interpolated a Function into ORDER BY (a 500 quoting
+    // the generated SQL). Unknown values still fall back to the default.
+    const sortKey: SessionSort = Object.hasOwn(SORT_SQL, sort ?? '')
+      ? (sort as SessionSort)
+      : 'recent';
     const whereSql = where.length ? `WHERE ${where.join(' AND ')}` : '';
 
     const limitSql = limit !== undefined && limit > 0 ? ` LIMIT ${limit}` : '';

--- a/packages/server/src/security.ts
+++ b/packages/server/src/security.ts
@@ -36,6 +36,9 @@ export const CONTENT_SECURITY_POLICY = [
   "object-src 'none'",
   "base-uri 'self'",
   "frame-ancestors 'none'",
+  // form-action is a NAVIGATION directive: unlike the fetch directives it does
+  // not inherit from default-src, so without this a form could post anywhere.
+  "form-action 'self'",
 ].join('; ');
 
 /**

--- a/packages/server/test/query-params.integration.test.ts
+++ b/packages/server/test/query-params.integration.test.ts
@@ -1,0 +1,280 @@
+/**
+ * Query-param validation — the params that used to reach SQL unchecked.
+ *
+ * Three things are pinned here:
+ *
+ *  1. **Sort allowlists are prototype-safe.** Both sort gates used `key in TABLE`,
+ *     which walks `Object.prototype`, so `?sort=toString` passed the gate and a
+ *     `Function` was interpolated into `ORDER BY` — a 500 quoting the generated
+ *     SQL. Unknown values must still fall back to the default (real clients rely
+ *     on that), so these assert 200 + default ordering, not 400.
+ *
+ *  2. **Date bounds are validated.** `sqlString` makes them injection-safe but
+ *     not castable, so `?from=not-a-date` was a DuckDB conversion error. Every
+ *     bounded endpoint now answers 400. The list is exhaustive on purpose:
+ *     validation lives in `scopeFilters`, and this is what proves the chokepoint
+ *     really covers all of them.
+ *
+ *  3. **Bound SEMANTICS survived consolidation.** Four routes had their own
+ *     hand-rolled bound filters and now share `scopeFilters`. Three of them
+ *     filter the EVENT timestamp while the shared default is the SESSION start —
+ *     a missed `ts` override would silently change what a date range means, and
+ *     no existing test would notice. The fixture makes the two answers differ, so
+ *     these assertions fail if the override is dropped.
+ *
+ * Plus: a 500 must not carry the generated SQL.
+ */
+
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import type { FastifyInstance } from 'fastify';
+
+// --- temp locations (decided before any server module is imported) ----------
+const work = mkdtempSync(join(tmpdir(), 'claudescope-params-'));
+const projectsDir = join(work, 'projects');
+
+process.env.CLAUDE_PROJECTS_DIR = projectsDir;
+for (const v of [
+  'CODEX_SESSIONS_DIR',
+  'JUNIE_SESSIONS_DIR',
+  'PI_SESSIONS_DIR',
+  'OPENCODE_DATA_DIR',
+  'COPILOT_SESSIONS_DIR',
+  'ANTIGRAVITY_CLI_DIR',
+  'ANTIGRAVITY_DIR',
+  'GROK_SESSIONS_DIR',
+]) {
+  process.env[v] = join(work, `${v.toLowerCase()}-empty`);
+}
+process.env.DUCKDB_PATH = join(work, 'index.duckdb');
+process.env.CLAUDESCOPE_HOME = join(work, 'home');
+process.env.REINDEX_INTERVAL_MS = '0';
+
+const DAY1 = '2026-03-01';
+const DAY2 = '2026-03-02';
+
+/**
+ * Two sessions, arranged so "filter by event timestamp" and "filter by session
+ * start" give DIFFERENT answers:
+ *  - `sOld`  starts on DAY1 and has one event on DAY1 and one on DAY2;
+ *  - `sNew`  starts on DAY2 with a single DAY2 event.
+ * So `from=DAY2` sees 3 events but only 1 session-started-on-or-after.
+ */
+function writeFixtures(): void {
+  const proj = join(projectsDir, 'enc-projQ');
+  mkdirSync(proj, { recursive: true });
+
+  const ev = (session: string, uuid: string, day: string, text: string): unknown => ({
+    sessionId: session,
+    cwd: '/tmp/projQ',
+    gitBranch: 'main',
+    type: 'assistant',
+    uuid,
+    parentUuid: null,
+    timestamp: `${day}T12:00:00.000Z`,
+    isSidechain: false,
+    message: {
+      role: 'assistant',
+      id: `m-${uuid}`,
+      model: 'claude-opus-4-8',
+      content: [{ type: 'tool_use', id: `t-${uuid}`, name: 'Read', input: {} }],
+      usage: { input_tokens: 10, output_tokens: 5 },
+    },
+    text,
+  });
+  const userEv = (session: string, uuid: string, day: string): unknown => ({
+    sessionId: session,
+    cwd: '/tmp/projQ',
+    type: 'user',
+    uuid,
+    parentUuid: null,
+    timestamp: `${day}T11:59:00.000Z`,
+    isSidechain: false,
+    message: { role: 'user', content: 'hello' },
+  });
+
+  const jsonl = (rows: unknown[]): string => rows.map((r) => JSON.stringify(r)).join('\n') + '\n';
+
+  writeFileSync(
+    join(proj, 'sOld.jsonl'),
+    jsonl([
+      userEv('sOld', 'o-u1', DAY1),
+      ev('sOld', 'o-a1', DAY1, 'day one'),
+      ev('sOld', 'o-a2', DAY2, 'day two'),
+    ]),
+  );
+  writeFileSync(
+    join(proj, 'sNew.jsonl'),
+    jsonl([userEv('sNew', 'n-u1', DAY2), ev('sNew', 'n-a1', DAY2, 'day two')]),
+  );
+}
+
+let app: FastifyInstance;
+let closeConnection: () => Promise<void>;
+
+beforeAll(async () => {
+  writeFixtures();
+  const Fastify = (await import('fastify')).default;
+  const { registerRoutes } = await import('../src/routes/index.js');
+  const { reindex } = await import('../src/data/index.js');
+  ({ closeConnection } = await import('../src/db/duckdb.js'));
+  app = Fastify();
+  await registerRoutes(app);
+  await reindex();
+  await app.ready();
+});
+
+afterAll(async () => {
+  await app?.close();
+  await closeConnection?.();
+  rmSync(work, { recursive: true, force: true });
+});
+
+const get = (url: string) => app.inject({ method: 'GET', url });
+
+describe('sort allowlists are prototype-safe', () => {
+  // `in` matched every one of these on Object.prototype.
+  const protoKeys = ['toString', 'constructor', '__proto__', 'hasOwnProperty', 'valueOf'];
+
+  it.each(protoKeys)('GET /api/sessions?sort=%s falls back instead of 500ing', async (key) => {
+    const res = await get(`/api/sessions?sort=${key}`);
+    expect(res.statusCode).toBe(200);
+    // Same ordering as the default (`recent`), i.e. the key was truly ignored.
+    const def = await get('/api/sessions');
+    expect(res.json()).toEqual(def.json());
+  });
+
+  it.each(protoKeys)(
+    'GET /api/analytics/sessions?sort=%s falls back instead of 500ing',
+    async (key) => {
+      const res = await get(`/api/analytics/sessions?sort=${key}`);
+      expect(res.statusCode).toBe(200);
+      const def = await get('/api/analytics/sessions');
+      expect(res.json()).toEqual(def.json());
+    },
+  );
+});
+
+describe('date bounds are validated at every bounded endpoint', () => {
+  // Exhaustive: proves validating inside scopeFilters really covers them all.
+  const bounded = [
+    '/api/analytics',
+    '/api/analytics/sessions',
+    '/api/analytics/agents',
+    '/api/analytics/activity',
+    '/api/analytics/tools',
+    '/api/analytics/impact',
+    '/api/analytics/errors',
+    '/api/analytics/digest',
+  ];
+
+  it.each(bounded)('%s?from=not-a-date → 400', async (path) => {
+    const res = await get(`${path}?from=not-a-date`);
+    expect(res.statusCode).toBe(400);
+    expect(res.json().error).toMatch(/^from must be/);
+  });
+
+  it.each(bounded)('%s?to=not-a-date → 400', async (path) => {
+    const res = await get(`${path}?to=not-a-date`);
+    expect(res.statusCode).toBe(400);
+    expect(res.json().error).toMatch(/^to must be/);
+  });
+
+  it('rejects a well-shaped but impossible calendar date', async () => {
+    // Passes a naive regex; DuckDB would have raised a conversion error.
+    const res = await get('/api/analytics?from=2026-13-45');
+    expect(res.statusCode).toBe(400);
+  });
+
+  it('never echoes the query or SQL back to the client', async () => {
+    const res = await get('/api/analytics?from=%27%29%20OR%201%3D1--');
+    expect(res.statusCode).toBe(400);
+    const body = res.body;
+    expect(body).not.toMatch(/SELECT|FROM events|::TIMESTAMP/i);
+  });
+
+  it.each([DAY1, `${DAY1}T00:00:00.000Z`, `${DAY1} 00:00:00`, `${DAY1}T00:00:00+02:00`])(
+    'accepts the format %s',
+    async (value) => {
+      const res = await get(`/api/analytics?from=${encodeURIComponent(value)}`);
+      expect(res.statusCode).toBe(200);
+    },
+  );
+});
+
+describe('bound semantics survived the scopeFilters consolidation', () => {
+  // The fixture is built so event-level and session-level bounds DISAGREE; each
+  // assertion below fails if a route lost its `ts` override (or gained one).
+  it('/api/analytics bounds the EVENT timestamp', async () => {
+    const all = await get('/api/analytics?groupBy=day');
+    expect(all.statusCode).toBe(200);
+    // Two distinct days of assistant events across both sessions.
+    expect(all.json().rows.map((r: { key: string }) => r.key).sort()).toEqual([DAY1, DAY2]);
+
+    const day2 = await get(`/api/analytics?groupBy=day&from=${DAY2}`);
+    expect(day2.json().rows.map((r: { key: string }) => r.key)).toEqual([DAY2]);
+    // sOld's DAY2 event is included even though sOld STARTED on DAY1 — that is
+    // the event-level semantics this route must keep.
+    expect(day2.json().totals.messageCount).toBe(2);
+  });
+
+  it('/api/analytics/sessions bounds the SESSION START', async () => {
+    const all = await get('/api/analytics/sessions');
+    expect(all.json().rows).toHaveLength(2);
+
+    const day2 = await get(`/api/analytics/sessions?from=${DAY2}`);
+    // Only sNew started on DAY2; sOld is excluded despite having a DAY2 event.
+    expect(day2.json().rows.map((r: { sessionId: string }) => r.sessionId)).toEqual(['sNew']);
+  });
+
+  it('/api/analytics/tools bounds the EVENT timestamp', async () => {
+    const all = await get('/api/analytics/tools');
+    const total = (body: { rows: { count: number }[] }): number =>
+      body.rows.reduce((n, r) => n + r.count, 0);
+    expect(total(all.json())).toBe(3); // one Read per assistant event
+
+    const day2 = await get(`/api/analytics/tools?from=${DAY2}`);
+    expect(total(day2.json())).toBe(2); // sOld's DAY2 call + sNew's
+  });
+
+  it('/api/analytics/activity bounds the EVENT timestamp', async () => {
+    const all = await get('/api/analytics/activity?tzOffsetMinutes=0');
+    const cells = (body: { heatmap: { count: number }[] }): number =>
+      body.heatmap.reduce((n, c) => n + c.count, 0);
+    expect(cells(all.json())).toBe(2); // one user prompt per session
+
+    const day2 = await get(`/api/analytics/activity?tzOffsetMinutes=0&from=${DAY2}`);
+    expect(cells(day2.json())).toBe(1); // only sNew's prompt is on DAY2
+  });
+
+  it('/api/analytics/digest bounds the SESSION START', async () => {
+    const all = await get(`/api/analytics/digest?from=${DAY1}&to=${DAY2}T23:59:59.999Z`);
+    expect(all.json().totals.sessions).toBe(2);
+
+    const day2 = await get(`/api/analytics/digest?from=${DAY2}&to=${DAY2}T23:59:59.999Z`);
+    expect(day2.json().totals.sessions).toBe(1);
+  });
+});
+
+describe('the error handler', () => {
+  it('collapses an unexpected error to a generic 500 without internals', async () => {
+    const Fastify = (await import('fastify')).default;
+    const { registerErrorHandler } = await import('../src/routes/index.js');
+    // `logger: false` keeps the deliberate error out of the test output; the
+    // production instance logs it via req.log.error.
+    const bare = Fastify({ logger: false });
+    registerErrorHandler(bare);
+    bare.get('/boom', async () => {
+      throw new Error("Parser Error: syntax error at or near \"x\"\nLINE 1: SELECT * FROM events");
+    });
+    await bare.ready();
+
+    const res = await bare.inject({ method: 'GET', url: '/boom' });
+    expect(res.statusCode).toBe(500);
+    expect(res.json()).toEqual({ error: 'Internal Server Error' });
+    expect(res.body).not.toMatch(/Parser Error|SELECT|events/i);
+    await bare.close();
+  });
+});


### PR DESCRIPTION
Plan: [docs/plans/0053-validate-query-params.md](./docs/plans/0053-validate-query-params.md)

Second PR from the repo-wide review (after #72). Every query in this app is string-built; `sqlString` makes interpolated values injection-safe but not **valid**, and two param paths reached DuckDB unchecked — each answering 500 with the generated statement in the body. All reproduced against a real index.

## 1. The sort allowlist was bypassed by the prototype chain

Both gates tested membership with `in`, which walks `Object.prototype`:

```text
GET /api/sessions?sort=toString
→ 500  Parser Error: syntax error at or near "toString"
   LINE 1: SELECT * FROM sessions ORDER BY function toString() { [native code] }

GET /api/analytics/sessions?sort=constructor
→ 500  ORDER BY function Object() { [native code] } DESC NULLS LAST…
```

Not injection — the value is a `Function`, not attacker text — but it defeated the allowlist that `analytics-sessions.ts` documents as *"Never interpolate the raw param"*. `Object.hasOwn` closes it. `toString`, `constructor`, `__proto__`, `hasOwnProperty` and `valueOf` are all covered by tests.

**Unknown sorts still fall back to the default rather than 400ing** — that is existing behaviour clients rely on, and only the prototype keys were leaking.

## 2. Date bounds were interpolated unvalidated

```text
GET /api/analytics?from=not-a-date
→ 500  Conversion Error: invalid timestamp field format: "not-a-date"
   LINE 10: WHERE e.type = 'assistant' AND e.ts >= 'not-a-date'::TIMESTAMP
```

Validation now lives in `scopeFilters` — the one chokepoint every bounded endpoint passes through. That is **eight** endpoints, not the five interpolation sites: `/api/analytics`, `/analytics/sessions`, `/analytics/agents`, `/analytics/activity`, `/analytics/tools`, `/analytics/impact`, `/analytics/errors`, `/analytics/digest`. The test list is exhaustive on purpose, to prove the chokepoint really covers them. The MCP `get_analytics` tool now gets an actionable 400 instead of a SQL dump.

Accepts exactly what callers send: `YYYY-MM-DD` (MCP/CLI contract) and full ISO with optional time/fraction/offset (what the web sends via `toISOString()`, and what the digest's own default range builds). Shape by regex, calendar by `Date.parse` — so `2026-13-45` is rejected here rather than by DuckDB. `TIMESTAMP` (not `TIMESTAMPTZ`) semantics unchanged; this validates, it does not normalize.

### This is also the duplication fix

The same two-line bound filter was written five times, which is *why* the gap was 5× instead of 1×. `/api/analytics`, `/analytics/activity`, `/analytics/tools` and `/analytics/digest` now share the helper.

**The risk that created, and how it is guarded:** three of those bound the EVENT timestamp (`e.ts`) while the shared default is the SESSION start (`started_at`). A missed `ts` override would silently change what a date range means and no existing test would notice. The fixture is therefore built so the two answers *disagree* — `sOld` starts on day 1 but has a day-2 event — and each route's semantics is asserted explicitly. Dropping one override fails exactly one test.

## 3. 500s echoed the SQL

One `setErrorHandler`: `BadRequestError` → 400 with the reason, deliberate 4xx (unsupported media type, malformed JSON) preserved, everything else collapsed to `{error: 'Internal Server Error'}` with the real error going to `req.log.error`. Registered in `routes/index.ts` rather than `main()` so the test harness exercises the same behaviour as production.

## Ride-along: CSP `form-action`

Added `form-action 'self'`. Unlike the fetch directives, `form-action` does **not** inherit from `default-src`, so it was genuinely unrestricted. (I had this wrong in my own review notes first — worth stating plainly.)

## Testing

- `npm test` **526 passed / 57 files** (was 488/56), run 3×; typecheck, build, markdownlint clean.
- New `query-params.integration.test.ts` (38 cases): prototype keys on both sort routes, invalid `from`/`to` on all eight endpoints, an impossible calendar date, all four accepted formats still returning 200, the bound-semantics matrix, and a 500 body carrying no SQL.
- Verified the tests genuinely guard each fix by reverting them one at a time:
  - `Object.hasOwn` → `in`: **10 failures**
  - validation removed from `scopeFilters`: **18 failures**
  - one `ts` override dropped: **1 failure** (the silent-semantics guard)

## Behaviour change

A malformed date is now `400 {"error": "from must be YYYY-MM-DD or an ISO timestamp (got '…')"}` instead of a 500. No client can have been depending on the 500.

Also flips plan 0052 to `done` now that #72 is merged (repo convention: a follow-up commit once the PR lands).