### PR TITLE
feat: add Markdown source and Mermaid rendering

### DIFF
--- a/docs/plans/0061-markdown-mermaid-rendering.md
+++ b/docs/plans/0061-markdown-mermaid-rendering.md
@@ -1,0 +1,66 @@
+# 0061 — Markdown source view and Mermaid rendering
+
+- **Status:** done
+- **Date:** 2026-07-29
+- **PR:** <link, once opened>
+
+## Context
+
+Claudescope already renders transcript prose as GFM Markdown with Shiki-backed
+code fences, but readers cannot inspect the original Markdown in place and
+`mermaid` fences remain ordinary code. Rendering preferences are presentation
+state, so they should follow the existing browser-local theme model rather than
+expand the server settings contract.
+
+## Goal
+
+Let readers choose rendered or source Markdown globally and per transcript
+block, and render Mermaid fences locally without sending transcript content to
+an external service.
+
+## Decisions
+
+- **Browser-local preferences** — persist Markdown and Mermaid toggles in
+  `localStorage`; no server API or `settings.json` changes are needed.
+- **Temporary per-block override** — a block's Rendered/Source choice lasts
+  until navigation, while the Settings choice remains the default.
+- **Lazy, strict Mermaid rendering** — load Mermaid only for encountered
+  diagrams, use `securityLevel: "strict"`, and rely on the existing CSP as a
+  second network/script boundary.
+- **Source fallback** — invalid, oversized, or failed diagrams remain readable
+  as source and cannot fail the surrounding transcript block.
+- **PlantUML deferred** — keep the renderer boundary extensible, but do not add
+  PlantUML in this iteration.
+
+## Approach
+
+1. Add a rendering-preferences provider with resilient browser persistence and
+   immediate Settings controls.
+2. Add an opt-in Rendered/Source switch to semantic transcript Markdown,
+   including forced source while an in-session search match is active.
+3. Route `mermaid` fences to a lazy, theme-aware diagram renderer with size and
+   error fallbacks; leave all other fences on the existing Shiki path.
+4. Verify typechecking, tests, production build, and the security/performance
+   fallbacks, then review the complete diff.
+
+## Files affected
+
+- `packages/web/src/rendering/` — rendering preference context and persistence.
+- `packages/web/src/components/` — Markdown mode switch and Mermaid renderer.
+- `packages/web/src/pages/settings/` — browser-local rendering controls.
+- `packages/web/src/pages/session/` — opt transcript blocks into the local
+  switch and search-driven source reveal.
+- `packages/web/package.json` / `package-lock.json` — Mermaid dependency.
+
+## Testing
+
+- Run `npm run typecheck`, `npm test`, and `npm run build`.
+- Manually cover persisted defaults, per-block overrides, light/dark Mermaid,
+  disabled/invalid/oversized Mermaid source fallbacks, finder-driven source
+  reveal, and unchanged tool-output/memory behavior.
+
+## Risks / open questions
+
+- Mermaid is a sizeable dependency, so it must stay in a lazy chunk.
+- Mermaid keeps process-global configuration; rendering must reinitialize it
+  for the active theme without allowing stale asynchronous results to win.

--- a/docs/plans/0061-markdown-mermaid-rendering.md
+++ b/docs/plans/0061-markdown-mermaid-rendering.md
@@ -2,7 +2,7 @@
 
 - **Status:** done
 - **Date:** 2026-07-29
-- **PR:** <link, once opened>
+- **PR:** https://github.com/vladar107/claudescope/pull/81
 
 ## Context
 

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -85,3 +85,4 @@ decision, or a change worth explaining before doing. Skip it for one-line fixes.
 | 0058 | [Consolidate the analytics duplication](./0058-analytics-duplication.md) | done |
 | 0059 | [Three small cleanups from the review](./0059-small-cleanups.md) | done |
 | 0060 | [Dependabot alerts #13–#19](./0060-dependabot-alerts-13-19.md) | done |
+| 0061 | [Markdown source view and Mermaid rendering](./0061-markdown-mermaid-rendering.md) | done |

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,31 @@
         "node": ">=22.12"
       }
     },
+    "node_modules/@antfu/install-pkg": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@antfu/install-pkg/-/install-pkg-1.1.0.tgz",
+      "integrity": "sha512-MGQsmw10ZyI+EJo45CdSER4zEb+p31LpDAFp2Z3gkSd1yqVZGi0Ebx++YTEMonJy4oChEMLsxZ64j8FH6sSqtQ==",
+      "license": "MIT",
+      "dependencies": {
+        "package-manager-detector": "^1.3.0",
+        "tinyexec": "^1.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/@braintree/sanitize-url": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/@braintree/sanitize-url/-/sanitize-url-7.1.2.tgz",
+      "integrity": "sha512-jigsZK+sMF/cuiB7sERuo9V7N9jx+dhmHHnQyDSVdpZwVutaBu7WvNYqMDLSgFgfB30n452TP3vjDAvFC973mA==",
+      "license": "MIT"
+    },
+    "node_modules/@chevrotain/types": {
+      "version": "11.1.2",
+      "resolved": "https://registry.npmjs.org/@chevrotain/types/-/types-11.1.2.tgz",
+      "integrity": "sha512-U+HFai5+zmJCkK86QsaJtoITlboZHBqrVketcO2ROv865xfCMSFpELQoz1GkX5GzME8pTa+3kbKrZHQtI0gdbw==",
+      "license": "Apache-2.0"
+    },
     "node_modules/@claudescope/server": {
       "resolved": "packages/server",
       "link": true
@@ -843,6 +868,23 @@
         "hono": "^4"
       }
     },
+    "node_modules/@iconify/types": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@iconify/types/-/types-2.0.0.tgz",
+      "integrity": "sha512-+wluvCrRhXrhyOmRDJ3q8mux9JkKy5SJ/v8ol2tu4FVjyYvtEzkc/3pK15ET6RKg4b4w4BmTk1+gsCUhf21Ykg==",
+      "license": "MIT"
+    },
+    "node_modules/@iconify/utils": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/@iconify/utils/-/utils-3.1.4.tgz",
+      "integrity": "sha512-b1S7B1k9ohZ+iNTi2ATxbRYG9fTrJmUT0rc46bvVnNxqNRGW7dyo/vRREwyniI5IRN2RSJHDcm+s3BjWrSAjHw==",
+      "license": "MIT",
+      "dependencies": {
+        "@antfu/install-pkg": "^1.1.0",
+        "@iconify/types": "^2.0.0",
+        "import-meta-resolve": "^4.2.0"
+      }
+    },
     "node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.5.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
@@ -857,6 +899,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/@mermaid-js/parser": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@mermaid-js/parser/-/parser-1.2.0.tgz",
+      "integrity": "sha512-oYPyv8A4As1yH5Bx+04iQEQxXuIQDe0GKCNSRgao6z8AM9jixXIfP0vsppRLvGf+nKIOb9/LdpWA4YuJiVvESA==",
+      "license": "MIT",
+      "dependencies": {
+        "@chevrotain/types": "~11.1.2"
       }
     },
     "node_modules/@modelcontextprotocol/sdk": {
@@ -1361,10 +1412,72 @@
         "assertion-error": "^2.0.1"
       }
     },
+    "node_modules/@types/d3": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@types/d3/-/d3-7.4.3.tgz",
+      "integrity": "sha512-lZXZ9ckh5R8uiFVt8ogUNf+pIrK4EsWrx2Np75WvF/eTpJ0FMHNhjXk8CKEx/+gpHbNQyJWehbFaTvqmHWB3ww==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-array": "*",
+        "@types/d3-axis": "*",
+        "@types/d3-brush": "*",
+        "@types/d3-chord": "*",
+        "@types/d3-color": "*",
+        "@types/d3-contour": "*",
+        "@types/d3-delaunay": "*",
+        "@types/d3-dispatch": "*",
+        "@types/d3-drag": "*",
+        "@types/d3-dsv": "*",
+        "@types/d3-ease": "*",
+        "@types/d3-fetch": "*",
+        "@types/d3-force": "*",
+        "@types/d3-format": "*",
+        "@types/d3-geo": "*",
+        "@types/d3-hierarchy": "*",
+        "@types/d3-interpolate": "*",
+        "@types/d3-path": "*",
+        "@types/d3-polygon": "*",
+        "@types/d3-quadtree": "*",
+        "@types/d3-random": "*",
+        "@types/d3-scale": "*",
+        "@types/d3-scale-chromatic": "*",
+        "@types/d3-selection": "*",
+        "@types/d3-shape": "*",
+        "@types/d3-time": "*",
+        "@types/d3-time-format": "*",
+        "@types/d3-timer": "*",
+        "@types/d3-transition": "*",
+        "@types/d3-zoom": "*"
+      }
+    },
     "node_modules/@types/d3-array": {
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.2.tgz",
       "integrity": "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-axis": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-axis/-/d3-axis-3.0.6.tgz",
+      "integrity": "sha512-pYeijfZuBd87T0hGn0FO1vQ/cgLk6E1ALJjfkC0oJ8cbwkZl3TpgS8bVBLZN+2jjGgg38epgxb2zmoGtSfvgMw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-brush": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-brush/-/d3-brush-3.0.6.tgz",
+      "integrity": "sha512-nH60IZNNxEcrh6L1ZSMNA28rj27ut/2ZmI3r96Zd+1jrZD++zD3LsMIjWlvg4AYrHn/Pqz4CF3veCxGjtbqt7A==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-chord": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-chord/-/d3-chord-3.0.6.tgz",
+      "integrity": "sha512-LFYWWd8nwfwEmTZG9PfQxd17HbNPksHBiJHaKuY1XeqscXacsS2tyoo6OdRsjf+NQYeB6XrNL3a25E3gH69lcg==",
       "license": "MIT"
     },
     "node_modules/@types/d3-color": {
@@ -1373,10 +1486,83 @@
       "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
       "license": "MIT"
     },
