### PR TITLE
fix: prune the normalize cache when its source session is gone

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,6 +61,11 @@ npm-workspaces monorepo (`packages/*`):
   so global installs survive upgrades — do not move it back into the package.
 - App-owned state is created **owner-only** — always via `ensureStateDir()` from
   `config.ts`, never a bare `mkdirSync`.
+- The normalize cache (`cache/<agent>/*.ndjson`, written by `prepare()`) holds
+  transcript text **verbatim**, so it is pruned every pass once its source file is
+  gone — `ndjsonCache` owns the layout and `pruneNdjsonCaches` the sweep. A
+  connector whose `discover()` threw is excluded, exactly as its indexed sessions
+  are: the absence is transient, not a deletion.
 - The web Settings page's Start/Stop/Restart control the **indexer** (the
   reindex poller — `indexer-lifecycle.ts`), never the HTTP process; stopping
   the server stays terminal-only (`claudescope stop`). The pause flag is

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -43,10 +43,12 @@ None of these are misused; they're listed here so you can verify that.
 - **Writes** only inside its own state dir `~/.claudescope/` (override:
   `$CLAUDESCOPE_HOME`): the DuckDB index (a rebuildable cache), a user-editable
   `pricing.json`, the daemon PID/port file, and logs.
-- **Creates that state dir owner-only** (`0700`, files `0600`) — the index is a
-  searchable copy of every transcript it can read. A directory an older version
-  created with the default umask is tightened at startup; files already written
-  keep their mode, so run `chmod -R go-rwx ~/.claudescope` to tighten those.
+- **Creates that state dir owner-only** (`0700`, files `0600`) — the index, and
+  the normalized per-session copies under `cache/`, hold transcript text verbatim.
+  Those copies are removed automatically once the source session is gone.
+  A directory an older version created with the default umask is tightened at
+  startup; files already written keep their mode, so run
+  `chmod -R go-rwx ~/.claudescope` to tighten those.
 
 ### Network
 

--- a/docs/plans/0056-prune-normalize-cache.md
+++ b/docs/plans/0056-prune-normalize-cache.md
@@ -2,7 +2,7 @@
 
 - **Status:** done <!-- proposed | in-progress | done | superseded | abandoned -->
 - **Date:** 2026-07-29
-- **PR:** <link, once opened>
+- **PR:** https://github.com/vladar107/claudescope/pull/76
 
 ## Context
 

