### PR TITLE
refactor: give each derived analytics value one definition

### DIFF
--- a/docs/plans/0058-analytics-duplication.md
+++ b/docs/plans/0058-analytics-duplication.md
@@ -1,0 +1,113 @@
+# 0058 — Consolidate the analytics duplication
+
+- **Status:** done <!-- proposed | in-progress | done | superseded | abandoned -->
+- **Date:** 2026-07-29
+- **PR:** <link, once opened>
+
+## Context
+
+Seventh and last cleanup PR from the repo-wide review. No behaviour change
+intended; the point is that several derived values had more than one definition,
+and one of those definitions was already wrong.
+
+**1. The cache-hit ratio had three implementations.** Byte-identical TypeScript
+functions in `routes/analytics.ts` and `routes/analytics-agents.ts`, plus the same
+formula hand-written as SQL in `routes/analytics-sessions.ts`.
+
+**And the documentation of it was wrong.** `analytics.ts`'s header said:
+
+```text
+cacheHitRatio = cache_read / (cache_read + input)
+```
+
+while its own code — and an inline comment 50 lines below — included
+`cache_write`. Anyone trusting the header would compute a materially different
+number: for a session that primed a large cache (`cache_read: 1`,
+`cache_write: 999`) the documented formula gives **1.0** and the real one gives
+**0.001**.
+
+**2. Project-slug resolution had three copies.** `data/analytics-scope.ts` exists
+specifically to centralise it — its own header says *"Centralised here so the
+slug-resolution loop … can't drift between routes"* — yet `routes/sessions.ts` and
+`routes/search.ts` each carried their own copy of the loop **and** of the
+never-match sentinel `'\0'`.
+
+**3. MCP and CLI duplicated two pieces of shaping.** The session-windowing
+defaults (with a comment on one saying "Same defaulting as the MCP get_session
+tool") and the analytics totals line, both while already importing from a shared
+`agent/shape.ts`.
+
+**4. `db/schema.ts`'s header listed a `projects` table** that does not exist in
+the DDL.
+
+## Goal
+
+Each derived value has one definition. Where a second encoding is unavoidable, a
+test proves the two agree.
+
+## Decisions
+
+- **Keep both cache-hit encodings, and test their agreement** — the SQL one
+  cannot be replaced by the TS one: `/api/analytics/sessions` makes
+  `cache_hit_ratio` a sortable column and feeds it to `quantile_cont` for the
+  median/quartile summary, so it must exist inside the query. Rather than pretend
+  one can go, the formula is stated once in prose with the two encodings beside it
+  and a test evaluates the generated SQL in DuckDB against the TS function over
+  ten cases (zero denominator, NULLs, a case that truncates under integer
+  division, cache_write dominating). Same shape as the canonical-contract test in
+  0055: two representations, one source, enforced.
+- **Pin the new SQL against the expression it replaced** — the legacy hand-written
+  CASE is kept in the test as a literal and asserted equal, so the consolidation
+  provably changed no number.
+- **Decompose the slug resolution rather than route everything through
+  `scopeFilters`** — `/api/sessions` and `/api/search` have no date scope, so
+  calling a function named "scope filters" for a project-only filter reads wrong.
+  `resolveProjectCwd` and `projectFilter` are the pieces; `scopeFilters` now uses
+  them too, so all three callers share one loop and one sentinel.
+- **Do NOT cache `collectMemory`** — it was on the review list for re-reading
+  every memory file plus scanning `sessions` on each call, including per search
+  keystroke. Measured first, on a corpus matching the reviewer's shape (504
+  sessions, 56 project dirs, 96 fact files): **3.4 ms median**. At ~3 calls/second
+  while typing that is ~1% of one core. A TTL cache would trade that for staleness
+  in a feature deliberately documented as read-live-never-indexed. Not worth it;
+  recorded here so the next reader doesn't re-litigate it.
+
+## Approach
+
+1. `data/analytics-metrics.ts` — new; `cacheHitRatio` + `cacheHitRatioSql`, with
+   the formula documented once.
+2. `data/analytics-scope.ts` — add `resolveProjectCwd` / `projectFilter`, hoist
+   the sentinel to `NEVER_MATCHES`, and have `scopeFilters` delegate.
+3. `routes/{sessions,search}.ts` — use `projectFilter`.
+4. `agent/shape.ts` — add `resolveWindowArgs` + `analyticsTotalsLine`; `mcp.ts`
+   and `query.ts` use them.
+5. Fix the wrong formula in `analytics.ts`'s header and the phantom table in
+   `db/schema.ts`.
+
+## Files affected
+
+- `packages/server/src/data/analytics-metrics.ts` — new.
+- `packages/server/src/data/analytics-scope.ts` — resolution helpers + sentinel.
+- `packages/server/src/routes/{analytics,analytics-agents,analytics-sessions,sessions,search}.ts`
+- `packages/server/src/agent/{shape,mcp,query}.ts`
+- `packages/server/src/db/schema.ts` — doc only.
+- `packages/server/test/analytics-metrics.test.ts` — new.
+
+## Testing
+
+- `npm test` (583 → 588), `npm run typecheck`, `npm run build`, markdownlint.
+- The agreement test catches divergence from **either** side: dropping
+  `cache_write` from the SQL fails 2 cases, and dropping it from the TS fails 2.
+- Project filtering re-verified end to end through the existing API, query-param
+  and analytics-tools integration suites (68 cases) — those already assert
+  filtering by project id returns the right sessions.
+
+## Risks / open questions
+
+- `cacheHitRatioSql` takes column *expressions* as strings, so a caller could pass
+  something unexpected. Every call site is a literal in this repo, and the values
+  are column names rather than user input, but it is string-built SQL like the rest
+  of the query layer.
+- `projectFilter` runs a distinct-cwd scan per call, as all three copies did
+  before. Unchanged, and cheap (one row per project) — noted only because the
+  consolidation makes it easy to add a caller that calls it in a loop.

