### PR TITLE
fix: clear Dependabot alerts #13–#19

### DIFF
--- a/docs/plans/0060-dependabot-alerts-13-19.md
+++ b/docs/plans/0060-dependabot-alerts-13-19.md
@@ -1,0 +1,113 @@
+# 0060 — Dependabot alerts #13–#19
+
+- **Status:** in-progress <!-- proposed | in-progress | done | superseded | abandoned -->
+- **Date:** 2026-07-29
+- **PR:** <link, once opened>
+
+## Context
+
+Seven open Dependabot alerts (5 high, 2 moderate) on `main`, which are really
+**four distinct packages** — the `@fastify/static` findings are reported twice
+each, once against `packages/server/package.json` and once against
+`package-lock.json`.
+
+| alert(s) | package | sev | CVSS | fixed in | scope |
+| --- | --- | --- | --- | --- | --- |
+| #14, #18 | `@fastify/static` | high | 7.5 | 10.1.1 | runtime, **direct** |
+| #15, #19 | `@fastify/static` | medium | 5.3 | 10.1.2 | runtime, **direct** |
+| #17 | `brace-expansion` | high | 7.5 | 5.0.8 | runtime, transitive |
+| #13 | `postcss` | high | 7.5 | 8.5.18 | **development** only |
+| #16 | `react-router` | high | 0 | 8.3.0 | runtime, transitive via `react-router-dom` |
+
+Only one of these is a genuinely exposed runtime surface: `@fastify/static` is
+what serves the built SPA, and the high-severity advisory is a **route-guard
+bypass via path traversal** in exactly that component.
+
+## Goal
+
+`npm audit` clean and all seven alerts closed, with the two runtime-visible major
+bumps verified end to end rather than only by unit tests.
+
+## Decisions
+
+- **`@fastify/static` 9.1.3 → ^10.1.2 (major)** — no patch exists on the 9.x
+  line; 10.1.2 is the first release clearing both advisories. v10 depends on
+  `fastify-plugin@^6`, which targets Fastify 5, so it matches the pinned
+  `fastify@^5.2.0`.
+- **`brace-expansion` and `postcss` need no `overrides`** — both were already
+  satisfiable inside their parents' declared ranges (`minimatch` asks for
+  `^5.0.5`; `vite` asks for `^8.5.15`), so the lockfile was simply stale. A
+  targeted `npm update` moved them to 5.0.8 / 8.5.25. Deliberately not adding
+  root `overrides` for these, unlike alerts #7–#10 in
+  [0050](./0050-dependabot-alerts-7-10.md) — an override that merely restates
+  what the parent range already permits is dead weight that hides future drift.
+- **`postcss` is dev-only and not shipped** — it is Vite's, used at build time.
+  Fixed because it is free, but it is not a risk to anyone running the published
+  package.
+- **`react-router`: migrate off `react-router-dom` rather than dismiss** — the
+  advisory itself (**RSC Mode CSRF Bypass**, CVSS **0**) is *not reachable* here:
+  the app is a plain `<BrowserRouter>` SPA with no `createBrowserRouter`, no
+  loaders or actions, and no `@react-router/*` framework packages, so RSC mode
+  does not exist in it. Dismissing as not-applicable was therefore defensible.
+
+  It was fixed anyway because of what the alert exposed: **`react-router-dom` is a
+  dead end.** Its latest release is `7.18.2` and it pins `react-router` to exactly
+  `7.18.2`, so there is no 8.x of the shim and never will be — staying on it means
+  never receiving another router fix, applicable or not. The whole surface used is
+  nine stable exports (`BrowserRouter`, `NavLink`, `Outlet`, `Route`, `Routes`,
+  `useLocation`, `useOutletContext`, `useParams`, `useSearchParams`), all present
+  in `react-router@8.3.0`, so this is an import swap across 13 files. `react` and
+  `react-dom` were already at `19.2.7`, which is exactly v8's peer floor
+  (`>=19.2.7`), so no React bump was needed.
+- **Verify in a real browser, not just via the suite** — both majors land on things
+  unit tests do not touch: `@fastify/static` serves the SPA and backs the
+  deep-link `sendFile('index.html')` fallback, and the router owns every
+  navigation. A green suite would not have caught either breaking.
+- **Take the Nix `npmDepsHash` from CI** — the real dependency set changed, so the
+  `fetchNpmDeps` fixed-output hash changes with it. Nix is unavailable on this
+  machine; the CI `nix` job prints the expected value (same procedure as 0050).
+
+## Approach
+
+1. `npm install -w @claudescope/server @fastify/static@^10.1.2`.
+2. `npm update brace-expansion postcss` to refresh the stale transitive pins.
+3. Rewrite 13 `from 'react-router-dom'` imports to `from 'react-router'`, drop
+   `react-router-dom`, add `react-router@^8.3.0`.
+4. Verify: typecheck, suite ×3, build, `npm run bundle`, `npm audit`.
+5. Verify end to end against sandboxed fixtures — static assets, SPA fallback,
+   traversal refusal, every route, deep-link reload, back/forward.
+6. Refresh `flake.nix`'s `npmDepsHash` from the CI `nix` job.
+
+## Files affected
+
+- `packages/server/package.json` — `@fastify/static@^10.1.2`.
+- `packages/web/package.json` — `react-router-dom` out, `react-router` in.
+- `packages/web/src/**/*.tsx` — 13 import rewrites.
+- `package-lock.json` — the above plus refreshed `brace-expansion` / `postcss`.
+- `flake.nix` — `npmDepsHash`.
+
+## Testing
+
+- `npm test` 591/62 unchanged, run 3×; typecheck, build, `npm run bundle`, and
+  `npm audit` (**0 vulnerabilities**, with and without `--omit=dev`).
+- End-to-end against a sandboxed fixture corpus on port 4390:
+  - `@fastify/static` v10: root document and hashed asset serve with correct
+    content types; all seven deep links return `index.html`; `/api/*` 404s stay
+    JSON; four path-traversal shapes (raw, encoded, mixed, via `/assets/`) leak
+    nothing.
+  - Router v8: client-side navigation across Browse/Search/Analytics/Memory/
+    Settings with an in-page marker proving no full reload; project → session
+    detail renders the prompt text and the tool block; `useParams` resolves the
+    session id; back/forward; deep-link reload; and a cold deep link in a fresh
+    tab. **Zero console/page errors.**
+
+## Risks / open questions
+
+- `@fastify/static` v10 is a major bump. The API this repo uses is two calls
+  (`register(fastifyStatic, {root})` and `reply.sendFile`), both verified above,
+  but other v10 behaviour changes are untested because unused.
+- `react-router@8` is a major bump whose migration guide may cover APIs this app
+  does not use. Only the nine imported exports were checked.
+- The `react-router` alert may still show as open if GitHub matches on
+  `react-router-dom`'s pinned transitive `react-router` — it should close, since
+  that package is gone from the tree entirely.

