### PR TITLE
fix: harden the paths that render untrusted transcript content

### DIFF
--- a/docs/plans/0057-untrusted-content-hardening.md
+++ b/docs/plans/0057-untrusted-content-hardening.md
@@ -2,7 +2,7 @@
 
 - **Status:** done <!-- proposed | in-progress | done | superseded | abandoned -->
 - **Date:** 2026-07-29
-- **PR:** <link, once opened>
+- **PR:** https://github.com/vladar107/claudescope/pull/77
 
 ## Context
 

--- a/docs/plans/0057-untrusted-content-hardening.md
+++ b/docs/plans/0057-untrusted-content-hardening.md
@@ -1,0 +1,112 @@
+# 0057 — Untrusted-content hardening
+
+- **Status:** done <!-- proposed | in-progress | done | superseded | abandoned -->
+- **Date:** 2026-07-29
+- **PR:** <link, once opened>
+
+## Context
+
+Sixth PR from the repo-wide review. Four small guards on the paths that handle
+transcript content, which is untrusted: a transcript can be hand-edited, shared,
+or written by an agent that hit a bug. Two are live defects, two are latent — and
+the plan says which is which, because two of them would be easy to oversell.
+
+**1. `redactText` misses Windows home paths (LIVE).** The drive-letter branch was
+followed by a literal `\/`, so `C:\Users\alice\src` never matched and the username
+survived into exported Markdown and MCP/CLI output — exactly the thing the redact
+toggle exists to prevent. POSIX paths were fine.
+
+**2. Search snippets corrupt themselves (LIVE).** Marking escaped the window and
+then ran one regex replace *per term* over the result, so a later term could match
+markup an earlier one inserted. Searching `book mark` produced:
+
+```text
+the <<mark>mark</mark>>book</<mark>mark</mark>><mark>mark</mark> is here
+```
+
+Rendered through `dangerouslySetInnerHTML`. **Not XSS** — traced it: the only `<`
+and `>` introduced come from the two literal tag strings, and the replacement is a
+constant so `$&`-style injection is impossible. Garbled output, not a hole.
+
+**3. The thread assembler crashes on odd `message` shapes (LATENT).** Transcripts
+are read with `JSON.parse(...) as RawEvent` and never shape-checked, so a
+`user`/`assistant` row can carry no `message`, or a `content` that is neither
+string nor array. The indexer's SQL *explicitly* tolerates this
+(`WHEN message IS NULL THEN …`), so such rows get indexed — and then the detail
+route 500'd on `Cannot read properties of undefined`, leaving a session that lists
+in Browse but cannot be opened. Scanning the reviewer's real corpus found **0 of
+5,687** such rows, so this is a robustness guard, not a live bug.
+
+**4. `extractImage` trusts `media_type` (LATENT).** The base64 branch interpolated
+it verbatim, so a poisoned block yielded `data:text/html;base64,…` — while the
+sibling `url` branch carefully rejects non-image schemes and the *server's*
+inliner has had an allowlist all along. Inert today: both callers use it only as
+`<img src>`, where `text/html` simply fails to load, and the CSP allows `data:`
+for images only.
+
+## Goal
+
+Nothing in a transcript can crash a page, corrupt rendered output, or leak a
+username through the redact toggle.
+
+## Decisions
+
+- **Mark in one pass over the raw window instead of escaping first** — collect
+  match spans, merge them, then emit escaped text with `<mark>` around the
+  matched ranges. `<mark>` is never re-scanned, overlapping matches merge instead
+  of nesting, and it removes the need to regex-escape user input at all (matching
+  is `indexOf`-based, so there is no pattern). Rejected: marking with a
+  placeholder and substituting at the end — same result, more moving parts.
+- **A malformed row yields no blocks rather than a placeholder turn** — the
+  assembler already skips turns that produce no blocks (that is how tool-result-only
+  turns are folded away), so reusing that path needs no new concept. It also keeps
+  `event.message.role` safe below without a second guard, which is now noted at
+  that line because the dependency is not obvious.
+- **Accept any `image/*` subtype, not a fixed list** — the invariant is "an
+  `<img src>` only ever gets an image type", and enumerating formats would drop
+  legitimate ones (avif, and future additions). SVG cannot execute script when
+  loaded via `<img>`, so it needs no special case.
+- **Do NOT tighten path matching while fixing the Windows branch** — writing the
+  tests surfaced a pre-existing false positive: `/Users` is unanchored, so
+  `/var/Users/notahome` collapses to `/var~`. It is also what makes a mounted home
+  (`/mnt/backup/Users/alice`) redact correctly, and for a redaction helper
+  over-masking is the safe direction. Documented in a test rather than changed —
+  altering path semantics does not belong in a hardening PR.
+
+## Approach
+
+1. `routes/snippet.ts` — `matchSpans()` + single-pass emit; drop `escapeRegExp`.
+2. `shared/redact.ts` — separator character class, case-insensitive drive letter.
+3. `data/parser.ts` — one `messageContent()` helper for both deref sites.
+4. `web/components/image.ts` — `isImageMediaType()` on the base64 branch.
+5. Tests for each, extending the three existing files plus a new `redact.test.ts`.
+
+## Files affected
+
+- `packages/server/src/routes/snippet.ts`
+- `packages/shared/src/redact.ts`
+- `packages/server/src/data/parser.ts`
+- `packages/web/src/components/image.ts`
+- `packages/server/test/{snippet,parser}.test.ts`, `packages/web/test/image.test.ts`
+- `packages/shared/test/redact.test.ts` — new (redaction had no tests at all).
+
+## Testing
+
+- `npm test` (559 → 583), `npm run typecheck`, `npm run build`, markdownlint.
+- Each fix regression-checked by reverting it: snippet **2** failures, redact
+  **3**, parser **6**, image **1**.
+- The snippet tests pin the merge behaviour, casing preservation, escaping inside
+  a match, and that regex metacharacters in a term are now literal.
+- The parser tests assert the surrounding good turns survive one malformed row,
+  and that tool_use/tool_result pairing still works across one.
+
+## Risks / open questions
+
+- Snippet output changes shape for overlapping matches (one merged `<mark>`
+  instead of nested tags). Strictly better rendering; no caller parses it.
+- `redactText` remains deliberately conservative on secrets — prefix-anchored
+  patterns only. The new tests pin what it *claims* to cover rather than implying
+  completeness.
+- The unanchored `/Users` false positive is now documented, not fixed. If it ever
+  matters, the fix is a boundary assertion — but it would make mounted-home paths
+  leak instead.

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -81,3 +81,4 @@ decision, or a change worth explaining before doing. Skip it for one-line fixes.
 | 0054 | [Don't SIGTERM a PID we don't own; validate the port](./0054-daemon-pid-ownership-and-port.md) | done |
 | 0055 | [One canonical connector contract instead of sixteen](./0055-canonical-connector-contract.md) | done |
 | 0056 | [Prune the normalize cache when its source is gone](./0056-prune-normalize-cache.md) | done |