--- a/docs/plans/0058-analytics-duplication.md
+++ b/docs/plans/0058-analytics-duplication.md
@@ -2,7 +2,7 @@
 
 - **Status:** done <!-- proposed | in-progress | done | superseded | abandoned -->
 - **Date:** 2026-07-29
-- **PR:** <link, once opened>
+- **PR:** https://github.com/vladar107/claudescope/pull/78
 
 ## Context
 

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -82,3 +82,4 @@ decision, or a change worth explaining before doing. Skip it for one-line fixes.
 | 0055 | [One canonical connector contract instead of sixteen](./0055-canonical-connector-contract.md) | done |
 | 0056 | [Prune the normalize cache when its source is gone](./0056-prune-normalize-cache.md) | done |
 | 0057 | [Untrusted-content hardening](./0057-untrusted-content-hardening.md) | done |
+| 0058 | [Consolidate the analytics duplication](./0058-analytics-duplication.md) | done |

--- a/packages/server/src/agent/mcp.ts
+++ b/packages/server/src/agent/mcp.ts
@@ -26,9 +26,11 @@ import {
   DEFAULT_LIMIT,
   DEFAULT_MAX_TOOL_CHARS,
   DEFAULT_TURNS,
+  analyticsTotalsLine,
   day,
   fmtCost,
   fmtTokens,
+  resolveWindowArgs,
   shapeSearchResults,
   shapeSessionMarkdown,
 } from './shape.js';
@@ -174,11 +176,8 @@ export function createMcpServer(deps: McpDeps): McpServer {
       },
     },
     guarded(async (client, args: { sessionId: string; offset?: number; limit?: number; around?: string; radius?: number; maxToolChars?: number; redact?: boolean }) => {
-      const windowed = args.around === undefined && args.offset === undefined && args.limit === undefined
-        ? { offset: 0, limit: DEFAULT_TURNS }
-        : { offset: args.offset, limit: args.limit, around: args.around, radius: args.radius };
       const data = await client.session(args.sessionId, {
-        ...windowed,
+        ...resolveWindowArgs(args),
         maxToolChars: args.maxToolChars ?? DEFAULT_MAX_TOOL_CHARS,
       });
       return shapeSessionMarkdown(data, args.redact ?? false);
@@ -228,11 +227,7 @@ export function createMcpServer(deps: McpDeps): McpServer {
           `cache r/w ${fmtTokens(row.cacheReadTokens)}/${fmtTokens(row.cacheCreationTokens)}) · ` +
           `${fmtCost(row.costUsd)} · ${row.messageCount} responses`,
       );
-      const t = res.totals;
-      lines.push(
-        `Total: ${fmtTokens(t.totalTokens)} tok · ${fmtCost(t.costUsd)} · ${t.messageCount} responses · ` +
-          `cache hit ${(t.cacheHitRatio * 100).toFixed(0)}%`,
-      );
+      lines.push(analyticsTotalsLine(res.totals));
       return lines.join('\n');
     }),
   );

--- a/packages/server/src/agent/query.ts
+++ b/packages/server/src/agent/query.ts
@@ -14,10 +14,11 @@ import type { ApiClient } from './api-client.js';
 import {
   DEFAULT_LIMIT,
   DEFAULT_MAX_TOOL_CHARS,
-  DEFAULT_TURNS,
+  analyticsTotalsLine,
   day,
   fmtCost,
   fmtTokens,
+  resolveWindowArgs,
   shapeSearchResults,
   shapeSessionMarkdown,
 } from './shape.js';