--- a/docs/plans/0056-prune-normalize-cache.md
+++ b/docs/plans/0056-prune-normalize-cache.md
@@ -1,0 +1,97 @@
+# 0056 — Prune the normalize cache when its source is gone
+
+- **Status:** done <!-- proposed | in-progress | done | superseded | abandoned -->
+- **Date:** 2026-07-29
+- **PR:** <link, once opened>
+
+## Context
+
+Fifth PR from the repo-wide review, and the one [0055](./0055-canonical-connector-contract.md)
+was sequenced to unblock.
+
+Seven connectors write the normalized session to
+`~/.claudescope/cache/<agent>/<hash>.ndjson`. That file holds `text_content` for
+every event — the transcript **verbatim**, including any secret that appeared in
+it. Nothing ever removed one. Verified against a real index:
+
+```text
+after index   → cache: [{"f":"5be5aaac615e1f24.ndjson","bytes":1154}]
+              → cache contains the transcript secret verbatim: true
+after DELETE  → events in DB: 0 (correctly pruned)
+              → cache: [{"f":"5be5aaac615e1f24.ndjson","bytes":1154}] ← NOT pruned
+after REBUILD → cache: [{"f":"5be5aaac615e1f24.ndjson","bytes":1154}] ← still NOT pruned
+              → source file exists: false
+```
+
+Three paths that all looked like they should clean up, and none did: the
+indexer's removed-file prune deletes DB rows only, `discardDbFiles()` removes
+`index.duckdb*` only, and no CLI command touches the cache. So deleting a session
+from `~/.codex` left Claudescope's plaintext copy on disk indefinitely — which
+contradicts the read-only-viewer framing — and the directory only ever grew.
+
+## Goal
+
+A cache entry does not outlive the source file it was derived from, and orphans
+already on disk are cleaned up too.
+
+## Decisions
+
+- **Sweep, don't delete-on-removal** — the precise fix is to unlink the entry as
+  its source disappears in the removed-file loop. A sweep (keep exactly the
+  entries the live source set hashes to; delete the rest) is the same size and
+  also heals orphans already on disk: from versions before this change, and from
+  a crash between `prepare()` and the load. The sweep subsumes the precise case.
+- **Own it in `ndjson-cache.ts`, not on the connector port** — the indexer knows
+  each file's `connector.id` but not its cache path. Exposing `cachePath()` on
+  `AgentConnector` would leak the layout onto the port, and a per-connector
+  `prune()` would reintroduce the seven copies 0055 just removed. The cache
+  module already owns the naming rule, so it owns the sweep.
+- **Run it every pass, not only passes with work** — a handful of `readdir`s over
+  small directories, dwarfed by the hundreds of `stat`s discovery already does.
+  Gating it on "something changed" would leave pre-existing orphans until the next
+  real edit for no meaningful saving.
+- **Exclude a connector whose `discover()` threw** — the interesting edge. The
+  indexer already preserves such a connector's indexed sessions because the
+  absence is transient; its cache needs the same protection, or a flaky source
+  would delete the very entries it is about to need. Encoded as "an agent absent
+  from the live map is skipped entirely", which makes the caller's intent explicit
+  rather than passing an empty list.
+
+## Approach
+
+1. `connectors/ndjson-cache.ts` — extract `cacheFileName()` as the single naming
+   rule and add `pruneNdjsonCaches(live)`.
+2. `data/index.ts` — build the live map from `discovered`, skipping
+   `failedConnectors`, and sweep right after discovery.
+3. Tests — the deletion path, the orphan sweep, the do-not-touch-live-entries
+   guard, and the connector-failure isolation.
+
+## Files affected
+
+- `packages/server/src/connectors/ndjson-cache.ts` — `pruneNdjsonCaches`.
+- `packages/server/src/data/index.ts` — build the live map and sweep.
+- `packages/server/test/cache-prune.integration.test.ts` — new.
+- `CLAUDE.md` / `SECURITY.md` — the cache and its retention rule.
+
+## Testing
+
+- `npm test` (554 → 559), `npm run typecheck`, `npm run build`, markdownlint.
+- The tests assert the secret is present while the session exists and **absent**
+  after it is deleted, so they check the actual property that matters rather than
+  a file count.
+- Regression-checked both ways: removing the sweep fails 3 cases; sweeping without
+  the failed-connector exclusion fails the isolation case.
+- A "keeps the entry for a source that still exists" case guards the catastrophic
+  failure mode — only CHANGED files are re-`prepare()`d, so a wrongly-pruned entry
+  would leave the projection reading a missing file.
+
+## Risks / open questions
+
+- An agent whose source directory is temporarily absent (unmounted, renamed)
+  discovers zero files rather than throwing, so its cache is swept. That matches
+  what already happens to its indexed sessions in the same situation, so the two
+  stay consistent — but it means a re-mount pays a re-normalize.
+- The sweep only removes `*.ndjson`. Anything else under `cache/<agent>/` is left
+  alone, so an unrelated file dropped there is never deleted.
+- No CLI escape hatch was added (`claudescope cache clear`): the sweep makes it
+  unnecessary, and the state dir is already documented as safe to delete wholesale.

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -80,3 +80,4 @@ decision, or a change worth explaining before doing. Skip it for one-line fixes.
 | 0053 | [Validate query params before they reach SQL](./0053-validate-query-params.md) | done |
 | 0054 | [Don't SIGTERM a PID we don't own; validate the port](./0054-daemon-pid-ownership-and-port.md) | done |
 | 0055 | [One canonical connector contract instead of sixteen](./0055-canonical-connector-contract.md) | done |
+| 0056 | [Prune the normalize cache when its source is gone](./0056-prune-normalize-cache.md) | done |

--- a/packages/server/src/connectors/ndjson-cache.ts
+++ b/packages/server/src/connectors/ndjson-cache.ts
@@ -9,7 +9,7 @@
  */
 
 import { createHash } from 'node:crypto';
