### PR TITLE
fix: patch Mermaid and DOMPurify advisories

### DIFF
--- a/docs/plans/0066-dependabot-mermaid-dompurify.md
+++ b/docs/plans/0066-dependabot-mermaid-dompurify.md
@@ -2,7 +2,7 @@
 
 - **Status:** in-progress <!-- proposed | in-progress | done | superseded | abandoned -->
 - **Date:** 2026-08-09
-- **PR:** <link, once opened>
+- **PR:** https://github.com/vladar107/claudescope/pull/87
 
 ## Context
 
@@ -63,8 +63,9 @@ unnecessary overrides.
 - `npm run typecheck`
 - `npm run build`
 - `npm run bundle`
-- `nix build .#claudescope --no-link` when Nix is available; otherwise refresh
-  the hash from the CI mismatch and rerun the Nix job.
+- `nix build .#claudescope --no-link` in Linux and macOS CI; the first Linux
+  run supplied `sha256-Spb4aBNAyfdrjZvnC4of2PbKgmkMIt6GpJBIXH6UTNU=` for the
+  updated dependency set.
 
 ## Risks / open questions
 

--- a/docs/plans/0066-dependabot-mermaid-dompurify.md
+++ b/docs/plans/0066-dependabot-mermaid-dompurify.md
@@ -1,6 +1,6 @@
 # 0066 — Dependabot Mermaid and DOMPurify remediation
 
-- **Status:** in-progress <!-- proposed | in-progress | done | superseded | abandoned -->
+- **Status:** done <!-- proposed | in-progress | done | superseded | abandoned -->
 - **Date:** 2026-08-09
 - **PR:** https://github.com/vladar107/claudescope/pull/87
 

--- a/docs/plans/0066-dependabot-mermaid-dompurify.md
+++ b/docs/plans/0066-dependabot-mermaid-dompurify.md
@@ -1,0 +1,75 @@
+# 0066 — Dependabot Mermaid and DOMPurify remediation
+
+- **Status:** in-progress <!-- proposed | in-progress | done | superseded | abandoned -->
+- **Date:** 2026-08-09
+- **PR:** <link, once opened>
+
+## Context
+
+Dependabot alerts #26–#31 report five vulnerabilities in `mermaid@11.16.0`
+and one in its transitive `dompurify@3.4.12`. The Mermaid findings include
+prototype pollution, CSS injection, and two denial-of-service paths in diagram
+parsers; DOMPurify has an XSS path under a non-default in-place hook pattern.
+
+ClaudeScope renders Mermaid fences from transcript content in the browser. Its
+strict Mermaid configuration, CSP, and 50,000-character input limit reduce some
+of the exposure, and the DOMPurify hook conditions are not used directly, but
+the diagram source itself is untrusted. Patched releases are available without
+a major-version migration: Mermaid 11.16.1 and DOMPurify 3.4.13.
+
+A fresh `npm audit` also reports `nanoid@3.3.16` (development-only through
+Vite/PostCSS) for an infinite-loop advisory. Its parent range already permits
+the patched release; the targeted refresh resolves 3.3.18 (patched since
+3.3.17).
+
+## Goal
+
+Resolve all current Dependabot alerts and audit findings with targeted patch
+updates, preserving the existing Mermaid rendering behavior and avoiding
+unnecessary overrides.
+
+## Decisions
+
+- **Raise the direct Mermaid floor to `^11.16.1`** — this records the first safe
+  release in the manifest instead of relying only on a refreshed lockfile.
+- **Refresh DOMPurify and Nano ID transitively** — their parent ranges already
+  allow the patched releases, so direct dependencies or root overrides would
+  add maintenance without constraining the graph further.
+- **Keep the existing rendering boundary unchanged** — strict mode, the CSP,
+  and the diagram-size limit remain useful defense in depth; the dependency
+  patches do not require application-code changes.
+
+## Approach
+
+1. Update Mermaid to 11.16.1 and refresh DOMPurify to 3.4.13.
+2. Refresh Nano ID to 3.3.18 within PostCSS's existing range.
+3. Update the Nix `npmDepsHash` for the changed package-lock dependency set.
+4. Verify the resolved graph, audit result, tests, typecheck, build, and bundle.
+5. Review the final dependency-only diff and confirm Dependabot rescans cleanly.
+
+## Files affected
+
+- `packages/web/package.json` — require the first patched Mermaid release.
+- `package-lock.json` — resolve patched Mermaid, DOMPurify, and Nano ID versions.
+- `flake.nix` — refresh the fixed-output npm dependency hash.
+- `docs/plans/0066-dependabot-mermaid-dompurify.md` — record scope and validation.
+- `docs/plans/README.md` — index this plan.
+
+## Testing
+
+- `npm ls mermaid dompurify nanoid --all`
+- `npm audit --audit-level=low`
+- `npm test`
+- `npm run typecheck`
+- `npm run build`
+- `npm run bundle`
+- `nix build .#claudescope --no-link` when Nix is available; otherwise refresh
+  the hash from the CI mismatch and rerun the Nix job.
+
+## Risks / open questions
+
+- Mermaid and DOMPurify are runtime browser dependencies, but both changes are
+  patch releases. The full web build and existing rendering tests should catch
+  integration regressions.
+- GitHub may take a short time to rescan `package-lock.json` after the PR branch
+  is pushed; local `npm audit` and the resolved graph provide immediate proof.

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -90,4 +90,4 @@ decision, or a change worth explaining before doing. Skip it for one-line fixes.
 | 0063 | [Show detected agents in Memory](./0063-detected-agents-memory.md) | done |
 | 0064 | [MCP SDK v2 and `2026-07-28` stdio support](./0064-mcp-sdk-v2.md) | done |
 | 0065 | [Shared fallback-title selection](./0065-shared-fallback-title-selection.md) | done |