--- a/docs/plans/0060-dependabot-alerts-13-19.md
+++ b/docs/plans/0060-dependabot-alerts-13-19.md
@@ -1,8 +1,8 @@
 # 0060 — Dependabot alerts #13–#19
 
-- **Status:** in-progress <!-- proposed | in-progress | done | superseded | abandoned -->
+- **Status:** done <!-- proposed | in-progress | done | superseded | abandoned -->
 - **Date:** 2026-07-29
-- **PR:** <link, once opened>
+- **PR:** https://github.com/vladar107/claudescope/pull/80
 
 ## Context
 

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -84,4 +84,4 @@ decision, or a change worth explaining before doing. Skip it for one-line fixes.
 | 0057 | [Untrusted-content hardening](./0057-untrusted-content-hardening.md) | done |
 | 0058 | [Consolidate the analytics duplication](./0058-analytics-duplication.md) | done |
 | 0059 | [Three small cleanups from the review](./0059-small-cleanups.md) | done |
-| 0060 | [Dependabot alerts #13–#19](./0060-dependabot-alerts-13-19.md) | in-progress |
+| 0060 | [Dependabot alerts #13–#19](./0060-dependabot-alerts-13-19.md) | done |

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -84,3 +84,4 @@ decision, or a change worth explaining before doing. Skip it for one-line fixes.
 | 0057 | [Untrusted-content hardening](./0057-untrusted-content-hardening.md) | done |
 | 0058 | [Consolidate the analytics duplication](./0058-analytics-duplication.md) | done |
 | 0059 | [Three small cleanups from the review](./0059-small-cleanups.md) | done |
+| 0060 | [Dependabot alerts #13–#19](./0060-dependabot-alerts-13-19.md) | in-progress |

--- a/flake.nix
+++ b/flake.nix
@@ -55,7 +55,7 @@
           # `nix build .#claudescope` and the mismatch error prints the new value.
           npmDeps = pkgs.fetchNpmDeps {
             src = depsLock;
-            hash = "sha256-o1F0tWUYc/goXwgo3Q7tm1Tg5Ba0Wh42Dr4S4hssuF4=";
+            hash = "sha256-/PekghEraurKnqNNwxsmjyPRHN1+Bc9uazRiYwgYJoY=";
           };
 
           nodejs = node;

--- a/package-lock.json
+++ b/package-lock.json
@@ -794,9 +794,9 @@
       }
     },
     "node_modules/@fastify/static": {
-      "version": "9.1.3",
-      "resolved": "https://registry.npmjs.org/@fastify/static/-/static-9.1.3.tgz",
-      "integrity": "sha512-aXrYtsiryLhRxRNaxNqsn7FUISeb7rB9q4eHUPIot5aeQBLNahnz1m6thzm7JWC1poSGXS9XrX8DvuMivp2hkQ==",
+      "version": "10.1.2",
+      "resolved": "https://registry.npmjs.org/@fastify/static/-/static-10.1.2.tgz",
+      "integrity": "sha512-G/g18cG9tLutT/OVyN1AIsHIl9L1UwmJ+S3dkyhVpplIx0nEMicd7RGQ+uJLyhKKF4a3tTcQydccn3Mop1fX+Q==",
       "funding": [
         {
           "type": "github",
@@ -810,11 +810,25 @@
       "license": "MIT",
       "dependencies": {
         "@fastify/accept-negotiator": "^2.0.0",
+        "@fastify/error": "^4.0.0",
         "@fastify/send": "^4.0.0",
-        "content-disposition": "^1.0.1",
-        "fastify-plugin": "^5.0.0",
+        "content-disposition": "^2.0.1",
+        "fastify-plugin": "^6.0.0",
         "fastq": "^1.17.1",
         "glob": "^13.0.0"
+      }
+    },
+    "node_modules/@fastify/static/node_modules/content-disposition": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-2.0.1.tgz",
+      "integrity": "sha512-e+H0ZXHSWYrENhQzw1LPuP4oF5MzVKmDU6d3hxlvaPEYLLg62MxtQNPRx4SYSuYJSBUgnQIG4HIN2tEtNv7Dog==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/@hono/node-server": {
@@ -1799,15 +1813,15 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
-      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
+      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/bytes": {
@@ -2058,6 +2072,12 @@
         "type": "opencollective",
         "url": "https://opencollective.com/express"
       }
+    },
+    "node_modules/cookie-es": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/cookie-es/-/cookie-es-3.1.1.tgz",
+      "integrity": "sha512-UaXxwISYJPTr9hwQxMFYZ7kNhSXboMXP+Z3TRX6f1/NyaGPfuNUZOWP1pUEb75B2HjfklIYLVRfWiFZJyC6Npg==",
+      "license": "MIT"
     },
     "node_modules/cookie-signature": {
       "version": "1.2.2",
@@ -2692,9 +2712,9 @@
       }
     },
     "node_modules/fastify-plugin": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/fastify-plugin/-/fastify-plugin-5.1.0.tgz",
