### PR TITLE
fix: improve update status and identifier search

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,9 +47,10 @@ Claudescope works whether you use one agent or all eight. Adding another is just
 > `~/.copilot`, `~/.gemini`, `~/.grok`, and opencode's database) is treated as strictly read-only. Its only persistent
 > state lives in `~/.claudescope/` — a DuckDB index, a copy of the pricing file, and
 > a cached pricing snapshot (`pricing.fetched.json`), all safe to delete anytime. The
-> sole outbound requests are an optional daily check for a newer published version
-> (`claudescope update`) and an optional daily pricing refresh (`claudescope pricing
-> update`); nothing about your transcripts ever leaves your machine.
+> sole outbound requests are a cached daily check for a newer published version
+> (plus checks you explicitly trigger from Settings or with `claudescope update`)
+> and an optional daily pricing refresh (`claudescope pricing update`); nothing
+> about your transcripts ever leaves your machine.
 
 ---
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -62,7 +62,9 @@ None of these are misused; they're listed here so you can verify that.
 - Shipped code makes exactly **two kinds of outbound request**, both to
   hardcoded trusted endpoints:
   - a version check against `https://registry.npmjs.org` (cached for 24h) to
-    tell you when an update is available (`packages/server/src/cli.ts`);
+    tell you when an update is available; the Settings **Check Update** action
+    and `claudescope update` explicitly bypass that cache
+    (`packages/server/src/update-check.ts`);
   - a daily fetch of model pricing rates from LiteLLM's public table at
     `https://raw.githubusercontent.com/BerriAI/litellm/…/model_prices_and_context_window.json`
     (`packages/server/src/data/pricing-refresh.ts`), validated and written

--- a/docs/plans/0070-update-status-and-identifier-search.md
+++ b/docs/plans/0070-update-status-and-identifier-search.md
@@ -1,8 +1,8 @@
 # 0070 — Reliable update status and identifier search
 
-- **Status:** in-progress
+- **Status:** done
 - **Date:** 2026-08-14
-- **PR:** pending
+- **PR:** https://github.com/vladar107/claudescope/pull/91
 
 ## Context
 

--- a/docs/plans/0070-update-status-and-identifier-search.md
+++ b/docs/plans/0070-update-status-and-identifier-search.md
@@ -1,0 +1,82 @@
+# 0070 — Reliable update status and identifier search
+
+- **Status:** in-progress
+- **Date:** 2026-08-14
+- **PR:** pending
+
+## Context
+
+Two user-visible paths currently overstate their reliability:
+
+- The Settings page renders `up to date` whenever its one-time `/api/system`
+  response does not report an update. That includes an unknown registry state
+  and a result read from the documented 24-hour cache. It also does not react
+  when the health poll later learns that an update exists.
+- Transcript search builds DuckDB FTS with its default ignore expression, which
+  removes every non-alphabetic character. Versions, ticket numbers, and other
+  numeric identifiers therefore never enter the FTS dictionary; for example,
+  messages containing `v0.17.0` exist in the index while searches for
+  `v0.17.0`, `0.17.0`, or `17` return no hits.
+
+The default automatic update-check cadence remains once per day so this fix
+does not silently expand ClaudeScope's outbound network behavior.
+
+## Goal
+
+Make update status honest and refreshable on demand, and make transcript search
+reliably find versions, Jira-style ticket keys, and numeric identifiers without
+regressing prose-oriented BM25 search.
+
+## Decisions
+
+- **Keep the 24-hour automatic cache and add an explicit fresh check** — the
+  Settings action can bypass the cache without increasing background requests.
+- **Never label an unknown/cached-negative state as current** — Settings will
+  distinguish a cached no-update result from a fresh user-triggered check, and
+  will consume the live health-poller update value when one arrives.
+- **Extend the existing FTS index instead of adding a parallel search store** —
+  preserve digits while continuing to split punctuation, use conjunctive BM25
+  for queries containing digits, and rank literal full-query matches first.
+- **Rebuild the derived index through schema v14** — existing installations must
+  regenerate their FTS dictionary with numeric terms.
+
+## Approach
+
+1. Make daemon update refresh report success, add a force-refresh system route,
+   and expose it through the typed web client.
+2. Add the Settings action and honest cached/unknown/fresh status rendering,
+   while keeping the health poll as the live source for newly detected updates.
+3. Reconfigure DuckDB FTS to retain digits, select conjunctive identifier
+   matching, and prioritize exact query substrings in result ordering.
+4. Bump the derived schema, document the manual network check, and validate the
+   focused paths plus the repository's normal test/typecheck/build gates.
+
+## Files affected
+
+- `packages/server/src/update-check.ts` — forceable refresh with success state.
+- `packages/server/src/routes/system.ts` — on-demand update-check endpoint.
+- `packages/web/src/api/client.ts` — typed endpoint call.
+- `packages/web/src/pages/settings/SettingsPage.tsx` — update action and honest
+  status rendering.
+- `packages/server/src/data/index.ts` — numeric-aware FTS configuration.
+- `packages/server/src/routes/search.ts` — identifier query semantics and exact
+  match ranking.
+- `packages/server/src/db/schema.ts` — schema v14 rebuild trigger.
+- `README.md` / `SECURITY.md` — document the explicit on-demand registry check.
+- `docs/plans/README.md` — plan index entry.
+
+## Testing
+
+- Run the existing update-check and API integration suites.
+- Probe a synthetic FTS corpus for `v0.17.0`, `0.17.0`, `17`, `JIRA-123`, and
+  `123`, confirming exact identifiers rank before separated-term matches.
+- Run `npm test`, `npm run typecheck`, `npm run build`, and the search
+  performance scenario if its local prerequisites are available.
+
+## Risks / open questions
+
+- Numeric terms enlarge the FTS dictionary and may add matches to mixed prose
+  queries containing numbers. Conjunctive matching for digit-bearing queries
+  bounds that noise; exact full-query matches sort first.
+- A manual update check adds a registry request only after an explicit click.
+  Failure must remain visible rather than falling back to a false success state.

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -94,3 +94,4 @@ decision, or a change worth explaining before doing. Skip it for one-line fixes.
 | 0067 | [Claude Code plugin and marketplace](./0067-claude-code-plugin-marketplace.md) | done |
 | 0068 | [Raycast extension and deep-link CLI seam](./0068-raycast-extension.md) | in-progress |
 | 0069 | [Shared Claude Code and Codex plugin](./0069-shared-claude-codex-plugin.md) | done |
