### PR TITLE
fix: use the first real prompt for fallback session titles

### DIFF
--- a/docs/plans/0065-shared-fallback-title-selection.md
+++ b/docs/plans/0065-shared-fallback-title-selection.md
@@ -2,7 +2,7 @@
 
 - **Status:** done
 - **Date:** 2026-08-06
-- **PR:** <link, once opened>
+- **PR:** https://github.com/vladar107/claudescope/pull/86
 
 ## Context
 

--- a/docs/plans/0065-shared-fallback-title-selection.md
+++ b/docs/plans/0065-shared-fallback-title-selection.md
@@ -1,0 +1,86 @@
+# 0065 — Shared fallback-title selection
+
+- **Status:** done
+- **Date:** 2026-08-06
+- **PR:** <link, once opened>
+
+## Context
+
+Claude Code records `/clear` as a structured command turn with a user role. If
+the resulting session has no stored `ai-title`, ClaudeScope's fallback-title
+path currently ranks that earliest non-empty user event and derives the title
+`clear` instead of continuing to the person's first real prompt.
+
+The fallback itself is shared by all connectors, but its candidate-selection
+query currently makes the decision too early and contains Codex-specific
+bootstrap handling inline. The prior Codex fix established the desired rule:
+preserve injected records in the transcript, but do not use them as fallback
+titles.
+
+## Goal
+
+Choose fallback session titles from the first eligible human prompt for every
+provider. A leading Claude `/clear` command must be skipped in favor of the next
+real user message, without rewriting or hiding any transcript content.
+
+## Decisions
+
+- **Use one shared candidate-selection pipeline** — ordered user turns from any
+  connector pass through the same eligibility check before a fallback title is
+  chosen; selection continues when a candidate is synthetic or cleans to empty.
+- **Recognize only complete reserved turn shapes** — skip well-formed structured
+  command/system envelopes such as Claude's `<command-name>...</command-name>`
+  record. Malformed or unfamiliar text remains eligible so ordinary user prose
+  is not broadly classified as system input.
+- **Keep provider-specific preprocessing narrow** — Codex AGENTS/environment
+  bootstrap unwrapping remains conditional on the Codex connector, but runs
+  inside the shared selection pipeline rather than determining the first row in
+  SQL.
+- **Preserve real stored titles and source fidelity** — connector-provided
+  titles still win, and events remain unchanged for transcript rendering,
+  Source mode, search, and export.
+- **Rebuild persisted derived titles** — bump the schema version so existing
+  `clear` fallback titles are recalculated after upgrade.
+
+## Approach
+
+1. Add focused, connector-neutral candidate eligibility to the title module.
+   Keep the existing Codex bootstrap preprocessing in the candidate query so
+   large instruction blobs are removed before text crosses the 4 KiB result
+   boundary.
+2. Fetch ordered user candidates for untitled sessions in bounded per-session
+   batches and choose the first candidate accepted by the shared helper, rather
+   than ranking a single row before eligibility is known.
+3. Bump the derived index schema version.
+4. Run focused checks with a synthetic Claude `/clear` turn followed by a real
+   prompt, then run the existing tests, typecheck, build, and review the diff.
+
+## Files affected
+
+- `packages/server/src/data/title.ts` — shared candidate preprocessing,
+  synthetic-turn eligibility, and title selection helpers.
+- `packages/server/src/data/index.ts` — ordered fallback candidates and
+  first-eligible selection across providers.
+- `packages/server/src/db/schema.ts` — derived-data schema version bump.
+- `docs/plans/README.md` — plan index entry.
+
+## Testing
+
+- Focused synthetic indexing check: `/clear` remained in `events`, while the
+  following prompt became the derived session title.
+- Focused existing tests: 3 files, 53 tests passed, covering title cleaning,
+  Codex fallback behavior, stored Claude titles, and stale-title fallback.
+- `npm test`: 62 files, 591 tests passed.
+- `npm run typecheck`: passed.
+- `npm run build`: passed.
+- Final diff review and `git diff --check`: passed.
+- Do not add test files or test cases unless the maintainer explicitly requests
+  them.
+
+## Risks / open questions
+
+- The eligibility recognizer must stay conservative: matching incomplete tags
+  or arbitrary prose could skip a genuine first prompt.
+- Fetching more than one candidate per untitled session adds bounded rebuild
+  work; cap candidate text and stop selection as soon as a usable title is
+  found.

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -89,3 +89,4 @@ decision, or a change worth explaining before doing. Skip it for one-line fixes.
 | 0062 | [Codex title and metadata rendering](./0062-codex-title-and-metadata-rendering.md) | done |
 | 0063 | [Show detected agents in Memory](./0063-detected-agents-memory.md) | done |
 | 0064 | [MCP SDK v2 and `2026-07-28` stdio support](./0064-mcp-sdk-v2.md) | done |
