### PR TITLE
refactor: derive the canonical connector contract from one definition

### DIFF
--- a/docs/plans/0055-canonical-connector-contract.md
+++ b/docs/plans/0055-canonical-connector-contract.md
@@ -1,0 +1,107 @@
+# 0055 — One canonical connector contract instead of sixteen
+
+- **Status:** done <!-- proposed | in-progress | done | superseded | abandoned -->
+- **Date:** 2026-07-29
+- **PR:** <link, once opened>
+
+## Context
+
+Fourth PR from the repo-wide review (after [0052](./0052-indexer-durability-and-state-perms.md),
+[0053](./0053-validate-query-params.md), [0054](./0054-daemon-pid-ownership-and-port.md)).
+Unlike those, this fixes no user-visible defect — it removes the maintenance
+hazard that made the earlier ones easy to introduce.
+
+Seven connectors normalize a session to a canonical NDJSON and hand the indexer a
+`SELECT` that reads it back. That one contract was restated **three times per
+connector**:
+
+| duplicated thing | copies |
+| ---------------- | -----: |
+| `eventsProjectionSql` (16 lines; differ only by the `provider` column) | 7 |
+| `interface CanonicalRow` (differ only by optional `provider` / `title`) | 7 |
+| `CACHE_DIR` + `cachePath()` + `prepare()` | 7 |
+| `str` / `num` / `rec` coercion helpers | 7 |
+| `auxProjections` titles block (verbatim) | 4 |
+
+Nothing checked that the 21 columns agreed. `CANONICAL_EVENT_COLUMNS` in
+`types.ts` *looked* like the contract but was **dead** — grepping the whole
+monorepo found only its own declaration and one JSDoc reference. So adding
+`tool_error_count` in schema v10 meant editing ~16 hand-maintained lists, and a
+miss produces silently wrong data (a NULL column, a zeroed metric) rather than a
+type error.
+
+## Goal
+
+The canonical contract has exactly one definition, the row type / column map /
+SELECT list are all derived from it, and a test fails if any connector drifts.
+
+## Decisions
+
+- **Generate from a name→type map, don't just extract the string** — the obvious
+  refactor is one shared SQL template. But the column map and the SELECT list are
+  two views of the same contract, and a template still lets them disagree.
+  `CANONICAL_COLUMNS` is data, and both views are computed from it.
+- **Leave Claude Code's projection hand-written** — it reads raw JSONL with its
+  own column map plus a LATERAL block aggregate, has no cache file and no
+  canonical row. Forcing it through the shared generator would mean
+  parameterizing away everything that makes it different. It is therefore the one
+  connector that *can* still drift, which is the main reason the new contract test
+  exists.
+- **Prove SQL equivalence mechanically, not by reading the diff** — captured
+  every connector's generated `eventsProjectionSql` + `auxProjections` before the
+  change, then compared column maps and SELECT lists after. A refactor whose whole
+  risk is "silently wrong data" needs a mechanical check, not eyeballing 457
+  deleted lines.
+- **Unify `rec` on the stricter variant** — five copies rejected arrays, two
+  accepted them. Confirmed first that every call site only reads a property off
+  the result (never spreads or iterates it), which makes the two
+  indistinguishable: `[].field` and `{}.field` are both `undefined`.
+- **Leave `zeroUsage` alone** — the four copies look duplicated but the types
+  genuinely diverge: Codex's deliberately omits `cache_creation_input_tokens`, and
+  Junie's needs an index signature for delta accumulation. Unifying two of four
+  would add an import without removing the hazard.
+- **Don't export `CACHE_ROOT` "for later"** — the cache GC in the next PR will
+  want it, but shipping an unused export is the exact habit
+  `CANONICAL_EVENT_COLUMNS` demonstrated. Export it when something reads it.
+
+## Approach
+
+1. `connectors/canonical.ts` — `CANONICAL_COLUMNS`, the shared `CanonicalRow`,
+   `canonicalProjectionSql()`, `titlesProjectionSql()`.
+2. `connectors/ndjson-cache.ts` — `ndjsonCache(agentId)` owning the cache layout.
+3. `connectors/json.ts` — `str` / `num` / `rec`.
+4. Migrate the seven cache-backed connectors; delete the dead const in `types.ts`
+   and point its doc at the live contract.
+5. `test/canonical-contract.test.ts` — assert every connector (Claude Code
+   included) projects exactly the canonical column set, and that every canonical
+   column exists in the `events` DDL.
+
+## Files affected
+
+- `packages/server/src/connectors/canonical.ts`, `ndjson-cache.ts`, `json.ts` — new.
+- `packages/server/src/connectors/{codex,junie,pi,opencode,copilot,antigravity,grok}/{*.ts,normalize.ts}`
+  — use the shared helpers.
+- `packages/server/src/connectors/types.ts` — drop the dead const.
+- `packages/server/test/canonical-contract.test.ts` — new.
+
+## Testing
+
+- `npm test` (545 → 554), `npm run typecheck`, `npm run build`, markdownlint.
+- **Equivalence**: captured generated SQL before/after; column maps, SELECT lists
+  and aux projections are equivalent for all eight connectors (text differs only
+  in whitespace, and Claude Code's is byte-identical).
+- **Contract enforcement verified in both directions**: removing a column from
+  Claude Code's hand-written projection fails its case; adding one to
+  `CANONICAL_COLUMNS` without adding it to the `events` DDL fails the schema case.
+- The per-connector integration suites (`codex`, `pi`, `grok`, `copilot`,
+  `junie`, `opencode`, `antigravity`) are the behavioural net and all still pass.
+
+## Risks / open questions
+
+- The index is a derived cache, so even a missed column self-heals on rebuild —
+  but it would serve wrong analytics until then. Hence the equivalence check.
+- The shared generator emits columns in `CANONICAL_COLUMNS` order. `loadFile`
+  selects by name, so order is not load-bearing today; the contract test would
+  catch a set change but not a reorder.
+- Claude Code remains the drift risk by design. The contract test covers its
+  column set, not its expressions.

--- a/docs/plans/0055-canonical-connector-contract.md
+++ b/docs/plans/0055-canonical-connector-contract.md
@@ -2,7 +2,7 @@
 
 - **Status:** done <!-- proposed | in-progress | done | superseded | abandoned -->
 - **Date:** 2026-07-29
-- **PR:** <link, once opened>
+- **PR:** https://github.com/vladar107/claudescope/pull/75
 
 ## Context
 

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -79,3 +79,4 @@ decision, or a change worth explaining before doing. Skip it for one-line fixes.
 | 0052 | [Indexer durability + state-dir permissions](./0052-indexer-durability-and-state-perms.md) | done |
 | 0053 | [Validate query params before they reach SQL](./0053-validate-query-params.md) | done |
 | 0054 | [Don't SIGTERM a PID we don't own; validate the port](./0054-daemon-pid-ownership-and-port.md) | done |
+| 0055 | [One canonical connector contract instead of sixteen](./0055-canonical-connector-contract.md) | done |

--- a/packages/server/src/connectors/antigravity/antigravity.ts
+++ b/packages/server/src/connectors/antigravity/antigravity.ts
@@ -19,15 +19,13 @@
  * STRICTLY READ-ONLY with respect to ~/.gemini — files are only ever read.
  */
 
-import { createHash } from 'node:crypto';
-import { existsSync, mkdirSync, writeFileSync } from 'node:fs';
-import { join } from 'node:path';
+import { existsSync } from 'node:fs';
 import type { MemorySource, RawEvent } from '@claudescope/shared';
-import { CLAUDESCOPE_HOME } from '../../config.js';
 import { antigravityDirs, antigravitySourceDir } from '../../settings.js';
-import { sqlString } from '../../db/duckdb.js';
 import type { SessionData, SubagentSource } from '../../data/session-loader.js';
 import type { AgentConnector, AuxProjections, DiscoveredFile } from '../types.js';
+import { canonicalProjectionSql } from '../canonical.js';
+import { ndjsonCache } from '../ndjson-cache.js';
 import {
   getContext,
   listTranscripts,
@@ -38,13 +36,7 @@ import {
 } from './normalize.js';
 import { antigravityGlobalMemory } from './memory.js';
 
-const CACHE_DIR = join(CLAUDESCOPE_HOME, 'cache', 'antigravity');
-
-/** Deterministic temp NDJSON path for a given source file. */
-function cachePath(filePath: string): string {
-  const hash = createHash('sha1').update(filePath).digest('hex').slice(0, 16);
-  return join(CACHE_DIR, `${hash}.ndjson`);
-}
+const cache = ndjsonCache('antigravity');
 
 /** Every transcript across both Antigravity appDataDirs. */
 function discover(): DiscoveredFile[] {
@@ -74,25 +66,11 @@ function discover(): DiscoveredFile[] {
 /** Normalize a session to canonical NDJSON the projection will read. */
 async function prepare(filePath: string): Promise<void> {
   const rows = toCanonicalRows(parseAntigravitySession(filePath), filePath);
-  mkdirSync(CACHE_DIR, { recursive: true });
-  writeFileSync(cachePath(filePath), rows.map((r) => JSON.stringify(r)).join('\n') + '\n');
+  cache.write(filePath, rows);
 }
 
 function eventsProjectionSql(filePath: string): string {
-  const path = sqlString(cachePath(filePath));
-  return `
-    SELECT
-      file_path, session_id, uuid, parent_uuid, role, type, ts, cwd, git_branch,
-      model, CAST(NULL AS VARCHAR) AS provider, input_tokens, output_tokens, cache_read_tokens, cache_write_tokens,
-      service_tier, is_sidechain, tool_use_count, tool_names, tool_error_count, text_content,
-      CAST(NULL AS VARCHAR) AS message_id, CAST(NULL AS VARCHAR) AS forked_from_session_id
-    FROM read_ndjson(${path}, format='newline_delimited', maximum_object_size=268435456, ignore_errors=true, columns={
-      file_path:'VARCHAR', session_id:'VARCHAR', uuid:'VARCHAR', parent_uuid:'VARCHAR',
-      role:'VARCHAR', type:'VARCHAR', ts:'TIMESTAMP', cwd:'VARCHAR', git_branch:'VARCHAR',
-      model:'VARCHAR', input_tokens:'BIGINT', output_tokens:'BIGINT', cache_read_tokens:'BIGINT',
-      cache_write_tokens:'BIGINT', service_tier:'VARCHAR', is_sidechain:'BOOLEAN',
-      tool_use_count:'INTEGER', tool_names:'VARCHAR', tool_error_count:'INTEGER', text_content:'VARCHAR'
-    })`;
+  return canonicalProjectionSql(cache.path(filePath), { provider: false });
 }
 
 /** Antigravity stores no title → rely on the first-user-message fallback. */

--- a/packages/server/src/connectors/antigravity/normalize.ts
+++ b/packages/server/src/connectors/antigravity/normalize.ts
@@ -40,10 +40,9 @@ import type {
 } from '@claudescope/shared';
 import { resolveImageWithin } from '../safe-image.js';
 import { toolNamesCsv } from '../tool-names.js';
+import type { CanonicalRow } from '../canonical.js';
+import { rec, str } from '../json.js';
 
-const str = (v: unknown): string => (typeof v === 'string' ? v : '');
-const rec = (v: unknown): Record<string, unknown> =>
-  v && typeof v === 'object' ? (v as Record<string, unknown>) : {};
 /** First non-empty string among the candidates (unlike `??`, skips `''`). */
 const firstStr = (...vals: unknown[]): string => {
   for (const v of vals) {
@@ -587,29 +586,6 @@ export function parseAntigravitySession(
 
 // --- canonical index rows ---------------------------------------------------
 
-/** A canonical index row (matches the events NDJSON the projection reads). */
-export interface CanonicalRow {
-  file_path: string;
-  session_id: string;
-  uuid: string;
-  parent_uuid: string | null;
-  role: string;
-  type: string;
-  ts: string;
-  cwd: string;
-  git_branch: string | null;
-  model: string | null;
-  input_tokens: number;
-  output_tokens: number;
-  cache_read_tokens: number;
-  cache_write_tokens: number;
-  service_tier: string | null;
-  is_sidechain: boolean;
-  tool_use_count: number;
-  tool_names: string;
-  tool_error_count: number | null;
-  text_content: string;
-}
 
 /** Flatten a parsed session into canonical index rows for one file. */
 export function toCanonicalRows(session: AntigravitySession, filePath: string): CanonicalRow[] {

--- a/packages/server/src/connectors/canonical.ts
+++ b/packages/server/src/connectors/canonical.ts
@@ -1,0 +1,140 @@
+/**
+ * The canonical event contract, in ONE place.
+ *
+ * Connectors whose source format can't be projected per-row normalize a session
+ * to a canonical NDJSON first (`prepare()`), then hand the indexer a `SELECT`
+ * that reads it back. That contract used to be restated three times per
+ * connector — a `CanonicalRow` interface, a `read_ndjson` column map, and a
+ * SELECT list — across seven connectors, with nothing checking that the 21
+ * columns agreed. Adding `tool_error_count` in schema v10 therefore meant
+ * touching ~16 hand-maintained lists, where a miss produces silently wrong data
+ * rather than a type error.
+ *
+ * Now {@link CANONICAL_COLUMNS} is the single source: the row type, the column
+ * map, and the SELECT list are all derived from it.
+ *
+ * NOTE: the Claude Code connector deliberately does NOT use this. It projects
+ * its raw JSONL directly (its own column map plus a LATERAL block aggregate),
+ * so it has no cache file and no canonical row — see `claude-code/claude-code.ts`.
+ */
+
+import { sqlString } from '../db/duckdb.js';
+
+/**
+ * Canonical column → its DuckDB type in the cache NDJSON. Order is the contract:
+ * the generated SELECT emits these columns in exactly this order, and the
+ * indexer's `INSERT INTO events` (see `data/index.ts:loadFile`) selects them by
+ * name on top of that.
+ */
+export const CANONICAL_COLUMNS = {
+  file_path: 'VARCHAR',
+  session_id: 'VARCHAR',
+  uuid: 'VARCHAR',
+  parent_uuid: 'VARCHAR',
+  role: 'VARCHAR',
+  type: 'VARCHAR',
+  ts: 'TIMESTAMP',
+  cwd: 'VARCHAR',
+  git_branch: 'VARCHAR',
+  model: 'VARCHAR',
+  provider: 'VARCHAR',
+  input_tokens: 'BIGINT',
+  output_tokens: 'BIGINT',
+  cache_read_tokens: 'BIGINT',
+  cache_write_tokens: 'BIGINT',
+  service_tier: 'VARCHAR',
+  is_sidechain: 'BOOLEAN',
+  tool_use_count: 'INTEGER',
+  tool_names: 'VARCHAR',
+  tool_error_count: 'INTEGER',
+  text_content: 'VARCHAR',
+} as const;
+
+/**
+ * One row of a connector's canonical NDJSON — what `toCanonicalRows` returns.
+ *
+ * `provider` is optional because only pi/Codex/opencode record a serving
+ * provider; `title` is optional and is NOT an events column at all — it rides
+ * along in the same file for connectors that carry a real session title, read
+ * back by {@link titlesProjectionSql}.
+ */
+export interface CanonicalRow {
+  file_path: string;
+  session_id: string;
+  uuid: string;
+  parent_uuid: string | null;
+  role: string;
+  type: string;
+  ts: string;
+  cwd: string;
+  git_branch: string | null;
+  model: string | null;
+  /** Serving provider, when the source format records one (pi/Codex/opencode). */
+  provider?: string | null;
+  input_tokens: number;
+  output_tokens: number;
+  cache_read_tokens: number;
+  cache_write_tokens: number;
+  service_tier: string | null;
+  is_sidechain: boolean;
+  tool_use_count: number;
+  tool_names: string;
+  /** NULL when the source format carries no error signal — distinct from 0. */
+  tool_error_count: number | null;
+  text_content: string;
+  /** Session title; read by the aux projection, ignored by the events one. */
+  title?: string;
+}
+
+/**
+ * Shared `read_ndjson` options. `ignore_errors=true` skips a malformed line
+ * instead of failing the whole file (and with it the reindex pass); the large
+ * `maximum_object_size` covers transcripts with inlined base64 images.
+ */
+const READ_OPTS = "format='newline_delimited', maximum_object_size=268435456, ignore_errors=true";
+
+/** `columns={...}` map for the given canonical columns. */
+function columnsMap(names: readonly string[]): string {
+  const entries = names.map((n) => `${n}:'${CANONICAL_COLUMNS[n as keyof typeof CANONICAL_COLUMNS]}'`);
+  return `columns={${entries.join(', ')}}`;
+}
+
+/**
+ * The events projection for a cache-backed connector: reads its canonical NDJSON
+ * and emits the columns `loadFile` expects.
+ *
+ * `provider` is the only per-connector variation. When the connector doesn't
+ * record one it is left out of the column map and selected as a NULL literal, so
+ * the output shape is identical either way. `message_id` and
+ * `forked_from_session_id` are always NULL — they exist for Claude Code's
+ * usage-dedup election, and these formats accumulate usage once per call in
+ * their normalizers instead.
+ */
+export function canonicalProjectionSql(cachePath: string, opts: { provider: boolean }): string {
+  const names = Object.keys(CANONICAL_COLUMNS).filter(
+    (n) => n !== 'provider' || opts.provider,
+  );
+  const selected = Object.keys(CANONICAL_COLUMNS).map((n) =>
+    n === 'provider' && !opts.provider ? 'CAST(NULL AS VARCHAR) AS provider' : n,
+  );
+  return `
+    SELECT
+      ${selected.join(', ')},
+      CAST(NULL AS VARCHAR) AS message_id, CAST(NULL AS VARCHAR) AS forked_from_session_id
+    FROM read_ndjson(${sqlString(cachePath)}, ${READ_OPTS}, ${columnsMap(names)})`;
+}
+
+/**
+ * The `titles` aux projection for a connector whose canonical rows carry a real
+ * session title (Copilot's workspace name, Junie's taskName, opencode's and
+ * Grok's stored titles). Latest non-empty title in the file wins; an empty
+ * result simply leaves the first-user-message fallback in place.
+ */
+export function titlesProjectionSql(cachePath: string): string {
+  return `
+      SELECT session_id, last(title) AS title
+      FROM read_ndjson(${sqlString(cachePath)}, ${READ_OPTS},
+        columns={session_id:'VARCHAR', title:'VARCHAR'})
+      WHERE session_id IS NOT NULL AND title IS NOT NULL AND title <> ''
+      GROUP BY session_id`;
+}

--- a/packages/server/src/connectors/codex/codex.ts
+++ b/packages/server/src/connectors/codex/codex.ts
@@ -15,24 +15,15 @@
  * STRICTLY READ-ONLY with respect to ~/.codex — files are only ever read.
  */
 
-import { createHash } from 'node:crypto';
-import { mkdirSync, writeFileSync } from 'node:fs';
-import { join } from 'node:path';
-import { CLAUDESCOPE_HOME } from '../../config.js';
 import { codexSessionsDir } from '../../settings.js';
-import { sqlString } from '../../db/duckdb.js';
 import type { SessionData, SubagentSource } from '../../data/session-loader.js';
 import type { AgentConnector, AuxProjections, DiscoveredFile } from '../types.js';
+import { canonicalProjectionSql } from '../canonical.js';
+import { ndjsonCache } from '../ndjson-cache.js';
 import { codexGlobalMemory } from './memory.js';
 import { listRollouts, parseRollout, toCanonicalRows, type CodexSession } from './normalize.js';
 
-const CACHE_DIR = join(CLAUDESCOPE_HOME, 'cache', 'codex');
-
-/** Deterministic temp NDJSON path for a given rollout file. */
-function cachePath(filePath: string): string {
-  const hash = createHash('sha1').update(filePath).digest('hex').slice(0, 16);
-  return join(CACHE_DIR, `${hash}.ndjson`);
-}
+const cache = ndjsonCache('codex');
 
 /**
  * Every `rollout-*.jsonl` under the Codex sessions dir. Subagent rollouts are
@@ -47,26 +38,12 @@ function discover(): DiscoveredFile[] {
 /** Normalize a rollout to canonical NDJSON the projection will read. */
 async function prepare(filePath: string): Promise<void> {
   const session = parseRollout(filePath);
-  mkdirSync(CACHE_DIR, { recursive: true });
   const rows = session ? toCanonicalRows(session, filePath) : [];
-  writeFileSync(cachePath(filePath), rows.map((r) => JSON.stringify(r)).join('\n') + '\n');
+  cache.write(filePath, rows);
 }
 
 function eventsProjectionSql(filePath: string): string {
-  const path = sqlString(cachePath(filePath));
-  return `
-    SELECT
-      file_path, session_id, uuid, parent_uuid, role, type, ts, cwd, git_branch,
-      model, provider, input_tokens, output_tokens, cache_read_tokens, cache_write_tokens,
-      service_tier, is_sidechain, tool_use_count, tool_names, tool_error_count, text_content,
-      CAST(NULL AS VARCHAR) AS message_id, CAST(NULL AS VARCHAR) AS forked_from_session_id
-    FROM read_ndjson(${path}, format='newline_delimited', maximum_object_size=268435456, ignore_errors=true, columns={
-      file_path:'VARCHAR', session_id:'VARCHAR', uuid:'VARCHAR', parent_uuid:'VARCHAR',
-      role:'VARCHAR', type:'VARCHAR', ts:'TIMESTAMP', cwd:'VARCHAR', git_branch:'VARCHAR',
-      model:'VARCHAR', provider:'VARCHAR', input_tokens:'BIGINT', output_tokens:'BIGINT', cache_read_tokens:'BIGINT',
-      cache_write_tokens:'BIGINT', service_tier:'VARCHAR', is_sidechain:'BOOLEAN',
-      tool_use_count:'INTEGER', tool_names:'VARCHAR', tool_error_count:'INTEGER', text_content:'VARCHAR'
-    })`;
+  return canonicalProjectionSql(cache.path(filePath), { provider: true });
 }
 
 function auxProjections(_filePath: string): AuxProjections {

--- a/packages/server/src/connectors/codex/normalize.ts
+++ b/packages/server/src/connectors/codex/normalize.ts
@@ -33,6 +33,8 @@ import type {
 import { codexSessionsDir } from '../../settings.js';
 import { toolNamesCsv } from '../tool-names.js';
 import { toolErrorCount } from '../tool-errors.js';
+import type { CanonicalRow } from '../canonical.js';
+import { num, rec, str } from '../json.js';
 
 interface CodexLine {
   type?: string;
@@ -73,12 +75,8 @@ const zeroUsage = (): CodexUsage => ({
   cache_read_input_tokens: 0,
 });
 
-const str = (v: unknown): string => (typeof v === 'string' ? v : '');
-const num = (v: unknown): number => (typeof v === 'number' && Number.isFinite(v) ? v : 0);
 
 /** Coerce to a record, else `{}` (arrays are not records). */
-const rec = (v: unknown): Record<string, unknown> =>
-  v && typeof v === 'object' && !Array.isArray(v) ? (v as Record<string, unknown>) : {};
 
 // --- rollout discovery + subagent linkage -------------------------------------
 
@@ -698,30 +696,6 @@ export function parseRollout(path: string): CodexSession | null {
   return { sessionId, indexSessionId, isSidechain, agentRole, cwd, gitBranch, modelProvider, events, spawnedAgents };
 }
 
-/** A canonical index row (matches the events NDJSON the projection reads). */
-export interface CanonicalRow {
-  file_path: string;
-  session_id: string;
-  uuid: string;
-  parent_uuid: string | null;
-  role: string;
-  type: string;
-  ts: string;
-  cwd: string;
-  git_branch: string | null;
-  model: string | null;
-  provider: string | null;
-  input_tokens: number;
-  output_tokens: number;
-  cache_read_tokens: number;
-  cache_write_tokens: number;
-  service_tier: string | null;
-  is_sidechain: boolean;
-  tool_use_count: number;
-  tool_names: string;
-  tool_error_count: number | null;
-  text_content: string;
-}
 
 /** Flatten a parsed session into canonical index rows for one file. */
 export function toCanonicalRows(session: CodexSession, filePath: string): CanonicalRow[] {

--- a/packages/server/src/connectors/copilot/copilot.ts
+++ b/packages/server/src/connectors/copilot/copilot.ts
@@ -14,24 +14,17 @@
  * STRICTLY READ-ONLY with respect to ~/.copilot — files are only ever read.
  */
 
-import { createHash } from 'node:crypto';
-import { existsSync, mkdirSync, readdirSync, statSync, writeFileSync } from 'node:fs';
+import { existsSync, readdirSync, statSync } from 'node:fs';
 import { join } from 'node:path';
-import { CLAUDESCOPE_HOME } from '../../config.js';
 import { copilotSessionsDir } from '../../settings.js';
-import { sqlString } from '../../db/duckdb.js';
 import type { SessionData, SubagentSource } from '../../data/session-loader.js';
 import type { AgentConnector, AuxProjections, DiscoveredFile } from '../types.js';
+import { canonicalProjectionSql, titlesProjectionSql } from '../canonical.js';
+import { ndjsonCache } from '../ndjson-cache.js';
 import { parseCopilotSession, toCanonicalRows, type CopilotSession } from './normalize.js';
 import { copilotGlobalMemory } from './memory.js';
 
-const CACHE_DIR = join(CLAUDESCOPE_HOME, 'cache', 'copilot');
-
-/** Deterministic temp NDJSON path for a given session file. */
-function cachePath(filePath: string): string {
-  const hash = createHash('sha1').update(filePath).digest('hex').slice(0, 16);
-  return join(CACHE_DIR, `${hash}.ndjson`);
-}
+const cache = ndjsonCache('copilot');
 
 /** Collect every `<uuid>/events.jsonl` under the Copilot session-state dir. */
 function discover(): DiscoveredFile[] {
@@ -59,41 +52,19 @@ function discover(): DiscoveredFile[] {
 /** Normalize a session to canonical NDJSON the projection will read. */
 async function prepare(filePath: string): Promise<void> {
   const session = parseCopilotSession(filePath);
-  mkdirSync(CACHE_DIR, { recursive: true });
   const rows = session ? toCanonicalRows(session, filePath) : [];
-  writeFileSync(cachePath(filePath), rows.map((r) => JSON.stringify(r)).join('\n') + '\n');
+  cache.write(filePath, rows);
 }
 
 function eventsProjectionSql(filePath: string): string {
-  const path = sqlString(cachePath(filePath));
-  return `
-    SELECT
-      file_path, session_id, uuid, parent_uuid, role, type, ts, cwd, git_branch,
-      model, CAST(NULL AS VARCHAR) AS provider, input_tokens, output_tokens, cache_read_tokens, cache_write_tokens,
-      service_tier, is_sidechain, tool_use_count, tool_names, tool_error_count, text_content,
-      CAST(NULL AS VARCHAR) AS message_id, CAST(NULL AS VARCHAR) AS forked_from_session_id
-    FROM read_ndjson(${path}, format='newline_delimited', maximum_object_size=268435456, ignore_errors=true, columns={
-      file_path:'VARCHAR', session_id:'VARCHAR', uuid:'VARCHAR', parent_uuid:'VARCHAR',
-      role:'VARCHAR', type:'VARCHAR', ts:'TIMESTAMP', cwd:'VARCHAR', git_branch:'VARCHAR',
-      model:'VARCHAR', input_tokens:'BIGINT', output_tokens:'BIGINT', cache_read_tokens:'BIGINT',
-      cache_write_tokens:'BIGINT', service_tier:'VARCHAR', is_sidechain:'BOOLEAN',
-      tool_use_count:'INTEGER', tool_names:'VARCHAR', tool_error_count:'INTEGER', text_content:'VARCHAR'
-    })`;
+  return canonicalProjectionSql(cache.path(filePath), { provider: false });
 }
 
 /** Copilot carries a real session title (workspace.yaml `name`), threaded through
  *  the cache NDJSON; the first-user-message fallback applies when it's empty. */
 function auxProjections(filePath: string): AuxProjections {
-  if (!existsSync(cachePath(filePath))) return {};
-  const path = sqlString(cachePath(filePath));
-  return {
-    titles: `
-      SELECT session_id, last(title) AS title
-      FROM read_ndjson(${path}, format='newline_delimited', maximum_object_size=268435456, ignore_errors=true,
-        columns={session_id:'VARCHAR', title:'VARCHAR'})
-      WHERE session_id IS NOT NULL AND title IS NOT NULL AND title <> ''
-      GROUP BY session_id`,
-  };
+  if (!existsSync(cache.path(filePath))) return {};
+  return { titles: titlesProjectionSql(cache.path(filePath)) };
 }
 
 async function loadSession(_sessionId: string, paths: string[]): Promise<SessionData> {

--- a/packages/server/src/connectors/copilot/normalize.ts
+++ b/packages/server/src/connectors/copilot/normalize.ts
@@ -51,6 +51,8 @@ import type {
 import { resolveImageWithin } from '../safe-image.js';
 import { toolNamesCsv } from '../tool-names.js';
 import { toolErrorCount } from '../tool-errors.js';
+import type { CanonicalRow } from '../canonical.js';
+import { num, rec, str } from '../json.js';
 
 /** One inline subagent run, segmented out of the parent's event stream. */
 export interface CopilotSubagent {
@@ -73,10 +75,6 @@ export interface CopilotSession {
   subagents: CopilotSubagent[];
 }
 
-const str = (v: unknown): string => (typeof v === 'string' ? v : '');
-const num = (v: unknown): number => (typeof v === 'number' && Number.isFinite(v) ? v : 0);
-const rec = (v: unknown): Record<string, unknown> =>
-  v && typeof v === 'object' ? (v as Record<string, unknown>) : {};
 
 /** Copilot stores token counts as `{tokenCount: N}` buckets. */
 const tokenCount = (v: unknown): number => num(rec(v).tokenCount);
@@ -465,31 +463,6 @@ export function parseCopilotSession(
   return { sessionId, cwd, branch, title, events: main.events, subagents };
 }
 
-/** A canonical index row (matches the events NDJSON the projection reads). */
-export interface CanonicalRow {
-  file_path: string;
-  session_id: string;
-  uuid: string;
-  parent_uuid: string | null;
-  role: string;
-  type: string;
-  ts: string;
-  cwd: string;
-  git_branch: string | null;
-  model: string | null;
-  input_tokens: number;
-  output_tokens: number;
-  cache_read_tokens: number;
-  cache_write_tokens: number;
-  service_tier: string | null;
-  is_sidechain: boolean;
-  tool_use_count: number;
-  tool_names: string;
-  tool_error_count: number | null;
-  text_content: string;
-  /** Session title (read by auxProjections; ignored by the events projection). */
-  title: string;
-}
 
 /** Flatten a parsed session into canonical index rows for one file. Subagent
  *  events are included (same session, `is_sidechain` true) so their text is

--- a/packages/server/src/connectors/grok/grok.ts
+++ b/packages/server/src/connectors/grok/grok.ts
@@ -20,23 +20,16 @@
  * STRICTLY READ-ONLY with respect to ~/.grok — files are only ever read.
  */
 
-import { createHash } from 'node:crypto';
-import { existsSync, mkdirSync, readdirSync, statSync, writeFileSync } from 'node:fs';
+import { existsSync, readdirSync, statSync } from 'node:fs';
 import { dirname, join } from 'node:path';
-import { CLAUDESCOPE_HOME } from '../../config.js';
 import { grokSessionsDir } from '../../settings.js';
-import { sqlString } from '../../db/duckdb.js';
 import type { SessionData, SubagentSource } from '../../data/session-loader.js';
 import type { AgentConnector, AuxProjections, DiscoveredFile } from '../types.js';
+import { canonicalProjectionSql, titlesProjectionSql } from '../canonical.js';
+import { ndjsonCache } from '../ndjson-cache.js';
 import { parentSessionDirOf, parseGrokSession, subagentMetas, toCanonicalRows } from './normalize.js';
 
-const CACHE_DIR = join(CLAUDESCOPE_HOME, 'cache', 'grok');
-
-/** Deterministic temp NDJSON path for a given session file. */
-function cachePath(filePath: string): string {
-  const hash = createHash('sha1').update(filePath).digest('hex').slice(0, 16);
-  return join(CACHE_DIR, `${hash}.ndjson`);
-}
+const cache = ndjsonCache('grok');
 
 /**
  * Fold a session's three files into one change signal. The discovery unit is
@@ -103,41 +96,19 @@ function discover(): DiscoveredFile[] {
 /** Normalize a session to canonical NDJSON the projection will read. */
 async function prepare(filePath: string): Promise<void> {
   const session = parseGrokSession(filePath);
-  mkdirSync(CACHE_DIR, { recursive: true });
   const rows = session ? toCanonicalRows(session, filePath) : [];
-  writeFileSync(cachePath(filePath), rows.map((r) => JSON.stringify(r)).join('\n') + '\n');
+  cache.write(filePath, rows);
 }
 
 function eventsProjectionSql(filePath: string): string {
-  const path = sqlString(cachePath(filePath));
-  return `
-    SELECT
-      file_path, session_id, uuid, parent_uuid, role, type, ts, cwd, git_branch,
-      model, CAST(NULL AS VARCHAR) AS provider, input_tokens, output_tokens, cache_read_tokens, cache_write_tokens,
-      service_tier, is_sidechain, tool_use_count, tool_names, tool_error_count, text_content,
-      CAST(NULL AS VARCHAR) AS message_id, CAST(NULL AS VARCHAR) AS forked_from_session_id
-    FROM read_ndjson(${path}, format='newline_delimited', maximum_object_size=268435456, ignore_errors=true, columns={
-      file_path:'VARCHAR', session_id:'VARCHAR', uuid:'VARCHAR', parent_uuid:'VARCHAR',
-      role:'VARCHAR', type:'VARCHAR', ts:'TIMESTAMP', cwd:'VARCHAR', git_branch:'VARCHAR',
-      model:'VARCHAR', input_tokens:'BIGINT', output_tokens:'BIGINT', cache_read_tokens:'BIGINT',
-      cache_write_tokens:'BIGINT', service_tier:'VARCHAR', is_sidechain:'BOOLEAN',
-      tool_use_count:'INTEGER', tool_names:'VARCHAR', tool_error_count:'INTEGER', text_content:'VARCHAR'
-    })`;
+  return canonicalProjectionSql(cache.path(filePath), { provider: false });
 }
 
 /** Grok carries a real session title (summary.json `generated_title`), threaded
  *  through the cache NDJSON; the first-user-message fallback applies when empty. */
 function auxProjections(filePath: string): AuxProjections {
-  if (!existsSync(cachePath(filePath))) return {};
-  const path = sqlString(cachePath(filePath));
-  return {
-    titles: `
-      SELECT session_id, last(title) AS title
-      FROM read_ndjson(${path}, format='newline_delimited', maximum_object_size=268435456, ignore_errors=true,
-        columns={session_id:'VARCHAR', title:'VARCHAR'})
-      WHERE session_id IS NOT NULL AND title IS NOT NULL AND title <> ''
-      GROUP BY session_id`,
-  };
+  if (!existsSync(cache.path(filePath))) return {};
+  return { titles: titlesProjectionSql(cache.path(filePath)) };
 }
 
 async function loadSession(_sessionId: string, paths: string[]): Promise<SessionData> {

--- a/packages/server/src/connectors/grok/normalize.ts
+++ b/packages/server/src/connectors/grok/normalize.ts
@@ -36,6 +36,8 @@ import { existsSync, readdirSync, readFileSync, statSync } from 'node:fs';
 import { basename, dirname, join } from 'node:path';
 import type { AssistantEvent, ContentBlock, MessageUsage, UserEvent } from '@claudescope/shared';
 import { toolNamesCsv } from '../tool-names.js';
+import type { CanonicalRow } from '../canonical.js';
+import { num, rec, str } from '../json.js';
 
 export interface GrokSession {
   /** Indexing key: the parent's session id for a subagent child, else the own id. */
@@ -50,10 +52,6 @@ export interface GrokSession {
   events: (UserEvent | AssistantEvent)[];
 }
 
-const str = (v: unknown): string => (typeof v === 'string' ? v : '');
-const num = (v: unknown): number => (typeof v === 'number' && Number.isFinite(v) ? v : 0);
-const rec = (v: unknown): Record<string, unknown> =>
-  v && typeof v === 'object' && !Array.isArray(v) ? (v as Record<string, unknown>) : {};
 
 /** One raw line of `chat_history.jsonl` (fields we read; others ignored). */
 interface GrokChatLine {
@@ -601,32 +599,6 @@ export function parseGrokSession(path: string): GrokSession | null {
   return { sessionId, ownId, isSidechain, cwd, title: summary.title, events };
 }
 
-/** A canonical index row (matches the events NDJSON the projection reads). */
-export interface CanonicalRow {
-  file_path: string;
-  session_id: string;
-  uuid: string;
-  parent_uuid: string | null;
-  role: string;
-  type: string;
-  ts: string;
-  cwd: string;
-  git_branch: string | null;
-  model: string | null;
-  input_tokens: number;
-  output_tokens: number;
-  cache_read_tokens: number;
-  cache_write_tokens: number;
-  service_tier: string | null;
-  is_sidechain: boolean;
-  tool_use_count: number;
-  tool_names: string;
-  /** NULL — Grok tool results carry no error signal, so the count is unknown. */
-  tool_error_count: number | null;
-  text_content: string;
-  /** Session title (read by auxProjections; ignored by the events projection). */
-  title: string;
-}
 
 /** Flatten a parsed session into canonical index rows for one file. */
 export function toCanonicalRows(session: GrokSession, filePath: string): CanonicalRow[] {

--- a/packages/server/src/connectors/json.ts
+++ b/packages/server/src/connectors/json.ts
@@ -1,0 +1,26 @@
+/**
+ * Defensive accessors for reading untrusted JSON in the connectors.
+ *
+ * Every normalizer walks `JSON.parse` output from a transcript it does not
+ * control, so a missing or wrong-typed field must degrade rather than throw.
+ * These three coercions were copy-pasted into all seven normalizers; `str` and
+ * `num` were byte-identical, and `rec` had drifted into two variants (see below).
+ */
+
+/** A string, or `''` — never `undefined`, so callers can use it directly. */
+export const str = (v: unknown): string => (typeof v === 'string' ? v : '');
+
+/** A finite number, or `0`. Rejects NaN/Infinity, which would poison sums. */
+export const num = (v: unknown): number =>
+  typeof v === 'number' && Number.isFinite(v) ? v : 0;
+
+/**
+ * A plain object, or `{}` — so `rec(x).field` is always safe.
+ *
+ * Arrays are rejected. Two of the seven copies accepted them; unified on the
+ * stricter form after confirming every call site only reads a property off the
+ * result (never spreads or iterates it), which makes the two indistinguishable:
+ * `[].field` and `{}.field` are both `undefined`.
+ */
+export const rec = (v: unknown): Record<string, unknown> =>
+  v && typeof v === 'object' && !Array.isArray(v) ? (v as Record<string, unknown>) : {};

--- a/packages/server/src/connectors/junie/junie.ts
+++ b/packages/server/src/connectors/junie/junie.ts
@@ -11,25 +11,18 @@
  * STRICTLY READ-ONLY with respect to ~/.junie — files are only ever read.
  */
 
-import { createHash } from 'node:crypto';
-import { existsSync, mkdirSync, readFileSync, statSync, writeFileSync } from 'node:fs';
+import { existsSync, readFileSync, statSync } from 'node:fs';
 import { join } from 'node:path';
 import type { MemorySource } from '@claudescope/shared';
-import { CLAUDESCOPE_HOME } from '../../config.js';
 import { junieHome, junieSessionsDir } from '../../settings.js';
 import { contractHome } from '../../util/paths.js';
-import { sqlString } from '../../db/duckdb.js';
 import type { SessionData } from '../../data/session-loader.js';
 import type { AgentConnector, AuxProjections, DiscoveredFile } from '../types.js';
+import { canonicalProjectionSql, titlesProjectionSql } from '../canonical.js';
+import { ndjsonCache } from '../ndjson-cache.js';
 import { parseSession, toCanonicalRows } from './normalize.js';
 
-const CACHE_DIR = join(CLAUDESCOPE_HOME, 'cache', 'junie');
-
-/** Deterministic temp NDJSON path for a given events file. */
-function cachePath(filePath: string): string {
-  const hash = createHash('sha1').update(filePath).digest('hex').slice(0, 16);
-  return join(CACHE_DIR, `${hash}.ndjson`);
-}
+const cache = ndjsonCache('junie');
 
 /**
  * One `DiscoveredFile` per session listed in `index.jsonl`, pointing at that
@@ -73,40 +66,18 @@ function discover(): DiscoveredFile[] {
 /** Normalize a session to canonical NDJSON the projection will read. */
 async function prepare(filePath: string): Promise<void> {
   const session = parseSession(filePath);
-  mkdirSync(CACHE_DIR, { recursive: true });
   const rows = session ? toCanonicalRows(session, filePath) : [];
-  writeFileSync(cachePath(filePath), rows.map((r) => JSON.stringify(r)).join('\n') + '\n');
+  cache.write(filePath, rows);
 }
 
 function eventsProjectionSql(filePath: string): string {
-  const path = sqlString(cachePath(filePath));
-  return `
-    SELECT
-      file_path, session_id, uuid, parent_uuid, role, type, ts, cwd, git_branch,
-      model, CAST(NULL AS VARCHAR) AS provider, input_tokens, output_tokens, cache_read_tokens, cache_write_tokens,
-      service_tier, is_sidechain, tool_use_count, tool_names, tool_error_count, text_content,
-      CAST(NULL AS VARCHAR) AS message_id, CAST(NULL AS VARCHAR) AS forked_from_session_id
-    FROM read_ndjson(${path}, format='newline_delimited', maximum_object_size=268435456, ignore_errors=true, columns={
-      file_path:'VARCHAR', session_id:'VARCHAR', uuid:'VARCHAR', parent_uuid:'VARCHAR',
-      role:'VARCHAR', type:'VARCHAR', ts:'TIMESTAMP', cwd:'VARCHAR', git_branch:'VARCHAR',
-      model:'VARCHAR', input_tokens:'BIGINT', output_tokens:'BIGINT', cache_read_tokens:'BIGINT',
-      cache_write_tokens:'BIGINT', service_tier:'VARCHAR', is_sidechain:'BOOLEAN',
-      tool_use_count:'INTEGER', tool_names:'VARCHAR', tool_error_count:'INTEGER', text_content:'VARCHAR'
-    })`;
+  return canonicalProjectionSql(cache.path(filePath), { provider: false });
 }
 
 /** Junie has an explicit session title (taskName); no PR links. */
 function auxProjections(filePath: string): AuxProjections {
-  const path = sqlString(cachePath(filePath));
-  if (!existsSync(cachePath(filePath))) return {};
-  return {
-    titles: `
-      SELECT session_id, last(title) AS title
-      FROM read_ndjson(${path}, format='newline_delimited', maximum_object_size=268435456, ignore_errors=true,
-        columns={session_id:'VARCHAR', title:'VARCHAR'})
-      WHERE session_id IS NOT NULL AND title IS NOT NULL AND title <> ''
-      GROUP BY session_id`,
-  };
+  if (!existsSync(cache.path(filePath))) return {};
+  return { titles: titlesProjectionSql(cache.path(filePath)) };
 }
 
 async function loadSession(_sessionId: string, paths: string[]): Promise<SessionData> {

--- a/packages/server/src/connectors/junie/normalize.ts
+++ b/packages/server/src/connectors/junie/normalize.ts
@@ -36,6 +36,8 @@ import type {
 import { junieHome } from '../../settings.js';
 import { resolveImageWithin } from '../safe-image.js';
 import { toolNamesCsv } from '../tool-names.js';
+import type { CanonicalRow } from '../canonical.js';
+import { num, str } from '../json.js';
 
 export interface JunieSession {
   sessionId: string;
@@ -44,8 +46,6 @@ export interface JunieSession {
   events: (UserEvent | AssistantEvent)[];
 }
 
-const str = (v: unknown): string => (typeof v === 'string' ? v : '');
-const num = (v: unknown): number => (typeof v === 'number' && Number.isFinite(v) ? v : 0);
 
 /** cwd shown for sessions Junie never recorded a directory for. */
 const UNKNOWN_CWD = '(unknown — Junie)';
@@ -415,31 +415,6 @@ export function parseSession(eventsPath: string): JunieSession | null {
   return { sessionId, cwd: cwd || UNKNOWN_CWD, title, events };
 }
 
-/** A canonical index row (matches the events NDJSON the projection reads). */
-export interface CanonicalRow {
-  file_path: string;
-  session_id: string;
-  uuid: string;
-  parent_uuid: string | null;
-  role: string;
-  type: string;
-  ts: string;
-  cwd: string;
-  git_branch: string | null;
-  model: string | null;
-  input_tokens: number;
-  output_tokens: number;
-  cache_read_tokens: number;
-  cache_write_tokens: number;
-  service_tier: string | null;
-  is_sidechain: boolean;
-  tool_use_count: number;
-  tool_names: string;
-  tool_error_count: number | null;
-  text_content: string;
-  /** Not a canonical column — read separately by the title aux projection. */
-  title: string;
-}
 
 /** Flatten a parsed session into canonical index rows for one file. */
 export function toCanonicalRows(session: JunieSession, filePath: string): CanonicalRow[] {

--- a/packages/server/src/connectors/ndjson-cache.ts
+++ b/packages/server/src/connectors/ndjson-cache.ts
@@ -1,0 +1,49 @@
+/**
+ * The per-agent NDJSON cache used by every connector that normalizes in TS.
+ *
+ * Seven connectors had a byte-identical copy of this: a `CACHE_DIR` under
+ * `~/.claudescope/cache/<agent>`, a `cachePath()` that sha1s the source path, and
+ * a `prepare()` that mkdir'd and wrote the rows. Factored out so the cache layout
+ * — and anything that needs to reason about it, such as pruning entries whose
+ * source file is gone — has one owner.
+ */
+
+import { createHash } from 'node:crypto';
+import { writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { CLAUDESCOPE_HOME, ensureStateDir } from '../config.js';
+import type { CanonicalRow } from './canonical.js';
+
+/** Root of the normalize cache. Everything under it is derived and rebuildable. */
+const CACHE_ROOT = join(CLAUDESCOPE_HOME, 'cache');
+
+export interface NdjsonCache {
+  /** Deterministic cache path for a source file (or synthetic key). */
+  path(sourcePath: string): string;
+  /** Normalize + write, replacing whatever was there. */
+  write(sourcePath: string, rows: CanonicalRow[]): void;
+}
+
+/**
+ * The cache for one agent. `path()` is a sha1 of the source path truncated to
+ * 16 hex chars — deterministic, filesystem-safe, and short enough to stay
+ * readable; opencode relies on it accepting its synthetic `<db>#<id>` keys, which
+ * aren't valid filenames.
+ */
+export function ndjsonCache(agentId: string): NdjsonCache {
+  const dir = join(CACHE_ROOT, agentId);
+  // Standalone, not a `this.path` method call: callers may destructure the cache.
+  const path = (sourcePath: string): string => {
+    const hash = createHash('sha1').update(sourcePath).digest('hex').slice(0, 16);
+    return join(dir, `${hash}.ndjson`);
+  };
+  return {
+    path,
+    write(sourcePath: string, rows: CanonicalRow[]): void {
+      // Owner-only, like the rest of the state dir: these files hold transcript
+      // text verbatim (see the state-dir rules in CLAUDE.md).
+      ensureStateDir(dir);
+      writeFileSync(path(sourcePath), rows.map((r) => JSON.stringify(r)).join('\n') + '\n');
+    },
+  };
+}

--- a/packages/server/src/connectors/opencode/normalize.ts
+++ b/packages/server/src/connectors/opencode/normalize.ts
@@ -35,9 +35,9 @@ import type {
 import type { OpencodeRawSession } from './db.js';
 import { toolNamesCsv } from '../tool-names.js';
 import { toolErrorCount } from '../tool-errors.js';
+import type { CanonicalRow } from '../canonical.js';
+import { num, str } from '../json.js';
 
-const str = (v: unknown): string => (typeof v === 'string' ? v : '');
-const num = (v: unknown): number => (typeof v === 'number' && Number.isFinite(v) ? v : 0);
 
 function parseJson(s: string): Record<string, unknown> {
   try {
@@ -383,32 +383,6 @@ export function taskSpawns(
   return map;
 }
 
-/** A canonical index row (matches the events NDJSON the projection reads). */
-export interface CanonicalRow {
-  file_path: string;
-  session_id: string;
-  uuid: string;
-  parent_uuid: string | null;
-  role: string;
-  type: string;
-  ts: string;
-  cwd: string;
-  git_branch: string | null;
-  model: string | null;
-  provider: string | null;
-  input_tokens: number;
-  output_tokens: number;
-  cache_read_tokens: number;
-  cache_write_tokens: number;
-  service_tier: string | null;
-  is_sidechain: boolean;
-  tool_use_count: number;
-  tool_names: string;
-  tool_error_count: number | null;
-  text_content: string;
-  /** Session title (read by auxProjections; ignored by the events projection). */
-  title: string;
-}
 
 /** Flatten a parsed session into canonical index rows for one file. */
 export function toCanonicalRows(session: OpencodeRawSession, filePath: string): CanonicalRow[] {

--- a/packages/server/src/connectors/opencode/opencode.ts
+++ b/packages/server/src/connectors/opencode/opencode.ts
@@ -13,18 +13,16 @@
  * STRICTLY READ-ONLY with respect to the opencode DB — it is only ever read.
  */
 
-import { createHash } from 'node:crypto';
-import { existsSync, mkdirSync, writeFileSync } from 'node:fs';
-import { join } from 'node:path';
-import { CLAUDESCOPE_HOME } from '../../config.js';
+import { existsSync } from 'node:fs';
 import { opencodeDataDir, opencodeDbPath } from '../../settings.js';
-import { sqlString } from '../../db/duckdb.js';
 import type { SessionData, SubagentSource } from '../../data/session-loader.js';
 import type { AgentConnector, AuxProjections, DiscoveredFile } from '../types.js';
+import { canonicalProjectionSql, titlesProjectionSql } from '../canonical.js';
+import { ndjsonCache } from '../ndjson-cache.js';
 import { listSessions, readSession, statSession } from './db.js';
 import { buildEvents, taskSpawns, toCanonicalRows } from './normalize.js';
 
-const CACHE_DIR = join(CLAUDESCOPE_HOME, 'cache', 'opencode');
+const cache = ndjsonCache('opencode');
 
 /** Synthetic per-session key → its DB path + session id. opencode ids are
  *  `ses_<base62>` (no `#`), so splitting on the first `#` is unambiguous. */
@@ -33,12 +31,6 @@ function parseKey(filePath: string): { dbPath: string; sessionId: string } {
   return i === -1
     ? { dbPath: filePath, sessionId: '' }
     : { dbPath: filePath.slice(0, i), sessionId: filePath.slice(i + 1) };
-}
-
-/** Deterministic temp NDJSON path for a given synthetic session key. */
-function cachePath(filePath: string): string {
-  const hash = createHash('sha1').update(filePath).digest('hex').slice(0, 16);
-  return join(CACHE_DIR, `${hash}.ndjson`);
 }
 
 /**
@@ -61,40 +53,18 @@ function discover(): DiscoveredFile[] {
 async function prepare(filePath: string): Promise<void> {
   const { dbPath, sessionId } = parseKey(filePath);
   const session = readSession(dbPath, sessionId);
-  mkdirSync(CACHE_DIR, { recursive: true });
   const rows = session ? toCanonicalRows(session, filePath) : [];
-  writeFileSync(cachePath(filePath), rows.map((r) => JSON.stringify(r)).join('\n') + '\n');
+  cache.write(filePath, rows);
 }
 
 function eventsProjectionSql(filePath: string): string {
-  const path = sqlString(cachePath(filePath));
-  return `
-    SELECT
-      file_path, session_id, uuid, parent_uuid, role, type, ts, cwd, git_branch,
-      model, provider, input_tokens, output_tokens, cache_read_tokens, cache_write_tokens,
-      service_tier, is_sidechain, tool_use_count, tool_names, tool_error_count, text_content,
-      CAST(NULL AS VARCHAR) AS message_id, CAST(NULL AS VARCHAR) AS forked_from_session_id
-    FROM read_ndjson(${path}, format='newline_delimited', maximum_object_size=268435456, ignore_errors=true, columns={
-      file_path:'VARCHAR', session_id:'VARCHAR', uuid:'VARCHAR', parent_uuid:'VARCHAR',
-      role:'VARCHAR', type:'VARCHAR', ts:'TIMESTAMP', cwd:'VARCHAR', git_branch:'VARCHAR',
-      model:'VARCHAR', provider:'VARCHAR', input_tokens:'BIGINT', output_tokens:'BIGINT', cache_read_tokens:'BIGINT',
-      cache_write_tokens:'BIGINT', service_tier:'VARCHAR', is_sidechain:'BOOLEAN',
-      tool_use_count:'INTEGER', tool_names:'VARCHAR', tool_error_count:'INTEGER', text_content:'VARCHAR'
-    })`;
+  return canonicalProjectionSql(cache.path(filePath), { provider: true });
 }
 
 /** opencode stores a real per-session title; carried through the cache NDJSON. */
 function auxProjections(filePath: string): AuxProjections {
-  if (!existsSync(cachePath(filePath))) return {};
-  const path = sqlString(cachePath(filePath));
-  return {
-    titles: `
-      SELECT session_id, last(title) AS title
-      FROM read_ndjson(${path}, format='newline_delimited', maximum_object_size=268435456, ignore_errors=true,
-        columns={session_id:'VARCHAR', title:'VARCHAR'})
-      WHERE session_id IS NOT NULL AND title IS NOT NULL AND title <> ''
-      GROUP BY session_id`,
-  };
+  if (!existsSync(cache.path(filePath))) return {};
+  return { titles: titlesProjectionSql(cache.path(filePath)) };
 }
 
 /**

--- a/packages/server/src/connectors/pi/normalize.ts
+++ b/packages/server/src/connectors/pi/normalize.ts
@@ -37,6 +37,8 @@ import { basename, dirname } from 'node:path';
 import type { AssistantEvent, ContentBlock, MessageUsage, UserEvent } from '@claudescope/shared';
 import { toolNamesCsv } from '../tool-names.js';
 import { toolErrorCount } from '../tool-errors.js';
+import type { CanonicalRow } from '../canonical.js';
+import { num, rec, str } from '../json.js';
 
 export interface PiSession {
   /** Indexing key: the parent's session id for a nested subagent, else the own id. */
@@ -49,10 +51,6 @@ export interface PiSession {
   events: (UserEvent | AssistantEvent)[];
 }
 
-const str = (v: unknown): string => (typeof v === 'string' ? v : '');
-const num = (v: unknown): number => (typeof v === 'number' && Number.isFinite(v) ? v : 0);
-const rec = (v: unknown): Record<string, unknown> =>
-  v && typeof v === 'object' && !Array.isArray(v) ? (v as Record<string, unknown>) : {};
 
 /**
  * First line of a subagent task, truncated — used as the correlation key AND
@@ -457,30 +455,6 @@ export function subagentRuns(path: string): PiSubagentRun[] {
   return runs;
 }
 
-/** A canonical index row (matches the events NDJSON the projection reads). */
-export interface CanonicalRow {
-  file_path: string;
-  session_id: string;
-  uuid: string;
-  parent_uuid: string | null;
-  role: string;
-  type: string;
-  ts: string;
-  cwd: string;
-  git_branch: string | null;
-  model: string | null;
-  provider: string | null;
-  input_tokens: number;
-  output_tokens: number;
-  cache_read_tokens: number;
-  cache_write_tokens: number;
-  service_tier: string | null;
-  is_sidechain: boolean;
-  tool_use_count: number;
-  tool_names: string;
-  tool_error_count: number | null;
-  text_content: string;
-}
 
 /** Flatten a parsed session into canonical index rows for one file. */
 export function toCanonicalRows(session: PiSession, filePath: string): CanonicalRow[] {

--- a/packages/server/src/connectors/pi/pi.ts
+++ b/packages/server/src/connectors/pi/pi.ts
@@ -18,23 +18,16 @@
  * STRICTLY READ-ONLY with respect to ~/.pi — files are only ever read.
  */
 
-import { createHash } from 'node:crypto';
-import { mkdirSync, readdirSync, statSync, writeFileSync } from 'node:fs';
+import { readdirSync, statSync } from 'node:fs';
 import { basename, dirname, join } from 'node:path';
-import { CLAUDESCOPE_HOME } from '../../config.js';
 import { piSessionsDir } from '../../settings.js';
-import { sqlString } from '../../db/duckdb.js';
 import type { SessionData, SubagentSource } from '../../data/session-loader.js';
 import type { AgentConnector, AuxProjections, DiscoveredFile } from '../types.js';
+import { canonicalProjectionSql } from '../canonical.js';
+import { ndjsonCache } from '../ndjson-cache.js';
 import { parentSessionFile, parsePiSession, subagentRuns, toCanonicalRows } from './normalize.js';
 
-const CACHE_DIR = join(CLAUDESCOPE_HOME, 'cache', 'pi');
-
-/** Deterministic temp NDJSON path for a given session file. */
-function cachePath(filePath: string): string {
-  const hash = createHash('sha1').update(filePath).digest('hex').slice(0, 16);
-  return join(CACHE_DIR, `${hash}.ndjson`);
-}
+const cache = ndjsonCache('pi');
 
 /**
  * Recursively collect every `*.jsonl` under the pi sessions dir — including
@@ -74,26 +67,12 @@ function discover(): DiscoveredFile[] {
 /** Normalize a session to canonical NDJSON the projection will read. */
 async function prepare(filePath: string): Promise<void> {
   const session = parsePiSession(filePath);
-  mkdirSync(CACHE_DIR, { recursive: true });
   const rows = session ? toCanonicalRows(session, filePath) : [];
-  writeFileSync(cachePath(filePath), rows.map((r) => JSON.stringify(r)).join('\n') + '\n');
+  cache.write(filePath, rows);
 }
 
 function eventsProjectionSql(filePath: string): string {
-  const path = sqlString(cachePath(filePath));
-  return `
-    SELECT
-      file_path, session_id, uuid, parent_uuid, role, type, ts, cwd, git_branch,
-      model, provider, input_tokens, output_tokens, cache_read_tokens, cache_write_tokens,
-      service_tier, is_sidechain, tool_use_count, tool_names, tool_error_count, text_content,
-      CAST(NULL AS VARCHAR) AS message_id, CAST(NULL AS VARCHAR) AS forked_from_session_id
-    FROM read_ndjson(${path}, format='newline_delimited', maximum_object_size=268435456, ignore_errors=true, columns={
-      file_path:'VARCHAR', session_id:'VARCHAR', uuid:'VARCHAR', parent_uuid:'VARCHAR',
-      role:'VARCHAR', type:'VARCHAR', ts:'TIMESTAMP', cwd:'VARCHAR', git_branch:'VARCHAR',
-      model:'VARCHAR', provider:'VARCHAR', input_tokens:'BIGINT', output_tokens:'BIGINT', cache_read_tokens:'BIGINT',
-      cache_write_tokens:'BIGINT', service_tier:'VARCHAR', is_sidechain:'BOOLEAN',
-      tool_use_count:'INTEGER', tool_names:'VARCHAR', tool_error_count:'INTEGER', text_content:'VARCHAR'
-    })`;
+  return canonicalProjectionSql(cache.path(filePath), { provider: true });
 }
 
 function auxProjections(_filePath: string): AuxProjections {

--- a/packages/server/src/connectors/types.ts
+++ b/packages/server/src/connectors/types.ts
@@ -23,35 +23,14 @@ export interface DiscoveredFile {
 }
 
 /**
- * Canonical inner-column contract that `eventsProjectionSql` must emit, in any
- * order (the indexer selects them by name). Cost is NOT included — it is derived
- * centrally from the token columns × pricing.
+ * The canonical inner-column contract lives in `connectors/canonical.ts` as
+ * {@link CANONICAL_COLUMNS} — a name→DuckDB-type map that GENERATES the row type,
+ * the `read_ndjson` column map, and the projection's SELECT list. It used to be
+ * restated here as a documentation-only array that nothing read, alongside three
+ * hand-written copies per connector.
+ *
+ * Cost is not part of it: it is derived centrally from the token columns.
  */
-export const CANONICAL_EVENT_COLUMNS = [
-  'file_path',
-  'session_id',
-  'uuid',
-  'parent_uuid',
-  'role',
-  'type',
-  'ts',
-  'cwd',
-  'git_branch',
-  'model',
-  // Model provider that served the turn (e.g. 'lmstudio', 'anthropic', 'openai').
-  // Nullable — NULL when the source format records no provider signal (pi/codex/opencode do).
-  'provider',
-  'input_tokens',
-  'output_tokens',
-  'cache_read_tokens',
-  'cache_write_tokens',
-  'service_tier',
-  'is_sidechain',
-  'tool_use_count',
-  'tool_names',
-  'tool_error_count',
-  'text_content',
-] as const;
 
 /**
  * Optional auxiliary, session-keyed projections. Each value is a `SELECT` body
@@ -89,7 +68,7 @@ export interface AgentConnector {
 
   /**
    * A `SELECT` projecting the (possibly {@link prepare}d) file into the canonical
-   * event columns (see {@link CANONICAL_EVENT_COLUMNS}). Executed in DuckDB.
+   * event columns (see `CANONICAL_COLUMNS` in `canonical.ts`). Executed in DuckDB.
    */
   eventsProjectionSql(filePath: string): string;
 

--- a/packages/server/test/canonical-contract.test.ts
+++ b/packages/server/test/canonical-contract.test.ts
@@ -1,0 +1,96 @@
+/**
+ * The canonical column contract, enforced.
+ *
+ * Every connector's `eventsProjectionSql` has to emit the same columns, because
+ * `loadFile` selects them by name into `events`. That contract used to be
+ * restated by hand three times per connector (a row interface, a `read_ndjson`
+ * column map, and a SELECT list) with nothing checking they agreed — a documented
+ * `CANONICAL_EVENT_COLUMNS` array existed but was never read by anything. Adding
+ * a column therefore meant editing ~16 lists, and a miss produced silently wrong
+ * data rather than a type error.
+ *
+ * Six of the connectors now generate their projection from `CANONICAL_COLUMNS`,
+ * so they cannot drift. Claude Code's is still hand-written (it reads raw JSONL
+ * with a LATERAL block aggregate rather than a normalized cache), which makes it
+ * the one that CAN drift — and the main reason this test exists.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+const work = mkdtempSync(join(tmpdir(), 'claudescope-contract-'));
+process.env.CLAUDESCOPE_HOME = join(work, 'home');
+
+const { connectors } = await import('../src/connectors/registry.js');
+const { CANONICAL_COLUMNS } = await import('../src/connectors/canonical.js');
+
+/** Columns `loadFile` selects on top of the canonical set. */
+const EXTRA = ['message_id', 'forked_from_session_id'];
+
+/**
+ * Output column names of a projection's top-level SELECT list.
+ *
+ * Paren-depth aware on both boundaries: Claude Code's projection nests a
+ * `FROM json_each(...)` inside a LATERAL join and puts commas inside CASE
+ * expressions, so naive splitting picks up the subquery's columns instead.
+ */
+function selectedColumns(sql: string): string[] {
+  const flat = sql.replace(/\s+/g, ' ');
+  const start = flat.indexOf('SELECT ') + 7;
+  let depth = 0;
+  let end = flat.length;
+  for (let i = start; i < flat.length; i++) {
+    const ch = flat[i]!;
+    if (ch === '(') depth++;
+    else if (ch === ')') depth--;
+    else if (depth === 0 && flat.startsWith(' FROM ', i)) {
+      end = i;
+      break;
+    }
+  }
+  const body = flat.slice(start, end);
+  const out: string[] = [];
+  depth = 0;
+  let cur = '';
+  for (const ch of body) {
+    if (ch === '(') depth++;
+    else if (ch === ')') depth--;
+    if (ch === ',' && depth === 0) {
+      out.push(cur);
+      cur = '';
+    } else cur += ch;
+  }
+  out.push(cur);
+  return out.map((expr) => {
+    const e = expr.trim();
+    const aliased = /\sAS\s+([A-Za-z_][\w]*)$/i.exec(e);
+    if (aliased) return aliased[1]!.toLowerCase();
+    return (e.split('.').pop() ?? e).toLowerCase();
+  });
+}
+
+describe('every connector projects exactly the canonical columns', () => {
+  const expected = [...Object.keys(CANONICAL_COLUMNS), ...EXTRA].sort();
+
+  it.each(connectors.map((c) => c.id))('%s', (id) => {
+    const c = connectors.find((x) => x.id === id)!;
+    // A path is enough: the SQL is built from it, never read here.
+    const sql = c.eventsProjectionSql('/tmp/does-not-exist/session.jsonl');
+    expect(selectedColumns(sql).sort()).toEqual(expected);
+  });
+});
+
+describe('CANONICAL_COLUMNS matches the events table it feeds', () => {
+  it('names only columns that exist in the events schema', async () => {
+    const { SCHEMA_DDL } = await import('../src/db/schema.js');
+    const eventsDdl = SCHEMA_DDL.find((d) => d.includes('CREATE TABLE IF NOT EXISTS events'))!;
+    for (const col of [...Object.keys(CANONICAL_COLUMNS), ...EXTRA]) {
+      // A column the projection emits but `events` lacks would fail every load.
+      expect(eventsDdl, `events is missing '${col}'`).toMatch(new RegExp(`\\b${col}\\b`));
+    }
+  });
+});
+
+process.on('exit', () => rmSync(work, { recursive: true, force: true }));


### PR DESCRIPTION
Plan: [docs/plans/0055-canonical-connector-contract.md](./docs/plans/0055-canonical-connector-contract.md)

Fourth PR from the repo-wide review (after #72, #73, #74). Unlike those it fixes **no user-visible defect** — it removes the maintenance hazard that made the earlier ones easy to introduce. No behaviour change is intended, and that claim is checked mechanically below.

## The problem

Seven connectors normalize a session to a canonical NDJSON, then hand the indexer a `SELECT` that reads it back. That one contract was restated **three times per connector**:

| duplicated thing | copies |
| ---------------- | -----: |
| `eventsProjectionSql` (16 lines; differ only by the `provider` column) | 7 |
| `interface CanonicalRow` (differ only by optional `provider` / `title`) | 7 |
| `CACHE_DIR` + `cachePath()` + `prepare()` | 7 |
| `str` / `num` / `rec` coercion helpers | 7 |
| `auxProjections` titles block (verbatim) | 4 |

And nothing checked the 21 columns agreed. `CANONICAL_EVENT_COLUMNS` in `types.ts` *looked* like the contract but was **dead** — the only references anywhere in the monorepo were its own declaration and one JSDoc mention. So adding `tool_error_count` in schema v10 meant editing ~16 hand-maintained lists, where a miss produces **silently wrong data** (a NULL column, a zeroed metric) rather than a type error.

## The fix

`CANONICAL_COLUMNS` is now a name→DuckDB-type map, and the row type, the `read_ndjson` column map, and the SELECT list are all *derived* from it.

A map rather than a shared SQL template on purpose: the column map and the SELECT list are two views of the same contract, and a template still lets them disagree.

**Net: 457 lines deleted, 71 added**, plus 215 lines of shared modules.

| | before | after |
|---|---|---|
| `cachePath` / `CACHE_DIR` | 7 each | 0 (shared cache) |
| `interface CanonicalRow` | 7 | 1 |
| `str` / `num` / `rec` | 7 | 1 |
| titles projection | 4 | 1 |
| `read_ndjson` call sites | 8 | 3 (2 shared + Claude Code's) |

**Claude Code's projection stays hand-written.** It reads raw JSONL with its own column map plus a LATERAL block aggregate, and has no cache file and no canonical row — routing it through the generator would mean parameterizing away everything that makes it different. It is therefore the one connector that *can* still drift, which is precisely why the new contract test covers it too.

## How "no behaviour change" was verified

The risk here is silently wrong data, not a crash, so eyeballing 457 deleted lines isn't good enough. I captured every connector's generated `eventsProjectionSql` + `auxProjections` **before** the refactor and compared **after**:

```text
connector      events SQL   col map  select list    titles
claude-code     identical      True         True      True
codex         reformatted      True         True      True
junie         reformatted      True         True      True
pi            reformatted      True         True      True
opencode      reformatted      True         True      True
copilot       reformatted      True         True      True
antigravity   reformatted      True         True      True
grok          reformatted      True         True      True

column maps, SELECT lists and aux projections all equivalent: True
```

Text differs only in whitespace; Claude Code's is byte-identical because it wasn't touched.

## The contract is now actually enforced

`test/canonical-contract.test.ts` asserts every connector projects exactly the canonical column set, and that every canonical column exists in the `events` DDL. Verified it catches drift **in both directions**:

- removing a column from Claude Code's hand-written projection → its case fails;
- adding a column to `CANONICAL_COLUMNS` without adding it to the `events` DDL → the schema case fails.

That's the check `CANONICAL_EVENT_COLUMNS` never provided.

## Two judgement calls

**`rec` unified on the stricter variant.** Five copies rejected arrays, two accepted them. I confirmed first that every call site only reads a property off the result (never spreads or iterates it), which makes the two indistinguishable — `[].field` and `{}.field` are both `undefined`.

**`zeroUsage` left alone.** Its four copies look duplicated, but the types genuinely diverge: Codex's deliberately omits `cache_creation_input_tokens`, and Junie's needs an index signature for delta accumulation. Unifying two of four would add an import without removing the hazard — a token dedup that reads worse than leaving it.

## Testing

- `npm test` **554 passed / 58 files** (was 545/57), run 3×; typecheck, build, markdownlint clean.
- The per-connector integration suites (`codex`, `pi`, `grok`, `copilot`, `junie`, `opencode`, `antigravity`) are the behavioural net and all still pass unchanged.

## Follow-up this unblocks

Pruning the normalize cache (a deleted source currently leaves its plaintext copy behind forever) was 7 edits before; with one `ndjsonCache` owner it's a handful of lines. That's the next PR.