-      "integrity": "sha512-FAIDA8eovSt5qcDgcBvDuX/v0Cjz0ohGhENZ/wpc3y+oZCY2afZ9Baqql3g/lC+OHRnciQol4ww7tuthOb9idw==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/fastify-plugin/-/fastify-plugin-6.0.0.tgz",
+      "integrity": "sha512-fZOty7z3O7vOliF6d8bHE3wiEh1KcNnKEQensSgTk9C1DvN6nRLS++XVd86v33Hw/8u9Un8A1zDrQ8ujcQDHEg==",
       "funding": [
         {
           "type": "github",
@@ -4496,9 +4516,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.12",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
-      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
       "dev": true,
       "funding": [
         {
@@ -4804,9 +4824,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.15",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
-      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+      "version": "8.5.25",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.25.tgz",
+      "integrity": "sha512-DTPx3RWSSnWyzLxQnlH0rJP+EW5ekl16ZU4/psbIhA0e53kJfdgaN5vKM+xP7yJtXVu+nfdVFmlgFDEKAe4Pyw==",
       "dev": true,
       "funding": [
         {
@@ -4824,7 +4844,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.12",
+        "nanoid": "^3.3.16",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -5009,41 +5029,24 @@
       }
     },
     "node_modules/react-router": {
-      "version": "7.18.1",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.18.1.tgz",
-      "integrity": "sha512-GDLgg3i3uM0aeJO3Fm+TCS+sDQ7gu12T6x0qdTEzcwqEfleci7JwugVNIF3U//0FWKnJT7ptG+20B2jfDqnZAg==",
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-8.3.0.tgz",
+      "integrity": "sha512-qyPMvW83jGIct3yiieisxdk9M745anqhpIMKN5m1t6yBMfgVPpt77aHOqs5fUlEJRMCGffg9BaQLH9oPVOL7xQ==",
       "license": "MIT",
       "dependencies": {
-        "cookie": "^1.0.1",
-        "set-cookie-parser": "^2.6.0"
+        "cookie-es": "^3.1.1"
       },
       "engines": {
-        "node": ">=20.0.0"
+        "node": ">=22.22.0"
       },
       "peerDependencies": {
-        "react": ">=18",
-        "react-dom": ">=18"
+        "react": ">=19.2.7",
+        "react-dom": ">=19.2.7"
       },
       "peerDependenciesMeta": {
         "react-dom": {
           "optional": true
         }
-      }
-    },
-    "node_modules/react-router-dom": {
-      "version": "7.18.1",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.18.1.tgz",
-      "integrity": "sha512-KaZh+X/6UtEp28x51AUYZDMg9NGoz2ja3dNHa+ta/tk40vCzKhQ/RypCWBMLbmDr6//E24Vv5uPsrqXFozdkAg==",
-      "license": "MIT",
-      "dependencies": {
-        "react-router": "7.18.1"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      },
-      "peerDependencies": {
-        "react": ">=18",
-        "react-dom": ">=18"
       }
     },
     "node_modules/real-require": {
@@ -6347,7 +6350,7 @@
       "dependencies": {
         "@claudescope/shared": "*",
         "@duckdb/node-api": "^1.5.3-r.3",
-        "@fastify/static": "^9.1.3",
+        "@fastify/static": "^10.1.2",
         "@modelcontextprotocol/sdk": "^1.29.0",
         "fastify": "^5.2.0",
         "zod": "^4.4.3"
@@ -6371,7 +6374,7 @@
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
         "react-markdown": "^10.1.0",
-        "react-router-dom": "^7.1.1",
+        "react-router": "^8.3.0",
         "recharts": "^3.8.1",
         "remark-gfm": "^4.0.0",
         "shiki": "^4.2.0"

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "@claudescope/shared": "*",
     "@duckdb/node-api": "^1.5.3-r.3",
-    "@fastify/static": "^9.1.3",
+    "@fastify/static": "^10.1.2",
     "@modelcontextprotocol/sdk": "^1.29.0",
     "fastify": "^5.2.0",
     "zod": "^4.4.3"

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -14,7 +14,7 @@
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "react-markdown": "^10.1.0",
-    "react-router-dom": "^7.1.1",
+    "react-router": "^8.3.0",
     "recharts": "^3.8.1",
     "remark-gfm": "^4.0.0",
     "shiki": "^4.2.0"

--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -1,4 +1,4 @@
-import { NavLink, Route, Routes, useLocation } from 'react-router-dom';
+import { NavLink, Route, Routes, useLocation } from 'react-router';
 import { Cpu, FolderOpen, LineChart, Search, Settings, type LucideIcon } from 'lucide-react';
 import { ErrorBoundary } from './components';
 import { useServerStatus } from './status/StatusProvider.js';

--- a/packages/web/src/main.tsx
+++ b/packages/web/src/main.tsx
@@ -1,6 +1,6 @@
 import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
-import { BrowserRouter } from 'react-router-dom';
+import { BrowserRouter } from 'react-router';
 import { App } from './App.js';
 import { ThemeProvider } from './theme/ThemeProvider.js';
 import { StatusProvider } from './status/StatusProvider.js';

--- a/packages/web/src/pages/analytics/SessionEfficiencyTable.tsx
+++ b/packages/web/src/pages/analytics/SessionEfficiencyTable.tsx
@@ -9,7 +9,7 @@
  * consistently regardless of page. Rows deep-link to the session. The Cache column
  * appears only when "Show cache" is on.
  */
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import type {
   SessionEfficiencyResponse,
   SessionEfficiencyRow,

--- a/packages/web/src/pages/browse/BrowsePage.tsx
+++ b/packages/web/src/pages/browse/BrowsePage.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import type { ProjectMeta, SourceInfo } from '@claudescope/shared';
 import { api, ApiError } from '../../api/client.js';
 import { AgentBadge, ErrorBox, formatCost, formatCount, SearchField, Spinner, SummaryStrip } from '../../components';

--- a/packages/web/src/pages/browse/ProjectLayout.tsx
+++ b/packages/web/src/pages/browse/ProjectLayout.tsx
@@ -10,7 +10,7 @@
  */
 
 import { useEffect, useState } from 'react';
-import { Link, NavLink, Outlet, useOutletContext, useParams } from 'react-router-dom';
+import { Link, NavLink, Outlet, useOutletContext, useParams } from 'react-router';
 import type { ProjectMeta } from '@claudescope/shared';
 import { api, ApiError } from '../../api/client.js';
 import { formatCost, formatCount, SummaryStrip } from '../../components';

--- a/packages/web/src/pages/browse/SessionList.tsx
+++ b/packages/web/src/pages/browse/SessionList.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useState } from 'react';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import type { SessionMeta, SessionSort } from '@claudescope/shared';
 import { api, ApiError } from '../../api/client.js';
 import { AgentBadge, agentLabel, ErrorBox, formatCost, formatCount, LocalBadge, ModelChips, SearchField, Spinner } from '../../components';

--- a/packages/web/src/pages/memory/AgentMemoryPage.tsx
+++ b/packages/web/src/pages/memory/AgentMemoryPage.tsx
@@ -9,7 +9,7 @@
  */
 
 import { useEffect, useMemo, useState } from 'react';
-import { Link, useParams } from 'react-router-dom';
+import { Link, useParams } from 'react-router';
 import type { MemoryResponse, MemorySource } from '@claudescope/shared';
 import { api } from '../../api/client.js';
 import { AgentBadge, agentLabel, ErrorBox, Spinner } from '../../components';

--- a/packages/web/src/pages/memory/AgentProjectMemoryPage.tsx
+++ b/packages/web/src/pages/memory/AgentProjectMemoryPage.tsx
@@ -9,7 +9,7 @@
  */
 
 import { useEffect, useMemo, useState } from 'react';
-import { Link, useParams } from 'react-router-dom';
+import { Link, useParams } from 'react-router';
 import type { ProjectMemoryResponse } from '@claudescope/shared';
 import { api } from '../../api/client.js';
 import { AgentBadge, agentLabel, ErrorBox, Spinner } from '../../components';

--- a/packages/web/src/pages/memory/MemoryPage.tsx
+++ b/packages/web/src/pages/memory/MemoryPage.tsx
@@ -10,7 +10,7 @@
  */
 
 import { useEffect, useState } from 'react';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import type { MemoryConnectorOverview, MemoryPreview, MemoryResponse } from '@claudescope/shared';
 import { api } from '../../api/client.js';
 import { AgentBadge, ErrorBox, Spinner } from '../../components';

--- a/packages/web/src/pages/memory/MemorySourceCard.tsx
+++ b/packages/web/src/pages/memory/MemorySourceCard.tsx
@@ -11,7 +11,7 @@
  */
 
 import { Fragment, useMemo, type ReactNode } from 'react';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import type { MemorySource } from '@claudescope/shared';
 import { Markdown } from '../../components';
 import { anchorId, splitWikiLinks } from './wiki.js';

--- a/packages/web/src/pages/memory/ProjectMemoryPage.tsx
+++ b/packages/web/src/pages/memory/ProjectMemoryPage.tsx
@@ -9,7 +9,7 @@
  */
 
 import { useEffect, useState } from 'react';
-import { useParams } from 'react-router-dom';
+import { useParams } from 'react-router';
 import type { ProjectMemoryResponse } from '@claudescope/shared';
 import { api } from '../../api/client.js';
 import { ErrorBox, Spinner } from '../../components';

--- a/packages/web/src/pages/search/SearchPage.tsx
+++ b/packages/web/src/pages/search/SearchPage.tsx
@@ -16,7 +16,7 @@
  */
 
 import { useEffect, useMemo, useRef, useState } from 'react';
-import { Link, useSearchParams } from 'react-router-dom';
+import { Link, useSearchParams } from 'react-router';
 import { ChevronDown, MessageSquare } from 'lucide-react';
 import type {
   MemorySearchHit,

--- a/packages/web/src/pages/session/SessionPage.tsx
+++ b/packages/web/src/pages/session/SessionPage.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { Link, useParams, useSearchParams } from 'react-router-dom';
+import { Link, useParams, useSearchParams } from 'react-router';
 import { ArrowUpRight, GitBranch, GitPullRequest, MessageSquare, RefreshCw, Wrench } from 'lucide-react';
 import type { SessionDetailResponse, SubagentRun } from '@claudescope/shared';
 import { api, ApiError } from '../../api/client.js';


### PR DESCRIPTION
Plan: [docs/plans/0060-dependabot-alerts-13-19.md](./docs/plans/0060-dependabot-alerts-13-19.md)

Seven alerts (5 high, 2 moderate), which are really **four distinct packages** — the `@fastify/static` findings are reported twice each, once per manifest.

| alert(s) | package | sev | CVSS | action | scope |
| --- | --- | --- | --- | --- | --- |
| #14, #18 | `@fastify/static` | high | 7.5 | 9.1.3 → **^10.1.2** (major) | runtime, direct |
| #15, #19 | `@fastify/static` | medium | 5.3 | same | runtime, direct |
| #17 | `brace-expansion` | high | 7.5 | 5.0.7 → **5.0.8** (lockfile) | runtime, transitive |
| #13 | `postcss` | high | 7.5 | 8.5.15 → **8.5.25** (lockfile) | **dev only** |
| #16 | `react-router` | high | 0 | `react-router-dom` → **`react-router@^8.3.0`** | runtime |

`npm audit`: **0 vulnerabilities**, with and without `--omit=dev`.

## Only one of these is a real exposure

`@fastify/static` is what serves the built SPA, and the high advisory is a **route-guard bypass via path traversal** in exactly that component. No patch exists on the 9.x line, so this is a major bump; v10 depends on `fastify-plugin@^6`, which targets Fastify 5 and so matches the pinned `fastify@^5.2.0`.

## No `overrides` needed for the two transitive ones

Both were already satisfiable inside their parents' declared ranges (`minimatch` asks `^5.0.5`, `vite` asks `^8.5.15`) — the lockfile was simply stale, and a targeted `npm update` moved them.

Deliberately **not** adding root `overrides` here, unlike #7–#10 in 0050: an override that merely restates what the parent range already permits is dead weight that hides future drift. `postcss` is also dev-only (Vite's, build time) and isn't in the published artifact.

## react-router: the advisory doesn't apply, but the fix is still right

The advisory is **RSC Mode CSRF Bypass, CVSS 0**. RSC mode doesn't exist in this app — it's a plain `<BrowserRouter>` SPA with no `createBrowserRouter`, no loaders or actions, and no `@react-router/*` packages. Dismissing it as not-applicable would have been defensible.

I fixed it anyway because of what the alert *exposed*: **`react-router-dom` is a dead end.** Its latest release is `7.18.2` and it pins `react-router` to exactly `7.18.2` — there is no 8.x of the shim and never will be. Staying on it means never receiving another router fix, applicable or not.

The migration is cheap: all nine exports the app uses (`BrowserRouter`, `NavLink`, `Outlet`, `Route`, `Routes`, `useLocation`, `useOutletContext`, `useParams`, `useSearchParams`) exist in `react-router@8.3.0`, so it's an import swap across 13 files. `react`/`react-dom` were already at `19.2.7` — exactly v8's peer floor — so no React bump was needed.

## Verified in a real browser, not just by the suite

Both majors land on things unit tests don't touch: `@fastify/static` serves the SPA and backs the deep-link `sendFile('index.html')` fallback, and the router owns every navigation. A green suite wouldn't have caught either breaking. Driven against sandboxed fixtures on port 4390:

**`@fastify/static` v10**

```text
GET /                        -> 200 text/html
GET /assets/index-*.js       -> 200 application/javascript
deep links (7, incl. /sessions/sessDemo, /deep/nested/route) -> 200, index.html=1
/api/nope                    -> 404 {"error":"Not Found"}   (JSON, not the SPA)
traversal x4 (raw, encoded, mixed, via /assets/) -> leaked_passwd=0
```

**Router v8**

```text
nav /  /search  /analytics  /memory  /settings   -> spa_preserved=true (no reload)
project -> session detail                        -> useParams ok, prompt + tool block rendered
back / forward                                   -> ok
reload on the session route                       -> renders after a real reload
cold deep link in a fresh tab                     -> renders
No console/page errors.  Aborted fetches: 0
```

Session detail screenshot confirmed: breadcrumb, cost/token badges, conversation, `Write a.ts` tool block, Files-changed tab.

Also ran `npm run bundle` — esbuild still inlines `@fastify/static` into the published artifact cleanly.

## Nix

`flake.nix`'s `npmDepsHash` is refreshed to `sha256-/Pekgh…` — the real dependency set changed, so the `fetchNpmDeps` fixed-output hash changes with it. Nix is unavailable on this machine, so the value came from the CI `nix` job (same procedure as 0050); this PR was opened as a draft first for exactly that.

## Note

The `react-router` alert should close since `react-router-dom` is gone from the tree entirely — flagging in case GitHub still matches it transitively.