+    "node_modules/@types/d3-contour": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-contour/-/d3-contour-3.0.6.tgz",
+      "integrity": "sha512-BjzLgXGnCWjUSYGfH1cpdo41/hgdWETu4YxpezoztawmqsvCeep+8QGfiY6YbDvfgHz/DkjeIkkZVJavB4a3rg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-array": "*",
+        "@types/geojson": "*"
+      }
+    },
+    "node_modules/@types/d3-delaunay": {
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-delaunay/-/d3-delaunay-6.0.4.tgz",
+      "integrity": "sha512-ZMaSKu4THYCU6sV64Lhg6qjf1orxBthaC161plr5KuPHo3CNm8DTHiLw/5Eq2b6TsNP0W0iJrUOFscY6Q450Hw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-dispatch": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-dispatch/-/d3-dispatch-3.0.7.tgz",
+      "integrity": "sha512-5o9OIAdKkhN1QItV2oqaE5KMIiXAvDWBDPrD85e58Qlz1c1kI/J0NcqbEG88CoTwJrYe7ntUCVfeUl2UJKbWgA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-drag": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-drag/-/d3-drag-3.0.7.tgz",
+      "integrity": "sha512-HE3jVKlzU9AaMazNufooRJ5ZpWmLIoc90A37WU2JMmeq28w1FQqCZswHZ3xR+SuxYftzHq6WU6KJHvqxKzTxxQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-dsv": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-dsv/-/d3-dsv-3.0.7.tgz",
+      "integrity": "sha512-n6QBF9/+XASqcKK6waudgL0pf/S5XHPPI8APyMLLUHd8NqouBGLsU8MgtO7NINGtPBtk9Kko/W4ea0oAspwh9g==",
+      "license": "MIT"
+    },
     "node_modules/@types/d3-ease": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.2.tgz",
       "integrity": "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-fetch": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-fetch/-/d3-fetch-3.0.7.tgz",
+      "integrity": "sha512-fTAfNmxSb9SOWNB9IoG5c8Hg6R+AzUHDRlsXsDZsNp6sxAEOP0tkP3gKkNSO/qmHPoBFTxNrjDprVHDQDvo5aA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-dsv": "*"
+      }
+    },
+    "node_modules/@types/d3-force": {
+      "version": "3.0.10",
+      "resolved": "https://registry.npmjs.org/@types/d3-force/-/d3-force-3.0.10.tgz",
+      "integrity": "sha512-ZYeSaCF3p73RdOKcjj+swRlZfnYpK1EbaDiYICEEp5Q6sUiqFaFQ9qgoshp5CzIyyb/yD09kD9o2zEltCexlgw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-format": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-format/-/d3-format-3.0.4.tgz",
+      "integrity": "sha512-fALi2aI6shfg7vM5KiR1wNJnZ7r6UuggVqtDA+xiEdPZQwy/trcQaHnwShLuLdta2rTymCNpxYTiMZX/e09F4g==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-geo": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@types/d3-geo/-/d3-geo-3.1.0.tgz",
+      "integrity": "sha512-856sckF0oP/diXtS4jNsiQw/UuK5fQG8l/a9VVLeSouf1/PPbBE1i1W852zVwKwYCBkFJJB7nCFTbk6UMEXBOQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/geojson": "*"
+      }
+    },
+    "node_modules/@types/d3-hierarchy": {
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-hierarchy/-/d3-hierarchy-3.1.7.tgz",
+      "integrity": "sha512-tJFtNoYBtRtkNysX1Xq4sxtjK8YgoWUNpIiUee0/jHGRwqvzYxkq0hGVbbOGSz+JgFxxRu4K8nb3YpG3CMARtg==",
       "license": "MIT"
     },
     "node_modules/@types/d3-interpolate": {
@@ -1394,6 +1580,24 @@
       "integrity": "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==",
       "license": "MIT"
     },
+    "node_modules/@types/d3-polygon": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-polygon/-/d3-polygon-3.0.2.tgz",
+      "integrity": "sha512-ZuWOtMaHCkN9xoeEMr1ubW2nGWsp4nIql+OPQRstu4ypeZ+zk3YKqQT0CXVe/PYqrKpZAi+J9mTs05TKwjXSRA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-quadtree": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-quadtree/-/d3-quadtree-3.0.6.tgz",
+      "integrity": "sha512-oUzyO1/Zm6rsxKRHA1vH0NEDG58HrT5icx/azi9MF1TWdtttWl0UIUsjEQBBh+SIkrpd21ZjEv7ptxWys1ncsg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-random": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-random/-/d3-random-3.0.4.tgz",
+      "integrity": "sha512-UHYId5WTCx4L4YNel7NU00XUXXgvgpgZOvp10PuvsQENjMDXhh2RyFc0KBjO7B45ne4Ha1yVH7ii0vnzKkuzWA==",
+      "license": "MIT"
+    },
     "node_modules/@types/d3-scale": {
       "version": "4.0.9",
       "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.9.tgz",
@@ -1402,6 +1606,18 @@
       "dependencies": {
         "@types/d3-time": "*"
       }
+    },
+    "node_modules/@types/d3-scale-chromatic": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale-chromatic/-/d3-scale-chromatic-3.1.0.tgz",
+      "integrity": "sha512-iWMJgwkK7yTRmWqRB5plb1kadXyQ5Sj8V/zYlFGMUBbIPKQScw+Dku9cAAMgJG+z5GYDoMjWGLVOvjghDEFnKQ==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-selection": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/@types/d3-selection/-/d3-selection-3.0.11.tgz",
+      "integrity": "sha512-bhAXu23DJWsrI45xafYpkQ4NtcKMwWnAC/vKrd2l+nxMFuvOT3XMYTIj2opv8vq8AO5Yh7Qac/nSeP/3zjTK0w==",
+      "license": "MIT"
     },
     "node_modules/@types/d3-shape": {
       "version": "3.1.8",
@@ -1418,11 +1634,36 @@
       "integrity": "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==",
       "license": "MIT"
     },
+    "node_modules/@types/d3-time-format": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-time-format/-/d3-time-format-4.0.3.tgz",
+      "integrity": "sha512-5xg9rC+wWL8kdDj153qZcsJ0FWiFt0J5RB6LYUNZjwSnesfblqrI/bJ1wBdJ8OQfncgbJG5+2F+qfqnqyzYxyg==",
+      "license": "MIT"
+    },
     "node_modules/@types/d3-timer": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
       "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
       "license": "MIT"
+    },
+    "node_modules/@types/d3-transition": {
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-transition/-/d3-transition-3.0.9.tgz",
+      "integrity": "sha512-uZS5shfxzO3rGlu0cC3bjmMFKsXv+SmZZcgp0KD22ts4uGXp5EVYGzu/0YdwZeKmddhcAccYtREJKkPfXkZuCg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-zoom": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/@types/d3-zoom/-/d3-zoom-3.0.8.tgz",
+      "integrity": "sha512-iqMC4/YlFCSlO8+2Ii1GGGliCAY4XdeG748w5vQUbevlbDu0zSjH/+jojorQVBK/se0j6DUFNPBGSqD3YWYnDw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-interpolate": "*",
+        "@types/d3-selection": "*"
+      }
     },
     "node_modules/@types/debug": {
       "version": "4.1.13",
@@ -1454,6 +1695,12 @@
       "dependencies": {
         "@types/estree": "*"
       }
+    },
+    "node_modules/@types/geojson": {
+      "version": "7946.0.16",
+      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.16.tgz",
+      "integrity": "sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==",
+      "license": "MIT"
     },
     "node_modules/@types/hast": {
       "version": "3.0.4",
@@ -1508,6 +1755,13 @@
         "@types/react": "^19.2.0"
       }
     },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/@types/unist": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
