### PR TITLE
chore: fix three small cleanups from the review

### DIFF
--- a/docs/plans/0059-small-cleanups.md
+++ b/docs/plans/0059-small-cleanups.md
@@ -1,0 +1,91 @@
+# 0059 — Three small cleanups from the review
+
+- **Status:** done <!-- proposed | in-progress | done | superseded | abandoned -->
+- **Date:** 2026-07-29
+- **PR:** <link, once opened>
+
+## Context
+
+Last of the eight PRs from the repo-wide review. Three items I listed as "micro"
+and left until the substantive clusters were done. Two are genuinely trivial; the
+third turned out to have a real design question and an untested invariant behind
+it, which is why this has a plan at all.
+
+**1. `existsSync(WEB_DIST_DIR)` evaluated twice** (`index.ts:121,133`) — once to
+decide whether to register the static handler, once to build the startup banner.
+
+**2. `rows[0]` cast and read twice** (`sessions.ts:153,159`) — `rowToSessionMeta`
+reads the row, then the handler re-casts the same row to pull `project_cwd` out
+for the resume command.
+
+**3. `SET scalar_subquery_error_on_multiple_rows = false` run per request**
+(`search.ts:44`). This is a **connection-level** setting, applied to the singleton
+connection the indexer and every other route share — so an unrelated HTTP call
+silently changed query semantics process-wide, and left them changed. It was also
+order-dependent: the first search on a fresh process was what armed it.
+
+And it was **completely untested**. Deleting the line outright left all 588 tests
+green, so the one reason it exists — `match_bm25(uuid, …)` doing a scalar-subquery
+lookup on a `uuid` that fork/resume copies duplicate — had no coverage at all.
+
+## Goal
+
+The two duplications are gone, and the DuckDB setting is a declared property of
+the connection with a test that fails without it.
+
+## Decisions
+
+- **Write the missing test before moving the setting** — moving an untested line
+  is unverified by definition. The new test builds an original session plus a fork
+  that preserves its uuids (the precondition), asserts the duplicate really is in
+  `events`, and then searches. It fails with `More than one row returned by a
+  subquery` when the setting is absent from *either* location, so it pins the
+  behaviour rather than the placement.
+- **Apply it at connection open, not per request** — rejected keeping it in the
+  handler but guarding it with a module-level "already done" flag: that is still
+  lazy hidden global initialisation, just cheaper. Rejected set-then-reset around
+  the query: with a shared connection, a reset can land while another search is
+  in flight. Open time makes it deterministic instead of dependent on whether a
+  search has run yet.
+- **Accept that the indexer now always runs with the relaxed setting** — before,
+  a fresh process's initial build ran with it strict and only searches relaxed it.
+  Every scalar subquery in the indexer is `LIMIT 1`-bounded, so there is no
+  practical change; and "deterministic for all queries" beats "strict until
+  someone searches". Called out because it is a real, if small, semantic shift.
+
+## Approach
+
+1. `test/search-forked.integration.test.ts` — new; pin the fork/duplicate-uuid
+   search path.
+2. `db/duckdb.ts` — apply the setting in `openAndPrepare`, documented.
+3. `routes/search.ts` — drop the per-request `SET`, leave a pointer comment.
+4. `index.ts` — hoist `servesWeb`.
+5. `routes/sessions.ts` — hoist the row cast.
+
+## Files affected
+
+- `packages/server/src/db/duckdb.ts` — the setting, at open time.
+- `packages/server/src/routes/search.ts` — per-request `SET` removed.
+- `packages/server/src/index.ts` — `servesWeb` hoisted.
+- `packages/server/src/routes/sessions.ts` — row cast hoisted.
+- `packages/server/test/search-forked.integration.test.ts` — new.
+
+## Testing
+
+- `npm test` (588 → 591), `npm run typecheck`, `npm run build`, markdownlint.
+- The new test fails (2 cases) with the setting removed from the handler, and
+  fails identically with it removed from `openAndPrepare` — so it verifies the
+  behaviour at the new location, not just that a line exists somewhere.
+- `openAndPrepare` is also the path the corrupt-DB recovery and the explicit
+  index rebuild take (`closeConnection` → `discardDbFiles` → `getConnection`), so
+  a rebuilt connection gets the setting too.
+
+## Risks / open questions
+
+- Relaxing the setting for indexer queries could in principle mask a genuine
+  multi-row scalar subquery there. Reviewed: all of them are `LIMIT 1`. If one is
+  ever added without a bound, it will silently pick a row rather than error.
+- The underlying cause is untouched: `events.uuid` is not unique. Making the FTS
+  key genuinely unique (or de-duplicating fork copies before indexing) would remove
+  the need for the setting entirely — a bigger change, and the duplicates are
+  identical so there is no wrong answer today.