@@ -104,14 +105,8 @@ export interface SessionArgs {
 }
 
 export async function querySession(client: ApiClient, id: string, args: SessionArgs): Promise<string> {
-  // Same defaulting as the MCP get_session tool: no windowing params → the
-  // first DEFAULT_TURNS turns, so a huge session never dumps whole.
-  const windowed =
-    args.around === undefined && args.offset === undefined && args.limit === undefined
-      ? { offset: 0, limit: DEFAULT_TURNS }
-      : { offset: args.offset, limit: args.limit, around: args.around, radius: args.radius };
   const data = await client.session(id, {
-    ...windowed,
+    ...resolveWindowArgs(args),
     maxToolChars: args.maxToolChars ?? DEFAULT_MAX_TOOL_CHARS,
   });
   if (args.json) return json(data);
@@ -148,7 +143,6 @@ export async function queryAnalytics(client: ApiClient, args: AnalyticsArgs): Pr
   const res = await client.analytics({ groupBy: args.groupBy ?? 'project', from: args.from, to: args.to });
   if (args.json) return json(res);
   if (res.rows.length === 0) return 'No usage in range.';
-  const t = res.totals;
   return (
     table(
       ['KEY', 'TOKENS', 'IN', 'OUT', 'COST', 'RESPONSES'],
@@ -162,8 +156,7 @@ export async function queryAnalytics(client: ApiClient, args: AnalyticsArgs): Pr
       ]),
       [false, true, true, true, true, true],
     ) +
-    `\n\nTotal: ${fmtTokens(t.totalTokens)} tok · ${fmtCost(t.costUsd)} · ${t.messageCount} responses · ` +
-    `cache hit ${(t.cacheHitRatio * 100).toFixed(0)}%`
+    `\n\n${analyticsTotalsLine(res.totals)}`
   );
 }
 

--- a/packages/server/src/agent/shape.ts
+++ b/packages/server/src/agent/shape.ts
@@ -5,7 +5,7 @@
  * talks to the network.
  */
 
-import type { SearchResponse, SessionDetailResponse } from '@claudescope/shared';
+import type { AnalyticsResponse, SearchResponse, SessionDetailResponse } from '@claudescope/shared';
 import { redactText, threadItemsToMarkdown } from '@claudescope/shared';
 
 /** Default hits/rows returned by the list-shaped tools/commands. */
@@ -18,6 +18,40 @@ export const DEFAULT_TURNS = 20;
 export const fmtCost = (usd: number): string => `$${usd.toFixed(2)}`;
 export const fmtTokens = (n: number): string => n.toLocaleString('en-US');
 export const day = (iso: string): string => iso.slice(0, 10);
+
+/** Windowing params a session request may carry. */
+export interface WindowArgs {
+  offset?: number;
+  limit?: number;
+  around?: string;
+  radius?: number;
+}
+
+/**
+ * Resolve the window for a session request. With no windowing params at all,
+ * default to the first {@link DEFAULT_TURNS} turns so a huge session never dumps
+ * whole into an agent's context (or a terminal); otherwise pass the caller's
+ * params through untouched.
+ *
+ * Shared so the MCP `get_session` tool and `claudescope session` cannot drift —
+ * they had the same block copied, with a comment on one saying "same defaulting
+ * as the MCP get_session tool".
+ */
+export function resolveWindowArgs(args: WindowArgs): WindowArgs {
+  const unwindowed =
+    args.around === undefined && args.offset === undefined && args.limit === undefined;
+  return unwindowed
+    ? { offset: 0, limit: DEFAULT_TURNS }
+    : { offset: args.offset, limit: args.limit, around: args.around, radius: args.radius };
+}
+
+/** The one-line totals summary appended to analytics output. */
+export function analyticsTotalsLine(totals: AnalyticsResponse['totals']): string {
+  return (
+    `Total: ${fmtTokens(totals.totalTokens)} tok · ${fmtCost(totals.costUsd)} · ` +
+    `${totals.messageCount} responses · cache hit ${(totals.cacheHitRatio * 100).toFixed(0)}%`
+  );
+}
 
 /**
  * Search hits as compact text: transcript hits carry the sessionId +

--- a/packages/server/src/data/analytics-metrics.ts
+++ b/packages/server/src/data/analytics-metrics.ts
@@ -1,0 +1,44 @@
+/**
+ * Derived analytics metrics with more than one consumer.
+ *
+ * The cache-hit ratio had three implementations: byte-identical TypeScript
+ * functions in `routes/analytics.ts` and `routes/analytics-agents.ts`, plus the
+ * same formula hand-written as SQL in `routes/analytics-sessions.ts`. Worse, the
+ * header comment on `analytics.ts` documented a DIFFERENT formula from the one
+ * its own code computed — so a reader trusting the doc would get a different
+ * number.
+ *
+ * Both representations are needed and neither can replace the other: the SQL one
+ * has to exist because `/api/analytics/sessions` makes `cache_hit_ratio` a
+ * sortable column and feeds it to `quantile_cont` for the median/quartile
+ * summary. So the formula is stated once here, in prose, with the two encodings
+ * beside it — and a test evaluates the SQL in DuckDB against the TS function on
+ * the same inputs, so they cannot drift silently.
+ */
+
+/**
+ * THE FORMULA — fraction of prompt tokens served from cache:
+ *
+ * ```text
+ *   cache_read / (cache_read + cache_write + input)
+ * ```
+ *
+ * Cache *writes* and uncached input are both freshly processed, so they belong in
+ * the denominator; leaving `cache_write` out pins the ratio near 100% for any
+ * session that primed a large cache. A zero denominator yields 0, not NaN.
+ */
+export function cacheHitRatio(cacheRead: number, cacheWrite: number, input: number): number {
+  const denominator = cacheRead + cacheWrite + input;
+  return denominator > 0 ? cacheRead / denominator : 0;
+}
+
+/**
+ * {@link cacheHitRatio} as a SQL expression over three (possibly NULL) column
+ * expressions. Each is COALESCEd to 0, and the division is forced to DOUBLE so
+ * integer token columns don't truncate to 0.
+ */
+export function cacheHitRatioSql(cacheRead: string, cacheWrite: string, input: string): string {
+  const read = `COALESCE(${cacheRead}, 0)`;
+  const denominator = `(${read} + COALESCE(${cacheWrite}, 0) + COALESCE(${input}, 0))`;
+  return `CASE WHEN ${denominator} > 0 THEN ${read}::DOUBLE / ${denominator} ELSE 0 END`;
+}