+| 0065 | [Shared fallback-title selection](./0065-shared-fallback-title-selection.md) | done |

--- a/packages/server/src/data/index.ts
+++ b/packages/server/src/data/index.ts
@@ -22,7 +22,7 @@ import { connectors } from '../connectors/registry.js';
 import { pruneNdjsonCaches } from '../connectors/ndjson-cache.js';
 import type { AgentConnector, DiscoveredFile } from '../connectors/types.js';
 import { loadPricing } from './pricing.js';
-import { cleanFallbackTitle } from './title.js';
+import { cleanFallbackTitleCandidate } from './title.js';
 import { electCanonicalEdits, refreshFileEdits } from './file-edits.js';
 
 /** Tracks whether the initial index build has finished (server readiness). */
@@ -412,100 +412,138 @@ async function rebuildSessions(conn: DuckDBConnection): Promise<void> {
 
 /**
  * Fill in fallback titles for sessions with no real stored title, by cleaning
- * the first genuine user message (see {@link cleanFallbackTitle}). Runs after
- * the derived `sessions` rebuild, so it only touches rows whose `title` came
- * back empty.
+ * the first genuine user message (see {@link cleanFallbackTitleCandidate}).
+ * Runs after the derived `sessions` rebuild, so it only touches rows whose
+ * `title` came back empty.
  *
  * Codex records its injected AGENTS/environment bootstrap with a user role. The
- * candidate CTE removes only that complete, leading wrapper before ranking: an
- * empty bootstrap-only row falls away, while a prompt coalesced into the same
- * event remains. Other connectors and unfamiliar/malformed Codex shapes pass
- * through untouched. The selected candidate is capped to a few KB only AFTER
- * wrapper removal, then cleaned in TS and written with `title_derived = TRUE`.
+ * candidate CTE removes only that complete, leading wrapper: an empty
+ * bootstrap-only row falls away, while a prompt coalesced into the same event
+ * remains. Other connectors and unfamiliar/malformed Codex shapes pass through
+ * untouched.
+ *
+ * Candidates are considered in small per-session batches. The shared TS
+ * eligibility rule can therefore reject a complete harness turn (such as
+ * Claude Code's `/clear`) and continue to the next user message without loading
+ * every turn into memory. Candidate text is capped to a few KB only AFTER
+ * Codex wrapper removal, then cleaned and written with `title_derived = TRUE`.
  */
 async function applyFallbackTitles(conn: DuckDBConnection): Promise<void> {
-  const rows = await queryRows(
-    conn,
-    `
-    WITH user_text AS (
-      SELECT
-        e.session_id,
-        e.text_content,
-        ltrim(e.text_content) AS source,
-        e.ts,
-        e.uuid,
-        s.connector_id
-      FROM events e
-      JOIN sessions s ON s.id = e.session_id AND COALESCE(s.title, '') = ''
-      WHERE e.role = 'user' AND e.text_content IS NOT NULL AND length(trim(e.text_content)) > 0
-    ), instruction_bounds AS (
-      SELECT
-        *,
-        strpos(source, '<INSTRUCTIONS>') AS instructions_start,
-        strpos(source, '</INSTRUCTIONS>') AS instructions_end
-      FROM user_text
-    ), instruction_remainders AS (
-      SELECT
-        *,
-        CASE
-          WHEN connector_id = 'codex'
-            AND starts_with(source, '# AGENTS.md instructions for ')
-            AND instructions_start > 0
-            AND instructions_end > instructions_start
-          THEN substring(source, instructions_end + length('</INSTRUCTIONS>'))
-          ELSE NULL
-        END AS instructions_remainder
-      FROM instruction_bounds
-    ), candidates AS (
-      SELECT
-        session_id,
-        ts,
-        uuid,
-        CASE
-          WHEN instructions_remainder IS NOT NULL THEN
-            CASE
-              WHEN starts_with(ltrim(instructions_remainder), '<environment_context>') THEN
-                CASE
-                  WHEN strpos(ltrim(instructions_remainder), '</environment_context>')
-                    > length('<environment_context>')
-                  THEN substring(
-                    ltrim(instructions_remainder),
-                    strpos(ltrim(instructions_remainder), '</environment_context>')
-                      + length('</environment_context>')
-                  )
-                  ELSE text_content
-                END
-              ELSE instructions_remainder
-            END
-          WHEN connector_id = 'codex'
-            AND starts_with(source, '<environment_context>')
-            AND strpos(source, '</environment_context>') > length('<environment_context>')
-          THEN substring(
-            source,
-            strpos(source, '</environment_context>') + length('</environment_context>')
-          )
-          ELSE text_content
-        END AS raw
-      FROM instruction_remainders
-    ), ranked AS (
-      SELECT
-        session_id,
-        left(raw, 4096) AS raw,
-        row_number() OVER (
-          PARTITION BY session_id ORDER BY ts ASC NULLS LAST, uuid
-        ) AS rn
-      FROM candidates
-      WHERE length(trim(raw)) > 0
-    )
-    SELECT session_id, raw FROM ranked WHERE rn = 1
-    `,
-  );
-
   const updates: string[] = [];
-  for (const r of rows) {
-    const title = cleanFallbackTitle(r.raw != null ? String(r.raw) : null);
-    if (title.length === 0) continue;
-    updates.push(`(${sqlString(String(r.session_id))}, ${sqlString(title)})`);
+  const CANDIDATE_BATCH_SIZE = 8;
+  let firstRank = 1;
+  let pendingSessionIds: string[] | null = null;
+
+  while (true) {
+    const sessionFilter = pendingSessionIds
+      ? `AND e.session_id IN (${pendingSessionIds.map(sqlString).join(', ')})`
+      : '';
+    const lastRank = firstRank + CANDIDATE_BATCH_SIZE - 1;
+    const rows = await queryRows(
+      conn,
+      `
+      WITH user_text AS (
+        SELECT
+          e.session_id,
+          e.text_content,
+          ltrim(e.text_content) AS source,
+          e.ts,
+          e.uuid,
+          s.connector_id
+        FROM events e
+        JOIN sessions s ON s.id = e.session_id AND COALESCE(s.title, '') = ''
+        WHERE e.role = 'user'
+          AND e.text_content IS NOT NULL
+          AND length(trim(e.text_content)) > 0
+          ${sessionFilter}
+      ), instruction_bounds AS (
+        SELECT
+          *,
+          strpos(source, '<INSTRUCTIONS>') AS instructions_start,
+          strpos(source, '</INSTRUCTIONS>') AS instructions_end
+        FROM user_text
+      ), instruction_remainders AS (
+        SELECT
+          *,
+          CASE
+            WHEN connector_id = 'codex'
+              AND starts_with(source, '# AGENTS.md instructions for ')
+              AND instructions_start > 0
+              AND instructions_end > instructions_start
+            THEN substring(source, instructions_end + length('</INSTRUCTIONS>'))
+            ELSE NULL
+          END AS instructions_remainder
+        FROM instruction_bounds
+      ), candidates AS (
+        SELECT
+          session_id,
+          ts,
+          uuid,
+          CASE
+            WHEN instructions_remainder IS NOT NULL THEN
+              CASE
+                WHEN starts_with(ltrim(instructions_remainder), '<environment_context>') THEN
+                  CASE
+                    WHEN strpos(ltrim(instructions_remainder), '</environment_context>')
+                      > length('<environment_context>')
+                    THEN substring(
+                      ltrim(instructions_remainder),
+                      strpos(ltrim(instructions_remainder), '</environment_context>')
+                        + length('</environment_context>')
+                    )
+                    ELSE text_content
+                  END
+                ELSE instructions_remainder
+              END
+            WHEN connector_id = 'codex'
+              AND starts_with(source, '<environment_context>')
+              AND strpos(source, '</environment_context>') > length('<environment_context>')
+            THEN substring(
+              source,
+              strpos(source, '</environment_context>') + length('</environment_context>')
+            )
+            ELSE text_content
+          END AS raw
+        FROM instruction_remainders
+      ), ranked AS (
+        SELECT
+          session_id,
+          left(raw, 4096) AS raw,
+          row_number() OVER (
+            PARTITION BY session_id ORDER BY ts ASC NULLS LAST, uuid
+          ) AS candidate_rank
+        FROM candidates
+        WHERE length(trim(raw)) > 0
+      )
+      SELECT session_id, raw
+      FROM ranked
+      WHERE candidate_rank BETWEEN ${firstRank} AND ${lastRank}
+      ORDER BY session_id, candidate_rank
+      `,
+    );
+    if (rows.length === 0) break;
+
+    const candidateCounts = new Map<string, number>();
+    const resolvedSessionIds = new Set<string>();
+    for (const r of rows) {
+      const sessionId = String(r.session_id);
+      candidateCounts.set(sessionId, (candidateCounts.get(sessionId) ?? 0) + 1);
+      if (resolvedSessionIds.has(sessionId)) continue;
+
+      const title = cleanFallbackTitleCandidate(r.raw != null ? String(r.raw) : null);
+      if (title.length === 0) continue;
+      updates.push(`(${sqlString(sessionId)}, ${sqlString(title)})`);
+      resolvedSessionIds.add(sessionId);
+    }
+
+    pendingSessionIds = [...candidateCounts]
+      .filter(
+        ([sessionId, count]) =>
+          !resolvedSessionIds.has(sessionId) && count === CANDIDATE_BATCH_SIZE,
+      )
+      .map(([sessionId]) => sessionId);
+    if (pendingSessionIds.length === 0) break;
+    firstRank += CANDIDATE_BATCH_SIZE;
   }
   if (updates.length === 0) return;
 

--- a/packages/server/src/data/title.ts
+++ b/packages/server/src/data/title.ts
@@ -2,9 +2,9 @@
  * Fallback session-title cleaning.
  *
  * Codex and pi sessions store no title (and a Claude session may never have
- * been auto-titled), so the indexer falls back to the session's first user
- * message (see `first_user` in `index.ts`). That raw message is often markup or
- * a tool-injected blob — a leading `# AGENTS.md instructions for /…` heading, a
+ * been auto-titled), so the indexer falls back to the session's first eligible
+ * user message. That raw message is often markup or a tool-injected blob — a
+ * leading `# AGENTS.md instructions for /…` heading, an
  * `<INSTRUCTIONS>…</INSTRUCTIONS>` wrapper, system reminders — which makes an
  * ugly, leaky title.
  *
@@ -21,6 +21,29 @@
 export const TITLE_MAX_LENGTH = 80;
 
 const ELLIPSIS = '…';
+
+/**
+ * Complete reserved envelopes that represent harness activity rather than a
+ * person's prompt. They can still be stored with a user role by an agent (for
+ * example Claude Code's `/clear` record), so fallback-title selection must
+ * reject them and continue to the next user turn.
+ *
+ * Matching is deliberately whole-string and requires closing tags. An
+ * unfamiliar or truncated shape remains eligible rather than risking the loss
+ * of genuine user prose that happens to begin with an XML-like tag.
+ */
+const COMPLETE_SYNTHETIC_TURN = [
+  /^<command-name>[\s\S]*?<\/command-name>(?:\s*<command-message>[\s\S]*?<\/command-message>)?(?:\s*<command-args>[\s\S]*?<\/command-args>)?$/i,
+  /^<(command-message|command-args|task-notification|system-reminder|local-command-stdout|local-command-stderr|local-command-caveat|bash-input)>[\s\S]*?<\/\1>$/i,
+  /^<bash-stdout>[\s\S]*?<\/bash-stdout>(?:\s*<bash-stderr>[\s\S]*?<\/bash-stderr>)?$/i,
+  /^<bash-stderr>[\s\S]*?<\/bash-stderr>(?:\s*<bash-stdout>[\s\S]*?<\/bash-stdout>)?$/i,
+];
+
+/** True only for a complete, reserved harness turn stored as user text. */
+function isSyntheticTurn(raw: string): boolean {
+  const text = raw.trim();
+  return COMPLETE_SYNTHETIC_TURN.some((pattern) => pattern.test(text));
+}
 
 /**
  * Lines that are clearly system/tool-injected rather than user prose. We skip
@@ -85,4 +108,17 @@ export function cleanFallbackTitle(raw: string | null | undefined): string {
   // Clip to the limit (ellipsis included), trimming a dangling space so we
   // don't render "word …".
   return text.slice(0, TITLE_MAX_LENGTH - ELLIPSIS.length).trimEnd() + ELLIPSIS;
+}
+
+/**
+ * Turn one ordered user-message candidate into a fallback title.
+ *
+ * Returns `''` for complete harness-generated turns so the caller can keep
+ * scanning later candidates. This eligibility rule is connector-neutral: any
+ * provider that normalizes a reserved command/system envelope as user text gets
+ * the same behavior.
+ */
+export function cleanFallbackTitleCandidate(raw: string | null | undefined): string {
+  if (!raw || isSyntheticTurn(raw)) return '';
+  return cleanFallbackTitle(raw);
 }

--- a/packages/server/src/db/schema.ts
+++ b/packages/server/src/db/schema.ts
@@ -32,7 +32,8 @@
 // v11: provider-aware cost — events.provider + sessions.providers; providers
 //      listed in pricing 'providers' zero-rate at index time.
 // v12: Codex fallback titles skip the injected AGENTS/environment bootstrap.
-export const SCHEMA_VERSION = 12;
+// v13: fallback titles skip complete synthetic command/system turns for every connector.
+export const SCHEMA_VERSION = 13;
 
 /** All DDL statements, executed in order at startup. Idempotent. */
 export const SCHEMA_DDL: readonly string[] = [


### PR DESCRIPTION
## Summary

- skip complete harness-generated command and system turns when deriving fallback session titles
- continue to the next eligible user prompt through one shared selector for every provider
- preserve stored titles and original transcript content
- rebuild derived titles with index schema v13

## Root cause

Claude Code records `/clear` as a structured command turn with a user role. The fallback-title query ranked the earliest non-empty user event before checking whether it was human-authored, so untitled sessions could be named `clear` instead of using the next real prompt.

## User impact

Claude sessions started after `/clear` now get a useful name from the person's first genuine prompt. The same conservative eligibility rule applies across providers, while malformed or unfamiliar tagged text remains eligible and source transcripts remain unchanged.

## Validation

- focused synthetic indexing check: `/clear` stayed in the event stream and the following prompt became the derived title
- focused server tests: 3 files, 53 tests passed
- `npm test`: 62 files, 591 tests passed
- `npm run typecheck`
- `npm run build`
- final diff review and `git diff --check`

## Plan

- [0065 — Shared fallback-title selection](https://github.com/vladar107/claudescope/blob/fix/shared-fallback-title-selection/docs/plans/0065-shared-fallback-title-selection.md)