### PR TITLE
fix: handle Codex session metadata

### DIFF
--- a/docs/plans/0062-codex-title-and-metadata-rendering.md
+++ b/docs/plans/0062-codex-title-and-metadata-rendering.md
@@ -2,7 +2,7 @@
 
 - **Status:** done
 - **Date:** 2026-07-29
-- **PR:** —
+- **PR:** https://github.com/vladar107/claudescope/pull/83
 
 ## Context
 
@@ -100,4 +100,3 @@ rendered assistant Markdown without changing the stored/source transcript.
 - Memory-citation metadata remains searchable/exportable because this change is
   presentation-only. That preserves transcript fidelity; filtering those other
   surfaces would be a separate product decision.
-- Add the final PR URL here once a PR is opened.

--- a/docs/plans/0062-codex-title-and-metadata-rendering.md
+++ b/docs/plans/0062-codex-title-and-metadata-rendering.md
@@ -1,0 +1,103 @@
+# 0062 — Codex title and metadata rendering
+
+- **Status:** done
+- **Date:** 2026-07-29
+- **PR:** —
+
+## Context
+
+Recent Codex rollouts can begin with a user-role bootstrap containing the
+project's `AGENTS.md` instructions and an `<environment_context>` envelope.
+ClaudeScope correctly preserves that source in the transcript, but Codex has no
+stored session title, so the generic first-user-message fallback can derive the
+title from the injected bootstrap instead of the person's first prompt.
+The same bootstrap currently renders as ordinary Markdown, producing a large
+wall of XML-like instructions and environment metadata above the real prompt.
+
+Codex assistant text can also end with a reserved `<oai-mem-citation>` envelope.
+Because raw HTML is intentionally disabled in the Markdown renderer, the
+envelope is currently shown as ordinary prose. It is metadata, but it remains
+part of the original transcript and should still be inspectable in Source mode.
+
+## Goal
+
+Derive untitled Codex session names from the first genuine user prompt while
+preserving the injected startup context in the session behind a compact,
+collapsed disclosure. Hide well-formed Codex memory-citation metadata from
+rendered assistant Markdown without changing the stored/source transcript.
+
+## Decisions
+
+- **Preserve Codex bootstrap turns** — do not drop or rewrite the AGENTS and
+  environment context during normalization; it remains useful provenance in the
+  transcript.
+- **Fix title selection at the title boundary** — when a Codex fallback
+  candidate is exactly the known bootstrap envelope, skip it; when Codex has
+  coalesced the bootstrap and real prompt into one user event, strip only the
+  leading well-formed envelope before applying the existing title cleaner.
+- **Fail closed on unfamiliar shapes** — malformed or unrecognized text is left
+  untouched instead of broadly classifying arbitrary user prose as system input.
+- **Collapse, do not discard, startup context** — recognize complete Codex
+  AGENTS/instructions and environment blocks at the presentation boundary and
+  render their exact text in collapsed system-style disclosures. If a real
+  prompt shares the same text block, render the remainder normally.
+- **Rendered derivative only for memory citations** — remove a well-formed,
+  trailing `<oai-mem-citation>…</oai-mem-citation>` block only from assistant
+  Markdown passed to the renderer. Keep `block.text` as the exact Source-mode
+  value and do not alter indexing, export, or connector normalization.
+- **Rebuild the derived index** — bump the schema version because existing
+  persisted fallback titles must be recalculated after upgrading.
+
+## Approach
+
+1. Update fallback-title selection to identify Codex sessions and remove only a
+   leading, well-formed AGENTS/instructions/environment bootstrap before ranking
+   candidates. This skips a bootstrap-only row and retains the prompt from a
+   coalesced bootstrap-plus-prompt row before the existing Markdown/title cleanup.
+2. Bump the index schema version so installed databases rebuild and replace
+   already-derived bootstrap titles.
+3. Recognize complete Codex instructions/environment prefixes in session text
+   blocks and render them as collapsed context, leaving any trailing prompt as
+   normal user Markdown.
+4. Add a session-rendering text helper for trailing Codex memory-citation
+   envelopes and apply it only to assistant text's rendered value, passing the
+   original text through the existing `source` prop.
+5. Run the existing test suite, typecheck, and production build; verify the two
+   supplied transcript shapes with focused local checks; then review the diff.
+
+## Files affected
+
+- `packages/server/src/data/index.ts` — connector-aware fallback-title candidate
+  selection.
+- `packages/server/src/db/schema.ts` — derived-data schema version bump.
+- `packages/web/src/pages/session/text.ts` — startup-context recognition and
+  rendered-only memory-citation cleanup.
+- `packages/web/src/pages/session/blocks.tsx` — collapse preserved startup
+  context and render cleaned assistant Markdown while retaining exact source.
+- `packages/web/src/pages/session/ThreadView.tsx` — pass the turn role to the
+  block renderer so user-authored examples are not hidden.
+- `docs/plans/README.md` — plan index entry.
+
+## Testing
+
+- Run `npm test`.
+- Run `npm run typecheck`.
+- Run `npm run build`.
+- Use focused local checks for both Codex storage shapes: a bootstrap-only first
+  user event followed by a prompt, and a coalesced bootstrap-plus-prompt event.
+- Confirm rendered assistant prose omits a trailing memory-citation envelope,
+  while Source mode still shows the exact original block.
+- Confirm complete AGENTS and environment blocks are collapsed but recoverable,
+  and a coalesced real prompt remains visible outside the disclosure.
+- Per repository instruction, do not add new test files or cases unless the
+  maintainer explicitly requests them.
+
+## Risks / open questions
+
+- The title recognizer intentionally depends on Codex's reserved wrapper shape;
+  a future incompatible wrapper will remain visible and may require a small
+  follow-up rather than risking false positives on genuine prompts.
+- Memory-citation metadata remains searchable/exportable because this change is
+  presentation-only. That preserves transcript fidelity; filtering those other
+  surfaces would be a separate product decision.
+- Add the final PR URL here once a PR is opened.

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -86,3 +86,4 @@ decision, or a change worth explaining before doing. Skip it for one-line fixes.
 | 0059 | [Three small cleanups from the review](./0059-small-cleanups.md) | done |
 | 0060 | [Dependabot alerts #13–#19](./0060-dependabot-alerts-13-19.md) | done |
 | 0061 | [Markdown source view and Mermaid rendering](./0061-markdown-mermaid-rendering.md) | done |
+| 0062 | [Codex title and metadata rendering](./0062-codex-title-and-metadata-rendering.md) | done |

--- a/packages/server/src/data/index.ts
+++ b/packages/server/src/data/index.ts
@@ -412,28 +412,92 @@ async function rebuildSessions(conn: DuckDBConnection): Promise<void> {
 
 /**
  * Fill in fallback titles for sessions with no real stored title, by cleaning
- * the first user message in TS (see {@link cleanFallbackTitle}). Runs after the
- * derived `sessions` rebuild, so it only touches rows whose `title` came back
- * empty. Cleaning happens in TS — not SQL — so markup/wrapper-blob stripping can
- * be tested as a pure function and stays deterministic across re-index.
+ * the first genuine user message (see {@link cleanFallbackTitle}). Runs after
+ * the derived `sessions` rebuild, so it only touches rows whose `title` came
+ * back empty.
  *
- * The raw first user turn per untitled session is fetched in one query (capped
- * to a few KB per row — cleaning only needs the head), then each cleaned title
- * is written back with `title_derived = TRUE`.
+ * Codex records its injected AGENTS/environment bootstrap with a user role. The
+ * candidate CTE removes only that complete, leading wrapper before ranking: an
+ * empty bootstrap-only row falls away, while a prompt coalesced into the same
+ * event remains. Other connectors and unfamiliar/malformed Codex shapes pass
+ * through untouched. The selected candidate is capped to a few KB only AFTER
+ * wrapper removal, then cleaned in TS and written with `title_derived = TRUE`.
  */
 async function applyFallbackTitles(conn: DuckDBConnection): Promise<void> {
   const rows = await queryRows(
     conn,
     `
-    SELECT session_id, raw FROM (
+    WITH user_text AS (
       SELECT
         e.session_id,
-        left(e.text_content, 4096) AS raw,
-        row_number() OVER (PARTITION BY e.session_id ORDER BY e.ts ASC NULLS LAST) AS rn
+        e.text_content,
+        ltrim(e.text_content) AS source,
+        e.ts,
+        e.uuid,
+        s.connector_id
       FROM events e
       JOIN sessions s ON s.id = e.session_id AND COALESCE(s.title, '') = ''
       WHERE e.role = 'user' AND e.text_content IS NOT NULL AND length(trim(e.text_content)) > 0
-    ) WHERE rn = 1
+    ), instruction_bounds AS (
+      SELECT
+        *,
+        strpos(source, '<INSTRUCTIONS>') AS instructions_start,
+        strpos(source, '</INSTRUCTIONS>') AS instructions_end
+      FROM user_text
+    ), instruction_remainders AS (
+      SELECT
+        *,
+        CASE
+          WHEN connector_id = 'codex'
+            AND starts_with(source, '# AGENTS.md instructions for ')
+            AND instructions_start > 0
+            AND instructions_end > instructions_start
+          THEN substring(source, instructions_end + length('</INSTRUCTIONS>'))
+          ELSE NULL
+        END AS instructions_remainder
+      FROM instruction_bounds
+    ), candidates AS (
+      SELECT
+        session_id,
+        ts,
+        uuid,
+        CASE
+          WHEN instructions_remainder IS NOT NULL THEN
+            CASE
+              WHEN starts_with(ltrim(instructions_remainder), '<environment_context>') THEN
+                CASE
+                  WHEN strpos(ltrim(instructions_remainder), '</environment_context>')
+                    > length('<environment_context>')
+                  THEN substring(
+                    ltrim(instructions_remainder),
+                    strpos(ltrim(instructions_remainder), '</environment_context>')
+                      + length('</environment_context>')
+                  )
+                  ELSE text_content
+                END
+              ELSE instructions_remainder
+            END
+          WHEN connector_id = 'codex'
+            AND starts_with(source, '<environment_context>')
+            AND strpos(source, '</environment_context>') > length('<environment_context>')
+          THEN substring(
+            source,
+            strpos(source, '</environment_context>') + length('</environment_context>')
+          )
+          ELSE text_content
+        END AS raw
+      FROM instruction_remainders
+    ), ranked AS (
+      SELECT
+        session_id,
+        left(raw, 4096) AS raw,
+        row_number() OVER (
+          PARTITION BY session_id ORDER BY ts ASC NULLS LAST, uuid
+        ) AS rn
+      FROM candidates
+      WHERE length(trim(raw)) > 0
+    )
+    SELECT session_id, raw FROM ranked WHERE rn = 1
     `,
   );
 

--- a/packages/server/src/db/schema.ts
+++ b/packages/server/src/db/schema.ts
@@ -31,7 +31,8 @@
 //      (NULL = the source format carries no error signal, distinct from 0).
 // v11: provider-aware cost — events.provider + sessions.providers; providers
 //      listed in pricing 'providers' zero-rate at index time.
-export const SCHEMA_VERSION = 11;
+// v12: Codex fallback titles skip the injected AGENTS/environment bootstrap.
+export const SCHEMA_VERSION = 12;
 
 /** All DDL statements, executed in order at startup. Idempotent. */
 export const SCHEMA_DDL: readonly string[] = [

--- a/packages/web/src/pages/session/ThreadView.tsx
+++ b/packages/web/src/pages/session/ThreadView.tsx
@@ -92,7 +92,11 @@ const Turn = memo(function Turn({
               block.kind === 'tool' ? subagentsByToolUseId?.get(block.id) : undefined;
             return (
               <Fragment key={i}>
-                <RevealableBlock blockId={blockRevealId(item.uuid, i)} block={block} />
+                <RevealableBlock
+                  blockId={blockRevealId(item.uuid, i)}
+                  block={block}
+                  role={item.role}
+                />
                 {runs?.map((run) => (
                   <SubagentBlock key={run.agentId} run={run} />
                 ))}
@@ -110,7 +114,15 @@ const Turn = memo(function Turn({
  * finder step re-renders only these wrappers — the memoized ThreadBlockView
  * bails out everywhere except the block whose `forceOpen` actually flipped.
  */
-function RevealableBlock({ blockId, block }: { blockId: string; block: ThreadBlock }) {
+function RevealableBlock({
+  blockId,
+  block,
+  role,
+}: {
+  blockId: string;
+  block: ThreadBlock;
+  role: ThreadItem['role'];
+}) {
   const { blockIds } = useContext(SessionSearchContext);
   return (
     <div className="tv-block" data-block-id={blockId}>
@@ -122,7 +134,7 @@ function RevealableBlock({ blockId, block }: { blockId: string; block: ThreadBlo
         resetKeys={[block]}
         fallback={(error) => <ErrorBox error={error} title="This block failed to render" />}
       >
-        <ThreadBlockView block={block} forceOpen={blockIds.has(blockId)} />
+        <ThreadBlockView block={block} role={role} forceOpen={blockIds.has(blockId)} />
       </ErrorBoundary>
     </div>
   );

--- a/packages/web/src/pages/session/blocks.tsx
+++ b/packages/web/src/pages/session/blocks.tsx
@@ -1,7 +1,19 @@
 import { memo } from 'react';
-import type { ThreadBlock } from '@claudescope/shared';
-import { Markdown, ThinkingBlock, ToolBlock, extractImage } from '../../components';
-import { stripImageMarkers } from './text.js';
+import type { ThreadBlock, ThreadItem } from '@claudescope/shared';
+import {
+  ClampedText,
+  Collapsible,
+  Markdown,
+  ThinkingBlock,
+  ToolBlock,
+  extractImage,
+} from '../../components';
+import {
+  splitCodexSessionContext,
+  stripCodexMemoryCitation,
+  stripImageMarkers,
+  type CodexSessionContext,
+} from './text.js';
 
 /**
  * Render a single parsed thread block by its `kind` discriminator.
@@ -16,15 +28,39 @@ import { stripImageMarkers } from './text.js';
  */
 export const ThreadBlockView = memo(function ThreadBlockView({
   block,
+  role,
   forceOpen = false,
 }: {
   block: ThreadBlock;
+  /** Owning turn role; Codex metadata handling is role-specific. */
+  role: ThreadItem['role'];
   /** Force a collapsible block (thinking/tool) open — used by in-session search. */
   forceOpen?: boolean;
 }) {
   switch (block.kind) {
     case 'text': {
-      const text = stripImageMarkers(block.text);
+      const context = role === 'user' ? splitCodexSessionContext(block.text) : null;
+      if (context) {
+        const prompt = stripImageMarkers(context.remainder);
+        return (
+          <>
+            <CodexContextBlock value={context} forceOpen={forceOpen} />
+            {prompt ? (
+              <Markdown
+                source={context.remainder}
+                toggleable
+                forceExpand={forceOpen}
+                forceSource={forceOpen}
+              >
+                {prompt}
+              </Markdown>
+            ) : null}
+          </>
+        );
+      }
+
+      const renderedText = role === 'assistant' ? stripCodexMemoryCitation(block.text) : block.text;
+      const text = stripImageMarkers(renderedText);
       return text ? (
         <Markdown
           source={block.text}
@@ -44,6 +80,33 @@ export const ThreadBlockView = memo(function ThreadBlockView({
       return <AttachmentView attachment={block.attachment} />;
   }
 });
+
+/** Compact presentation for preserved Codex startup metadata. */
+function CodexContextBlock({
+  value,
+  forceOpen,
+}: {
+  value: CodexSessionContext;
+  forceOpen: boolean;
+}) {
+  const subtitle =
+    value.kind === 'environment'
+      ? 'runtime environment'
+      : value.includesEnvironment
+        ? 'AGENTS.md and runtime environment'
+        : 'AGENTS.md instructions';
+  return (
+    <Collapsible
+      className="tv-collapsible--system"
+      icon="⚙︎"
+      title="Codex session context"
+      subtitle={subtitle}
+      open={forceOpen || undefined}
+    >
+      <ClampedText className="tv-system-turn__pre" text={value.context} />
+    </Collapsible>
+  );
+}
 
 /**
  * Best-effort rendering for attachment blocks. Image blocks (the observed

--- a/packages/web/src/pages/session/text.ts
+++ b/packages/web/src/pages/session/text.ts
@@ -15,6 +15,83 @@ export function stripImageMarkers(text: string): string {
   return text.replace(IMAGE_MARKER_RE, '').trim();
 }
 
+/** Reserved metadata Codex appends to assistant prose when memory was used. */
+const CODEX_MEMORY_CITATION_RE =
+  /\s*<oai-mem-citation>\s*<citation_entries>[\s\S]*?<\/citation_entries>\s*<rollout_ids>[\s\S]*?<\/rollout_ids>\s*<\/oai-mem-citation>\s*$/i;
+
+/**
+ * Remove a complete trailing Codex memory-citation envelope for rendered
+ * Markdown. Callers retain the original block as the Source-mode value; an
+ * incomplete envelope or one followed by prose is left untouched.
+ */
+export function stripCodexMemoryCitation(text: string): string {
+  const match = CODEX_MEMORY_CITATION_RE.exec(text);
+  return match ? text.slice(0, match.index).trimEnd() : text;
+}
+
+export interface CodexSessionContext {
+  /** Exact recognized prefix shown inside the collapsed disclosure. */
+  context: string;
+  /** User-authored text following the prefix, if Codex coalesced both. */
+  remainder: string;
+  kind: 'instructions' | 'environment';
+  includesEnvironment: boolean;
+}
+
+/**
+ * Split a complete Codex startup-context prefix from any trailing user prompt.
+ * Both the AGENTS wrapper and a standalone environment wrapper are recognized;
+ * malformed wrappers return null so ordinary user prose is never hidden.
+ */
+export function splitCodexSessionContext(text: string): CodexSessionContext | null {
+  const leadingWhitespace = text.search(/\S|$/);
+  const source = text.slice(leadingWhitespace);
+  const instructionsOpen = '<INSTRUCTIONS>';
+  const instructionsClose = '</INSTRUCTIONS>';
+  const environmentOpen = '<environment_context>';
+  const environmentClose = '</environment_context>';
+
+  let end = 0;
+  let kind: CodexSessionContext['kind'];
+  let includesEnvironment = false;
+
+  if (source.startsWith('# AGENTS.md instructions for ')) {
+    const open = source.indexOf(instructionsOpen);
+    const close = source.indexOf(instructionsClose, open + instructionsOpen.length);
+    if (open < 0 || close < 0) return null;
+    end = close + instructionsClose.length;
+    kind = 'instructions';
+
+    const gap = source.slice(end).match(/^\s*/)?.[0].length ?? 0;
+    const environmentStart = end + gap;
+    if (source.startsWith(environmentOpen, environmentStart)) {
+      const environmentEnd = source.indexOf(
+        environmentClose,
+        environmentStart + environmentOpen.length,
+      );
+      if (environmentEnd < 0) return null;
+      end = environmentEnd + environmentClose.length;
+      includesEnvironment = true;
+    }
+  } else if (source.startsWith(environmentOpen)) {
+    const close = source.indexOf(environmentClose, environmentOpen.length);
+    if (close < 0) return null;
+    end = close + environmentClose.length;
+    kind = 'environment';
+    includesEnvironment = true;
+  } else {
+    return null;
+  }
+
+  const absoluteEnd = leadingWhitespace + end;
+  return {
+    context: text.slice(0, absoluteEnd).trimEnd(),
+    remainder: text.slice(absoluteEnd).trimStart(),
+    kind,
+    includesEnvironment,
+  };
+}
+
 /** Leading tags that mark a user turn as harness/system-injected, not a person. */
 export const SYSTEM_TURN_TAGS: { tag: string; label: string }[] = [
   { tag: '<task-notification>', label: 'Task notification' },


### PR DESCRIPTION
## What changed

- derive untitled Codex sessions from the first real user prompt, skipping complete AGENTS and environment bootstrap records
- preserve Codex startup context in the transcript behind compact collapsed disclosures
- hide complete trailing memory-citation metadata from rendered assistant prose while retaining the original Source, search, and export data
- bump the derived index schema so existing fallback titles are rebuilt

## Why

Codex stores startup instructions and runtime context as user-role transcript data. ClaudeScope's generic fallback therefore treated bootstrap metadata as the first user message, which produced incorrect session names and a large raw metadata wall above the actual conversation. Assistant memory citations were likewise being displayed as ordinary prose.

## Impact

Codex sessions get useful titles and cleaner transcript rendering without deleting or rewriting source data. Other connectors and malformed or unfamiliar wrapper shapes are left unchanged.

## Checks

- `npm test` — 62 files, 591 tests passed
- `npm run typecheck`
- `npm run build`
- live browser verification against the reported Codex session

## Plan

- [0062 — Codex title and metadata rendering](https://github.com/vladar107/claudescope/blob/fix/codex-session-metadata/docs/plans/0062-codex-title-and-metadata-rendering.md)