--- a/packages/server/src/data/analytics-scope.ts
+++ b/packages/server/src/data/analytics-scope.ts
@@ -28,6 +28,49 @@ export interface ScopeColumns {
 }
 
 /**
+ * A condition that matches nothing. Used when a project slug resolves to no cwd,
+ * so an unknown param returns empty rather than everything. Standard SQL does not
+ * process backslash escapes inside single quotes, so this is the literal
+ * two-character string `\0` — which no real cwd can be.
+ */
+const NEVER_MATCHES = "'\\0'";
+
+/**
+ * Resolve a project slug id to the `project_cwd` it came from, or `null` when no
+ * indexed session matches.
+ *
+ * Slugs are hashed from the cwd (see `projectIdFromCwd`), so there is no inverse
+ * — the resolution is a scan of the distinct cwds. Cheap: the set is one row per
+ * project, and the alternative (storing the slug) would duplicate derivable state.
+ */
+export async function resolveProjectCwd(
+  conn: DuckDBConnection,
+  projectId: string,
+): Promise<string | null> {
+  const cwds = await queryRows(
+    conn,
+    'SELECT DISTINCT project_cwd FROM sessions WHERE project_cwd IS NOT NULL',
+  );
+  return cwds.map((c) => String(c.project_cwd)).find((c) => projectIdFromCwd(c) === projectId) ?? null;
+}
+
+/**
+ * SQL condition restricting `cwdCol` to one project slug.
+ *
+ * Shared with the routes that filter by project but have no date scope
+ * (/api/sessions, /api/search) — they each had their own copy of the resolution
+ * loop AND of the never-match sentinel, so all three could drift.
+ */
+export async function projectFilter(
+  conn: DuckDBConnection,
+  projectId: string,
+  cwdCol = 'project_cwd',
+): Promise<string> {
+  const match = await resolveProjectCwd(conn, projectId);
+  return `${cwdCol} = ${match ? sqlString(match) : NEVER_MATCHES}`;
+}
+
+/**
  * SQL filter conditions for the scope. The project slug is resolved to its
  * cwd by scanning the distinct `project_cwd` values (same resolution
  * /api/sessions uses); an unknown slug yields a never-matching condition so
@@ -50,16 +93,7 @@ export async function scopeFilters(
   const from = timestampParam(scope.from, 'from');
   const to = timestampParam(scope.to, 'to');
   const filters: string[] = [];
-  if (scope.project) {
-    const cwds = await queryRows(
-      conn,
-      'SELECT DISTINCT project_cwd FROM sessions WHERE project_cwd IS NOT NULL',
-    );
-    const match = cwds
-      .map((c) => String(c.project_cwd))
-      .find((c) => projectIdFromCwd(c) === scope.project);
-    filters.push(`${cwdCol} = ${match ? sqlString(match) : "'\\0'"}`);
-  }
+  if (scope.project) filters.push(await projectFilter(conn, scope.project, cwdCol));
   if (from) filters.push(`${tsCol} >= ${sqlString(from)}::TIMESTAMP`);
   if (to) filters.push(`${tsCol} <= ${sqlString(to)}::TIMESTAMP`);
   return filters;

--- a/packages/server/src/db/schema.ts
+++ b/packages/server/src/db/schema.ts
@@ -12,7 +12,6 @@
  *  - events:   one row per conversational (user/assistant) event, with usage,
  *              per-event cost, and extracted plain text for full-text search.
  *  - sessions: derived per-session metadata (counts, totals, time span, etc).
- *  - projects: derived per-cwd metadata.
  *  - pr_links: pr-link events keyed by sessionId.
  *  - titles:   ai-title events keyed by sessionId (latest wins).
  */

