### PR TITLE
fix: never SIGTERM a PID we can't confirm is our daemon; validate the port

### DIFF
--- a/docs/plans/0054-daemon-pid-ownership-and-port.md
+++ b/docs/plans/0054-daemon-pid-ownership-and-port.md
@@ -2,7 +2,7 @@
 
 - **Status:** done <!-- proposed | in-progress | done | superseded | abandoned -->
 - **Date:** 2026-07-29
-- **PR:** <link, once opened>
+- **PR:** https://github.com/vladar107/claudescope/pull/74
 
 ## Context
 
@@ -60,10 +60,12 @@ says why instead of timing out silently.
   Rejected: comparing process start time (no Node API for an arbitrary PID, and
   parsing `ps -o lstart` is brittle) and dropping the wedged self-heal entirely
   (it is a real feature — a hung daemon should get replaced).
-- **Match the command line on `claudescope`, not just the exact entry path** —
-  after an upgrade or a brew/nix relocation, the running daemon's path may differ
-  from this CLI's `SERVER_ENTRY`. A false `false` is safe (we don't kill, we hit
-  `EADDRINUSE` instead); a false `true` is not.
+- **Match on `claudescope` AND the server bundle's filename** — not the exact
+  `SERVER_ENTRY` path, which an upgrade or brew/nix relocation moves. Matching
+  `claudescope` alone was tried first and rejected: the new test caught it
+  claiming this repo's own vitest process (the checkout is named `claudescope`),
+  and it would equally claim a sibling `claudescope mcp`/`search`. A false `false`
+  is safe (we don't kill, we hit `EADDRINUSE`); a false `true` is the bug.
 - **`owns` goes on `DaemonProbes`** — the existing seam that lets the CLI tests
   cover this without spawning or killing anything (`classifyExisting`
   precedent). `start()` in `cli.ts` gets the same treatment.

--- a/docs/plans/0054-daemon-pid-ownership-and-port.md
+++ b/docs/plans/0054-daemon-pid-ownership-and-port.md
@@ -1,0 +1,120 @@
+# 0054 — Don't SIGTERM a PID we don't own; validate the port
+
+- **Status:** done <!-- proposed | in-progress | done | superseded | abandoned -->
+- **Date:** 2026-07-29
+- **PR:** <link, once opened>
+
+## Context
+
+Third PR from the repo-wide review (after [0052](./0052-indexer-durability-and-state-perms.md)
+and [0053](./0053-validate-query-params.md)). Two process-lifecycle defects, both
+in `daemon.ts`/`cli.ts`.
+
+**1. A recycled PID gets SIGTERMed.** `classifyExisting` decides what to do with
+`daemon.json` from two signals: is the PID alive, and does its recorded port
+answer `/api/health`. Alive-but-unhealthy is classified `wedged`, and both
+`start()` and `ensureDaemon()` respond by SIGTERMing it to free the port. After a
+crash (the record is left behind) plus PID reuse, that PID belongs to **an
+unrelated process** — and we signal it. Confirmed with the real classifier:
+
+```text
+classifyExisting({pid: 424242, port: 4317}, alive=true, healthy=false)
+→ 'wedged'   → terminateDaemon() SIGTERMs pid 424242
+```
+
+Low probability, but the consequence is killing something that isn't ours, and
+`daemon.json` already carries enough context to do better.
+
+**2. `--port` is unvalidated.** `cli.ts` does `values.port ? Number(values.port)
+: DEFAULT_PORT`, so:
+
+```text
+--port abc    → NaN    → ERR_SOCKET_BAD_PORT, daemon dies instantly
+--port 99999  → 99999  → ERR_SOCKET_BAD_PORT, daemon dies instantly
+--port -1     → -1     → ERR_SOCKET_BAD_PORT, daemon dies instantly
+--port 0      → 0      → binds a RANDOM port; health checks then never match
+```
+
+In every case `daemon.json` records the bad value (`NaN` serializes to `null`)
+and the CLI waits the full 20s health timeout before printing "Server did not
+become healthy in time", which describes a symptom and not the cause. The same
+value reaches the server through the `PORT` env var, which `config.ts` also does
+not validate.
+
+## Goal
+
+Claudescope never signals a process it cannot confirm is its own daemon, a bad
+port is rejected before anything is spawned, and a daemon that dies on startup
+says why instead of timing out silently.
+
+## Decisions
+
+- **Verify ownership before signalling; when in doubt, don't** — a new `owns`
+  probe inspects the PID's command line (`ps` on POSIX, PowerShell
+  `Get-CimInstance` on Windows) and returns `true` / `false` / `'unknown'`:
+  - `true` → terminate, exactly as today;
+  - `false` → the PID was recycled, so the record is stale: delete it, signal
+    nothing, and carry on to spawn;
+  - `'unknown'` → refuse to signal and tell the user which PID to inspect.
+    Killing a process we cannot identify is worse than failing loudly.
+  Rejected: comparing process start time (no Node API for an arbitrary PID, and
+  parsing `ps -o lstart` is brittle) and dropping the wedged self-heal entirely
+  (it is a real feature — a hung daemon should get replaced).
+- **Match the command line on `claudescope`, not just the exact entry path** —
+  after an upgrade or a brew/nix relocation, the running daemon's path may differ
+  from this CLI's `SERVER_ENTRY`. A false `false` is safe (we don't kill, we hit
+  `EADDRINUSE` instead); a false `true` is not.
+- **`owns` goes on `DaemonProbes`** — the existing seam that lets the CLI tests
+  cover this without spawning or killing anything (`classifyExisting`
+  precedent). `start()` in `cli.ts` gets the same treatment.
+- **Reject port `0` rather than treating it as "any port"** — the CLI records the
+  requested port in `daemon.json` and polls it for health, so an OS-assigned port
+  can never be discovered. It is a bad value here even though it is legal to
+  `listen()` on.
+- **An invalid `PORT` env var warns and falls back** rather than throwing —
+  `config.ts` is imported at module load by the CLI, the server, and the MCP
+  entry, so throwing there would break unrelated commands. The CLI flag, which is
+  a direct user action, does hard-fail.
+- **On health timeout, print the tail of the daemon log** instead of changing
+  `spawnDaemon`'s signature to report early exit. Same diagnostic value, no churn
+  through `DaemonProbes`, and it covers every startup failure (bad port, port in
+  use, corrupt index) rather than just the ones we predicted.
+
+## Approach
+
+1. `daemon.ts`: add `daemonOwnsPid()`, put it on `DaemonProbes` as `owns`, and
+   gate the `wedged` branch of `ensureDaemon()` on it.
+2. `cli.ts`: same gate in `start()`; validate `--port` via the existing
+   `UsageError` path; print the log tail when health never arrives.
+3. `config.ts`: validate the `PORT` env var, warn and fall back to 4317.
+4. Tests: ownership verdicts drive the right action, a recycled PID is never
+   signalled, and every bad `--port` value is rejected before a spawn.
+
+## Files affected
+
+- `packages/server/src/daemon.ts` — `daemonOwnsPid`, `owns` probe, gated wedge.
+- `packages/server/src/cli.ts` — port validation, gated wedge, log tail on failure.
+- `packages/server/src/config.ts` — validate `PORT`.
+- `packages/server/test/cli.test.ts` — ownership + port cases.
+
+## Testing
+
+- `npm test`, `npm run typecheck`, `npm run build`, markdownlint.
+- New cases assert `terminate` is NOT called when `owns` returns `false` or
+  `'unknown'`, that it IS called when `owns` returns `true` (no regression to the
+  wedged self-heal), and that a `false` verdict clears the stale record and still
+  spawns.
+- Port cases go through the real arg parsing so a rejected value provably never
+  reaches `spawnDaemon`.
+- Regression check: reverting each gate must fail the new tests.
+
+## Risks / open questions
+
+- `daemonOwnsPid` shells out (`ps` / PowerShell). It runs only in the rare wedged
+  branch, is bounded by a short timeout, and any failure degrades to `'unknown'`
+  (refuse to signal) rather than throwing.
+- The Windows path uses PowerShell, which is slower (~hundreds of ms). Acceptable
+  for a branch that only fires when a daemon is hung.
+- Refusing to signal on `'unknown'` means `claudescope start` can now fail where
+  it previously (dangerously) succeeded. The message names the PID and the manual
+  command, which is the correct trade.

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -78,3 +78,4 @@ decision, or a change worth explaining before doing. Skip it for one-line fixes.
 | 0051 | [Settings page: indexer lifecycle + settings.json layer](./0051-settings-page.md) | done |
 | 0052 | [Indexer durability + state-dir permissions](./0052-indexer-durability-and-state-perms.md) | done |
 | 0053 | [Validate query params before they reach SQL](./0053-validate-query-params.md) | done |