-import { writeFileSync } from 'node:fs';
+import { readdirSync, rmSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { CLAUDESCOPE_HOME, ensureStateDir } from '../config.js';
 import type { CanonicalRow } from './canonical.js';
@@ -30,13 +30,59 @@ export interface NdjsonCache {
  * readable; opencode relies on it accepting its synthetic `<db>#<id>` keys, which
  * aren't valid filenames.
  */
+/** The cache filename a source path maps to. The layout's one naming rule. */
+function cacheFileName(sourcePath: string): string {
+  return `${createHash('sha1').update(sourcePath).digest('hex').slice(0, 16)}.ndjson`;
+}
+
+/**
+ * Delete cache entries whose source file is no longer indexed.
+ *
+ * These files hold the normalized transcript **verbatim** — prompts, responses,
+ * tool output, and whatever secrets happened to appear in them. Nothing used to
+ * remove them: not the indexer's removed-file prune (which only deleted DB rows),
+ * not "Rebuild index" (which only discards `index.duckdb*`), and no CLI command.
+ * So deleting a session from `~/.codex` left Claudescope's plaintext copy on disk
+ * indefinitely, and the directory grew without bound.
+ *
+ * Sweeping (rather than deleting one entry as its source disappears) also heals
+ * orphans already on disk — from earlier versions, or from a crash between
+ * `prepare()` and the load.
+ *
+ * `live` maps an agent id to the source paths that agent currently owns. An agent
+ * ABSENT from the map is skipped entirely, which is how the caller protects a
+ * connector whose discovery just failed: its files are missing this pass, but
+ * that is transient, not a deletion. Returns the number of files removed.
+ */
+export function pruneNdjsonCaches(live: Map<string, Iterable<string>>): number {
+  let removed = 0;
+  for (const [agentId, sourcePaths] of live) {
+    const dir = join(CACHE_ROOT, agentId);
+    let entries: string[];
+    try {
+      entries = readdirSync(dir);
+    } catch {
+      continue; // no cache dir for this agent (e.g. it needs no prepare())
+    }
+    const keep = new Set<string>();
+    for (const p of sourcePaths) keep.add(cacheFileName(p));
+    for (const entry of entries) {
+      if (!entry.endsWith('.ndjson') || keep.has(entry)) continue;
+      try {
+        rmSync(join(dir, entry), { force: true });
+        removed += 1;
+      } catch {
+        /* best-effort: a file we can't remove must not fail the pass */
+      }
+    }
+  }
+  return removed;
+}
+
 export function ndjsonCache(agentId: string): NdjsonCache {
   const dir = join(CACHE_ROOT, agentId);
   // Standalone, not a `this.path` method call: callers may destructure the cache.
-  const path = (sourcePath: string): string => {
-    const hash = createHash('sha1').update(sourcePath).digest('hex').slice(0, 16);
-    return join(dir, `${hash}.ndjson`);
-  };
+  const path = (sourcePath: string): string => join(dir, cacheFileName(sourcePath));
   return {
     path,
     write(sourcePath: string, rows: CanonicalRow[]): void {

--- a/packages/server/src/data/index.ts
+++ b/packages/server/src/data/index.ts
@@ -19,6 +19,7 @@ import type { DuckDBConnection } from '@duckdb/node-api';
 import type { IndexingProgress, PricingConfig, ReindexResponse } from '@claudescope/shared';
 import { closeConnection, discardDbFiles, getConnection, queryRows, sqlString } from '../db/duckdb.js';
 import { connectors } from '../connectors/registry.js';
+import { pruneNdjsonCaches } from '../connectors/ndjson-cache.js';
 import type { AgentConnector, DiscoveredFile } from '../connectors/types.js';
 import { loadPricing } from './pricing.js';
 import { cleanFallbackTitle } from './title.js';
@@ -561,6 +562,24 @@ async function doReindex(): Promise<ReindexResponse> {
         err,
       );
     }
+  }
+
+  // Drop normalize-cache entries whose source file is gone. These hold the
+  // transcript verbatim, so a deleted session must not leave a plaintext copy
+  // behind (nothing removed them before — not the prune below, not a rebuild).
+  // A connector whose discovery just failed is EXCLUDED, for the same reason its
+  // indexed sessions are: its files are missing transiently, not deleted.
+  // Runs every pass, not just passes with work — it is a handful of readdirs
+  // against small directories, dwarfed by discovery's own stat calls, and that
+  // makes it self-healing for orphans left by older versions.
+  const liveByAgent = new Map<string, string[]>();
+  for (const connector of connectors) {
+    if (!failedConnectors.has(connector.id)) liveByAgent.set(connector.id, []);
+  }
+  for (const { file, connector } of discovered) liveByAgent.get(connector.id)?.push(file.path);
+  const prunedCacheFiles = pruneNdjsonCaches(liveByAgent);
+  if (prunedCacheFiles > 0) {
+    console.warn(`claudescope: pruned ${prunedCacheFiles} stale normalize-cache file(s)`);
   }
 
   // Build a lookup of already-indexed (path -> mtime,size,connector).

--- a/packages/server/test/cache-prune.integration.test.ts
+++ b/packages/server/test/cache-prune.integration.test.ts
@@ -1,0 +1,165 @@
+/**
+ * Normalize-cache pruning.
+ *
+ * Connectors that can't be projected per-row write the normalized session to
+ * `~/.claudescope/cache/<agent>/<hash>.ndjson` — the transcript **verbatim**,
+ * including whatever secrets appeared in it. Nothing removed those files: not the
+ * indexer's removed-file prune (DB rows only), not "Rebuild index" (which discards
+ * `index.duckdb*`), and no CLI command. So deleting a session from `~/.codex` left
+ * Claudescope's plaintext copy on disk indefinitely, and the directory only grew.
+ *
+ * The interesting edge is the interaction with connector isolation: a connector
+ * whose `discover()` throws has its indexed sessions deliberately preserved
+ * (the absence is transient), so its cache must be preserved too — otherwise a
+ * flaky source would delete the cache it is about to need again.
+ */
+
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { existsSync, mkdirSync, mkdtempSync, readdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+// --- temp locations (decided before any server module is imported) ----------
+const work = mkdtempSync(join(tmpdir(), 'claudescope-cacheprune-'));
+const home = join(work, 'home');
+const codexDir = join(work, 'codex');
+
+process.env.CLAUDE_PROJECTS_DIR = join(work, 'claude-empty');
+process.env.CODEX_SESSIONS_DIR = codexDir;
+for (const v of [
+  'JUNIE_SESSIONS_DIR',
+  'PI_SESSIONS_DIR',
+  'OPENCODE_DATA_DIR',
+  'COPILOT_SESSIONS_DIR',
+  'ANTIGRAVITY_CLI_DIR',
+  'ANTIGRAVITY_DIR',
+  'GROK_SESSIONS_DIR',
+]) {
+  process.env[v] = join(work, `${v.toLowerCase()}-empty`);
+}
+process.env.DUCKDB_PATH = join(work, 'index.duckdb');
+process.env.CLAUDESCOPE_HOME = home;
+process.env.REINDEX_INTERVAL_MS = '0';
+
+const SECRET = 'sk-cache-prune-must-not-outlive-the-source-9f2b';
+const ts = (s: number) => new Date(Date.UTC(2026, 2, 1, 10, 0, s)).toISOString();
+const codexCache = join(home, 'cache', 'codex');
+
+/** A minimal but real Codex rollout, so the normalizer actually produces rows. */
+function writeRollout(name: string, sessionId: string, secret: string): string {
+  const dir = join(codexDir, '2026', '03', '01');
+  mkdirSync(dir, { recursive: true });
+  const file = join(dir, `rollout-2026-03-01T10-00-00-${name}.jsonl`);
+  writeFileSync(
+    file,
+    [
+      { type: 'session_meta', timestamp: ts(0), payload: { id: sessionId, cwd: '/tmp/cacheproj', cli_version: '0.122.0', model_provider: 'openai', git: { branch: 'main' } } },
+      { type: 'turn_context', timestamp: ts(1), payload: { model: 'gpt-5.4', cwd: '/tmp/cacheproj' } },
+      { type: 'response_item', timestamp: ts(2), payload: { type: 'message', role: 'user', content: [{ type: 'input_text', text: secret }] } },
+      { type: 'response_item', timestamp: ts(3), payload: { type: 'message', role: 'assistant', content: [{ type: 'output_text', text: 'noted' }] } },
+      { type: 'event_msg', timestamp: ts(4), payload: { type: 'token_count', info: { last_token_usage: { input_tokens: 100, output_tokens: 50 } }, rate_limits: {} } },
+    ]
+      .map((r) => JSON.stringify(r))
+      .join('\n') + '\n',
+  );
+  return file;
+}
+
+const cacheFiles = (): string[] => {
+  try {
+    return readdirSync(codexCache).filter((f) => f.endsWith('.ndjson')).sort();
+  } catch {
+    return [];
+  }
+};
+
+/** Does any cache file still contain the transcript's secret? */
+const secretOnDisk = (): boolean =>
+  cacheFiles().some((f) => readFileSync(join(codexCache, f), 'utf8').includes(SECRET));
+
+let reindex: () => Promise<import('@claudescope/shared').ReindexResponse>;
+let closeConnection: () => Promise<void>;
+let fileA: string;
+let fileB: string;
+
+beforeAll(async () => {
+  mkdirSync(home, { recursive: true });
+  fileA = writeRollout('aaaaaaaa-0000-4000-8000-00000000000a', 'codex-cache-a', SECRET);
+  fileB = writeRollout('bbbbbbbb-0000-4000-8000-00000000000b', 'codex-cache-b', 'nothing secret here');
+
+  ({ reindex } = await import('../src/data/index.js'));
+  ({ closeConnection } = await import('../src/db/duckdb.js'));
+  await reindex();
+});
+
+afterAll(async () => {
+  await closeConnection?.();
+  rmSync(work, { recursive: true, force: true });
+});
+
+describe('a deleted session leaves no plaintext copy behind', () => {
+  it('caches both sessions while they exist', () => {
+    expect(cacheFiles()).toHaveLength(2);
+    // The whole reason this matters: the cache holds the transcript verbatim.
+    expect(secretOnDisk()).toBe(true);
+  });
+
+  it('prunes the cache entry when its source file is deleted', async () => {
+    rmSync(fileA);
+    await reindex();
+
+    expect(cacheFiles()).toHaveLength(1);
+    expect(secretOnDisk()).toBe(false);
+    // The surviving session is untouched — pruning is per-file, not a wipe.
+    expect(readFileSync(join(codexCache, cacheFiles()[0]!), 'utf8')).toContain('codex-cache-b');
+  });
+
+  it('sweeps an orphan that no connector ever claimed', async () => {
+    // Simulates a file left by an older version, or a crash between prepare()
+    // and the load. The name is not any live source's hash, so it must go.
+    const orphan = join(codexCache, 'deadbeefdeadbeef.ndjson');
+    writeFileSync(orphan, `{"session_id":"gone","text_content":"${SECRET}"}\n`);
+    expect(existsSync(orphan)).toBe(true);
+
+    await reindex();
+    expect(existsSync(orphan)).toBe(false);
+    expect(secretOnDisk()).toBe(false);
+  });
+
+  it('keeps the entry for a source that still exists', async () => {
+    // Guards the obvious catastrophic failure: an over-eager sweep deleting the
+    // cache of every unchanged file (only CHANGED files are re-prepared, so a
+    // wrongly-pruned entry would leave the projection reading a missing file).
+    const before = cacheFiles();
+    await reindex();
+    await reindex();
+    expect(cacheFiles()).toEqual(before);
+    expect(existsSync(fileB)).toBe(true);
+  });
+});
+
+describe('a connector whose discovery fails keeps its cache', () => {
+  it('does not prune when discover() throws', async () => {
+    const { connectors } = await import('../src/connectors/registry.js');
+    const codex = connectors.find((c) => c.id === 'codex')!;
+    const realDiscover = codex.discover;
+    const before = cacheFiles();
+    expect(before).toHaveLength(1);
+
+    // Same isolation the indexer applies to indexed sessions: a throwing
+    // connector's absence is transient, so its cache must survive.
+    codex.discover = () => {
+      throw new Error('transient source failure');
+    };
+    try {
+      await reindex();
+      expect(cacheFiles()).toEqual(before);
+    } finally {
+      codex.discover = realDiscover;
+    }
+
+    // And it recovers once discovery works again.
+    await reindex();
+    expect(cacheFiles()).toEqual(before);
+  });
+});


### PR DESCRIPTION
Plan: [docs/plans/0056-prune-normalize-cache.md](./docs/plans/0056-prune-normalize-cache.md)

Fifth PR from the repo-wide review, and the one #75 was sequenced to unblock.

## The problem

Seven connectors write the normalized session to `~/.claudescope/cache/<agent>/<hash>.ndjson`. That file holds `text_content` for every event — the transcript **verbatim**, including any secret that appeared in it. Nothing ever removed one.

Three paths that all look like they should clean up, and none did:

| path | what it actually removes |
|---|---|
| the indexer's removed-file prune | DB rows only |
| `discardDbFiles()` ("Rebuild index") | `index.duckdb*` only |
| any CLI command | nothing |

Verified against a real index before the fix:

```text
after index   → cache: [{"f":"5be5aaac615e1f24.ndjson","bytes":1154}]
              → cache contains the transcript secret verbatim: true
after DELETE  → events in DB: 0 (correctly pruned)
              → cache: [{"f":"5be5aaac615e1f24.ndjson","bytes":1154}] ← NOT pruned
after REBUILD → cache: [{"f":"5be5aaac615e1f24.ndjson","bytes":1154}] ← still NOT pruned
              → source file exists: false
```

So deleting a session from `~/.codex` left Claudescope's plaintext copy on disk indefinitely — which contradicts the read-only-viewer framing — and the directory only ever grew.

## The fix

`pruneNdjsonCaches(live)` keeps exactly the entries the live source set hashes to and deletes the rest, every pass.

**A sweep rather than an unlink in the removed-file loop.** Same size, and it also heals orphans already on disk: from versions before this change, and from a crash between `prepare()` and the load.

**It lives in `ndjson-cache.ts`** because that module already owns the naming rule. Putting `cachePath()` on `AgentConnector` would leak the layout onto the port, and a per-connector `prune()` would reintroduce the seven copies #75 just removed. Net effect of doing #75 first: this is ~40 lines instead of seven edits.

**Runs every pass, not only passes with work** — a handful of `readdir`s over small directories, dwarfed by the hundreds of `stat`s discovery already does. Gating it on "something changed" would leave pre-existing orphans until the next real edit for no meaningful saving.

## The edge worth your attention

A connector whose `discover()` **throws** is excluded from the sweep. The indexer already preserves such a connector's indexed sessions because the absence is transient (a flaky opencode SQLite read, say) — its cache needs the same protection, or that same flake would delete the entries it is about to need again.

Encoded as "an agent absent from the live map is skipped entirely", so the caller's intent is explicit rather than relying on an empty list meaning something special. There's a dedicated test for it.

## Testing

- `npm test` **559 passed / 59 files** (was 554/59), run 3×; typecheck, build, markdownlint clean.
- The tests assert the **secret is present** while the session exists and **absent** after deletion — checking the property that actually matters, not a file count.
- Regression-checked both directions:
  - removing the sweep → **3 failures**;
  - sweeping *without* the failed-connector exclusion → the isolation case fails.
- A "keeps the entry for a source that still exists" case guards the catastrophic failure mode: only CHANGED files are re-`prepare()`d, so a wrongly-pruned entry would leave the projection reading a missing file.

## Docs

Two short factual clauses, in the same register as the ones you kept last time — `CLAUDE.md` (the state list never mentioned the cache at all, plus the isolation rule) and `SECURITY.md` (the retention behaviour, which is what an auditor would want to know). Happy to drop either.

## Note

An agent whose source directory is temporarily absent (unmounted, renamed) discovers zero files rather than throwing, so its cache is swept. That matches what already happens to its indexed sessions in the same situation — the two stay consistent — but it means a re-mount pays a re-normalize.