--- a/packages/server/src/routes/analytics-agents.ts
+++ b/packages/server/src/routes/analytics-agents.ts
@@ -27,6 +27,7 @@ import type {
 } from '@claudescope/shared';
 import { getConnection, queryRows } from '../db/duckdb.js';
 import { readRow } from '../db/row.js';
+import { cacheHitRatio } from '../data/analytics-metrics.js';
 import { scopeFilters } from '../data/analytics-scope.js';
 import { errorSignalsByAgent } from './analytics-errors.js';
 
@@ -60,12 +61,6 @@ const AVAILABILITY_NOTES: Record<string, string> = {
   junie: 'Junie delegates via plain terminal commands, so subagent usage is invisible.',
   grok: 'Grok records usage once per user turn (in updates.jsonl); a session whose updates file is missing or truncated reports zero tokens.',
 };
-
-/** Shared cache-hit denominator (see /api/analytics). */
-function cacheHitRatio(cacheRead: number, cacheWrite: number, input: number): number {
-  const denom = cacheRead + cacheWrite + input;
-  return denom > 0 ? cacheRead / denom : 0;
-}
 
 export async function registerAgentComparisonRoute(app: FastifyInstance): Promise<void> {
   app.get<{

--- a/packages/server/src/routes/analytics-sessions.ts
+++ b/packages/server/src/routes/analytics-sessions.ts
@@ -19,6 +19,7 @@ import type {
 } from '@claudescope/shared';
 import { getConnection, queryRows } from '../db/duckdb.js';
 import { scopeFilters } from '../data/analytics-scope.js';
+import { cacheHitRatioSql } from '../data/analytics-metrics.js';
 import { readRow } from '../db/row.js';
 import { projectIdFromCwd, displayNameFromCwd } from '../data/project-id.js';
 import { toIso } from './projects.js';
@@ -103,12 +104,7 @@ export async function registerSessionEfficiencyRoute(app: FastifyInstance): Prom
           a.responses                       AS responses,
           (COALESCE(a.input_tokens,0) + COALESCE(a.output_tokens,0)
             + COALESCE(a.cache_write_tokens,0) + COALESCE(a.cache_read_tokens,0)) AS total_tokens,
-          CASE
-            WHEN (COALESCE(a.cache_read_tokens,0) + COALESCE(a.cache_write_tokens,0) + COALESCE(a.input_tokens,0)) > 0
-            THEN COALESCE(a.cache_read_tokens,0)::DOUBLE
-                 / (COALESCE(a.cache_read_tokens,0) + COALESCE(a.cache_write_tokens,0) + COALESCE(a.input_tokens,0))
-            ELSE 0
-          END AS cache_hit_ratio,
+          ${cacheHitRatioSql('a.cache_read_tokens', 'a.cache_write_tokens', 'a.input_tokens')} AS cache_hit_ratio,
           COALESCE(a.cost_usd,0)::DOUBLE / NULLIF(a.responses, 0) AS cost_per_response,
           (COALESCE(a.input_tokens,0) + COALESCE(a.output_tokens,0)
             + COALESCE(a.cache_write_tokens,0) + COALESCE(a.cache_read_tokens,0))::DOUBLE

--- a/packages/server/src/routes/analytics.ts
+++ b/packages/server/src/routes/analytics.ts
@@ -2,9 +2,11 @@
  * GET /api/analytics — token + cost aggregation grouped by project, model, or
  * day, with overall totals and a cache-hit ratio.
  *
- * cacheHitRatio = cache_read / (cache_read + input). Computed both per-row and
- * for the totals. Optional inclusive date bounds `from` / `to` filter on the
- * event timestamp.
+ * cacheHitRatio is the shared formula in `data/analytics-metrics.ts` — computed
+ * both per-row and for the totals. (This header used to document
+ * `cache_read / (cache_read + input)`, which is NOT what the code computed:
+ * `cache_write` belongs in the denominator too.) Optional inclusive date bounds
+ * `from` / `to` filter on the event timestamp.
  *
  * Token/cost SUMs and messageCount filter on `usage_canonical` so one billed API
  * call counts once (Claude Code writes a row per content block and copies usage
@@ -20,6 +22,7 @@ import type {
 } from '@claudescope/shared';
 import { getConnection, queryRows } from '../db/duckdb.js';
 import { readRow } from '../db/row.js';
+import { cacheHitRatio } from '../data/analytics-metrics.js';
 import { scopeFilters } from '../data/analytics-scope.js';
 import { projectIdFromCwd } from '../data/project-id.js';
 
@@ -47,17 +50,6 @@ function groupSource(groupBy: AnalyticsGroupBy): { keyExpr: string; fromSql: str
         fromSql: 'FROM events e JOIN sessions s ON e.session_id = s.id',
       };
   }
-}
-
-/**
- * Fraction of prompt tokens served from cache:
- *   cache_read / (cache_read + cache_creation + input)
- * Cache-creation (writes) and uncached input are both freshly processed, so
- * they belong in the denominator — otherwise the ratio pins at ~100%.
- */
-function cacheHitRatio(cacheRead: number, cacheWrite: number, input: number): number {
-  const denom = cacheRead + cacheWrite + input;
-  return denom > 0 ? cacheRead / denom : 0;
 }
 
 export async function registerAnalyticsRoute(app: FastifyInstance): Promise<void> {

--- a/packages/server/src/routes/search.ts
+++ b/packages/server/src/routes/search.ts
@@ -20,6 +20,7 @@ import type {
 import { getConnection, queryRows, sqlString } from '../db/duckdb.js';
 import { readRow } from '../db/row.js';
 import { projectIdFromCwd } from '../data/project-id.js';
+import { projectFilter } from '../data/analytics-scope.js';
 import { collectMemory } from '../data/memory.js';
 import { makeSnippet } from './snippet.js';
 
@@ -44,14 +45,7 @@ async function searchSessions(
 
   const filters: string[] = ['score IS NOT NULL'];
   if (type === 'user' || type === 'assistant') filters.push(`role = ${sqlString(type)}`);
-  if (project) {
-    const cwds = await queryRows(
-      conn,
-      'SELECT DISTINCT project_cwd FROM sessions WHERE project_cwd IS NOT NULL',
-    );
-    const match = cwds.map((c) => String(c.project_cwd)).find((c) => projectIdFromCwd(c) === project);
-    filters.push(`project_cwd = ${match ? sqlString(match) : "'\\0'"}`);
-  }
+  if (project) filters.push(await projectFilter(conn, project));
 
   const rows = await queryRows(
     conn,

--- a/packages/server/src/routes/sessions.ts
+++ b/packages/server/src/routes/sessions.ts
@@ -20,6 +20,7 @@ import { isZeroRated } from '@claudescope/shared';
 import { getConnection, queryRows, sqlLikeEscape, sqlString } from '../db/duckdb.js';
 import { readRow } from '../db/row.js';
 import { displayNameFromCwd, projectIdFromCwd } from '../data/project-id.js';
+import { projectFilter } from '../data/analytics-scope.js';
 import { toIso } from './projects.js';
 import { assembleThread, buildSubagentRuns } from '../data/parser.js';
 import { loadSessionData } from '../data/session-loader.js';
@@ -93,18 +94,9 @@ export async function registerSessionsRoutes(app: FastifyInstance): Promise<void
     if (agent) {
       where.push(`connector_id = ${sqlString(agent)}`);
     }
-    if (project) {
-      // project is the slug id; match against the slug of project_cwd.
-      // We resolve the cwd by scanning distinct cwds (small set).
-      const cwds = await queryRows(
-        conn,
-        'SELECT DISTINCT project_cwd FROM sessions WHERE project_cwd IS NOT NULL',
-      );
-      const match = cwds
-        .map((c) => String(c.project_cwd))
-        .find((c) => projectIdFromCwd(c) === project);
-      where.push(`project_cwd = ${match ? sqlString(match) : "'\\0'"}`);
-    }
+    // `project` is the slug id; resolution + the unknown-slug sentinel are shared
+    // with /api/search and the analytics routes.
+    if (project) where.push(await projectFilter(conn, project));
     if (q && q.trim()) {
       where.push(
         `(lower(title) LIKE ${sqlString('%' + sqlLikeEscape(q.toLowerCase()) + '%')} ESCAPE '\\')`,

--- a/packages/server/test/analytics-metrics.test.ts
+++ b/packages/server/test/analytics-metrics.test.ts
@@ -1,0 +1,122 @@
+/**
+ * The cache-hit ratio has to exist twice — as TypeScript for the routes that
+ * compute it per row, and as SQL because `/api/analytics/sessions` makes
+ * `cache_hit_ratio` a sortable column and feeds it to `quantile_cont`. Neither
+ * can replace the other, so this asserts they agree.
+ *
+ * It also pins the new generated SQL against the hand-written expression it
+ * replaced, so the consolidation provably didn't change any number. Before this,
+ * there were three implementations (two identical TS functions plus the SQL) and
+ * `analytics.ts`'s own header documented a *different* formula from the one its
+ * code computed.
+ */
+
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import type { DuckDBConnection } from '@duckdb/node-api';
+import { cacheHitRatio, cacheHitRatioSql } from '../src/data/analytics-metrics.js';
+
+const work = mkdtempSync(join(tmpdir(), 'claudescope-metrics-'));
+process.env.DUCKDB_PATH = join(work, 'index.duckdb');
+process.env.CLAUDESCOPE_HOME = join(work, 'home');
+
+/** The expression as it was hand-written in analytics-sessions.ts before this. */
+const LEGACY_SQL = `
+  CASE
+    WHEN (COALESCE(t.cache_read_tokens,0) + COALESCE(t.cache_write_tokens,0) + COALESCE(t.input_tokens,0)) > 0
+    THEN COALESCE(t.cache_read_tokens,0)::DOUBLE
+         / (COALESCE(t.cache_read_tokens,0) + COALESCE(t.cache_write_tokens,0) + COALESCE(t.input_tokens,0))
+    ELSE 0
+  END`;
+
+/**
+ * (cache_read, cache_write, input) — the edges worth pinning: a zero denominator
+ * (must be 0, not NaN), a case that would truncate to 0 under integer division,
+ * cache_write dominating (the reason it belongs in the denominator at all), and
+ * NULLs, which only the SQL side can receive.
+ */
+const CASES: [number | null, number | null, number | null][] = [
+  [0, 0, 0],
+  [1, 0, 2],
+  [1, 999, 0],
+  [0, 0, 100],
+  [100, 0, 0],
+  [50, 25, 25],
+  [null, null, null],
+  [10, null, 30],
+  [null, 5, 5],
+  [1_000_000_000, 1, 1],
+];
+
+let conn: DuckDBConnection;
+let closeConnection: () => Promise<void>;
+
+beforeAll(async () => {
+  const duck = await import('../src/db/duckdb.js');
+  closeConnection = duck.closeConnection;
+  conn = await duck.getConnection();
+  await conn.run(
+    'CREATE OR REPLACE TEMP TABLE t (i INTEGER, cache_read_tokens BIGINT, cache_write_tokens BIGINT, input_tokens BIGINT)',
+  );
+  const values = CASES.map(
+    ([r, w, i], idx) => `(${idx}, ${r ?? 'NULL'}, ${w ?? 'NULL'}, ${i ?? 'NULL'})`,
+  ).join(', ');
+  await conn.run(`INSERT INTO t VALUES ${values}`);
+});
+
+afterAll(async () => {
+  await closeConnection?.();
+  rmSync(work, { recursive: true, force: true });
+});
+
+/** Evaluate an expression over the fixture table, ordered by row index. */
+async function evaluate(expr: string): Promise<number[]> {
+  const reader = await conn.run(`SELECT ${expr} AS v FROM t ORDER BY i`);
+  return (await reader.getRowObjects()).map((r) => Number(r.v));
+}
+
+describe('cacheHitRatio: the TS and SQL encodings agree', () => {
+  it('produces the same value for every case', async () => {
+    const sql = await evaluate(
+      cacheHitRatioSql('t.cache_read_tokens', 't.cache_write_tokens', 't.input_tokens'),
+    );
+    // NULL is the SQL-only input; COALESCE makes it 0, which is what the TS
+    // callers pass after readRow's null→0 coercion.
+    const ts = CASES.map(([r, w, i]) => cacheHitRatio(r ?? 0, w ?? 0, i ?? 0));
+    expect(sql).toHaveLength(CASES.length);
+    for (const [idx, expected] of ts.entries()) {
+      expect(sql[idx], `case ${idx}: ${JSON.stringify(CASES[idx])}`).toBeCloseTo(expected, 12);
+    }
+  });
+
+  it('matches the hand-written expression it replaced', async () => {
+    const generated = await evaluate(
+      cacheHitRatioSql('t.cache_read_tokens', 't.cache_write_tokens', 't.input_tokens'),
+    );
+    expect(generated).toEqual(await evaluate(LEGACY_SQL));
+  });
+});
+
+describe('cacheHitRatio semantics', () => {
+  it('is 0 — not NaN — when nothing was processed', () => {
+    expect(cacheHitRatio(0, 0, 0)).toBe(0);
+    expect(Number.isNaN(cacheHitRatio(0, 0, 0))).toBe(false);
+  });
+
+  it('counts cache writes as freshly processed', () => {
+    // The bug the wrong header comment would have caused: omitting cache_write
+    // pins a cache-priming session near 100% instead of ~0.1%.
+    expect(cacheHitRatio(1, 999, 0)).toBeCloseTo(1 / 1000, 12);
+    expect(cacheHitRatio(1, 999, 0)).not.toBe(1);
+  });
+
+  it('does not truncate to an integer', async () => {
+    expect(cacheHitRatio(1, 0, 2)).toBeCloseTo(1 / 3, 12);
+    const [sql] = await evaluate(
+      `${cacheHitRatioSql('1::BIGINT', '0::BIGINT', '2::BIGINT')}`,
+    );
+    expect(sql).toBeCloseTo(1 / 3, 12);
+  });
+});


### PR DESCRIPTION
Plan: [docs/plans/0058-analytics-duplication.md](./docs/plans/0058-analytics-duplication.md)

Seventh and last cleanup PR from the repo-wide review. No behaviour change intended — but one of the duplicated definitions was already wrong.

## The cache-hit ratio had three implementations, and the docs described a fourth

Byte-identical TS functions in `analytics.ts` and `analytics-agents.ts`, plus the same formula hand-written as SQL in `analytics-sessions.ts`. And `analytics.ts`'s header said:

```text
cacheHitRatio = cache_read / (cache_read + input)
```

while its own code — and an inline comment 50 lines below — included `cache_write`. That's not a cosmetic doc bug:

| inputs | documented formula | actual formula |
|---|---|---|
| `cache_read: 1`, `cache_write: 999` | **1.0** | **0.001** |

A session that primed a large cache reads as a ~100% cache hit under the documented formula. Anyone trusting the header would compute a materially different number.

**Both encodings have to stay.** `/api/analytics/sessions` makes `cache_hit_ratio` a sortable column *and* feeds it to `quantile_cont` for the median/quartile summary, so it must exist inside the query. Rather than pretend one can go, the formula is now stated once in prose with the two encodings beside it — and a test **evaluates the generated SQL in DuckDB against the TS function** over ten cases: zero denominator, NULLs, a case that truncates to 0 under integer division, `cache_write` dominating.

Same shape as the canonical-contract test in #75: two representations, one source, agreement enforced. It catches divergence from **either** side — dropping `cache_write` from the SQL fails 2 cases, dropping it from the TS fails 2.

The legacy hand-written `CASE` is kept in the test as a literal and asserted equal, so the consolidation provably changed no number.

## Project-slug resolution had three copies

`data/analytics-scope.ts` exists specifically to centralise this — its header literally says *"Centralised here so the slug-resolution loop … can't drift between routes"* — yet `routes/sessions.ts` and `routes/search.ts` each carried their own copy of the loop **and** of the never-match `'\0'` sentinel.

Decomposed into `resolveProjectCwd` / `projectFilter` rather than routing everything through `scopeFilters`: those two routes have no date scope, and calling a function named "scope filters" for a project-only filter reads wrong. `scopeFilters` now uses the same pieces.

| | before | after |
|---|---|---|
| distinct-cwd slug scans | 3 | 1 |
| never-match sentinels | 3 | 1 |
| windowing-default blocks | 2 | 1 |
| totals-line formatting | 2 | 1 |
| `cacheHitRatio` definitions | 3 (+1 wrong doc) | 1 formula, 2 encodings, tested |

Also drops a `projects` table from `db/schema.ts`'s header that doesn't exist in the DDL.

## One item deliberately *not* done

Caching `collectMemory` was on the review list — it re-reads every memory file plus scans `sessions` on each call, including per search keystroke. I measured it first, on a corpus matching your real shape (504 sessions, 56 project dirs, 96 fact files):

```text
collectMemory(): median 3.4ms  min 3.0ms  max 10.7ms
```

At ~3 calls/second while typing that's ~1% of one core. A TTL cache would trade that for staleness in a feature deliberately documented as read-live-never-indexed. Not worth it — recorded in the plan so the next reader doesn't re-litigate it.

## Testing

- `npm test` **588 passed / 61 files** (was 583/60), run 3×; typecheck, build, markdownlint clean.
- Project filtering re-verified end to end through the existing API, query-param and analytics-tools integration suites (68 cases), which already assert that filtering by project id returns the right sessions.

## After this

Only **P7** remains from the review: the per-pass scalability finding (an O(1) transcript change costs O(corpus) work; the full FTS rebuild is 57–70% of it, measured linear at 335ms@26k → 750ms@70k events). That's a design decision rather than a patch, so I'd rather talk through the options than open a PR for it.