@@ -1525,6 +1779,16 @@
       "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.1.tgz",
       "integrity": "sha512-mUFwbeTqrVgDQxFveS+df2yfap6iuP20NAKAsBt5jDEoOTDew+zwLAOilHCeQJOVSvmgCX4ogqIrA0mnyr08yQ==",
       "license": "ISC"
+    },
+    "node_modules/@upsetjs/venn.js": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@upsetjs/venn.js/-/venn.js-2.0.0.tgz",
+      "integrity": "sha512-WbBhLrooyePuQ1VZxrJjtLvTc4NVfpOyKx0sKqioq9bX1C1m7Jgykkn8gLrtwumBioXIqam8DLxp88Adbue6Hw==",
+      "license": "MIT",
+      "optionalDependencies": {
+        "d3-selection": "^3.0.0",
+        "d3-transition": "^3.0.1"
+      }
     },
     "node_modules/@vitest/expect": {
       "version": "4.1.9",
@@ -2006,6 +2270,15 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/commander": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
+      "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10"
+      }
+    },
     "node_modules/concurrently": {
       "version": "9.2.4",
       "resolved": "https://registry.npmjs.org/concurrently/-/concurrently-9.2.4.tgz",
@@ -2105,6 +2378,15 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/cose-base": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/cose-base/-/cose-base-1.0.3.tgz",
+      "integrity": "sha512-s9whTXInMSgAp/NVXVNuVxVKzGH2qck3aQlVHxDCdAEPgtMKwc4Wq6/QKhgdEdgbLSi9rBTAcPoRa6JpiG4ksg==",
+      "license": "MIT",
+      "dependencies": {
+        "layout-base": "^1.0.0"
+      }
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -2125,6 +2407,95 @@
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "license": "MIT"
     },
+    "node_modules/cytoscape": {
+      "version": "3.34.0",
+      "resolved": "https://registry.npmjs.org/cytoscape/-/cytoscape-3.34.0.tgz",
+      "integrity": "sha512-62rNSrioXw93uliKFBwjukeQyeWwH2PqDrTac31r2P6464u3AUvTk0xS4LVvT251g7IgkFunrI48ZEZGjywSOg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/cytoscape-cose-bilkent": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/cytoscape-cose-bilkent/-/cytoscape-cose-bilkent-4.1.0.tgz",
+      "integrity": "sha512-wgQlVIUJF13Quxiv5e1gstZ08rnZj2XaLHGoFMYXz7SkNfCDOOteKBE6SYRfA9WxxI/iBc3ajfDoc6hb/MRAHQ==",
+      "license": "MIT",
+      "dependencies": {
+        "cose-base": "^1.0.0"
+      },
+      "peerDependencies": {
+        "cytoscape": "^3.2.0"
+      }
+    },
+    "node_modules/cytoscape-fcose": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/cytoscape-fcose/-/cytoscape-fcose-2.2.0.tgz",
+      "integrity": "sha512-ki1/VuRIHFCzxWNrsshHYPs6L7TvLu3DL+TyIGEsRcvVERmxokbf5Gdk7mFxZnTdiGtnA4cfSmjZJMviqSuZrQ==",
+      "license": "MIT",
+      "dependencies": {
+        "cose-base": "^2.2.0"
+      },
+      "peerDependencies": {
+        "cytoscape": "^3.2.0"
+      }
+    },
+    "node_modules/cytoscape-fcose/node_modules/cose-base": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/cose-base/-/cose-base-2.2.0.tgz",
+      "integrity": "sha512-AzlgcsCbUMymkADOJtQm3wO9S3ltPfYOFD5033keQn9NJzIbtnZj+UdBJe7DYml/8TdbtHJW3j58SOnKhWY/5g==",
+      "license": "MIT",
+      "dependencies": {
+        "layout-base": "^2.0.0"
+      }
+    },
+    "node_modules/cytoscape-fcose/node_modules/layout-base": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/layout-base/-/layout-base-2.0.1.tgz",
+      "integrity": "sha512-dp3s92+uNI1hWIpPGH3jK2kxE2lMjdXdr+DH8ynZHpd6PUlH6x6cbuXnoMmiNumznqaNO31xu9e79F0uuZ0JFg==",
+      "license": "MIT"
+    },
+    "node_modules/d3": {
+      "version": "7.9.0",
+      "resolved": "https://registry.npmjs.org/d3/-/d3-7.9.0.tgz",
+      "integrity": "sha512-e1U46jVP+w7Iut8Jt8ri1YsPOvFpg46k+K8TpCb0P+zjCkjkPnV7WzfDJzMHy1LnA+wj5pLT1wjO901gLXeEhA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "3",
+        "d3-axis": "3",
+        "d3-brush": "3",
+        "d3-chord": "3",
+        "d3-color": "3",
+        "d3-contour": "4",
+        "d3-delaunay": "6",
+        "d3-dispatch": "3",
+        "d3-drag": "3",
+        "d3-dsv": "3",
+        "d3-ease": "3",
+        "d3-fetch": "3",
+        "d3-force": "3",
+        "d3-format": "3",
+        "d3-geo": "3",
+        "d3-hierarchy": "3",
+        "d3-interpolate": "3",
+        "d3-path": "3",
+        "d3-polygon": "3",
+        "d3-quadtree": "3",
+        "d3-random": "3",
+        "d3-scale": "4",
+        "d3-scale-chromatic": "3",
+        "d3-selection": "3",
+        "d3-shape": "3",
+        "d3-time": "3",
+        "d3-time-format": "4",
+        "d3-timer": "3",
+        "d3-transition": "3",
+        "d3-zoom": "3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/d3-array": {
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
@@ -2132,6 +2503,43 @@
       "license": "ISC",
       "dependencies": {
         "internmap": "1 - 2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-axis": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-axis/-/d3-axis-3.0.0.tgz",
+      "integrity": "sha512-IH5tgjV4jE/GhHkRV0HiVYPDtvfjHQlQfJHs0usq7M30XcSBvOotpmH1IgkcXsO/5gEQZD43B//fc7SRT5S+xw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-brush": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-brush/-/d3-brush-3.0.0.tgz",
+      "integrity": "sha512-ALnjWlVYkXsVIGlOsuWH1+3udkYFI48Ljihfnh8FZPF2QS9o+PzGLBslO0PjzVoHLZ2KCVgAM8NVkXPJB2aNnQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-drag": "2 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-selection": "3",
+        "d3-transition": "3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-chord": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-chord/-/d3-chord-3.0.1.tgz",
+      "integrity": "sha512-VE5S6TNa+j8msksl7HwjxMHDM2yNK3XCkusIlpX5kwauBfXuyLAtNg9jCp/iHH61tgI4sb6R/EIMWCqEIdjT/g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-path": "1 - 3"
       },
       "engines": {
         "node": ">=12"
@@ -2146,6 +2554,89 @@
         "node": ">=12"
       }
     },
+    "node_modules/d3-contour": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-contour/-/d3-contour-4.0.2.tgz",
+      "integrity": "sha512-4EzFTRIikzs47RGmdxbeUvLWtGedDUNkTcmzoeyg4sP/dvCexO47AaQL7VKy/gul85TOxw+IBgA8US2xwbToNA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "^3.2.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-delaunay": {
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/d3-delaunay/-/d3-delaunay-6.0.4.tgz",
+      "integrity": "sha512-mdjtIZ1XLAM8bm/hx3WwjfHt6Sggek7qH043O8KEjDXN40xi3vx/6pYSVTwLjEgiXQTbvaouWKynLBiUZ6SK6A==",
+      "license": "ISC",
+      "dependencies": {
+        "delaunator": "5"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-dispatch": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-dispatch/-/d3-dispatch-3.0.1.tgz",
+      "integrity": "sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-drag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-drag/-/d3-drag-3.0.0.tgz",
+      "integrity": "sha512-pWbUJLdETVA8lQNJecMxoXfH6x+mO2UQo8rSmZ+QqxcbyA3hfeprFgIT//HW2nlHChWeIIMwS2Fq+gEARkhTkg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-selection": "3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-dsv": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-dsv/-/d3-dsv-3.0.1.tgz",
+      "integrity": "sha512-UG6OvdI5afDIFP9w4G0mNq50dSOsXHJaRE8arAS5o9ApWnIElp8GZw1Dun8vP8OyHOZ/QJUKUJwxiiCCnUwm+Q==",
+      "license": "ISC",
+      "dependencies": {
+        "commander": "7",
+        "iconv-lite": "0.6",
+        "rw": "1"
+      },
+      "bin": {
+        "csv2json": "bin/dsv2json.js",
+        "csv2tsv": "bin/dsv2dsv.js",
+        "dsv2dsv": "bin/dsv2dsv.js",
+        "dsv2json": "bin/dsv2json.js",
+        "json2csv": "bin/json2dsv.js",
+        "json2dsv": "bin/json2dsv.js",
+        "json2tsv": "bin/json2dsv.js",
+        "tsv2csv": "bin/dsv2dsv.js",
+        "tsv2json": "bin/dsv2json.js"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-dsv/node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/d3-ease": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
@@ -2155,10 +2646,57 @@
         "node": ">=12"
       }
     },
+    "node_modules/d3-fetch": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-fetch/-/d3-fetch-3.0.1.tgz",
+      "integrity": "sha512-kpkQIM20n3oLVBKGg6oHrUchHM3xODkTzjMoj7aWQFq5QEM+R6E4WkzT5+tojDY7yjez8KgCBRoj4aEr99Fdqw==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dsv": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-force": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-force/-/d3-force-3.0.0.tgz",
+      "integrity": "sha512-zxV/SsA+U4yte8051P4ECydjD/S+qeYtnaIyAs9tgHCqfguma/aAQDjo85A9Z6EKhBirHRJHXIgJUlffT4wdLg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-quadtree": "1 - 3",
+        "d3-timer": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/d3-format": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.2.tgz",
       "integrity": "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-geo": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/d3-geo/-/d3-geo-3.1.1.tgz",
+      "integrity": "sha512-637ln3gXKXOwhalDzinUgY83KzNWZRKbYubaG+fGVuc/dxO64RRljtCTnf5ecMyE1RIdtqpkVcq0IbtU2S8j2Q==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.5.0 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-hierarchy": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/d3-hierarchy/-/d3-hierarchy-3.1.2.tgz",
+      "integrity": "sha512-FX/9frcub54beBdugHjDCdikxThEqjnR93Qt7PvQTOHxyiNCAlvMrHhclk3cD5VeAaq9fxmfRp+CnWw9rEMBuA==",
       "license": "ISC",
       "engines": {
         "node": ">=12"
@@ -2185,6 +2723,73 @@
         "node": ">=12"
       }
     },
