### PR TITLE
feat: add Raycast deep links

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,7 +164,8 @@ claudescope start      # start in the background (idempotent), open the browser
 claudescope stop       # stop the background server
 claudescope restart    # restart it
 claudescope status     # is it running? is an update available?
-claudescope open       # open the running app in your browser
+claudescope open       # start if needed, then open the app in your browser
+claudescope open --session <id> [--around <uuid>]  # open an exact session/message
 claudescope logs -f    # tail the server log
 claudescope update          # upgrade to the latest published version and restart
 claudescope pricing update  # fetch current model prices (LiteLLM) into the local rate table
@@ -234,13 +235,16 @@ start the background server on first use and print tables (or raw JSON with
 claudescope search "duckdb lock" --limit 5      # where did I hit this before?
 claudescope sessions --agent codex --sort cost  # priciest Codex sessions
 claudescope session <id> --around <uuid>        # open a search hit, windowed
+claudescope open --session <id> --around <uuid> # open that hit in the web app
 claudescope analytics --group-by day --json | jq '.rows[] | [.key, .costUsd]'
 claudescope digest --from 2026-06-23 --to 2026-06-29   # week in review, as Markdown
 ```
 
 `session` prints a pageable window of turns as Markdown (`--offset/--limit`,
 `--redact` to mask paths/secrets); `--json` returns the raw API response
-unredacted. See `claudescope help` for the full flag list.
+unredacted. `open` starts the daemon lazily and preserves its configured port;
+session ids and message anchors are URL-encoded before the browser opens. See
+`claudescope help` for the full flag list.
 
 ---
 

--- a/docs/plans/0068-raycast-extension.md
+++ b/docs/plans/0068-raycast-extension.md
@@ -1,0 +1,194 @@
+# 0068 — Raycast extension and deep-link CLI seam
+
+- **Status:** in-progress
+- **Date:** 2026-08-11
+- **PR:** ClaudeScope: https://github.com/vladar107/claudescope/pull/89;
+  Raycast Store: pending
+
+## Context
+
+ClaudeScope already exposes machine-readable, read-only query commands that
+start the daemon lazily. Search is capped server-side, session listings accept a
+limit, and the web application has stable session/message routes at
+`/sessions/:id#<message-uuid>`. This is enough data for a focused Raycast
+experience without duplicating transcript parsers or talking directly to
+DuckDB, agent source directories, or a hosted service.
+
+Two integration gaps remain. Raycast may not inherit the user's interactive
+shell `PATH`, so it needs safe executable discovery with an override. And
+`claudescope open` can currently open only the application root of an already
+running daemon; it cannot lazily start the app or open a selected session/search
+hit. A small CLI deep-link contract keeps port and daemon-state knowledge inside
+ClaudeScope instead of leaking it into the extension.
+
+Public Raycast extensions are reviewed and published through the Raycast Store.
+The extension therefore needs its own package/repository and Store assets rather
+than becoming another workspace in the ClaudeScope monorepo. See Raycast's
+[preparation checklist](https://developers.raycast.com/basics/prepare-an-extension-for-store)
+and [publishing workflow](https://developers.raycast.com/basics/publish-an-extension).
+
+## Goal
+
+Publish a local-only Raycast extension with three commands — Search ClaudeScope,
+Recent Sessions, and Open ClaudeScope — backed exclusively by the installed
+ClaudeScope CLI. Selecting a transcript hit must open the exact session/message
+in the user's running app, including when ClaudeScope uses a non-default port.
+
+## Decisions
+
+- **Keep extension code outside the ClaudeScope npm workspaces** — develop a
+  dedicated `raycast-claudescope` package/repository and publish it through the
+  Raycast Store workflow. This plan records the cross-repository contract; the
+  Store PR owns the extension source once submitted.
+- **Use the CLI, never transcript storage or DuckDB** — invoke documented
+  `claudescope ... --json` commands, parse their bounded output, and leave daemon
+  startup, index compatibility, and source access inside ClaudeScope. The
+  extension makes no outbound requests and requires no API key.
+- **Ship a deliberately small command set** — Search ClaudeScope provides
+  debounced full-text results and message-level opening; Recent Sessions lists
+  and filters the latest sessions; Open ClaudeScope launches the main UI. Do not
+  add resume, fork, delete, prompt execution, dashboards, or transcript parsing
+  to the first Store submission.
+- **Add one stable deep-link seam** — extend the CLI to accept
+  `claudescope open --session <id> [--around <message-uuid>]`. `open` should
+  ensure the daemon is available, validate its port, construct a loopback-only
+  URL, encode path/fragment values, and preserve plain `claudescope open` as
+  the root-app form. `--around` without `--session` is a usage error.
+- **Resolve and execute the binary safely** — prefer an optional executable-path
+  preference, otherwise discover `claudescope` through the user's login shell.
+  Validate the resolved executable and always pass search text and identifiers
+  as argv elements; never interpolate them into a shell command.
+- **Treat the published CLI version as a dependency** — merge and release the
+  deep-link command before Store publication, document the minimum compatible
+  ClaudeScope version, and show an update/install action when the binary is
+  absent or too old.
+- **Keep Store data local and transparent** — declare macOS support, explain
+  that transcript snippets are rendered locally, include no telemetry, and
+  provide actions to open the result in ClaudeScope or copy non-secret metadata.
+
+## Approach
+
+1. **ClaudeScope deep-link contract (simple; no prerequisites)** — update the
+   `open` command to ensure the daemon, accept `--session` plus the existing
+   `--around` value, construct encoded session URLs from a validated loopback
+   port, and update CLI help and user documentation.
+   Acceptance: plain `open` still opens the app root; a session id opens
+   `/sessions/<encoded-id>`; an anchor adds an encoded fragment; stopped daemons
+   start safely; custom running ports are preserved; invalid flag combinations
+   fail before opening a browser.
+2. **Extension foundation (complex; can begin alongside 1)** — create the
+   standard Raycast TypeScript/React package with MIT metadata, a custom icon,
+   npm lockfile, macOS platform declaration, executable preference, minimal
+   local response types, and a shared argv-based ClaudeScope client. Normalize
+   missing binary, non-zero exit, malformed JSON, indexing, and incompatible
+   version errors into actionable Raycast states.
+   Acceptance: the extension resolves npm, Homebrew, and Nix-style installations
+   or honors the explicit path; user input never reaches a shell string; no
+   direct filesystem-source or network access exists.
+3. **Three-command MVP (complex; depends on 2, exact opening depends on 1)** —
+   implement debounced transcript search, a recent-session list with local
+   filtering, and a no-view open command. Add actions to open the exact hit or
+   session, open the ClaudeScope root, copy a session id/snippet, retry, and open
+   extension preferences when setup is incomplete.
+   Acceptance: result titles, agent, project, date, snippet, tokens/cost, and
+   empty/error/loading states render clearly; queries remain responsive; every
+   selected result opens the expected ClaudeScope route.
+4. **Store presentation and local validation (simple; depends on 2-3)** — write
+   a concise README/privacy section and changelog, prepare Store-sized icon and
+   screenshots using synthetic or scrubbed data, and run Raycast's lint/build
+   checks plus manual installation from source.
+   Acceptance: Store metadata differentiates ClaudeScope as multi-agent,
+   read-only, local transcript search; screenshots expose no private paths or
+   conversation text; the extension passes current Store checks.
+5. **Release and publication handoff (external; depends on 1-4)** — merge and
+   publish a ClaudeScope release containing the deep-link seam, verify that
+   npm/Homebrew/Nix users can update to it, then run Raycast's publish command to
+   open the Store PR. Keep both PR URLs and the final minimum version in this
+   plan. Tagging/releasing ClaudeScope and opening the external Store PR require
+   explicit maintainer authorization at their respective steps.
+   Acceptance: the public extension installs from the Store, operates against
+   the documented ClaudeScope version, and its Store source/review link is
+   recorded here and in the user-facing README.
+
+## Files affected
+
+ClaudeScope repository:
+
+- `packages/server/src/cli.ts` — lazy root/session/message opening and CLI flag
+  validation.
+- `README.md` — deep-link command and Raycast installation/documentation once
+  the Store listing exists.
+- `docs/plans/0068-raycast-extension.md` — this cross-repository plan; keep
+  status, versions, and both PR links current.
+- `docs/plans/README.md` — plan index entry.
+
+External `raycast-claudescope` package/repository (exact scaffold names may
+follow the current Raycast generator):
+
+- `package.json` and `package-lock.json` — Raycast manifest, commands,
+  preferences, platform, scripts, and locked dependencies.
+- `src/lib/claudescope.ts` — executable discovery, argv execution, JSON parsing,
+  compatibility checks, and shared error mapping.
+- `src/search-claudescope.tsx` — debounced transcript-search list and actions.
+- `src/recent-sessions.tsx` — recent-session list, filtering, metadata, and
+  actions.
+- `src/open-claudescope.ts` — immediate root-app launcher.
+- `assets/extension-icon.png` and Store screenshots — non-default, privacy-safe
+  presentation assets.
+- `README.md` and `CHANGELOG.md` — setup, privacy, minimum version, usage, and
+  version history.
+
+## Testing
+
+1. Build ClaudeScope and manually verify `open`, `open --session`, and
+   `open --session --around` against a temporary/synthetic ClaudeScope home,
+   stopped and running daemons, encoded identifiers, and a non-default port.
+2. Run the existing ClaudeScope checks: `npm test`, `npm run typecheck`,
+   `npm run build`, `npm run bundle`, `git diff --check`, and a final code-review
+   pass. Do not add automated tests unless the maintainer explicitly requests
+   them.
+3. In the Raycast package, run the current scaffold's lint and production-build
+   commands, import the extension locally, and exercise all commands with:
+   normal results, no results, rapid query changes, missing/incorrect executable
+   paths, stopped/indexing daemons, malformed/non-zero CLI output, and the
+   minimum supported ClaudeScope version.
+4. Verify deep links with npm, Homebrew, and Nix-style executable locations
+   where available; otherwise simulate the resolved absolute paths and document
+   which install methods received live verification.
+5. Inspect the final extension bundle, manifest, screenshots, and Store PR for
+   accidental network clients, telemetry, secrets, private transcript text, or
+   direct agent-source access.
+
+## Implementation status
+
+- The ClaudeScope branch implements and documents lazy root/session/message
+  opening. Existing tests, typecheck, build, bundle, and safe manual checks pass,
+  including validation-before-startup, encoded identifiers, a stopped daemon,
+  and a running daemon on a custom port.
+- The separate Raycast branch implements the three-command MVP, confirmed
+  `vladar107` as the manifest author, reuses ClaudeScope's icon, and passes the
+  current Raycast lint/build checks plus local source import.
+- This plan remains in progress until a ClaudeScope release containing the
+  deep-link contract exists, end-to-end Store screenshots can be captured
+  against that version, and the separately authorized Raycast Store PR is
+  opened. No release or publication action has been taken.
+
+## Risks / open questions
+
+- The Raycast `author` field is confirmed as `vladar107` and validated by the
+  current Raycast manifest linter.
+- Raycast's process environment may not include the interactive shell `PATH`.
+  Discovery must fail clearly and the explicit executable preference must
+  always win.
+- CLI JSON is a documented scripting surface but not a separately versioned
+  SDK. Parse only the fields used by the UI, tolerate additional fields, and
+  keep a clear minimum-version boundary.
+- Live search starts a short CLI process after a debounce. Avoid firing on empty
+  or very short input and discard stale responses so typing cannot reorder the
+  results.
+- Store review may request metadata, screenshots, or implementation changes.
+  Keep those changes in the external extension unless they expose a genuine
+  ClaudeScope integration-contract problem.
+- ClaudeScope release publication and `npm run publish` for Raycast change
+  external state. Planning and implementation approval do not by themselves
+  authorize either action; pause at both handoff points.

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -92,3 +92,4 @@ decision, or a change worth explaining before doing. Skip it for one-line fixes.
 | 0065 | [Shared fallback-title selection](./0065-shared-fallback-title-selection.md) | done |
 | 0066 | [Dependabot Mermaid and DOMPurify remediation](./0066-dependabot-mermaid-dompurify.md) | done |
 | 0067 | [Claude Code plugin and marketplace](./0067-claude-code-plugin-marketplace.md) | done |
+| 0068 | [Raycast extension and deep-link CLI seam](./0068-raycast-extension.md) | in-progress |

--- a/packages/server/src/cli.ts
+++ b/packages/server/src/cli.ts
@@ -189,14 +189,30 @@ async function status(): Promise<void> {
   await maybeNotifyUpdate(true);
 }
 
-/** Open the running app, or hint to start it first. */
-function openApp(): void {
-  const d = readDaemon();
-  if (d && isAlive(d.pid)) {
-    openBrowser(d.url);
-  } else {
-    console.log('claudescope is not running. Start it with: claudescope start');
+/** Open the app root or an encoded session/message deep link, starting the
+ *  daemon first when needed. Flag validation happens before daemon startup. */
+async function openApp(session: string | undefined, around: string | undefined): Promise<void> {
+  if (around !== undefined && session === undefined) {
+    throw new UsageError('usage: claudescope open [--session id] [--around uuid]');
   }
+  if (session !== undefined && session.length === 0) {
+    throw new UsageError('--session expects a non-empty session id');
+  }
+  if (around !== undefined && around.length === 0) {
+    throw new UsageError('--around expects a non-empty message uuid');
+  }
+
+  const d = await ensureDaemon();
+  if (!Number.isInteger(d.port) || d.port < 1 || d.port > 65535) {
+    throw new UsageError('claudescope daemon returned an invalid port; run `claudescope restart`');
+  }
+  // daemon.json is local state but not a trusted navigation target. Rebuild the
+  // URL from the ensured, validated port so `open` can only reach loopback.
+  const baseUrl = `http://127.0.0.1:${d.port}`;
+  const url = session
+    ? `${baseUrl}/sessions/${encodeURIComponent(session)}${around ? `#${encodeURIComponent(around)}` : ''}`
+    : baseUrl;
+  openBrowser(url);
 }
 
 /** Last `n` lines of the daemon log, or '' when there is nothing to show.
@@ -388,7 +404,8 @@ Commands:
   stop             Stop the background server
   restart          Restart the background server
   status           Show whether the server is running and if an update exists
-  open             Open the running app in your browser
+  open             Open the app, starting it first if needed
+                   [--session id] [--around uuid]
   logs [-f]        Print the server log (-f / --follow to tail it)
   mcp              Run an MCP stdio server exposing transcript search/reading
                    (register with: claude mcp add claudescope -- claudescope mcp)
@@ -443,6 +460,7 @@ async function main(): Promise<void> {
       q: { type: 'string' },
       limit: { type: 'string' },
       offset: { type: 'string' },
+      session: { type: 'string' },
       around: { type: 'string' },
       radius: { type: 'string' },
       'max-tool-chars': { type: 'string' },
@@ -477,7 +495,7 @@ async function main(): Promise<void> {
       await status();
       break;
     case 'open':
-      openApp();
+      await openApp(values.session, values.around);
       break;
     case 'logs':
       logs(Boolean(values.follow));


### PR DESCRIPTION
## Summary

- extend `claudescope open` with encoded session and message deep links
- lazily start ClaudeScope when opening the root app or a selected transcript
- validate the daemon port and reconstruct a loopback-only URL instead of trusting stored navigation state
- document the CLI contract and the separate Raycast Store integration plan

## Why

The Raycast extension needs a stable way to open an exact transcript hit without duplicating ClaudeScope's daemon, port, or routing logic. Keeping that contract in the CLI also preserves custom ports and avoids direct access to transcript files or DuckDB.

## User impact

The CLI now supports:

```bash
claudescope open
claudescope open --session <id>
claudescope open --session <id> --around <message-uuid>
```

Plain `open` remains supported and now starts the daemon when necessary. Invalid flag combinations fail before daemon startup or browser opening.

## Validation

- `npm test` — 62 files, 591 tests passed
- `npm run typecheck`
- `npm run build`
- `npm run bundle`
- `git diff --check origin/main...HEAD`
- manual bundled-CLI checks covered lazy startup, custom ports, encoded identifiers, and validation-before-startup
- tampered daemon URL check confirmed navigation remains on validated `127.0.0.1:<port>`
- independent review completed with no findings after amendments

The standalone Raycast extension is maintained separately and passes Raycast lint, TypeScript, and production build checks. Store submission remains gated on a public ClaudeScope release containing this CLI contract and privacy-safe screenshots.

## Plan

[Plan 0068 — Raycast extension and deep-link CLI seam](https://github.com/vladar107/claudescope/blob/feat/raycast-integration/docs/plans/0068-raycast-extension.md)