--- a/docs/plans/0059-small-cleanups.md
+++ b/docs/plans/0059-small-cleanups.md
@@ -2,7 +2,7 @@
 
 - **Status:** done <!-- proposed | in-progress | done | superseded | abandoned -->
 - **Date:** 2026-07-29
-- **PR:** <link, once opened>
+- **PR:** https://github.com/vladar107/claudescope/pull/79
 
 ## Context
 

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -83,3 +83,4 @@ decision, or a change worth explaining before doing. Skip it for one-line fixes.
 | 0056 | [Prune the normalize cache when its source is gone](./0056-prune-normalize-cache.md) | done |
 | 0057 | [Untrusted-content hardening](./0057-untrusted-content-hardening.md) | done |
 | 0058 | [Consolidate the analytics duplication](./0058-analytics-duplication.md) | done |
+| 0059 | [Three small cleanups from the review](./0059-small-cleanups.md) | done |

--- a/packages/server/src/db/duckdb.ts
+++ b/packages/server/src/db/duckdb.ts
@@ -64,6 +64,20 @@ async function openAndPrepare(): Promise<{ conn: DuckDBConnection; inst: DuckDBI
   await conn.run('INSTALL json; LOAD json;');
   await conn.run('INSTALL fts; LOAD fts;');
 
+  // `events.uuid` is NOT unique: fork/resume copies re-list the same lines under
+  // a new session id. `fts_main_events.match_bm25(uuid, …)` looks the document up
+  // with a scalar subquery keyed by uuid, so it legitimately hits multiple rows,
+  // and newer DuckDB raises on that. The duplicates are identical copies, so
+  // picking a representative is correct (see routes/search.ts).
+  //
+  // Applied here, at open time, rather than inside the search handler: this is a
+  // CONNECTION-level setting on a connection shared with the indexer and every
+  // other route, so setting it per request meant an unrelated HTTP call silently
+  // changed query semantics process-wide — and left them changed. Doing it once
+  // makes the connection's behaviour deterministic instead of depending on
+  // whether a search has run yet.
+  await conn.run('SET scalar_subquery_error_on_multiple_rows = false');
+
   // A schema-version mismatch means the persisted shape is outdated. The index
   // is a derived cache, so signal a discard+rebuild rather than migrate in place.
   if (await isStaleSchema(conn)) {

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -118,7 +118,8 @@ async function main(): Promise<void> {
   }
 
   // In production, serve the built SPA. In dev, Vite serves it and proxies /api.
-  if (existsSync(WEB_DIST_DIR)) {
+  const servesWeb = existsSync(WEB_DIST_DIR);
+  if (servesWeb) {
     await app.register(fastifyStatic, { root: WEB_DIST_DIR });
     // SPA fallback for client-side routing.
     app.setNotFoundHandler((req, reply) => {
@@ -130,7 +131,6 @@ async function main(): Promise<void> {
     });
   }
 
-  const servesWeb = existsSync(WEB_DIST_DIR);
   if (!existsSync(claudeProjectsDir())) {
     app.log.warn(
       `sessions directory not found: ${claudeProjectsDir()} — the app will be empty. ` +

--- a/packages/server/src/routes/search.ts
+++ b/packages/server/src/routes/search.ts
@@ -35,13 +35,10 @@ async function searchSessions(
   project: string | undefined,
   format: SnippetFormat,
 ): Promise<SearchResult[]> {
+  // NOTE: this query depends on `scalar_subquery_error_on_multiple_rows = false`,
+  // which is applied once when the connection opens (see db/duckdb.ts) rather than
+  // here — it is a connection-level setting, and the connection is shared.
   const conn = await getConnection();
-  // `events.uuid` is duplicated by fork/resume copies (the same lines re-listed
-  // under a new session id), so `match_bm25(uuid, …)` — whose internal lookup is
-  // a scalar subquery keyed by uuid — can hit multiple rows. Newer DuckDB errors
-  // on that; this restores the prior "pick a representative row" behavior (the
-  // duplicates are identical copies, so any is fine). Pre-existing issue on main.
-  await conn.run('SET scalar_subquery_error_on_multiple_rows = false');
 
   const filters: string[] = ['score IS NOT NULL'];
   if (type === 'user' || type === 'assistant') filters.push(`role = ${sqlString(type)}`);

--- a/packages/server/src/routes/sessions.ts
+++ b/packages/server/src/routes/sessions.ts
@@ -150,13 +150,14 @@ export async function registerSessionsRoutes(app: FastifyInstance): Promise<void
         reply.code(404).send({ error: 'Session not found' });
         return;
       }
-      const meta = rowToSessionMeta(rows[0] as Record<string, unknown>);
+      const row = rows[0] as Record<string, unknown>;
+      const meta = rowToSessionMeta(row);
 
       const { mainEvents, subagents: subagentSources } = await loadSessionData(id);
       let thread = assembleThread(mainEvents);
       let subagents = buildSubagentRuns(thread, subagentSources);
 
-      const cwd = readRow(rows[0] as Record<string, unknown>, 'sessions').str('project_cwd');
+      const cwd = readRow(row, 'sessions').str('project_cwd');
       const resume = buildResumeInfo(connectorById(meta.connectorId), id, cwd || null);
 
       const res: SessionDetailResponse = { meta, thread, subagents };

--- a/packages/server/test/search-forked.integration.test.ts
+++ b/packages/server/test/search-forked.integration.test.ts
@@ -1,0 +1,155 @@
+/**
+ * Full-text search over a corpus containing fork/resume copies.
+ *
+ * `events.uuid` is NOT unique: forking or resuming a session copies the whole
+ * history into a new file with the uuids preserved, so the same uuid exists under
+ * two session ids. `fts_main_events.match_bm25(uuid, …)` looks the document up by
+ * that key with a scalar subquery, which therefore returns multiple rows — and
+ * newer DuckDB raises `More than one row returned by a subquery` for that.
+ *
+ * The search route relies on `scalar_subquery_error_on_multiple_rows = false` to
+ * keep working (the duplicates are identical copies, so picking either is fine).
+ * Nothing tested that: deleting the setting outright left the whole suite green,
+ * which meant the one reason it exists was unverified — and it is a
+ * connection-level setting on the connection the indexer shares, so where it gets
+ * applied matters.
+ */
+
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import type { FastifyInstance } from 'fastify';
+
+// --- temp locations (decided before any server module is imported) ----------
+const work = mkdtempSync(join(tmpdir(), 'claudescope-searchfork-'));
+const projectsDir = join(work, 'projects');
+
+process.env.CLAUDE_PROJECTS_DIR = projectsDir;
+for (const v of [
+  'CODEX_SESSIONS_DIR',
+  'JUNIE_SESSIONS_DIR',
+  'PI_SESSIONS_DIR',
+  'OPENCODE_DATA_DIR',
+  'COPILOT_SESSIONS_DIR',
+  'ANTIGRAVITY_CLI_DIR',
+  'ANTIGRAVITY_DIR',
+  'GROK_SESSIONS_DIR',
+]) {
+  process.env[v] = join(work, `${v.toLowerCase()}-empty`);
+}
+process.env.DUCKDB_PATH = join(work, 'index.duckdb');
+process.env.CLAUDESCOPE_HOME = join(work, 'home');
+process.env.REINDEX_INTERVAL_MS = '0';
+
+/** A rare token so the BM25 hit is unambiguous. */
+const NEEDLE = 'xyzzyplugh';
+
+/**
+ * An original session plus a fork of it. The fork preserves every uuid (that is
+ * what makes this the interesting case) and rewrites only the session id.
+ */
+function writeFixtures(): void {
+  const proj = join(projectsDir, 'enc-projS');
+  mkdirSync(proj, { recursive: true });
+
+  const lines = (sessionId: string, forked: boolean): string =>
+    [
+      {
+        sessionId,
+        cwd: '/tmp/projS',
+        type: 'user',
+        uuid: 'shared-u1',
+        parentUuid: null,
+        timestamp: '2026-04-01T10:00:00.000Z',
+        isSidechain: false,
+        message: { role: 'user', content: `please find ${NEEDLE} in here` },
+        ...(forked ? { forkedFrom: { sessionId: 'sessOrig', messageUuid: 'shared-u1' } } : {}),
+      },
+      {
+        sessionId,
+        cwd: '/tmp/projS',
+        type: 'assistant',
+        uuid: 'shared-a1',
+        parentUuid: 'shared-u1',
+        timestamp: '2026-04-01T10:00:01.000Z',
+        isSidechain: false,
+        message: {
+          role: 'assistant',
+          id: 'msg_shared',
+          model: 'claude-opus-4-8',
+          content: [{ type: 'text', text: `found ${NEEDLE} for you` }],
+          usage: { input_tokens: 10, output_tokens: 5 },
+        },
+        ...(forked ? { forkedFrom: { sessionId: 'sessOrig', messageUuid: 'shared-a1' } } : {}),
+      },
+    ]
+      .map((r) => JSON.stringify(r))
+      .join('\n') + '\n';
+
+  writeFileSync(join(proj, 'sessOrig.jsonl'), lines('sessOrig', false));
+  writeFileSync(join(proj, 'sessFork.jsonl'), lines('sessFork', true));
+}
+
+let app: FastifyInstance;
+let closeConnection: () => Promise<void>;
+let queryRows: typeof import('../src/db/duckdb.js').queryRows;
+
+beforeAll(async () => {
+  writeFixtures();
+  const Fastify = (await import('fastify')).default;
+  const { registerRoutes } = await import('../src/routes/index.js');
+  const { reindex } = await import('../src/data/index.js');
+  const duck = await import('../src/db/duckdb.js');
+  ({ closeConnection, queryRows } = duck);
+  app = Fastify();
+  await registerRoutes(app);
+  await reindex();
+  await app.ready();
+});
+
+afterAll(async () => {
+  await app?.close();
+  await closeConnection?.();
+  rmSync(work, { recursive: true, force: true });
+});
+
+describe('a duplicated events.uuid', () => {
+  it('really is present — the precondition for the multi-row lookup', async () => {
+    const conn = await (await import('../src/db/duckdb.js')).getConnection();
+    const rows = await queryRows(
+      conn,
+      "SELECT uuid, count(*) AS n FROM events WHERE uuid = 'shared-a1' GROUP BY uuid",
+    );
+    expect(Number(rows[0]?.n)).toBe(2);
+  });
+});
+
+describe('GET /api/search over forked sessions', () => {
+  it('returns hits instead of failing on the multi-row subquery', async () => {
+    const res = await app.inject({ method: 'GET', url: `/api/search?q=${NEEDLE}` });
+    expect(res.statusCode).toBe(200);
+    const body = res.json();
+    // The route catches its own errors and returns [], so an empty list is how a
+    // broken FTS lookup shows up here — assert we actually got hits.
+    expect(body.sessions.length).toBeGreaterThan(0);
+    expect(body.sessions[0].snippet).toContain('<mark>');
+  });
+
+  it('works on a connection that has served no prior search', async () => {
+    // The setting used to be applied inside the search handler, so the FIRST
+    // search on a fresh process was the one that armed it. Sequencing that way
+    // means a different first query could have hit the error instead. Search from
+    // a second app on the same (already-open) connection to make the point that
+    // the setting is a property of the connection, not of having searched before.
+    const Fastify = (await import('fastify')).default;
+    const { registerRoutes } = await import('../src/routes/index.js');
+    const fresh = Fastify();
+    await registerRoutes(fresh);
+    await fresh.ready();
+    const res = await fresh.inject({ method: 'GET', url: `/api/search?q=${NEEDLE}` });
+    expect(res.statusCode).toBe(200);
+    expect(res.json().sessions.length).toBeGreaterThan(0);
+    await fresh.close();
+  });
+});


### PR DESCRIPTION
Plan: [docs/plans/0059-small-cleanups.md](./docs/plans/0059-small-cleanups.md)

Last of the eight PRs from the repo-wide review. Two of these are trivial; the third turned out to have a real design question and an untested invariant behind it.

## The two trivial ones

- **`index.ts`** evaluated `existsSync(WEB_DIST_DIR)` twice — once to decide whether to register the static handler, once for the startup banner. Hoisted to one `servesWeb`.
- **The session-detail route** cast and read `rows[0]` twice: once via `rowToSessionMeta`, again to pull `project_cwd` for the resume command. Hoisted.

## The third one wasn't trivial

`search.ts` ran `SET scalar_subquery_error_on_multiple_rows = false` **per request**. That's a *connection-level* setting on the singleton connection the indexer and every other route share — so an unrelated HTTP call silently changed query semantics process-wide, and left them changed. It was also order-dependent: the first search on a fresh process was what armed it.

Same shared-connection surface that bit me in #72, where wrapping the load in a transaction swept in concurrent route queries.

### And it was completely untested

Deleting the line outright left **all 588 tests green**. So the one reason it exists — `match_bm25(uuid, …)` doing a scalar-subquery lookup keyed by `events.uuid`, which fork/resume copies duplicate — had no coverage at all.

Moving an untested line is unverified by definition, so I wrote the test first. It builds an original session plus a fork that preserves its uuids, asserts the duplicate really is in `events` (the precondition), then searches:

```text
with the setting    → 3 passed
without the setting → 2 failed  ("More than one row returned by a subquery")
```

It fails identically whether the setting is missing from the handler *or* from `openAndPrepare`, so it pins the **behaviour**, not the placement.

### Where it went, and what I rejected

Applied in `openAndPrepare`, so it's a declared property of the connection.

- **Rejected:** guarding the handler with a module-level "already done" flag — still lazy hidden global initialisation, just cheaper.
- **Rejected:** set-then-reset around the query — with a shared connection, a reset can land while another search is in flight.

`openAndPrepare` is also the path taken by the corrupt-DB recovery and by the explicit index rebuild (`closeConnection` → `discardDbFiles` → `getConnection`), so a rebuilt connection gets it too.

## One real semantic shift, flagged

The indexer now **always** runs with the relaxed setting. Before, a fresh process's initial build ran strict and only a search relaxed it. I reviewed the indexer's scalar subqueries — all are `LIMIT 1`-bounded — so there's no practical change, and deterministic beats order-dependent. But it is a change, and if an unbounded scalar subquery is ever added there it will silently pick a row rather than error.

The underlying cause is untouched: `events.uuid` simply isn't unique. Making the FTS key unique (or de-duplicating fork copies before indexing) would remove the need for the setting entirely — bigger change, and the duplicates are identical so there's no wrong answer today. Noted in the plan.

## Testing

- `npm test` **591 passed / 62 files** (was 588/61), run 3×; typecheck, build, markdownlint clean.