### PR TITLE
fix: show only detected agents on the Memory page

### DIFF
--- a/docs/plans/0063-detected-agents-memory.md
+++ b/docs/plans/0063-detected-agents-memory.md
@@ -2,7 +2,7 @@
 
 - **Status:** done
 - **Date:** 2026-07-29
-- **PR:** <link, once opened>
+- **PR:** https://github.com/vladar107/claudescope/pull/84
 
 ## Context
 

--- a/docs/plans/0063-detected-agents-memory.md
+++ b/docs/plans/0063-detected-agents-memory.md
@@ -1,0 +1,64 @@
+# 0063 — Show detected agents in Memory
+
+- **Status:** done
+- **Date:** 2026-07-29
+- **PR:** <link, once opened>
+
+## Context
+
+The Memory landing page renders one card for every connector compiled into
+ClaudeScope. On a machine with only Claude Code and Codex data, this makes six
+absent agents look like locally available choices. The app already has a
+canonical detection rule for `/api/sources`: a connector is local when its
+configured transcript source path exists. Actual memory content is also a local
+signal because a global instruction file can predate the transcript directory.
+
+## Goal
+
+Only show agents detected on the current machine in the Memory card grid, while
+preserving the useful "no memory store" state for detected transcript-only
+agents.
+
+## Decisions
+
+- **Reuse source-path detection** — use the same connector helper for
+  `/api/sources` and `/api/memory`; Memory may additionally retain connectors
+  that contributed real memory content. Do not add CLI-binary probing.
+- **Filter on the server** — keep the API contract truthful and avoid sending
+  unavailable connector choices for the web client to discard.
+- **Keep detected agents without memory visible** — the issue is absent agents,
+  not the explanatory empty state for a locally present transcript source.
+
+## Approach
+
+1. Extract the existing source-path existence check into the connector registry.
+2. Build Memory overviews from that detected connector list.
+3. Update contract comments and the focused overview test for the filtered list.
+4. Run the relevant test, full tests, typecheck, and a final diff review.
+
+## Files affected
+
+- `packages/server/src/connectors/registry.ts` — expose detected connectors.
+- `packages/server/src/routes/sources.ts` — consume the shared detection helper.
+- `packages/server/src/routes/memory.ts` — pass detected connectors to the
+  overview builder.
+- `packages/server/src/data/memory.ts` — roll up an explicit connector list.
+- `packages/server/test/memory-overview.test.ts` — verify only supplied detected
+  connectors render.
+- `packages/shared/src/api.ts` — describe the filtered response accurately.
+- `packages/web/src/pages/memory/MemoryPage.tsx` — align page-level documentation.
+
+## Testing
+
+- `npm test -- --run packages/server/test/memory-overview.test.ts`
+- `npm test`
+- `npm run typecheck`
+- Review the response/UI behavior with only Claude Code and Codex source paths
+  present: the grid contains exactly those two cards.
+
+## Risks / open questions
+
+- "Detected" means the configured transcript source path exists or the connector
+  contributes an actual memory item. A CLI installed but never run and with no
+  memory file will not appear, which is appropriate because ClaudeScope has
+  nothing to read from it.

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -87,3 +87,4 @@ decision, or a change worth explaining before doing. Skip it for one-line fixes.
 | 0060 | [Dependabot alerts #13–#19](./0060-dependabot-alerts-13-19.md) | done |
 | 0061 | [Markdown source view and Mermaid rendering](./0061-markdown-mermaid-rendering.md) | done |
 | 0062 | [Codex title and metadata rendering](./0062-codex-title-and-metadata-rendering.md) | done |
+| 0063 | [Show detected agents in Memory](./0063-detected-agents-memory.md) | done |

--- a/packages/server/src/connectors/registry.ts
+++ b/packages/server/src/connectors/registry.ts
@@ -3,6 +3,7 @@
  * implementing an {@link AgentConnector} and registering it here.
  */
 
+import { existsSync } from 'node:fs';
 import type { AgentConnector } from './types.js';
 import { claudeCodeConnector } from './claude-code/claude-code.js';
 import { codexConnector } from './codex/codex.js';
@@ -23,6 +24,18 @@ export const connectors: AgentConnector[] = [
   antigravityConnector,
   grokConnector,
 ];
+
+/**
+ * Connectors whose configured read-only transcript source exists locally, plus
+ * any connector IDs for which a caller has another concrete local signal (for
+ * example, a global memory file before the first transcript directory exists).
+ */
+export function detectedConnectors(additionalIds: Iterable<string> = []): AgentConnector[] {
+  const detectedIds = new Set(additionalIds);
+  return connectors.filter(
+    (connector) => detectedIds.has(connector.id) || existsSync(connector.sourceDir),
+  );
+}
 
 /** The connector with the given id, falling back to Claude Code if unknown. */
 export function connectorById(id: string | null | undefined): AgentConnector {

--- a/packages/server/src/data/memory.ts
+++ b/packages/server/src/data/memory.ts
@@ -151,8 +151,8 @@ function toPreview(it: AttributedMemory): MemoryPreview {
 
 /**
  * Roll up {@link collectMemory} items into one {@link MemoryConnectorOverview}
- * per KNOWN connector (every registered agent, including those with no memory
- * store). Pure given its `items` input — the route passes `collectMemory()`.
+ * per supplied connector. The route supplies the connectors detected on the
+ * current machine, including detected agents with no memory store.
  *
  * Counts mirror the web's prior `summarize()`: `globalFiles` = the connector's
  * global sources; `projectsWithFacts` = distinct projects with ≥1 of its
@@ -161,7 +161,10 @@ function toPreview(it: AttributedMemory): MemoryPreview {
  * project items, omitted when it has none. Sort: supported-with-content first,
  * then supported-empty, then unsupported; ties broken by label.
  */
-export function buildConnectorOverviews(items: AttributedMemory[]): MemoryConnectorOverview[] {
+export function buildConnectorOverviews(
+  items: AttributedMemory[],
+  visibleConnectors: AgentConnector[],
+): MemoryConnectorOverview[] {
   const byConnector = new Map<string, AttributedMemory[]>();
   for (const it of items) {
     const list = byConnector.get(it.connectorId);
@@ -169,7 +172,7 @@ export function buildConnectorOverviews(items: AttributedMemory[]): MemoryConnec
     else byConnector.set(it.connectorId, [it]);
   }
 
-  const overviews = connectors.map((c): MemoryConnectorOverview => {
+  const overviews = visibleConnectors.map((c): MemoryConnectorOverview => {
     const mine = byConnector.get(c.id) ?? [];
     const globalFiles = mine.filter((it) => it.scope === 'global').length;
     const projectItems = mine.filter((it) => it.scope === 'project');

--- a/packages/server/src/routes/memory.ts
+++ b/packages/server/src/routes/memory.ts
@@ -6,8 +6,9 @@
  *                                             have any project memory, and a
  *                                             per-connector overview (counts +
  *                                             content preview) for the landing
- *                                             cards — including agents that keep
- *                                             no memory store (`supported: false`).
+ *                                             cards — including detected agents
+ *                                             that keep no memory store
+ *                                             (`supported: false`).
  *   - GET /api/projects/:projectId/memory   → per-agent memory for one project.
  *
  * Attribution (origin-session → project, dir slug fallback) lives in
@@ -17,6 +18,7 @@
 
 import type { FastifyInstance } from 'fastify';
 import type { GlobalMemory, MemoryResponse, MemorySource, ProjectMemoryResponse } from '@claudescope/shared';
+import { detectedConnectors } from '../connectors/registry.js';
 import { buildConnectorOverviews, collectMemory, type AttributedMemory } from '../data/memory.js';
 
 /** Group attributed memory by `projectId` then `connectorId`. */
@@ -70,7 +72,14 @@ export async function registerMemoryRoute(app: FastifyInstance): Promise<void> {
       .sort((a, b) => b.total - a.total || a.displayName.localeCompare(b.displayName))
       .map(({ projectId, displayName, counts }) => ({ projectId, displayName, counts }));
 
-    return { global: [...globalByConnector.values()], projects, connectors: buildConnectorOverviews(items) };
+    return {
+      global: [...globalByConnector.values()],
+      projects,
+      connectors: buildConnectorOverviews(
+        items,
+        detectedConnectors(items.map((item) => item.connectorId)),
+      ),
+    };
   });
 
   app.get<{ Params: { projectId: string } }>(

--- a/packages/server/src/routes/sources.ts
+++ b/packages/server/src/routes/sources.ts
@@ -6,16 +6,14 @@
  * to `~` for display.
  */
 
-import { existsSync } from 'node:fs';
 import type { FastifyInstance } from 'fastify';
 import type { SourcesResponse } from '@claudescope/shared';
-import { connectors } from '../connectors/registry.js';
+import { detectedConnectors } from '../connectors/registry.js';
 import { contractHome } from '../util/paths.js';
 
 export async function registerSourcesRoute(app: FastifyInstance): Promise<void> {
   app.get('/api/sources', async (): Promise<SourcesResponse> => {
-    return connectors
-      .filter((c) => existsSync(c.sourceDir))
+    return detectedConnectors()
       .map((c) => ({ id: c.id, label: c.label, path: contractHome(c.sourceDir) }));
   });
 }

--- a/packages/server/test/memory-overview.test.ts
+++ b/packages/server/test/memory-overview.test.ts
@@ -6,8 +6,13 @@
  */
 
 import { describe, expect, it } from 'vitest';
+import { connectors } from '../src/connectors/registry.js';
 import type { AttributedMemory } from '../src/data/memory.js';
 import { buildConnectorOverviews } from '../src/data/memory.js';
+
+function allOverviews(items: AttributedMemory[]) {
+  return buildConnectorOverviews(items, connectors);
+}
 
 /** A project fact with sensible defaults; override what each case cares about. */
 function fact(over: Partial<AttributedMemory> & { connectorId: string; updatedAt: string; title: string }): AttributedMemory {
@@ -36,7 +41,7 @@ describe('buildConnectorOverviews', () => {
       fact({ connectorId: 'claude-code', title: 'newest', updatedAt: '2026-03-01T00:00:00.000Z', projectId: 'proj-b' }),
       fact({ connectorId: 'claude-code', title: 'mid', updatedAt: '2026-02-01T00:00:00.000Z', projectId: 'proj-b' }),
     ];
-    const overviews = buildConnectorOverviews(items);
+    const overviews = allOverviews(items);
     const cc = overviews.find((o) => o.connectorId === 'claude-code')!;
     expect(cc.supported).toBe(true);
     expect(cc.globalFiles).toBe(0);
@@ -64,7 +69,7 @@ describe('buildConnectorOverviews', () => {
         },
       },
     ];
-    const codex = buildConnectorOverviews(items).find((o) => o.connectorId === 'codex')!;
+    const codex = allOverviews(items).find((o) => o.connectorId === 'codex')!;
     expect(codex.supported).toBe(true);
     expect(codex.globalFiles).toBe(1);
     expect(codex.totalFacts).toBe(0);
@@ -76,7 +81,7 @@ describe('buildConnectorOverviews', () => {
 
   it('marks a no-provider connector supported=false with no preview', () => {
     // pi and opencode implement neither globalMemory nor projectMemory.
-    const overviews = buildConnectorOverviews([]);
+    const overviews = allOverviews([]);
     for (const id of ['pi', 'opencode']) {
       const o = overviews.find((x) => x.connectorId === id)!;
       expect(o, id).toBeDefined();
@@ -106,23 +111,22 @@ describe('buildConnectorOverviews', () => {
         },
       },
     ];
-    const cc = buildConnectorOverviews(items).find((o) => o.connectorId === 'claude-code')!;
+    const cc = allOverviews(items).find((o) => o.connectorId === 'claude-code')!;
     expect(cc.preview?.description).toBe(
       'Heading Commit as the user only and omit the trailer.',
     );
   });
 
-  it('includes every registered connector and orders content > supported-empty > unsupported', () => {
+  it('includes only visible connectors and orders content > supported-empty > unsupported', () => {
     const items: AttributedMemory[] = [
       // claude-code has content (a fact) → rank 0.
       fact({ connectorId: 'claude-code', title: 'f', updatedAt: '2026-01-01T00:00:00.000Z' }),
-      // codex/junie/copilot are supported but empty here → rank 1.
-      // pi/opencode/grok are unsupported → rank 2.
+      // codex is supported but empty here → rank 1; pi is unsupported → rank 2.
     ];
-    const overviews = buildConnectorOverviews(items);
-    // Every registered agent appears (claude-code, codex, junie, pi, opencode, copilot, antigravity, grok).
+    const visible = connectors.filter((c) => ['claude-code', 'codex', 'pi'].includes(c.id));
+    const overviews = buildConnectorOverviews(items, visible);
     expect(overviews.map((o) => o.connectorId).sort()).toEqual(
-      ['claude-code', 'codex', 'copilot', 'junie', 'opencode', 'pi', 'antigravity', 'grok'].sort(),
+      ['claude-code', 'codex', 'pi'].sort(),
     );
     const rank = (o: { supported: boolean; preview?: unknown }) =>
       o.supported && o.preview ? 0 : o.supported ? 1 : 2;

--- a/packages/shared/src/api.ts
+++ b/packages/shared/src/api.ts
@@ -648,8 +648,8 @@ export interface MemoryPreview {
 
 /**
  * Per-connector rollup for the memory landing page: counts plus a content
- * preview, listed for EVERY known agent so the UI can mark agents that keep no
- * memory store at all (`supported: false`).
+ * preview, listed for every agent detected on the current machine. Detected
+ * agents that keep no memory store have `supported: false`.
  */
 export interface MemoryConnectorOverview {
   connectorId: string;
@@ -670,7 +670,7 @@ export interface MemoryConnectorOverview {
 export interface MemoryResponse {
   global: GlobalMemory[];
   projects: ProjectMemorySummary[];
-  /** One rollup per known agent connector, for the landing-page cards. */
+  /** One rollup per locally detected agent connector, for the landing-page cards. */
   connectors: MemoryConnectorOverview[];
 }
 

--- a/packages/web/src/pages/memory/MemoryPage.tsx
+++ b/packages/web/src/pages/memory/MemoryPage.tsx
@@ -1,5 +1,6 @@
 /**
- * Memory landing (`/memory`) — a folder grid, one card per agent (connector).
+ * Memory landing (`/memory`) — a folder grid, one card per locally detected
+ * agent (connector).
  * Each card previews real content (the latest memory item) so the screen is
  * never just bare counts; agents that keep no memory store are shown explicitly
  * as such rather than hidden (so "no store" reads as a fact, not a bug).


### PR DESCRIPTION
## What changed

- show Memory cards only for agents detected from their configured local source path
- retain agents that contribute actual memory even before a transcript directory exists
- share the detection helper with the existing Sources endpoint
- preserve the “no memory store” explanation for detected transcript-only agents

## Why

The Memory landing page previously rendered every connector compiled into ClaudeScope. On a machine with only Claude Code and Codex, the other supported adapters appeared as if they were locally available choices.

The page now reflects what ClaudeScope can actually read on the current machine. On the reported machine, detection returns exactly Claude Code and Codex.

## Validation

- `npm test -- --run packages/server/test/memory-overview.test.ts`
- `npm test` — 591 tests passed
- `npm run typecheck`
- local detector check returned `claude-code` and `codex`