+| 0070 | [Reliable update status and identifier search](./0070-update-status-and-identifier-search.md) | in-progress |

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -94,4 +94,4 @@ decision, or a change worth explaining before doing. Skip it for one-line fixes.
 | 0067 | [Claude Code plugin and marketplace](./0067-claude-code-plugin-marketplace.md) | done |
 | 0068 | [Raycast extension and deep-link CLI seam](./0068-raycast-extension.md) | in-progress |
 | 0069 | [Shared Claude Code and Codex plugin](./0069-shared-claude-codex-plugin.md) | done |
-| 0070 | [Reliable update status and identifier search](./0070-update-status-and-identifier-search.md) | in-progress |
+| 0070 | [Reliable update status and identifier search](./0070-update-status-and-identifier-search.md) | done |

--- a/packages/server/src/data/index.ts
+++ b/packages/server/src/data/index.ts
@@ -561,9 +561,13 @@ async function applyFallbackTitles(conn: DuckDBConnection): Promise<void> {
 
 /** (Re)build the BM25 full-text index over event text. */
 async function rebuildFtsIndex(conn: DuckDBConnection): Promise<void> {
-  // create_fts_index requires overwrite=1 to replace an existing index.
+  // DuckDB's default ignore expression drops every non-letter, which makes
+  // versions, issue numbers, and other identifiers impossible to find. Keep
+  // digits as terms while punctuation remains a token boundary.
   await conn.run(`
-    PRAGMA create_fts_index('events', 'uuid', 'text_content', overwrite=1)
+    PRAGMA create_fts_index(
+      'events', 'uuid', 'text_content', ignore='[^a-z0-9]+', overwrite=1
+    )
   `);
   // Force a CHECKPOINT so the FTS index DDL is merged into the main DB file
   // instead of lingering in the WAL. DuckDB cannot replay the FTS schema's

--- a/packages/server/src/db/schema.ts
+++ b/packages/server/src/db/schema.ts
@@ -33,7 +33,8 @@
 //      listed in pricing 'providers' zero-rate at index time.
 // v12: Codex fallback titles skip the injected AGENTS/environment bootstrap.
 // v13: fallback titles skip complete synthetic command/system turns for every connector.
-export const SCHEMA_VERSION = 13;
+// v14: FTS retains numeric terms for versions, issue keys, and other identifiers.
+export const SCHEMA_VERSION = 14;
 
 /** All DDL statements, executed in order at startup. Idempotent. */
 export const SCHEMA_DDL: readonly string[] = [

--- a/packages/server/src/routes/search.ts
+++ b/packages/server/src/routes/search.ts
@@ -39,6 +39,11 @@ async function searchSessions(
   // which is applied once when the connection opens (see db/duckdb.ts) rather than
   // here — it is a connection-level setting, and the connection is shared.
   const conn = await getConnection();
+  const identifierQuery = /\d/.test(q);
+  const matchExpression = `fts_main_events.match_bm25(
+    e.uuid,
+    ${sqlString(q)}${identifierQuery ? ', conjunctive := true' : ''}
+  )`;
 
   const filters: string[] = ['score IS NOT NULL'];
   if (type === 'user' || type === 'assistant') filters.push(`role = ${sqlString(type)}`);
@@ -54,13 +59,18 @@ async function searchSessions(
          e.text_content AS text_content,
          s.project_cwd AS project_cwd,
          s.title AS title,
-         fts_main_events.match_bm25(e.uuid, ${sqlString(q)}) AS score
+         ${
+           identifierQuery
+             ? `contains(lower(e.text_content), ${sqlString(q.toLowerCase())})`
+             : 'FALSE'
+         } AS exact_match,
+         ${matchExpression} AS score
        FROM events e
        JOIN sessions s ON s.id = e.session_id
        WHERE e.text_content IS NOT NULL
      )
      WHERE ${filters.join(' AND ')}
-     ORDER BY score DESC
+     ORDER BY exact_match DESC, score DESC
      LIMIT 50`,
   );
 

--- a/packages/server/src/routes/system.ts
+++ b/packages/server/src/routes/system.ts
@@ -9,22 +9,39 @@ import type { SystemInfoResponse } from '@claudescope/shared';
 import { APP_VERSION } from '../config.js';
 import { getDataVersion } from '../data/index.js';
 import { detectInstallMethod, updateCommandFor } from '../install-method.js';
-import { getCachedLatest, updateAvailable } from '../update-check.js';
+import { getCachedLatest, refreshLatestVersion, updateAvailable } from '../update-check.js';
 
 /** Stamped at module load ≈ process start; good enough for an uptime display. */
 const startedAt = new Date().toISOString();
 
+/** Snapshot the current process/update state for both the read and refresh routes. */
+function systemInfo(): SystemInfoResponse {
+  const installMethod = detectInstallMethod();
+  return {
+    version: APP_VERSION,
+    latestVersion: getCachedLatest(),
+    updateAvailable: updateAvailable() !== null,
+    installMethod,
+    updateCommand: updateCommandFor(installMethod),
+    startedAt,
+    dataVersion: getDataVersion(),
+  };
+}
+
 export async function registerSystemRoute(app: FastifyInstance): Promise<void> {
-  app.get('/api/system', async (): Promise<SystemInfoResponse> => {
-    const installMethod = detectInstallMethod();
-    return {
-      version: APP_VERSION,
-      latestVersion: getCachedLatest(),
-      updateAvailable: updateAvailable() !== null,
-      installMethod,
-      updateCommand: updateCommandFor(installMethod),
-      startedAt,
-      dataVersion: getDataVersion(),
-    };
-  });
+  app.get('/api/system', async (): Promise<SystemInfoResponse> => systemInfo());
+
+  app.post(
+    '/api/system/update-check',
+    async (_req, reply): Promise<SystemInfoResponse | undefined> => {
+      if (!(await refreshLatestVersion(true))) {
+        app.log.warn('on-demand update check failed');
+        void reply
+          .code(502)
+          .send({ error: 'update check failed — could not reach the npm registry' });
+        return;
+      }
+      return systemInfo();
+    },
+  );
 }

--- a/packages/server/src/update-check.ts
+++ b/packages/server/src/update-check.ts
@@ -67,12 +67,17 @@ export function getCachedLatest(): string | null {
   return cachedLatest;
 }
 
-/** Refresh the daemon-side cache from the (file-cached) registry lookup.
- *  Never throws — offline just leaves the last-known value in place. */
-export async function refreshLatestVersion(): Promise<void> {
+/** Refresh the daemon-side cache from the registry lookup. `force` bypasses the
+ *  24-hour file cache for an explicit user check. Never throws: offline keeps
+ *  the last-known value and reports failure to callers that need to surface it. */
+export async function refreshLatestVersion(force = false): Promise<boolean> {
   try {
-    cachedLatest = (await getLatestVersion(false)) ?? cachedLatest;
+    const latest = await getLatestVersion(force);
+    if (latest === null) return false;
+    cachedLatest = latest;
+    return true;
   } catch {
     /* offline or registry hiccup — keep the last-known value */
+    return false;
   }
 }

--- a/packages/web/src/api/client.ts
+++ b/packages/web/src/api/client.ts
@@ -293,4 +293,9 @@ export const api = {
   systemInfo(signal?: AbortSignal): Promise<SystemInfoResponse> {
     return request<SystemInfoResponse>('/system', { signal });
   },
+
+  /** POST /api/system/update-check — bypass the daily cache and check now. */
+  refreshUpdateCheck(signal?: AbortSignal): Promise<SystemInfoResponse> {
+    return request<SystemInfoResponse>('/system/update-check', { method: 'POST', signal });
+  },
 };

--- a/packages/web/src/pages/settings/SettingsPage.tsx
+++ b/packages/web/src/pages/settings/SettingsPage.tsx
@@ -15,6 +15,7 @@ import {
   Moon,
   Monitor,
   Play,
+  RefreshCw,
   RotateCcw,
   Square,
   Sun,
@@ -113,6 +114,10 @@ export function SettingsPage() {
   const [pricingBusy, setPricingBusy] = useState(false);
   const [pricingResult, setPricingResult] = useState<string | null>(null);
 
+  const [updateCheckBusy, setUpdateCheckBusy] = useState(false);
+  const [updateCheckedNow, setUpdateCheckedNow] = useState(false);
+  const [updateCheckError, setUpdateCheckError] = useState<string | null>(null);
+
   const [rebuildOpen, setRebuildOpen] = useState(false);
   const [rebuildBusy, setRebuildBusy] = useState(false);
 
@@ -145,6 +150,8 @@ export function SettingsPage() {
   }, [seedDraft]);
 
   const editable = settings?.editable ?? [];
+  const availableVersion =
+    health.updateAvailable ?? (system?.updateAvailable ? system.latestVersion : null);
   const dirtyKeys = useMemo(
     // String-compare: number inputs hold strings mid-edit, so '15000' vs
     // 15000 must not count as dirty when the user reverts an edit.
@@ -164,6 +171,19 @@ export function SettingsPage() {
     setFieldErrors({});
     setNotice(null);
   }, [settings, seedDraft]);
+
+  const checkUpdate = useCallback(async () => {
+    setUpdateCheckBusy(true);
+    setUpdateCheckError(null);
+    try {
+      setSystem(await api.refreshUpdateCheck());
+      setUpdateCheckedNow(true);
+    } catch (err) {
+      setUpdateCheckError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setUpdateCheckBusy(false);
+    }
+  }, []);
 
   const save = useCallback(async () => {
     if (!settings || dirtyKeys.length === 0) return;
@@ -366,21 +386,33 @@ export function SettingsPage() {
             busy={pricingBusy}
             onClick={() => void syncPricing()}
           />
+          <ActionTile
+            icon={RefreshCw}
+            label="Check Update"
+            busy={updateCheckBusy}
+            onClick={() => void checkUpdate()}
+          />
         </div>
         <div className="tv-settings__meta">
           {system ? (
             <>
               v{system.version} · up {formatUptime(system.startedAt)}
-              {system.updateAvailable && system.latestVersion ? (
+              {availableVersion ? (
                 <>
                   {' · '}
                   <span className="tv-settings__hint--warn">
-                    v{system.latestVersion} available:{' '}
+                    v{availableVersion} available:{' '}
                     <code className="tv-mono">{system.updateCommand}</code>
                   </span>
                 </>
+              ) : updateCheckError ? (
+                <span className="tv-settings__hint--warn"> · update check failed</span>
+              ) : updateCheckedNow ? (
+                ' · up to date (checked now)'
+              ) : system.latestVersion ? (
+                ' · no update in cached daily check'
               ) : (
-                ' · up to date'
+                ' · update status unavailable'
               )}
             </>
           ) : null}


### PR DESCRIPTION
## Summary

- replace the misleading Settings up-to-date fallback with cached, unavailable, fresh, and available states
- add an explicit Check Update action that bypasses the 24-hour cache without increasing automatic outbound checks
- retain numeric FTS terms, make digit-bearing queries conjunctive, and rank exact version and ticket matches first
- bump the derived index to schema v14 so existing installations rebuild search data

## Validation

- npm test (62 files, 591 tests)
- npm run typecheck
- npm run build
- npm run bench -- --out /private/tmp/claudescope-0070-perf.json --scale 1 --runs 3 (search p95 9.57 ms)
- live-index clone: v0.17.0, 0.17.0, and 17 all return literal matches first
- stubbed update endpoint: unknown status becomes a fresh newer-version result

## Plan

- docs/plans/0070-update-status-and-identifier-search.md