-| 0066 | [Dependabot Mermaid and DOMPurify remediation](./0066-dependabot-mermaid-dompurify.md) | in-progress |
+| 0066 | [Dependabot Mermaid and DOMPurify remediation](./0066-dependabot-mermaid-dompurify.md) | done |

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -90,3 +90,4 @@ decision, or a change worth explaining before doing. Skip it for one-line fixes.
 | 0063 | [Show detected agents in Memory](./0063-detected-agents-memory.md) | done |
 | 0064 | [MCP SDK v2 and `2026-07-28` stdio support](./0064-mcp-sdk-v2.md) | done |
 | 0065 | [Shared fallback-title selection](./0065-shared-fallback-title-selection.md) | done |
+| 0066 | [Dependabot Mermaid and DOMPurify remediation](./0066-dependabot-mermaid-dompurify.md) | in-progress |

--- a/flake.nix
+++ b/flake.nix
@@ -55,7 +55,7 @@
           # `nix build .#claudescope` and the mismatch error prints the new value.
           npmDeps = pkgs.fetchNpmDeps {
             src = depsLock;
-            hash = "sha256-0c9Lbr5eS//8BzcU+V6XSMVClutrRjw7yueS4DPbPtE=";
+            hash = "sha256-Spb4aBNAyfdrjZvnC4of2PbKgmkMIt6GpJBIXH6UTNU=";
           };
 
           nodejs = node;

--- a/package-lock.json
+++ b/package-lock.json
@@ -2867,9 +2867,9 @@
       }
     },
     "node_modules/dompurify": {
-      "version": "3.4.12",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.12.tgz",
-      "integrity": "sha512-zQvGet8Z2sWbQhCmfFz/T5QWH2oBmjnqK3qvOjaqaNLrLEF912WamU+ohnTp0TCep/MFVHpdJuCZEdFOdTnEFg==",
+      "version": "3.4.13",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.13.tgz",
+      "integrity": "sha512-2vmYIoqjze2d+kakP8S/nS5shfsl587kzwEjcGlTdiksUVgFHnFCsLYDVj/JNqJVOQZGSYBTmuycv0PodwmnMQ==",
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"
@@ -4178,9 +4178,9 @@
       }
     },
     "node_modules/mermaid": {
-      "version": "11.16.0",
-      "resolved": "https://registry.npmjs.org/mermaid/-/mermaid-11.16.0.tgz",
-      "integrity": "sha512-Zvm3kbstgdpvIJPPItlL7fppIZ3kibvc1oZIGxdvk9t6UFz6flv+Jw7FtRGKwfcI8OckmH04LqG6LlS6X4B1pA==",
+      "version": "11.16.1",
+      "resolved": "https://registry.npmjs.org/mermaid/-/mermaid-11.16.1.tgz",
+      "integrity": "sha512-TQsq6u22fAn3rek5VOubrhKPo1g5hwC3FXUN9hiyupTckcYiGuuKGkNQrKYwGJkXUxZdojwRG46gsSCFZMDp4g==",
       "license": "MIT",
       "dependencies": {
         "@braintree/sanitize-url": "^7.1.2",
@@ -4812,9 +4812,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "dev": true,
       "funding": [
         {
@@ -6419,7 +6419,7 @@
       "dependencies": {
         "@claudescope/shared": "*",
         "lucide-react": "^1.20.0",
-        "mermaid": "^11.16.0",
+        "mermaid": "^11.16.1",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
         "react-markdown": "^10.1.0",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "@claudescope/shared": "*",
     "lucide-react": "^1.20.0",
-    "mermaid": "^11.16.0",
+    "mermaid": "^11.16.1",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "react-markdown": "^10.1.0",


### PR DESCRIPTION
## Summary

- update Mermaid to 11.16.1 to resolve Dependabot alerts #26–#30
- refresh transitive DOMPurify to 3.4.13 for alert #31
- refresh development-only Nano ID to 3.3.18 for the additional high-severity `npm audit` finding
- refresh the Nix dependency hash and document the remediation in plan 0066

## Why

ClaudeScope renders Mermaid fences from transcript content, so the diagram parser receives untrusted input. Existing strict mode, CSP, and size limits reduce exposure, but the available patch releases remove the vulnerable parser and sanitizer paths directly.

## Impact

This is a patch-only dependency update. No application logic or rendering configuration changes.

## Validation

- `npm ci --ignore-scripts`
- `npm ls mermaid dompurify nanoid --all`
- `npm audit --audit-level=low` — 0 vulnerabilities
- `npm test` — 62 files / 591 tests passed
- `npm run typecheck`
- `npm run build`
- `npm run bundle`
- GitHub CI matrix — Ubuntu/Windows with Node 22/24 passed
- Nix builds — Ubuntu and macOS passed with the refreshed hash
- CodeQL — passed