+    "node_modules/d3-polygon": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-polygon/-/d3-polygon-3.0.1.tgz",
+      "integrity": "sha512-3vbA7vXYwfe1SYhED++fPUQlWSYTTGmFmQiany/gdbiWgU/iEyQzyymwL9SkJjFFuCS4902BSzewVGsHHmHtXg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-quadtree": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-quadtree/-/d3-quadtree-3.0.1.tgz",
+      "integrity": "sha512-04xDrxQTDTCFwP5H6hRhsRcb9xxv2RzkcsygFzmkSIOJy3PeRJP7sNk3VRIbKXcog561P9oU0/rVH6vDROAgUw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-random": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-random/-/d3-random-3.0.1.tgz",
+      "integrity": "sha512-FXMe9GfxTxqd5D6jFsQ+DJ8BJS4E/fT5mqqdjovykEB2oFbTMDVdg1MGFxfQW+FBOGoB++k8swBrgwSHT1cUXQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-sankey": {
+      "version": "0.12.3",
+      "resolved": "https://registry.npmjs.org/d3-sankey/-/d3-sankey-0.12.3.tgz",
+      "integrity": "sha512-nQhsBRmM19Ax5xEIPLMY9ZmJ/cDvd1BG3UVvt5h3WRxKg5zGRbvnteTyWAbzeSvlh3tW7ZEmq4VwR5mB3tutmQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "d3-array": "1 - 2",
+        "d3-shape": "^1.2.0"
+      }
+    },
+    "node_modules/d3-sankey/node_modules/d3-array": {
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-2.12.1.tgz",
+      "integrity": "sha512-B0ErZK/66mHtEsR1TkPEEkwdy+WDesimkM5gpZr5Dsg54BiTA5RXtYW5qTLIAcekaS9xfZrzBLF/OAkB3Qn1YQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "internmap": "^1.0.0"
+      }
+    },
+    "node_modules/d3-sankey/node_modules/d3-path": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-1.0.9.tgz",
+      "integrity": "sha512-VLaYcn81dtHVTjEHd8B+pbe9yHWpXKZUC87PzoFmsFrJqgFwDe/qxfp5MlfsfM1V5E/iVt0MmEbWQ7FVIXh/bg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/d3-sankey/node_modules/d3-shape": {
+      "version": "1.3.7",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-1.3.7.tgz",
+      "integrity": "sha512-EUkvKjqPFUAZyOlhY5gzCxCeI0Aep04LwIRpsZ/mLFelJiUfnK56jo5JMDSE7yyP2kLSb6LtF+S5chMk7uqPqw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "d3-path": "1"
+      }
+    },
+    "node_modules/d3-sankey/node_modules/internmap": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-1.0.1.tgz",
+      "integrity": "sha512-lDB5YccMydFBtasVtxnZ3MRBHuaoE8GKsppq+EchKL2U4nK/DmEpPHNH8MZe5HkMtpSiTSOZwfN0tzYjO/lJEw==",
+      "license": "ISC"
+    },
     "node_modules/d3-scale": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
@@ -2197,6 +2802,28 @@
         "d3-time": "2.1.1 - 3",
         "d3-time-format": "2 - 4"
       },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale-chromatic": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-scale-chromatic/-/d3-scale-chromatic-3.1.0.tgz",
+      "integrity": "sha512-A3s5PWiZ9YCXFye1o246KoscMWqf8BsD9eRiJ3He7C9OBaxKhAd5TFCdEx/7VbKtxxTsu//1mMJFrEt572cEyQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3",
+        "d3-interpolate": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-selection": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
+      "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
+      "license": "ISC",
       "engines": {
         "node": ">=12"
       }
@@ -2246,6 +2873,57 @@
         "node": ">=12"
       }
     },
+    "node_modules/d3-transition": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-transition/-/d3-transition-3.0.1.tgz",
+      "integrity": "sha512-ApKvfjsSR6tg06xrL434C0WydLr7JewBB3V+/39RMHsaXTOG0zmt/OAXeng5M5LBm0ojmxJrpomQVZ1aPvBL4w==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3",
+        "d3-dispatch": "1 - 3",
+        "d3-ease": "1 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-timer": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "d3-selection": "2 - 3"
+      }
+    },
+    "node_modules/d3-zoom": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-zoom/-/d3-zoom-3.0.0.tgz",
+      "integrity": "sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-drag": "2 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-selection": "2 - 3",
+        "d3-transition": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/dagre-d3-es": {
+      "version": "7.0.14",
+      "resolved": "https://registry.npmjs.org/dagre-d3-es/-/dagre-d3-es-7.0.14.tgz",
+      "integrity": "sha512-P4rFMVq9ESWqmOgK+dlXvOtLwYg0i7u0HBGJER0LZDJT2VHIPAMZ/riPxqJceWMStH5+E61QxFra9kIS3AqdMg==",
+      "license": "MIT",
+      "dependencies": {
+        "d3": "^7.9.0",
+        "lodash-es": "^4.17.21"
+      }
+    },
+    "node_modules/dayjs": {
+      "version": "1.11.21",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.21.tgz",
+      "integrity": "sha512-98IT+HOahAisibz/yjKbzuOBwYcjJ7BCLPzARyHiyEBmRz4fatF+KPJszEHXsGYjUG234aH/cOjW1wwTbKUZlA==",
+      "license": "MIT"
+    },
     "node_modules/debug": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
@@ -2280,6 +2958,15 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/delaunator": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/delaunator/-/delaunator-5.1.0.tgz",
+      "integrity": "sha512-AGrQ4QSgssa1NGmWmLPqN5NY2KajF5MqxetNEO+o0n3ZwZZeTmt7bBnvzHWrmkZFxGgr4HdyFgelzgi06otLuQ==",
+      "license": "ISC",
+      "dependencies": {
+        "robust-predicates": "^3.0.2"
       }
     },
     "node_modules/depd": {
@@ -2320,6 +3007,15 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/dompurify": {
+      "version": "3.4.12",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.12.tgz",
+      "integrity": "sha512-zQvGet8Z2sWbQhCmfFz/T5QWH2oBmjnqK3qvOjaqaNLrLEF912WamU+ohnTp0TCep/MFVHpdJuCZEdFOdTnEFg==",
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
       }
     },
     "node_modules/dunder-proto": {
@@ -2919,6 +3615,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/hachure-fill": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/hachure-fill/-/hachure-fill-0.5.2.tgz",
+      "integrity": "sha512-3GKBOn+m2LX9iq+JC1064cSFprJY4jL1jCXTcpnfER5HYE2l/4EfWSGzkPa/ZDBmYI0ZOEj5VHV/eKnPGkHuOg==",
+      "license": "MIT"
+    },
     "node_modules/has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
@@ -3091,6 +3793,16 @@
         "url": "https://opencollective.com/immer"
       }
     },