+| 0054 | [Don't SIGTERM a PID we don't own; validate the port](./0054-daemon-pid-ownership-and-port.md) | done |

--- a/packages/server/src/cli.ts
+++ b/packages/server/src/cli.ts
@@ -35,9 +35,11 @@ import {
   EXIT_WAIT_MS,
   LOG_FILE,
   classifyExisting,
+  daemonOwnsPid,
   fetchDaemonHealth,
   isAlive,
   isHealthy,
+  planWedgeAction,
   readDaemon,
   spawnDaemon,
   terminateDaemon,
@@ -112,13 +114,26 @@ async function start(port: number, open: boolean): Promise<void> {
   // SIGTERM and wait for it to exit, rather than spawning a second server that
   // would fail to bind (EADDRINUSE) and leave the old one orphaned.
   if (state === 'wedged' && existing) {
-    console.log(`claudescope (pid ${existing.pid}) is unresponsive; restarting it…`);
-    try {
-      await terminateDaemon(existing);
-    } catch (err) {
-      console.error(`✗ ${err instanceof Error ? err.message : String(err)}`);
+    // Only signal a PID we can confirm is ours — after a crash + PID reuse it
+    // belongs to an unrelated process (see planWedgeAction).
+    const action = planWedgeAction(existing, daemonOwnsPid(existing.pid));
+    if (action.kind === 'refuse') {
+      console.error(`✗ ${action.message}`);
       process.exitCode = 1;
       return;
+    }
+    if (action.kind === 'discard') {
+      console.log(`› ${action.message}`);
+      rmSync(DAEMON_FILE, { force: true });
+    } else {
+      console.log(`claudescope (pid ${existing.pid}) is unresponsive; restarting it…`);
+      try {
+        await terminateDaemon(existing);
+      } catch (err) {
+        console.error(`✗ ${err instanceof Error ? err.message : String(err)}`);
+        process.exitCode = 1;
+        return;
+      }
     }
   }
 
@@ -128,7 +143,13 @@ async function start(port: number, open: boolean): Promise<void> {
   process.stdout.write('› Starting claudescope');
   const ok = await waitForHealth(port, 20000, () => process.stdout.write('.'));
   if (!ok) {
-    console.error(`\n✗ Server did not become healthy in time. Inspect: claudescope logs`);
+    console.error(`\n✗ Server did not become healthy on port ${port}.`);
+    // The reason is almost always in the log the daemon just wrote to (a port
+    // already in use, a bad PORT, a corrupt index). Printing the tail turns a
+    // bare timeout into something actionable.
+    const tail = logTail(15);
+    if (tail) console.error(`\nLast lines of ${LOG_FILE}:\n${tail}`);
+    console.error('\nFull log: claudescope logs');
     process.exitCode = 1;
     return;
   }
@@ -175,6 +196,16 @@ function openApp(): void {
     openBrowser(d.url);
   } else {
     console.log('claudescope is not running. Start it with: claudescope start');
+  }
+}
+
+/** Last `n` lines of the daemon log, or '' when there is nothing to show.
+ *  Used to explain a startup failure instead of just reporting the timeout. */
+function logTail(n: number): string {
+  try {
+    return readFileSync(LOG_FILE, 'utf8').trimEnd().split('\n').slice(-n).join('\n');
+  } catch {
+    return '';
   }
 }
 
@@ -288,6 +319,22 @@ async function pricingUpdate(): Promise<void> {
 
 /** A bad flag value or missing argument on a query subcommand. */
 class UsageError extends Error {}
+
+/**
+ * Parse `--port`. Rejects everything the server cannot listen on, because an
+ * invalid value used to be recorded in daemon.json (NaN serializes to `null`)
+ * and then polled for 20s while the daemon was already dead with
+ * ERR_SOCKET_BAD_PORT. Port 0 is rejected too: it IS legal to listen on, but the
+ * OS then picks the port, so the recorded one can never answer a health check.
+ */
+export function parsePort(raw: string | undefined, dflt: number): number {
+  if (raw === undefined) return dflt;
+  const n = Number(raw);
+  if (!Number.isInteger(n) || n < 1 || n > 65535) {
+    throw new UsageError(`--port expects an integer between 1 and 65535 (got '${raw}')`);
+  }
+  return n;
+}
 
 /** Parse a non-negative integer flag; undefined when absent, UsageError when bogus. */
 function intFlag(name: string, v: string | undefined): number | undefined {
@@ -407,7 +454,7 @@ async function main(): Promise<void> {
     },
   });
 
-  const port = values.port ? Number(values.port) : DEFAULT_PORT;
+  const port = parsePort(values.port, DEFAULT_PORT);
   // Flag wins, then the persisted setting (which itself folds settings.json >
   // default true; the OPEN_BROWSER env var stays the launcher's contract).
   const open = values['no-open'] ? false : openBrowserOnStart();
@@ -544,7 +591,10 @@ function isEntrypoint(): boolean {
 
 if (isEntrypoint()) {
   main().catch((err) => {
-    console.error(err);
+    // A usage error is the user's typo, not a crash — print the message, not a
+    // stack (matches how the query subcommands report bad flags).
+    if (err instanceof UsageError) console.error(`✗ ${err.message}`);
+    else console.error(err);
     process.exit(1);
   });
 }

--- a/packages/server/src/config.ts
+++ b/packages/server/src/config.ts
@@ -22,8 +22,32 @@ export function firstExisting(candidates: string[], fallback: string): string {
   return candidates.find((p) => existsSync(p)) ?? fallback;
 }
 
-/** TCP port the Fastify server listens on. Override with PORT. */
-export const PORT = Number(process.env.PORT ?? 4317);
+/** Default TCP port when none is configured. */
+export const DEFAULT_PORT = 4317;
+
+/**
+ * TCP port the Fastify server listens on. Override with PORT.
+ *
+ * Validated because an unusable value used to reach `app.listen` and kill the
+ * daemon instantly with ERR_SOCKET_BAD_PORT, which the CLI could only report as
+ * a health timeout. Warn-and-fall-back rather than throw: this module is
+ * imported at load time by the CLI, the server, and the MCP entry, so throwing
+ * would break commands that never bind a port.
+ */
+function resolvePort(raw: string | undefined): number {
+  if (raw === undefined) return DEFAULT_PORT;
+  const n = Number(raw);
+  if (!Number.isInteger(n) || n < 1 || n > 65535) {
+    console.warn(
+      `[config] ignoring PORT='${raw}' — expected an integer between 1 and 65535; ` +
+        `using ${DEFAULT_PORT}`,
+    );
+    return DEFAULT_PORT;
+  }
+  return n;
+}
+
+export const PORT = resolvePort(process.env.PORT);
 
 /** Root directory of the server package (resolved from dist or src at runtime). */
 export const PACKAGE_ROOT = join(__dirname, '..');

--- a/packages/server/src/daemon.ts
+++ b/packages/server/src/daemon.ts
@@ -8,7 +8,7 @@
  * stdout, which an MCP stdio server owns as its protocol channel.
  */
 
-import { spawn } from 'node:child_process';
+import { execFileSync, spawn } from 'node:child_process';
 import {
   existsSync,
   openSync,
@@ -18,7 +18,7 @@ import {
   statSync,
   writeFileSync,
 } from 'node:fs';
-import { dirname, join } from 'node:path';
+import { basename, dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import type { HealthResponse } from '@claudescope/shared';
 import {
@@ -67,6 +67,54 @@ export function isAlive(pid: number): boolean {
   } catch {
     return false;
   }
+}
+
+/**
+ * Whether a live PID really belongs to a Claudescope daemon — `'unknown'` when
+ * we could not find out.
+ *
+ * `isAlive` only proves *something* holds the PID. After a crash leaves
+ * `daemon.json` behind and the OS recycles that PID, it belongs to an unrelated
+ * process — and the `wedged` branch's whole job is to SIGTERM it. So callers must
+ * confirm ownership first, and treat `'unknown'` as "do not signal": failing
+ * loudly beats killing a process we cannot identify.
+ *
+ * Implemented by reading the process's command line, which is the one signal
+ * that survives a crash (Node exposes no start-time API for an arbitrary PID).
+ *
+ * The match requires BOTH `claudescope` and the server bundle's filename, rather
+ * than this CLI's exact {@link SERVER_ENTRY} path — an upgrade or a brew/nix
+ * relocation moves that path, so pinning it would produce false negatives. Both
+ * halves are needed: `claudescope` alone also matches a sibling CLI invocation
+ * (`claudescope mcp`, `claudescope search`) and, in a dev checkout, any process
+ * launched from a directory named `claudescope`. A false negative is safe — we
+ * skip the kill and get a clear `EADDRINUSE` instead — whereas a false positive
+ * is exactly the bug this closes.
+ */
+export function daemonOwnsPid(pid: number): boolean | 'unknown' {
+  const [cmd, args] =
+    process.platform === 'win32'
+      ? [
+          'powershell.exe',
+          [
+            '-NoProfile',
+            '-Command',
+            `(Get-CimInstance Win32_Process -Filter "ProcessId=${pid}").CommandLine`,
+          ],
+        ]
+      : ['ps', ['-o', 'args=', '-p', String(pid)]];
+  let out: string;
+  try {
+    out = execFileSync(cmd, args, { encoding: 'utf8', timeout: 5000, stdio: ['ignore', 'pipe', 'ignore'] });
+  } catch {
+    // `ps` exits non-zero for an unknown PID — but by the time we get here the
+    // process was alive, so this is a probe failure (missing binary, timeout, no
+    // permission), not evidence either way.
+    return 'unknown';
+  }
+  const line = out.trim().toLowerCase();
+  if (line === '') return 'unknown';
+  return line.includes('claudescope') && line.includes(basename(SERVER_ENTRY).toLowerCase());
 }
 
 /** Probe the server's health endpoint (short timeout, never throws). */
@@ -154,6 +202,41 @@ export async function classifyExisting(
   return (await healthyFn(record.port)) ? 'healthy' : 'wedged';
 }
 
+/**
+ * Decide what to do with an alive-but-unhealthy (`wedged`) record, given an
+ * ownership verdict from {@link daemonOwnsPid}. Shared by `ensureDaemon` and the
+ * CLI's `start` so the two can't drift on something this consequential.
+ *
+ * - `replace` — it is our hung daemon: SIGTERM it and spawn a new one.
+ * - `discard` — the PID was recycled and belongs to someone else: the record is
+ *   stale, so drop it and spawn WITHOUT signalling anything.
+ * - `refuse`  — ownership is unknown; do not signal, surface `message`.
+ */
+export type WedgeAction =
+  | { kind: 'replace' }
+  | { kind: 'discard'; message: string }
+  | { kind: 'refuse'; message: string };
+
+export function planWedgeAction(record: DaemonRecord, owned: boolean | 'unknown'): WedgeAction {
+  if (owned === true) return { kind: 'replace' };
+  if (owned === false) {
+    return {
+      kind: 'discard',
+      message:
+        `pid ${record.pid} in daemon.json is not a claudescope process — the PID was ` +
+        'reused after a crash. Discarding the stale record without signalling it.',
+    };
+  }
+  return {
+    kind: 'refuse',
+    message:
+      `could not verify that pid ${record.pid} is the claudescope daemon, so it was ` +
+      'NOT signalled. Check it yourself and, if it is ours, stop it manually:\n' +
+      `  ps -p ${record.pid} -o args=\n` +
+      `  kill ${record.pid}`,
+  };
+}
+
 /** Roll the daemon log to `.1` once it exceeds {@link LOG_MAX_BYTES}. Best-effort. */
 export function rotateLogIfLarge(): void {
   try {
@@ -208,6 +291,8 @@ export interface EnsuredDaemon {
  *  {@link classifyExisting} pattern — tests never spawn or kill anything. */
 export interface DaemonProbes {
   alive: (pid: number) => boolean;
+  /** Confirms a live PID is really our daemon before we signal it. */
+  owns: (pid: number) => boolean | 'unknown';
   healthy: (port: number) => Promise<boolean>;
   health: (port: number) => Promise<HealthResponse | null>;
   terminate: (record: DaemonRecord) => Promise<void>;
@@ -217,6 +302,7 @@ export interface DaemonProbes {
 
 const realProbes: DaemonProbes = {
   alive: isAlive,
+  owns: daemonOwnsPid,
   healthy: isHealthy,
   health: fetchDaemonHealth,
   terminate: terminateDaemon,
@@ -261,9 +347,17 @@ export async function ensureDaemon(
   if (state === 'stale') rmSync(DAEMON_FILE, { force: true });
   if (state === 'wedged' && existing) {
     // Same replace semantics as `claudescope start`: SIGTERM and wait, rather
-    // than spawning a second server that would fail to bind.
-    log(`claudescope daemon (pid ${existing.pid}) is unresponsive; replacing it…`);
-    await p.terminate(existing);
+    // than spawning a second server that would fail to bind — but only once the
+    // PID is confirmed ours (see planWedgeAction).
+    const action = planWedgeAction(existing, p.owns(existing.pid));
+    if (action.kind === 'refuse') throw new Error(action.message);
+    if (action.kind === 'discard') {
+      log(action.message);
+      rmSync(DAEMON_FILE, { force: true });
+    } else {
+      log(`claudescope daemon (pid ${existing.pid}) is unresponsive; replacing it…`);
+      await p.terminate(existing);
+    }
   }
 
   // Respawn a healed (healthy-but-skewed) daemon on its original port — a

--- a/packages/server/test/cli.test.ts
+++ b/packages/server/test/cli.test.ts
@@ -191,6 +191,7 @@ describe('ensureDaemon version healing', () => {
   // these tests never spawn or kill anything.
   const probes = (over: Partial<import('../src/daemon.js').DaemonProbes> = {}) => ({
     alive: () => true,
+    owns: () => true as boolean | 'unknown',
     healthy: async () => true,
     terminate: vi.fn(async () => {}),
     spawn: vi.fn(),
@@ -262,5 +263,94 @@ describe('ensureDaemon version healing', () => {
     const d = await daemon.ensureDaemon(() => {}, p);
     expect(d.port).toBe(4317);
     expect(p.terminate).not.toHaveBeenCalled();
+  });
+});
+
+describe('wedged-daemon ownership (never SIGTERM a PID we do not own)', () => {
+  // A crash leaves daemon.json behind; if the OS reuses that PID, "alive but the
+  // port is silent" describes an UNRELATED process just as well as our hung
+  // daemon. planWedgeAction is the gate — these pin each verdict's action.
+  it('replaces the daemon when the PID is confirmed ours', () => {
+    expect(daemon.planWedgeAction(record(), true)).toEqual({ kind: 'replace' });
+  });
+
+  it('discards the record — without signalling — when the PID is someone else', () => {
+    const action = daemon.planWedgeAction(record(), false);
+    expect(action.kind).toBe('discard');
+    expect(action.kind !== 'replace' && action.message).toMatch(/PID was reused/i);
+  });
+
+  it('refuses to signal when ownership cannot be determined', () => {
+    const action = daemon.planWedgeAction(record(), 'unknown');
+    expect(action.kind).toBe('refuse');
+    // The message has to tell the user what to do, since we deliberately did nothing.
+    expect(action.kind !== 'replace' && action.message).toMatch(/kill 4242/);
+  });
+
+  it('never claims a non-daemon process, even one run from a claudescope checkout', () => {
+    // The invariant that matters. This very vitest process runs under node from a
+    // directory called `claudescope`, so a `claudescope`-only match claimed it —
+    // which is why the probe also requires the server bundle's filename.
+    expect(daemon.daemonOwnsPid(process.pid)).not.toBe(true);
+  });
+
+  it('daemonOwnsPid returns unknown for a PID that cannot be inspected', () => {
+    // 2^22 is above every platform's default pid_max, so the probe fails.
+    expect(daemon.daemonOwnsPid(4_194_304)).toBe('unknown');
+  });
+});
+
+describe('ensureDaemon on a wedged record', () => {
+  const base = (over: Partial<import('../src/daemon.js').DaemonProbes> = {}) => ({
+    alive: () => true,
+    owns: () => true as boolean | 'unknown',
+    healthy: async () => false, // wedged: alive but not answering
+    health: async () => null,
+    terminate: vi.fn(async () => {}),
+    spawn: vi.fn(),
+    waitHealthy: async () => true,
+    ...over,
+  });
+
+  it('SIGTERMs and respawns when the PID is ours', async () => {
+    writeFileSync(DAEMON_FILE, JSON.stringify(record()));
+    const p = base();
+    await daemon.ensureDaemon(() => {}, p);
+    expect(p.terminate).toHaveBeenCalledOnce();
+    expect(p.spawn).toHaveBeenCalledOnce();
+  });
+
+  it('spawns WITHOUT signalling when the PID was recycled', async () => {
+    writeFileSync(DAEMON_FILE, JSON.stringify(record()));
+    const p = base({ owns: () => false });
+    await daemon.ensureDaemon(() => {}, p);
+    expect(p.terminate).not.toHaveBeenCalled();
+    expect(p.spawn).toHaveBeenCalledOnce();
+  });
+
+  it('signals nothing and throws when ownership is unknown', async () => {
+    writeFileSync(DAEMON_FILE, JSON.stringify(record()));
+    const p = base({ owns: () => 'unknown' });
+    await expect(daemon.ensureDaemon(() => {}, p)).rejects.toThrow(/could not verify/i);
+    expect(p.terminate).not.toHaveBeenCalled();
+    expect(p.spawn).not.toHaveBeenCalled();
+  });
+});
+
+describe('parsePort', () => {
+  it('defaults when the flag is absent', () => {
+    expect(cli.parsePort(undefined, 4317)).toBe(4317);
+  });
+
+  it.each(['8080', '1', '65535'])('accepts %s', (v) => {
+    expect(cli.parsePort(v, 4317)).toBe(Number(v));
+  });
+
+  // Each of these used to reach spawnDaemon: the daemon died instantly with
+  // ERR_SOCKET_BAD_PORT (or bound a random port for 0) while the CLI polled the
+  // recorded value for 20s. `0` is legal to listen on but unusable here, because
+  // the OS picks the port and the recorded one can never answer.
+  it.each(['abc', '0', '-1', '99999', '80.5', '', ' '])('rejects %s', (v) => {
+    expect(() => cli.parsePort(v, 4317)).toThrow(/between 1 and 65535/);
   });
 });


### PR DESCRIPTION
Plan: [docs/plans/0054-daemon-pid-ownership-and-port.md](./docs/plans/0054-daemon-pid-ownership-and-port.md)

Third PR from the repo-wide review (after #72, #73). Two process-lifecycle defects, both in `daemon.ts`/`cli.ts`.

## 1. A recycled PID got SIGTERMed

`classifyExisting` decides what to do with `daemon.json` from two signals: is the PID alive, and does its recorded port answer `/api/health`. Alive-but-silent is classified `wedged`, and both `start()` and `ensureDaemon()` respond by SIGTERMing it to free the port. After a crash leaves the record behind **and** the OS recycles that PID, it belongs to an unrelated process:

```text
classifyExisting({pid: 424242, port: 4317}, alive=true, healthy=false)
→ 'wedged'   → terminateDaemon() SIGTERMs pid 424242
```

Ownership is now confirmed first by reading the process's command line — the only signal that survives a crash, since Node exposes no start-time API for an arbitrary PID. `planWedgeAction` maps the verdict to one action, shared by both call sites so they can't drift:

| verdict | action |
|---|---|
| ours | SIGTERM and respawn, exactly as before |
| someone else | record is stale → discard it, **signal nothing**, spawn |
| can't tell | **signal nothing**, report the PID and the manual command |

Refusing on "can't tell" is deliberate: killing a process we cannot identify is worse than failing loudly. The message names the PID and gives the `ps`/`kill` commands.

### The match needed tightening mid-implementation

My first version matched `claudescope` in the command line. The new test immediately caught that this claims **this repo's own vitest process** — the checkout is named `claudescope` — and it would equally claim a sibling `claudescope mcp` or `claudescope search`. It now requires both `claudescope` *and* the server bundle's filename. A false negative is safe (we skip the kill and get a clear `EADDRINUSE`); a false positive is the bug being fixed.

Rejected alternatives: comparing process start time (no Node API for an arbitrary PID; parsing `ps -o lstart` is brittle) and dropping the wedged self-heal entirely (replacing a hung daemon is a real feature).

## 2. `--port` was unvalidated

```text
--port abc    → NaN    → ERR_SOCKET_BAD_PORT, daemon dies instantly
--port 99999  → 99999  → ERR_SOCKET_BAD_PORT, daemon dies instantly
--port -1     → -1     → ERR_SOCKET_BAD_PORT, daemon dies instantly
--port 0      → 0      → binds a RANDOM port; the recorded one never answers
```

In every case `daemon.json` stored the bad value (`NaN` serializes to `null`) and the CLI polled it for the full 20s before printing "Server did not become healthy in time". Now:

```console
$ claudescope start --port abc
✗ --port expects an integer between 1 and 65535 (got 'abc')
```

— and the state dir is left untouched, i.e. nothing is spawned. Port `0` is rejected too: it is legal to `listen()` on, but the OS then picks the port so the recorded one can never answer a health check.

An invalid `PORT` env var warns and falls back rather than throwing, because `config.ts` is imported at load time by commands that never bind a port:

```console
$ PORT=99999 claudescope help
[config] ignoring PORT='99999' — expected an integer between 1 and 65535; using 4317
```

## 3. A health timeout now says why

The cause is almost always in the log the daemon just wrote — port in use, bad `PORT`, corrupt index — so a failed start prints its last 15 lines instead of only reporting the symptom. Chosen over changing `spawnDaemon`'s signature to detect early exit: same diagnostic value, no churn through `DaemonProbes`, and it covers every startup failure rather than just the predicted ones.

## Testing

- `npm test` **545 passed / 57 files** (was 526/57), run 3×; typecheck, build, markdownlint clean.
- 19 new cases: each ownership verdict → the right action, `ensureDaemon` on a wedged record for all three verdicts (asserting `terminate` is **not** called for `false`/`'unknown'`, and still **is** for `true` so the self-heal doesn't regress), the real `ps`/PowerShell probe never claiming a non-daemon process, and every rejected `--port` value.
- Verified the tests catch regressions: removing the ownership gate → **2 failures**; removing `parsePort` validation → **7 failures**.
- Manual end-to-end: `--port abc` fails before spawning and leaves no state dir; `PORT=99999` warns and falls back; `PORT=5555` is respected.

## Behaviour change

`claudescope start` can now **fail** where it previously (dangerously) succeeded — when it cannot verify the recorded PID. That is the intended trade; the message tells the user exactly what to inspect.