+| 0057 | [Untrusted-content hardening](./0057-untrusted-content-hardening.md) | done |

--- a/packages/server/src/data/parser.ts
+++ b/packages/server/src/data/parser.ts
@@ -34,6 +34,24 @@ function isConversational(e: RawEvent): e is UserEvent | AssistantEvent {
   return e.type === 'user' || e.type === 'assistant';
 }
 
+/**
+ * A conversational event's `message.content`, or `null` when the row can't
+ * supply one.
+ *
+ * Transcripts are parsed with `JSON.parse(...) as RawEvent` — no shape
+ * validation — so a `user`/`assistant` row may carry no `message` at all, or a
+ * `content` that is neither a string nor an array. The indexer's SQL already
+ * tolerates exactly this (`WHEN message IS NULL THEN …` in the Claude Code
+ * projection), so such rows DO get indexed; the session then appeared in Browse
+ * and the detail route 500'd on `Cannot read properties of undefined`. Returning
+ * null makes the row produce no blocks, which the assembler already skips.
+ */
+function messageContent(event: UserEvent | AssistantEvent): string | ContentBlock[] | null {
+  const content = (event as { message?: { content?: unknown } }).message?.content;
+  if (typeof content === 'string') return content;
+  return Array.isArray(content) ? (content as ContentBlock[]) : null;
+}
+
 /** Normalize tool_result.content (string | ContentBlock[]) to ContentBlock[]. */
 function normalizeResultContent(content: string | ContentBlock[]): ContentBlock[] {
   if (typeof content === 'string') {
@@ -60,7 +78,7 @@ export function assembleThread(events: RawEvent[]): ThreadItem[] {
     { isError: boolean; content: ContentBlock[] }
   >();
   for (const event of convo) {
-    const content = event.message.content;
+    const content = messageContent(event);
     if (!Array.isArray(content)) continue;
     for (const block of content) {
       if (block.type === 'tool_result') {
@@ -79,6 +97,8 @@ export function assembleThread(events: RawEvent[]): ThreadItem[] {
 
     // Skip turns that contain only tool_result blocks (those are folded into
     // the preceding assistant turn's ToolInteraction) and produced no blocks.
+    // This is also what makes the `event.message.*` reads below safe: a row with
+    // no usable `message` yields no blocks (see messageContent) and exits here.
     if (blocks.length === 0) continue;
 
     const item: ThreadItem = {
@@ -231,12 +251,15 @@ function parseBlocks(
   event: UserEvent | AssistantEvent,
   resultsByToolUseId: Map<string, { isError: boolean; content: ContentBlock[] }>,
 ): ThreadBlock[] {
-  const content = event.message.content;
+  const content = messageContent(event);
 
   // A plain-string message is a single text block.
   if (typeof content === 'string') {
     return content.length > 0 ? [{ kind: 'text', type: 'text', text: content }] : [];
   }
+  // No usable content (no `message`, or a non-array `content`) — no blocks, which
+  // the caller treats as "skip this turn" rather than crashing the whole session.
+  if (content === null) return [];
 
   const blocks: ThreadBlock[] = [];
   for (const block of content) {

--- a/packages/server/src/routes/snippet.ts
+++ b/packages/server/src/routes/snippet.ts
@@ -14,8 +14,37 @@ function escapeHtml(s: string): string {
   return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
 }
 
-function escapeRegExp(s: string): string {
-  return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+/**
+ * Non-overlapping `[start, end)` spans of the window matched by any term,
+ * merged and in order. Computed on the RAW window, case-insensitively.
+ *
+ * This is why marking is a single pass. The previous implementation escaped the
+ * window and then ran one regex replace per term over the *result*, so a term
+ * could match markup an earlier term had just inserted: searching `book mark`
+ * produced `the <<mark>mark</mark>>book</<mark>mark</mark>><mark>mark</mark> is
+ * here`. Collecting spans first means `<mark>` is never re-scanned, and it drops
+ * the need to regex-escape user input at all.
+ */
+function matchSpans(window: string, terms: string[]): [number, number][] {
+  const haystack = window.toLowerCase();
+  const spans: [number, number][] = [];
+  for (const term of terms) {
+    if (!term) continue;
+    const needle = term.toLowerCase();
+    for (let i = haystack.indexOf(needle); i !== -1; i = haystack.indexOf(needle, i + needle.length)) {
+      spans.push([i, i + needle.length]);
+    }
+  }
+  // Sort by start (longest first on a tie) so the merge below is a single sweep.
+  spans.sort((a, b) => a[0] - b[0] || b[1] - a[1]);
+  const merged: [number, number][] = [];
+  for (const [start, end] of spans) {
+    const last = merged[merged.length - 1];
+    // Overlapping or touching spans become one <mark> instead of nesting.
+    if (last && start <= last[1]) last[1] = Math.max(last[1], end);
+    else merged.push([start, end]);
+  }
+  return merged;
 }
 
 /**
@@ -38,10 +67,15 @@ export function makeSnippet(text: string, terms: string[], format: SnippetFormat
 
   if (format === 'plain') return window;
 
-  let escaped = escapeHtml(window);
-  for (const t of terms) {
-    if (!t) continue;
-    escaped = escaped.replace(new RegExp(`(${escapeRegExp(escapeHtml(t))})`, 'gi'), '<mark>$1</mark>');
+  // Escape and wrap in one pass over the raw window, so no <mark> we emit can be
+  // matched by a later term. Only the two literal tag strings are unescaped —
+  // everything from the transcript goes through escapeHtml.
+  let out = '';
+  let cursor = 0;
+  for (const [start, end] of matchSpans(window, terms)) {
+    out += escapeHtml(window.slice(cursor, start));
+    out += `<mark>${escapeHtml(window.slice(start, end))}</mark>`;
+    cursor = end;
   }
-  return escaped;
+  return out + escapeHtml(window.slice(cursor));
 }

--- a/packages/server/test/parser.test.ts
+++ b/packages/server/test/parser.test.ts
@@ -258,3 +258,69 @@ describe('buildSubagentRuns', () => {
     expect(new Set(runs.map((r) => r.toolUseId))).toEqual(new Set(['tu1', 'tu2']));
   });
 });
+
+describe('malformed transcript rows', () => {
+  // Transcripts are read with `JSON.parse(...) as RawEvent` — no shape check —
+  // and the indexer's SQL explicitly tolerates a user/assistant row with no
+  // `message` (`WHEN message IS NULL THEN …`). Such rows therefore reach the
+  // assembler, where dereferencing `message.content` used to throw and 500 the
+  // whole session-detail route: the session listed in Browse but could not be
+  // opened. 0 of 5,687 real rows hit this, so it is a robustness guard, not a
+  // live bug — but one bad line should never cost a whole transcript.
+  const raw = (o: unknown): RawEvent[] => [o] as unknown as RawEvent[];
+
+  it('skips a conversational row with no message object', () => {
+    expect(assembleThread(raw({ type: 'user', uuid: 'a', parentUuid: null }))).toEqual([]);
+  });
+
+  it.each([null, 42, 'x' as unknown, { blocks: [] }])(
+    'skips a row whose message.content is %s',
+    (content) => {
+      const events = raw({
+        type: 'assistant',
+        uuid: 'b',
+        parentUuid: null,
+        message: { role: 'assistant', content },
+      });
+      // A string IS valid content, so only that one produces a turn.
+      expect(assembleThread(events)).toHaveLength(typeof content === 'string' ? 1 : 0);
+    },
+  );
+
+  it('keeps the surrounding good turns when one row is malformed', () => {
+    const events = raw({ type: 'user', uuid: 'bad', parentUuid: null }).concat(
+      [
+        { type: 'user', uuid: 'u1', parentUuid: null, message: { role: 'user', content: 'hello' } },
+        {
+          type: 'assistant',
+          uuid: 'a1',
+          parentUuid: 'u1',
+          message: { role: 'assistant', content: [{ type: 'text', text: 'hi' }] },
+        },
+      ] as unknown as RawEvent[],
+    );
+    expect(assembleThread(events).map((t) => t.uuid)).toEqual(['u1', 'a1']);
+  });
+
+  it('still pairs a tool_result that arrives alongside a malformed row', () => {
+    const events = [
+      {
+        type: 'assistant',
+        uuid: 'a1',
+        parentUuid: null,
+        message: { role: 'assistant', content: [{ type: 'tool_use', id: 't1', name: 'Read', input: {} }] },
+      },
+      { type: 'user', uuid: 'bad', parentUuid: 'a1' },
+      {
+        type: 'user',
+        uuid: 'u2',
+        parentUuid: 'a1',
+        message: { role: 'user', content: [{ type: 'tool_result', tool_use_id: 't1', content: 'done' }] },
+      },
+    ] as unknown as RawEvent[];
+    const thread = assembleThread(events);
+    const tool = thread[0]?.blocks[0];
+    expect(tool?.kind).toBe('tool');
+    expect(tool?.kind === 'tool' && tool.result?.content).toEqual([{ type: 'text', text: 'done' }]);
+  });
+});

--- a/packages/server/test/snippet.test.ts
+++ b/packages/server/test/snippet.test.ts
@@ -35,4 +35,36 @@ describe('makeSnippet', () => {
     // Window is SNIPPET_RADIUS before + 2×SNIPPET_RADIUS after the match (+ ellipses).
     expect(s.length).toBeLessThanOrEqual(362);
   });
+
+  it('does not let one term match markup another term inserted', () => {
+    // The regression: marking used to run one regex replace per term over the
+    // ALREADY-marked string, so `mark` matched the `<mark>` tags `book` had just
+    // produced — `the <<mark>mark</mark>>book</<mark>mark</mark>>...`.
+    const s = makeSnippet('the bookmark is here', ['book', 'mark']);
+    expect(s).toBe('the <mark>bookmark</mark> is here');
+    expect(s).not.toContain('<<');
+    expect(s).not.toContain('</<');
+  });
+
+  it('merges overlapping matches into one mark instead of nesting them', () => {
+    expect(makeSnippet('abcd', ['abc', 'bcd'])).toBe('<mark>abcd</mark>');
+  });
+
+  it('marks every occurrence, preserving the original casing', () => {
+    expect(makeSnippet('MARK this and mark that', ['mark'])).toBe(
+      '<mark>MARK</mark> this and <mark>mark</mark> that',
+    );
+  });
+
+  it('escapes transcript content even inside a match', () => {
+    // A term matching text with HTML metacharacters must still be escaped —
+    // only the two literal <mark> strings are ever emitted unescaped.
+    expect(makeSnippet('a <img> b', ['<img>'])).toBe('a <mark>&lt;img&gt;</mark> b');
+  });
+
+  it('treats regex metacharacters in a term literally', () => {
+    // Matching is now indexOf-based, so there is no pattern to escape at all.
+    expect(makeSnippet('cost is 1+1 dollars', ['1+1'])).toContain('<mark>1+1</mark>');
+    expect(makeSnippet('a.b and axb', ['a.b'])).toBe('<mark>a.b</mark> and axb');
+  });
 });

--- a/packages/shared/src/redact.ts
+++ b/packages/shared/src/redact.ts
@@ -5,8 +5,16 @@
  * exotic token format.
  */
 
-// Home-dir paths -> `~` (drops the username segment too).
-const HOME_RE = /(?:\/Users|\/home|[A-Z]:\\Users)\/[^/\\\s"'`)]+/g;
+/**
+ * Home-dir paths -> `~` (drops the username segment too).
+ *
+ * The separator is a character class, not a literal `/`: the Windows branch
+ * previously required a forward slash after `C:\Users`, so `C:\Users\alice\src`
+ * never matched and the username survived into exported Markdown and MCP output.
+ * Drive letters are matched case-insensitively (`c:\` is as common as `C:\`), and
+ * `C:/Users/...` is covered too since some tools normalize separators.
+ */
+const HOME_RE = /(?:\/Users|\/home|[A-Za-z]:[\\/]Users)[\\/][^/\\\s"'`)]+/g;
 // Conservative, prefix-anchored secret patterns (avoid false positives).
 const SECRET_RES: [RegExp, string][] = [
   [/sk-[A-Za-z0-9_-]{16,}/g, '«redacted-key»'],

--- a/packages/shared/test/redact.test.ts
+++ b/packages/shared/test/redact.test.ts
@@ -1,0 +1,88 @@
+/**
+ * Redaction for output that may leave the machine — the Markdown export's
+ * "redact" toggle and the MCP/CLI `--redact` flag.
+ *
+ * The Windows cases are the reason this file exists: `HOME_RE` required a forward
+ * slash after the drive-letter branch (`[A-Z]:\\Users` followed by `\/`), so
+ * `C:\Users\alice\src` never matched and the username survived into exported
+ * transcripts. Deliberately conservative overall — false positives matter more
+ * than exhaustive coverage — so the secret cases pin the prefixes that ARE
+ * claimed, not every token format in existence.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { redactText } from '../src/redact.js';
+
+describe('home directory paths', () => {
+  it('masks POSIX home paths, keeping the trailing path', () => {
+    expect(redactText('/Users/alice/src/app/index.ts')).toBe('~/src/app/index.ts');
+    expect(redactText('/home/alice/src/app')).toBe('~/src/app');
+  });
+
+  it('masks Windows home paths (both separators, either drive-letter case)', () => {
+    expect(redactText('C:\\Users\\alice\\src\\app')).toBe('~\\src\\app');
+    expect(redactText('c:\\Users\\alice\\src')).toBe('~\\src');
+    expect(redactText('D:/Users/alice/src')).toBe('~/src');
+  });
+
+  it('drops the username, which is the point', () => {
+    for (const p of ['/Users/alice/x', '/home/alice/x', 'C:\\Users\\alice\\x']) {
+      expect(redactText(p)).not.toContain('alice');
+    }
+  });
+
+  it('masks every occurrence in a longer body', () => {
+    const out = redactText('read C:\\Users\\bob\\a.ts then /Users/bob/b.ts');
+    expect(out).toBe('read ~\\a.ts then ~/b.ts');
+  });
+
+  it('leaves paths with no home segment alone', () => {
+    expect(redactText('/usr/local/bin/node')).toBe('/usr/local/bin/node');
+    expect(redactText('/opt/tools/bin')).toBe('/opt/tools/bin');
+  });
+
+  it('also masks a home-looking segment mid-path', () => {
+    // Not anchored to the start, so `<prefix>/Users/<name>` collapses too. That
+    // is right for the case it exists for — a mounted or backed-up home, e.g.
+    // /mnt/backup/Users/alice — and it means an unrelated directory that happens
+    // to be called `Users` is over-redacted. Documented rather than tightened:
+    // for a redaction helper, over-masking is the safe direction to err in.
+    expect(redactText('/mnt/backup/Users/alice/src')).toBe('/mnt/backup~/src');
+    expect(redactText('/var/Users/notahome')).toBe('/var~');
+  });
+});
+
+describe('secrets', () => {
+  it('masks the prefix-anchored patterns it claims to cover', () => {
+    const cases: [string, string][] = [
+      ['sk-abcdefghijklmnopqrstuvwx', '«redacted-key»'],
+      ['ghp_abcdefghijklmnopqrstuvwxyz12', '«redacted-token»'],
+      ['github_pat_abcdefghijklmnopqrstuv', '«redacted-token»'],
+      ['AKIAIOSFODNN7EXAMPLE', '«redacted-aws-key»'],
+      ['xoxb-1234567890-abcdefg', '«redacted-slack-token»'],
+    ];
+    for (const [secret, marker] of cases) {
+      const out = redactText(`token: ${secret}`);
+      expect(out).toContain(marker);
+      expect(out).not.toContain(secret);
+    }
+  });
+
+  it('masks a private key block including its body', () => {
+    const key = '-----BEGIN RSA PRIVATE KEY-----\nMIIEow\nsecretline\n-----END RSA PRIVATE KEY-----';
+    const out = redactText(key);
+    expect(out).toBe('«redacted-private-key»');
+    expect(out).not.toContain('secretline');
+  });
+
+  it('keeps a Bearer scheme readable while masking the credential', () => {
+    expect(redactText('Authorization: Bearer abcdefghijklmnopqrst')).toBe(
+      'Authorization: Bearer «redacted»',
+    );
+  });
+
+  it('does not fire on short lookalikes (false positives are worse here)', () => {
+    expect(redactText('sk-short')).toBe('sk-short');
+    expect(redactText('the task is done')).toBe('the task is done');
+  });
+});

--- a/packages/web/src/components/image.ts
+++ b/packages/web/src/components/image.ts
@@ -18,12 +18,29 @@ function safeImageUrl(url: string): string | null {
 }
 
 /**
+ * A `media_type` we will put in a `data:` URI. Transcript content is untrusted,
+ * and the `url` branch above carefully rejects non-image schemes while the base64
+ * branch used to interpolate `media_type` verbatim — so a poisoned block could
+ * produce `data:text/html;base64,…`. Inert in the `<img src>` positions both
+ * callers use (and blocked by the CSP), but the asymmetry is the kind that turns
+ * into a real hole the moment a third caller appears. The server-side inliner has
+ * had an equivalent allowlist all along (`connectors/safe-image.ts`).
+ *
+ * Any `image/*` subtype is accepted rather than a fixed list, so legitimate
+ * formats aren't dropped; SVG cannot execute script when loaded via `<img>`.
+ */
+function isImageMediaType(mediaType: string): boolean {
+  return /^image\/[a-z0-9][a-z0-9.+-]*$/i.test(mediaType);
+}
+
+/**
  * Pull a renderable `<img src>` string out of an Anthropic-style image block.
  *
  * Handles two source types:
  * - `url`: returns the URL if it is a `data:image/` or same-origin URL
  *   (remote/schemed URLs are rejected — see {@link safeImageUrl}).
- * - `base64`: returns a `data:<media_type>;base64,<data>` URI.
+ * - `base64`: returns a `data:<media_type>;base64,<data>` URI, but only for an
+ *   `image/*` media type (see {@link isImageMediaType}).
  *
  * Returns `null` when the value is not a valid image block or has no
  * resolvable source.
@@ -40,6 +57,7 @@ export function extractImage(value: unknown): string | null {
   };
   if (source.type === 'url' && source.url) return safeImageUrl(source.url);
   if (source.type === 'base64' && source.data && source.media_type) {
+    if (!isImageMediaType(source.media_type)) return null;
     return `data:${source.media_type};base64,${source.data}`;
   }
   return null;

--- a/packages/web/test/image.test.ts
+++ b/packages/web/test/image.test.ts
@@ -28,4 +28,24 @@ describe('extractImage', () => {
     expect(extractImage({ type: 'text', text: 'hi' })).toBeNull();
     expect(extractImage({ type: 'image', source: { type: 'base64' } })).toBeNull();
   });
+
+  it('rejects a base64 source whose media_type is not an image', () => {
+    // Transcript content is untrusted: the base64 branch used to interpolate
+    // media_type verbatim, so a poisoned block yielded `data:text/html;base64,…`.
+    const b64 = (media_type: string) => ({
+      type: 'image',
+      source: { type: 'base64', media_type, data: 'PHNjcmlwdD4x' },
+    });
+    expect(extractImage(b64('text/html'))).toBeNull();
+    expect(extractImage(b64('application/javascript'))).toBeNull();
+    expect(extractImage(b64('image/png; x=<script>'))).toBeNull();
+    expect(extractImage(b64(''))).toBeNull();
+  });
+
+  it('accepts any image/* subtype so valid formats are not dropped', () => {
+    for (const t of ['image/png', 'image/jpeg', 'image/webp', 'image/avif', 'image/svg+xml']) {
+      expect(extractImage({ type: 'image', source: { type: 'base64', media_type: t, data: 'a' } }))
+        .toBe(`data:${t};base64,a`);
+    }
+  });
 });


### PR DESCRIPTION
Plan: [docs/plans/0057-untrusted-content-hardening.md](./docs/plans/0057-untrusted-content-hardening.md)

Sixth PR from the repo-wide review. Four small guards on paths that handle transcript content — which is untrusted, since a transcript can be hand-edited, shared, or written by an agent that hit a bug.

**Two are live, two are latent.** Keeping that straight matters, because two of these would be easy to oversell.

## LIVE — `redactText` missed Windows home paths

The drive-letter branch was followed by a literal `\/`, so `C:\Users\alice\src` never matched and the username survived into exported Markdown and MCP/CLI output — precisely what the redact toggle exists to prevent. POSIX was fine. Now a separator character class with a case-insensitive drive letter, covering `C:\Users\…`, `c:\Users\…` and `D:/Users/…`.

## LIVE — search snippets corrupted themselves

Marking escaped the window, then ran one regex replace **per term** over the result — so a later term matched markup an earlier one had just inserted:

```text
makeSnippet('the bookmark is here', ['book', 'mark'])
before → the <<mark>mark</mark>>book</<mark>mark</mark>><mark>mark</mark> is here
after  → the <mark>bookmark</mark> is here
```

**Not XSS.** I traced it: the only `<`/`>` introduced come from the two literal tag strings, and the replacement is a constant so `$&`-style injection is impossible. But it's rendered through `dangerouslySetInnerHTML` and looked broken for any query where one term appears inside another's markup.

Marking is now a single pass over the *raw* window — collect match spans, merge, emit escaped text with `<mark>` around matched ranges. `<mark>` is never re-scanned, overlaps merge instead of nesting, and matching is `indexOf`-based so **there is no pattern to regex-escape at all**.

## LATENT — the thread assembler crashed on odd `message` shapes

Transcripts are read as `JSON.parse(...) as RawEvent` with no shape check, and the indexer's SQL *explicitly* tolerates a `user`/`assistant` row with no `message` (`WHEN message IS NULL THEN …`). So such rows get indexed, and the detail route then 500'd on `Cannot read properties of undefined` — a session that lists in Browse but cannot be opened.

**0 of 5,687 rows** in the real corpus hit this, so it's a robustness guard, not a live bug. But one bad line shouldn't cost a whole transcript. A malformed row now yields no blocks, which the assembler already skips (the same path that folds away tool-result-only turns).

## LATENT — `extractImage` trusted `media_type`

The base64 branch interpolated it verbatim, so a poisoned block yielded `data:text/html;base64,…` — while the sibling `url` branch carefully rejects non-image schemes, and the *server's* inliner (`connectors/safe-image.ts`) has had an allowlist all along. Inert today: both callers use it only as `<img src>`, where `text/html` just fails to load, and the CSP allows `data:` for images only. Fixed because the asymmetry is what becomes a real hole the moment a third caller appears.

Any `image/*` subtype is accepted rather than a fixed list — enumerating formats would drop legitimate ones, and SVG can't execute script when loaded via `<img>`.

## A pre-existing issue the tests surfaced

Redaction had **no tests at all**. Writing them found that `/Users` is unanchored, so `/var/Users/notahome` collapses to `/var~`.

I left it and documented it in a test. It's the same behaviour that makes a mounted home (`/mnt/backup/Users/alice`) redact correctly, and for a redaction helper over-masking is the safe direction to err in. Changing path-matching semantics doesn't belong in a hardening PR.

## Testing

- `npm test` **583 passed / 60 files** (was 559/59), run 3×; typecheck, build, markdownlint clean.
- Each fix regression-checked by reverting it individually:

| fix | failures when reverted |
|---|---:|
| snippet single-pass marking | 2 |
| redact Windows branch | 3 |
| parser guards | 6 |
| image `media_type` | 1 |

- Snippet tests pin the merge behaviour, casing preservation, escaping *inside* a match, and that regex metacharacters in a term are now literal.
- Parser tests assert surrounding good turns survive one malformed row, and that tool_use/tool_result pairing still works across one.