+    "node_modules/import-meta-resolve": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/import-meta-resolve/-/import-meta-resolve-4.2.0.tgz",
+      "integrity": "sha512-Iqv2fzaTQN28s/FwZAoFq0ZSs/7hMAHJVX+w8PZl3cY19Pxk6jFFalxQoIfW2826i/fDLXv8IiEZRIT0lDuWcg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
@@ -3247,6 +3959,42 @@
       "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
       "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
       "license": "BSD-2-Clause"
+    },
+    "node_modules/katex": {
+      "version": "0.16.47",
+      "resolved": "https://registry.npmjs.org/katex/-/katex-0.16.47.tgz",
+      "integrity": "sha512-Eeo8Ys1doU1z+x8AZsPpQu+p/QcZBI5PeOo7QGQdy2x2m0MU/hYagBbGOmXwr5KVbEfVuWv9LpnQWeehogurjg==",
+      "funding": [
+        "https://opencollective.com/katex",
+        "https://github.com/sponsors/katex"
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "commander": "^8.3.0"
+      },
+      "bin": {
+        "katex": "cli.js"
+      }
+    },
+    "node_modules/katex/node_modules/commander": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
+      "integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/khroma": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/khroma/-/khroma-2.1.0.tgz",
+      "integrity": "sha512-Ls993zuzfayK269Svk9hzpeGUKob/sIgZzyHYdjQoAdQetRKpOLj+k/QQQ/6Qi0Yz65mlROrfd+Ev+1+7dz9Kw=="
+    },
+    "node_modules/layout-base": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/layout-base/-/layout-base-1.0.2.tgz",
+      "integrity": "sha512-8h2oVEZNktL4BH2JCOI90iD1yXwL6iNW7KcCKT2QZgQJR2vbqDsldCTPRU9NifTCqHZci57XvQQ15YTu+sTYPg==",
+      "license": "MIT"
     },
     "node_modules/light-my-request": {
       "version": "6.6.0",
@@ -3546,6 +4294,12 @@
         "url": "https://opencollective.com/parcel"
       }
     },
+    "node_modules/lodash-es": {
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.18.1.tgz",
+      "integrity": "sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==",
+      "license": "MIT"
+    },
     "node_modules/longest-streak": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/longest-streak/-/longest-streak-3.1.0.tgz",
@@ -3583,6 +4337,18 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/marked": {
+      "version": "16.4.2",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-16.4.2.tgz",
+      "integrity": "sha512-TI3V8YYWvkVf3KJe1dRkpnjs68JUPyEa5vjKrp1XEEJUAOaQc+Qj+L1qWbPd0SJuAdQkFU0h73sXXqwDYxsiDA==",
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 20"
       }
     },
     "node_modules/math-intrinsics": {
@@ -3883,6 +4649,35 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mermaid": {
+      "version": "11.16.0",
+      "resolved": "https://registry.npmjs.org/mermaid/-/mermaid-11.16.0.tgz",
+      "integrity": "sha512-Zvm3kbstgdpvIJPPItlL7fppIZ3kibvc1oZIGxdvk9t6UFz6flv+Jw7FtRGKwfcI8OckmH04LqG6LlS6X4B1pA==",
+      "license": "MIT",
+      "dependencies": {
+        "@braintree/sanitize-url": "^7.1.2",
+        "@iconify/utils": "^3.0.2",
+        "@mermaid-js/parser": "^1.2.0",
+        "@types/d3": "^7.4.3",
+        "@upsetjs/venn.js": "^2.0.0",
+        "cytoscape": "^3.33.3",
+        "cytoscape-cose-bilkent": "^4.1.0",
+        "cytoscape-fcose": "^2.2.0",
+        "d3": "^7.9.0",
+        "d3-sankey": "^0.12.3",
+        "dagre-d3-es": "7.0.14",
+        "dayjs": "^1.11.20",
+        "dompurify": "^3.3.3",
+        "es-toolkit": "^1.45.1",
+        "katex": "^0.16.45",
+        "khroma": "^2.1.0",
+        "marked": "^16.3.0",
+        "roughjs": "^4.6.6",
+        "stylis": "^4.3.6",
+        "ts-dedent": "^2.2.0",
+        "uuid": "^11.1.0 || ^12 || ^13 || ^14.0.0"
       }
     },
     "node_modules/micromark": {
@@ -4625,6 +5420,12 @@
         "regex-recursion": "^6.0.2"
       }
     },
+    "node_modules/package-manager-detector": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/package-manager-detector/-/package-manager-detector-1.8.0.tgz",
+      "integrity": "sha512-yQA4H19AmPEoMUeavPMDIe1higySl/gH/yaQrkT/s07Qp+7pp2hYz30N3z2l5BkjVkF9Ow6o0wjJamm2y7Sn0A==",
+      "license": "MIT"
+    },
     "node_modules/parse-entities": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-4.0.2.tgz",
@@ -4658,6 +5459,12 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/path-data-parser": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/path-data-parser/-/path-data-parser-0.1.0.tgz",
+      "integrity": "sha512-NOnmBpt5Y2RWbuv0LMzsayp3lVylAHLPUTut412ZA3l+C4uw4ZVkQbjShYCQ8TCpUMdPapr4YjUqLYD6v68j+w==",
+      "license": "MIT"
     },
     "node_modules/path-key": {
       "version": "3.1.1",
@@ -4821,6 +5628,22 @@
       ],
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/points-on-curve": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/points-on-curve/-/points-on-curve-0.2.0.tgz",
+      "integrity": "sha512-0mYKnYYe9ZcqMCWhUjItv/oHjvgEsfKvnUTg8sAtnHr3GVy7rGkXCb6d5cSyqrWqL4k81b9CPg3urd+T7aop3A==",
+      "license": "MIT"
+    },
+    "node_modules/points-on-path": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/points-on-path/-/points-on-path-0.2.1.tgz",
+      "integrity": "sha512-25ClnWWuw7JbWZcgqY/gJ4FQWadKxGWk+3kR/7kD0tCaDtPPMj7oHu2ToLaVhfpnHrZzYby2w6tUA0eOIuUg8g==",
+      "license": "MIT",
+      "dependencies": {
+        "path-data-parser": "0.1.0",
+        "points-on-curve": "0.2.0"
       }
     },
     "node_modules/postcss": {
@@ -5243,6 +6066,12 @@
       "integrity": "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==",
       "license": "MIT"
     },
+    "node_modules/robust-predicates": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/robust-predicates/-/robust-predicates-3.0.3.tgz",
+      "integrity": "sha512-NS3levdsRIUOmiJ8FZWCP7LG3QpJyrs/TE0Zpf1yvZu8cAJJ6QMW92H1c7kWpdIHo8RvmLxN/o2JXTKHp74lUA==",
+      "license": "Unlicense"
+    },
     "node_modules/rolldown": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.3.tgz",
@@ -5284,6 +6113,18 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/roughjs": {
+      "version": "4.6.6",
+      "resolved": "https://registry.npmjs.org/roughjs/-/roughjs-4.6.6.tgz",
+      "integrity": "sha512-ZUz/69+SYpFN/g/lUlo2FXcIjRkSu3nDarreVdGGndHEBJ6cXPdKguS8JGxwj5HA5xIbVKSmLgr5b3AWxtRfvQ==",
+      "license": "MIT",
+      "dependencies": {
+        "hachure-fill": "^0.5.2",
+        "path-data-parser": "^0.1.0",
+        "points-on-curve": "^0.2.0",
+        "points-on-path": "^0.2.1"
+      }
+    },
     "node_modules/router": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
@@ -5299,6 +6140,12 @@
       "engines": {
         "node": ">= 18"
       }
+    },
+    "node_modules/rw": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/rw/-/rw-1.3.3.tgz",
+      "integrity": "sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/rxjs": {
       "version": "7.8.2",
@@ -5679,6 +6526,12 @@
         "inline-style-parser": "0.2.7"
       }
     },
+    "node_modules/stylis": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.4.0.tgz",
+      "integrity": "sha512-5Z9ZpRzfuH6l/UAvCPAPUo3665Nk2wLaZU3x+TLHKVzIz33+sbJqbtrYoC3KD4/uVOr2Zp+L0LySezP9OHV9yA==",
+      "license": "MIT"
+    },
     "node_modules/supports-color": {
       "version": "8.1.1",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
@@ -5730,7 +6583,6 @@
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.4.tgz",
       "integrity": "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -5809,6 +6661,15 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/ts-dedent": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/ts-dedent/-/ts-dedent-2.3.0.tgz",
+      "integrity": "sha512-JfJeIHke7y2egdGGgRAvpCwYFUsHlM2gPcrVOxFkznt/4uzQ7HFmvE63iFHVLBJNDuyDOQgijDK/tXH/f6Msjg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.10"
       }
     },
     "node_modules/tslib": {
@@ -5992,6 +6853,19 @@
       "license": "MIT",
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/uuid": {
+      "version": "14.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.1.tgz",
+      "integrity": "sha512-6ZxzVpzDXDa3bJWaHilVayA+BH/1zmxCJoVgvmqJnid/gPoKHxUrS/aC/T6LGQtNHT+XHG9fXPJB4d+IrU30Ew==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist-node/bin/uuid"
       }
     },
     "node_modules/vary": {
@@ -6371,6 +7245,7 @@
       "dependencies": {
         "@claudescope/shared": "*",
         "lucide-react": "^1.20.0",
+        "mermaid": "^11.16.0",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
         "react-markdown": "^10.1.0",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -11,6 +11,7 @@
   "dependencies": {
     "@claudescope/shared": "*",
     "lucide-react": "^1.20.0",
+    "mermaid": "^11.16.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "react-markdown": "^10.1.0",

--- a/packages/web/src/components/Markdown.tsx
+++ b/packages/web/src/components/Markdown.tsx
@@ -1,13 +1,18 @@
 import { memo, useState, type ReactNode } from 'react';
+import { Code2, Eye } from 'lucide-react';
 import ReactMarkdown, { defaultUrlTransform, type Components } from 'react-markdown';
 import remarkGfm from 'remark-gfm';
+import { useRenderingPreferences } from '../rendering/RenderingProvider.js';
 import { CodeBlock } from './CodeBlock.js';
 import { ClampedText } from './ClampedText.js';
 import { MAX_MARKDOWN_CHARS } from './limits.js';
+import { MermaidBlock } from './MermaidBlock.js';
 
 export interface MarkdownProps {
   /** Markdown source to render. */
   children: string;
+  /** Exact text shown in source mode when rendering uses a cleaned derivative. */
+  source?: string;
   /**
    * When false, render the text verbatim in a <pre> (no markdown parsing).
    * Useful for tool outputs / logs that aren't markdown. Default true.
@@ -17,18 +22,31 @@ export interface MarkdownProps {
   className?: string;
   /** Fully expand clamped text (e.g. an in-session search match is in the tail). */
   forceExpand?: boolean;
+  /** Let the reader override the global rendered/source preference in place. */
+  toggleable?: boolean;
+  /** Temporarily reveal exact source (used by the in-session finder). */
+  forceSource?: boolean;
+}
+
+/** Diagram-aware fenced-code renderer; ordinary languages stay on Shiki. */
+function FencedCodeBlock({ code, lang }: { code: string; lang?: string }) {
+  const { mermaidEnabled } = useRenderingPreferences();
+  if (lang?.toLowerCase() === 'mermaid' && mermaidEnabled) {
+    return <MermaidBlock code={code} />;
+  }
+  return <CodeBlock code={code} lang={lang} />;
 }
 
 /**
- * Map markdown nodes to themed renderers. Fenced code blocks (those wrapped in
- * a <pre>) go through Shiki via {@link CodeBlock}; inline code stays as <code>.
- * react-markdown does not pass `inline` in v9+, so we detect block vs inline by
- * the presence of a `language-*` className (block fences) and newlines.
+ * Map markdown nodes to themed renderers. Mermaid fences use the local diagram
+ * renderer; other fenced blocks go through Shiki via {@link CodeBlock}, while
+ * inline code stays as <code>. react-markdown does not pass `inline` in v9+, so
+ * we detect block vs inline by a `language-*` className and newlines.
  */
 const components: Components = {
   code({ className, children, ...rest }) {
     const text = String(children ?? '');
-    const match = /language-(\w+)/.exec(className ?? '');
+    const match = /language-([\w-]+)/.exec(className ?? '');
     const isBlock = match !== null || text.includes('\n');
     if (!isBlock) {
       return (
@@ -38,7 +56,7 @@ const components: Components = {
       );
     }
     const lang = match?.[1];
-    return <CodeBlock code={text.replace(/\n$/, '')} lang={lang} />;
+    return <FencedCodeBlock code={text.replace(/\n$/, '')} lang={lang} />;
   },
   // `pre` is handled by CodeBlock; unwrap so we don't double-nest <pre>.
   pre({ children }) {
@@ -72,13 +90,24 @@ function urlTransform(url: string, _key: string, node: { tagName?: string }): st
 
 /**
  * Safe markdown renderer: react-markdown + remark-gfm (tables, strikethrough,
- * task lists, autolinks) with Shiki-highlighted code fences. Raw HTML is NOT
- * enabled, so content is sanitized by default. Falls back to a <pre> block when
- * `markdown` is false.
+ * task lists, autolinks), Shiki-highlighted code fences, and strict Mermaid
+ * diagrams. Raw HTML is NOT enabled, so content is sanitized by default. Falls
+ * back to a <pre> block when `markdown` is false.
  */
-function MarkdownImpl({ children, markdown = true, className, forceExpand = false }: MarkdownProps) {
+function MarkdownImpl({
+  children,
+  source = children,
+  markdown = true,
+  className,
+  forceExpand = false,
+  toggleable = false,
+  forceSource = false,
+}: MarkdownProps) {
+  const { markdownEnabled } = useRenderingPreferences();
   // Huge sources never hit the markdown parser unless the reader opts in.
   const [parseAnyway, setParseAnyway] = useState(false);
+  // null follows the browser preference; a click pins this block until unmount.
+  const [localRendered, setLocalRendered] = useState<boolean | null>(null);
   const cls = className ? `tv-md ${className}` : 'tv-md';
 
   if (!markdown) {
@@ -91,22 +120,55 @@ function MarkdownImpl({ children, markdown = true, className, forceExpand = fals
     );
   }
 
-  if (children.length > MAX_MARKDOWN_CHARS && !parseAnyway) {
-    return (
-      <div className={cls}>
-        <ClampedText className="tv-pre" text={children} forceExpand={forceExpand} />
-        <button type="button" className="tv-linkbtn tv-clamp-more" onClick={() => setParseAnyway(true)}>
-          Render as markdown anyway
-        </button>
-      </div>
-    );
-  }
-
-  return (
+  // Browser preferences govern transcript blocks that opted into switching;
+  // semantic document renderers (for example Memory) keep their existing mode.
+  const preferredRendered = toggleable ? (localRendered ?? markdownEnabled) : true;
+  const rendered = preferredRendered && !forceSource;
+  const body = !rendered ? (
+    <ClampedText
+      className={`tv-pre ${className ?? ''}`.trim()}
+      text={source}
+      forceExpand={forceExpand}
+    />
+  ) : children.length > MAX_MARKDOWN_CHARS && !parseAnyway ? (
+    <div className={cls}>
+      <ClampedText className="tv-pre" text={children} forceExpand={forceExpand} />
+      <button type="button" className="tv-linkbtn tv-clamp-more" onClick={() => setParseAnyway(true)}>
+        Render as markdown anyway
+      </button>
+    </div>
+  ) : (
     <div className={cls}>
       <ReactMarkdown remarkPlugins={[remarkGfm]} components={components} urlTransform={urlTransform}>
         {children}
       </ReactMarkdown>
+    </div>
+  );
+
+  if (!toggleable) return body;
+
+  return (
+    <div className={rendered ? 'tv-markdown-shell' : 'tv-markdown-shell is-source'}>
+      <div className="tv-markdown-shell__toolbar" data-finder-ignore>
+        <button
+          type="button"
+          className="tv-markdown-mode"
+          disabled={forceSource}
+          aria-pressed={!rendered}
+          title={
+            forceSource
+              ? 'Source is shown for the active search match'
+              : rendered
+                ? 'Show Markdown source'
+                : 'Render Markdown'
+          }
+          onClick={() => setLocalRendered(!rendered)}
+        >
+          {rendered ? <Code2 size={13} aria-hidden="true" /> : <Eye size={13} aria-hidden="true" />}
+          {forceSource ? 'Source (search)' : rendered ? 'Source' : 'Rendered'}
+        </button>
+      </div>
+      {body}
     </div>
   );
 }

--- a/packages/web/src/components/MermaidBlock.tsx
+++ b/packages/web/src/components/MermaidBlock.tsx
@@ -1,0 +1,106 @@
+import { useEffect, useState } from 'react';
+import { useTheme } from '../theme/ThemeProvider.js';
+import { ClampedText } from './ClampedText.js';
+import { MAX_DIAGRAM_CHARS } from './limits.js';
+
+export interface MermaidBlockProps {
+  /** Mermaid source, already stripped of the markdown fence. */
+  code: string;
+}
+
+type RenderState =
+  | { status: 'loading' }
+  | { status: 'rendered'; svg: string }
+  | { status: 'failed'; message: string };
+
+let renderSequence = 0;
+
+/** Keep arbitrary parser errors short and single-line in the transcript UI. */
+function readableError(error: unknown): string {
+  const raw = error instanceof Error ? error.message : String(error);
+  return raw.replace(/\s+/g, ' ').trim().slice(0, 240) || 'Unknown rendering error';
+}
+
+/**
+ * Lazy, local Mermaid renderer. Transcript text never leaves the browser;
+ * strict mode plus the app CSP keep diagram-authored HTML, scripts, links, and
+ * remote resources from becoming an active-content escape hatch.
+ */
+export function MermaidBlock({ code }: MermaidBlockProps) {
+  const { resolvedTheme } = useTheme();
+  const [state, setState] = useState<RenderState>(() =>
+    code.length > MAX_DIAGRAM_CHARS
+      ? {
+          status: 'failed',
+          message: `Diagram is too large to render (${code.length.toLocaleString('en-US')} characters).`,
+        }
+      : { status: 'loading' },
+  );
+
+  useEffect(() => {
+    if (code.length > MAX_DIAGRAM_CHARS) {
+      setState({
+        status: 'failed',
+        message: `Diagram is too large to render (${code.length.toLocaleString('en-US')} characters).`,
+      });
+      return;
+    }
+
+    let cancelled = false;
+    setState({ status: 'loading' });
+    const renderId = `claudescope-mermaid-${++renderSequence}`;
+
+    void import('mermaid')
+      .then(async ({ default: mermaid }) => {
+        mermaid.initialize({
+          startOnLoad: false,
+          securityLevel: 'strict',
+          suppressErrorRendering: true,
+          maxTextSize: MAX_DIAGRAM_CHARS,
+          theme: resolvedTheme === 'dark' ? 'dark' : 'default',
+        });
+        // A detached staging node contains Mermaid's temporary DOM and is
+        // discarded on both success and failure.
+        const staging = document.createElement('div');
+        const { svg } = await mermaid.render(renderId, code, staging);
+        if (!cancelled) setState({ status: 'rendered', svg });
+      })
+      .catch((error: unknown) => {
+        if (!cancelled) setState({ status: 'failed', message: readableError(error) });
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [code, resolvedTheme]);
+
+  if (state.status === 'loading') {
+    return (
+      <div className="tv-mermaid tv-mermaid--loading" role="status" aria-live="polite">
+        Rendering Mermaid diagram…
+      </div>
+    );
+  }
+
+  if (state.status === 'failed') {
+    return (
+      <figure className="tv-mermaid tv-mermaid--failed">
+        <figcaption className="tv-mermaid__error">
+          Mermaid diagram could not be rendered: {state.message}
+        </figcaption>
+        <ClampedText className="tv-pre" text={code} code />
+      </figure>
+    );
+  }
+
+  return (
+    <div
+      className="tv-mermaid tv-mermaid__svg"
+      role="img"
+      aria-label="Mermaid diagram"
+      // Mermaid generated this SVG under strict mode; raw transcript HTML is
+      // never passed through to this sink.
+      dangerouslySetInnerHTML={{ __html: state.svg }}
+    />
+  );
+}

--- a/packages/web/src/components/ThinkingBlock.tsx
+++ b/packages/web/src/components/ThinkingBlock.tsx
@@ -30,7 +30,9 @@ export function ThinkingBlock({ thinking, defaultOpen = false, forceOpen = false
       title="Thinking"
     >
       {hasText ? (
-        <Markdown forceExpand={forceOpen}>{thinking}</Markdown>
+        <Markdown toggleable forceExpand={forceOpen} forceSource={forceOpen}>
+          {thinking}
+        </Markdown>
       ) : (
         <p className="tv-muted" style={{ fontStyle: 'italic', margin: 0 }}>
           Thinking content isn’t stored in the transcript (only a signature).

--- a/packages/web/src/components/limits.ts
+++ b/packages/web/src/components/limits.ts
@@ -10,6 +10,9 @@ export const MAX_TEXT_CHARS = 50_000;
  */
 export const MAX_MARKDOWN_CHARS = 100_000;
 
+/** Maximum source size sent to a diagram parser. */
+export const MAX_DIAGRAM_CHARS = 50_000;
+
 /** Where to cut clamped text: the last newline before `limit`, if it isn't
  * pathologically early (single-line blobs cut mid-line at the limit). */
 export function clampCut(text: string, limit: number): number {

--- a/packages/web/src/main.tsx
+++ b/packages/web/src/main.tsx
@@ -2,6 +2,7 @@ import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 import { BrowserRouter } from 'react-router';
 import { App } from './App.js';
+import { RenderingProvider } from './rendering/RenderingProvider.js';
 import { ThemeProvider } from './theme/ThemeProvider.js';
 import { StatusProvider } from './status/StatusProvider.js';
 import './styles/global.css';
@@ -12,11 +13,13 @@ if (!root) throw new Error('Root element #root not found');
 createRoot(root).render(
   <StrictMode>
     <ThemeProvider>
-      <StatusProvider>
-        <BrowserRouter>
-          <App />
-        </BrowserRouter>
-      </StatusProvider>
+      <RenderingProvider>
+        <StatusProvider>
+          <BrowserRouter>
+            <App />
+          </BrowserRouter>
+        </StatusProvider>
+      </RenderingProvider>
     </ThemeProvider>
   </StrictMode>,
 );

--- a/packages/web/src/pages/session/blocks.tsx
+++ b/packages/web/src/pages/session/blocks.tsx
@@ -25,7 +25,16 @@ export const ThreadBlockView = memo(function ThreadBlockView({
   switch (block.kind) {
     case 'text': {
       const text = stripImageMarkers(block.text);
-      return text ? <Markdown forceExpand={forceOpen}>{text}</Markdown> : null;
+      return text ? (
+        <Markdown
+          source={block.text}
+          toggleable
+          forceExpand={forceOpen}
+          forceSource={forceOpen}
+        >
+          {text}
+        </Markdown>
+      ) : null;
     }
     case 'thinking':
       return <ThinkingBlock thinking={block.thinking} forceOpen={forceOpen} />;

--- a/packages/web/src/pages/session/finderDom.ts
+++ b/packages/web/src/pages/session/finderDom.ts
@@ -28,7 +28,12 @@ function collectRanges(root: HTMLElement, query: string): Range[] {
   const ranges: Range[] = [];
   if (!q) return ranges;
   const walker = document.createTreeWalker(root, NodeFilter.SHOW_TEXT, {
-    acceptNode: (n) => (n.nodeValue && n.nodeValue.trim() ? NodeFilter.FILTER_ACCEPT : NodeFilter.FILTER_REJECT),
+    acceptNode: (n) => {
+      if (n.parentElement?.closest('[data-finder-ignore]')) return NodeFilter.FILTER_REJECT;
+      return n.nodeValue && n.nodeValue.trim()
+        ? NodeFilter.FILTER_ACCEPT
+        : NodeFilter.FILTER_REJECT;
+    },
   });
   let node: Node | null;
   while ((node = walker.nextNode())) {

--- a/packages/web/src/pages/settings/SettingsPage.tsx
+++ b/packages/web/src/pages/settings/SettingsPage.tsx
@@ -4,8 +4,9 @@
  * terminal-only), Global Configuration | Appearance side by side, a full-width
  * Path Configuration card, and Advanced Runtime with the danger zone.
  *
- * Edits persist to ~/.claudescope/settings.json; env vars always win and
- * shadowed fields get a warning.
+ * Runtime edits persist to ~/.claudescope/settings.json; env vars always win
+ * and shadowed fields get a warning. Appearance/rendering preferences are
+ * presentation-only and persist in the current browser.
  */
 
 import { useCallback, useEffect, useMemo, useState } from 'react';
@@ -29,6 +30,7 @@ import type {
 } from '@claudescope/shared';
 import { ApiError, api } from '../../api/client.js';
 import { ConfirmDialog, ErrorBox, Spinner } from '../../components';
+import { useRenderingPreferences } from '../../rendering/RenderingProvider.js';
 import { useServerStatus } from '../../status/StatusProvider.js';
 import { useTheme, type ThemeChoice } from '../../theme/ThemeProvider.js';
 import { SettingRow } from './SettingRow.js';
@@ -115,6 +117,12 @@ export function SettingsPage() {
   const [rebuildBusy, setRebuildBusy] = useState(false);
 
   const { theme, setTheme } = useTheme();
+  const {
+    markdownEnabled,
+    mermaidEnabled,
+    setMarkdownEnabled,
+    setMermaidEnabled,
+  } = useRenderingPreferences();
 
   const seedDraft = useCallback((res: SettingsResponse) => {
     const next: Record<string, SettingValue> = {};
@@ -439,6 +447,43 @@ export function SettingsPage() {
           </div>
           <div className="tv-settings__hints">
             <span className="tv-settings__hint">Stored per browser, not on the server.</span>
+          </div>
+          <div className="tv-settings__appearance-divider" />
+          <span className="tv-settings__label">Transcript Rendering</span>
+          <div
+            className="tv-settings__rendering-options"
+            role="group"
+            aria-label="Transcript rendering"
+          >
+            <label className="tv-settings__toggle">
+              <input
+                type="checkbox"
+                checked={markdownEnabled}
+                onChange={(event) => setMarkdownEnabled(event.target.checked)}
+              />
+              <span>Render Markdown</span>
+            </label>
+            <label
+              className={
+                markdownEnabled
+                  ? 'tv-settings__toggle'
+                  : 'tv-settings__toggle is-disabled'
+              }
+            >
+              <input
+                type="checkbox"
+                checked={mermaidEnabled}
+                disabled={!markdownEnabled}
+                onChange={(event) => setMermaidEnabled(event.target.checked)}
+              />
+              <span>Render Mermaid diagrams</span>
+            </label>
+          </div>
+          <div className="tv-settings__hints">
+            <span className="tv-settings__hint">
+              Applies immediately and is stored per browser. Individual transcript blocks can
+              override the Markdown default.
+            </span>
           </div>
         </section>
       </div>

--- a/packages/web/src/pages/settings/settings.css
+++ b/packages/web/src/pages/settings/settings.css
@@ -225,6 +225,19 @@
 .tv-settings__toggle-text {
   color: var(--tv-fg-muted);
 }
+.tv-settings__toggle.is-disabled {
+  cursor: default;
+  opacity: 0.5;
+}
+.tv-settings__appearance-divider {
+  border-top: 1px solid var(--tv-border);
+}
+.tv-settings__rendering-options {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: var(--tv-space-2);
+}
 
 /* Provenance badges */
 .tv-settings__badge {

--- a/packages/web/src/rendering/RenderingProvider.tsx
+++ b/packages/web/src/rendering/RenderingProvider.tsx
@@ -1,0 +1,92 @@
+/**
+ * Browser-local transcript rendering preferences. These choices affect only
+ * presentation, so they intentionally live beside the theme preference rather
+ * than in the daemon's settings.json contract.
+ */
+
+import { createContext, useContext, useEffect, useState, type ReactNode } from 'react';
+
+export const RENDERING_STORAGE_KEY = 'claudescope-rendering';
+const STORAGE_VERSION = 1;
+
+interface StoredRenderingPreferences {
+  version: typeof STORAGE_VERSION;
+  markdownEnabled: boolean;
+  mermaidEnabled: boolean;
+}
+
+export interface RenderingPreferences {
+  markdownEnabled: boolean;
+  mermaidEnabled: boolean;
+  setMarkdownEnabled: (enabled: boolean) => void;
+  setMermaidEnabled: (enabled: boolean) => void;
+}
+
+const DEFAULTS: StoredRenderingPreferences = {
+  version: STORAGE_VERSION,
+  markdownEnabled: true,
+  mermaidEnabled: true,
+};
+
+const RenderingContext = createContext<RenderingPreferences | null>(null);
+
+/** Read and validate the persisted value; corrupt/old data safely resets. */
+function readStored(): StoredRenderingPreferences {
+  try {
+    const raw = localStorage.getItem(RENDERING_STORAGE_KEY);
+    if (!raw) return DEFAULTS;
+    const parsed: unknown = JSON.parse(raw);
+    if (
+      parsed !== null &&
+      typeof parsed === 'object' &&
+      (parsed as Partial<StoredRenderingPreferences>).version === STORAGE_VERSION &&
+      typeof (parsed as Partial<StoredRenderingPreferences>).markdownEnabled === 'boolean' &&
+      typeof (parsed as Partial<StoredRenderingPreferences>).mermaidEnabled === 'boolean'
+    ) {
+      return parsed as StoredRenderingPreferences;
+    }
+  } catch {
+    /* localStorage may be unavailable or contain invalid JSON */
+  }
+  return DEFAULTS;
+}
+
+function persist(preferences: StoredRenderingPreferences): void {
+  try {
+    localStorage.setItem(RENDERING_STORAGE_KEY, JSON.stringify(preferences));
+  } catch {
+    /* persistence failure must not make the transcript unreadable */
+  }
+}
+
+export function RenderingProvider({ children }: { children: ReactNode }) {
+  const [preferences, setPreferences] = useState<StoredRenderingPreferences>(readStored);
+
+  useEffect(() => persist(preferences), [preferences]);
+
+  const update = (patch: Partial<StoredRenderingPreferences>) => {
+    setPreferences((current) => {
+      const next: StoredRenderingPreferences = { ...current, ...patch, version: STORAGE_VERSION };
+      return next;
+    });
+  };
+
+  return (
+    <RenderingContext.Provider
+      value={{
+        markdownEnabled: preferences.markdownEnabled,
+        mermaidEnabled: preferences.mermaidEnabled,
+        setMarkdownEnabled: (enabled) => update({ markdownEnabled: enabled }),
+        setMermaidEnabled: (enabled) => update({ mermaidEnabled: enabled }),
+      }}
+    >
+      {children}
+    </RenderingContext.Provider>
+  );
+}
+
+export function useRenderingPreferences(): RenderingPreferences {
+  const context = useContext(RenderingContext);
+  if (!context) throw new Error('useRenderingPreferences must be used within RenderingProvider');
+  return context;
+}

--- a/packages/web/src/styles/global.css
+++ b/packages/web/src/styles/global.css
@@ -786,6 +786,93 @@ button {
   margin: var(--tv-space-4) 0;
 }
 
+/* In-place transcript Markdown source/rendered control. */
+.tv-markdown-shell {
+  position: relative;
+  min-width: 0;
+}
+.tv-markdown-shell__toolbar {
+  position: absolute;
+  top: 0;
+  right: 0;
+  z-index: 2;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.12s ease;
+}
+.tv-markdown-shell:hover .tv-markdown-shell__toolbar,
+.tv-markdown-shell:focus-within .tv-markdown-shell__toolbar,
+.tv-markdown-shell.is-source .tv-markdown-shell__toolbar {
+  opacity: 1;
+  pointer-events: auto;
+}
+.tv-markdown-shell.is-source .tv-markdown-shell__toolbar {
+  position: static;
+  display: flex;
+  justify-content: flex-end;
+  margin-bottom: var(--tv-space-1);
+}
+.tv-markdown-mode {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 2px var(--tv-space-2);
+  border: 1px solid var(--tv-border-strong);
+  border-radius: var(--tv-radius-sm);
+  background: var(--tv-bg-elevated);
+  color: var(--tv-fg-muted);
+  font: inherit;
+  font-size: var(--tv-fs-sm);
+  cursor: pointer;
+}
+.tv-markdown-mode:hover:not(:disabled) {
+  color: var(--tv-fg);
+  border-color: var(--tv-accent);
+}
+.tv-markdown-mode:disabled {
+  cursor: default;
+  opacity: 0.7;
+}
+@media (hover: none) {
+  .tv-markdown-shell__toolbar {
+    position: static;
+    display: flex;
+    justify-content: flex-end;
+    margin-bottom: var(--tv-space-1);
+    opacity: 1;
+    pointer-events: auto;
+  }
+}
+
+/* Lazy Mermaid fences. SVG is generated locally under strict mode. */
+.tv-mermaid {
+  margin: 0 0 var(--tv-space-3);
+  border: 1px solid var(--tv-border);
+  border-radius: var(--tv-radius);
+  background: var(--tv-bg-inset);
+  padding: var(--tv-space-3);
+  overflow-x: auto;
+}
+.tv-mermaid--loading {
+  color: var(--tv-fg-faint);
+  font-size: var(--tv-fs-sm);
+}
+.tv-mermaid--failed {
+  display: flex;
+  flex-direction: column;
+  gap: var(--tv-space-2);
+}
+.tv-mermaid__error {
+  color: var(--tv-danger);
+  font-size: var(--tv-fs-sm);
+}
+.tv-mermaid__svg svg {
+  display: block;
+  max-width: 100%;
+  height: auto;
+  margin: 0 auto;
+}
+
 /* Plain (non-markdown) preformatted text fallback. */
 .tv-pre {
   font-family: var(--tv-font-mono);


### PR DESCRIPTION
## Summary

- add browser-local Markdown and Mermaid rendering preferences to Settings
- let readers switch transcript prose and thinking blocks between rendered and source views in place
- render `mermaid` fences locally with lazy loading, strict security, theme support, and readable fallbacks
- preserve exact source for in-session search and document the implementation in [plan 0061](https://github.com/vladar107/claudescope/blob/agent/markdown-mermaid-rendering/docs/plans/0061-markdown-mermaid-rendering.md)

## Why

Claudescope already rendered Markdown, but readers could not inspect the original source in place and Mermaid fences remained ordinary code. These changes add both capabilities without sending transcript content to an external rendering service.

## User impact

Rendering defaults can be changed immediately per browser, while individual transcript blocks can temporarily override the Markdown default. Invalid or oversized Mermaid diagrams remain readable as clamped source instead of breaking the surrounding transcript.

## Validation

- `npm run typecheck`
- `npm test` — 62 files, 591 tests
- `npm run build`
- `npm run bundle`
- `npm pack ./dist --dry-run --json --cache /private/tmp/claudescope-npm-cache`
