### PR TITLE
fix: validate runtime and query parameters

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,7 +102,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest]
-        node: ['22', '24'] # 22 = engines floor, 24 = latest
+        node: ['22.13.0', '24'] # exact engines floor + latest
     uses: ./.github/workflows/build-test.yml
     with:
       os: ${{ matrix.os }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,7 @@ them merged. For architecture and conventions, see [`CLAUDE.md`](./CLAUDE.md)
 
 ## Prerequisites
 
-- [Node.js](https://nodejs.org) **22.12 or newer** (`node -v`) — matches the
+- [Node.js](https://nodejs.org) **22.13 or newer** (`node -v`) — matches the
   `engines` field in `package.json`.
 
 ## Setup & dev loop

--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ your browser. Run it once and forget it; new sessions appear automatically.
 
 ### npm (recommended)
 
-**Prerequisite:** [Node.js](https://nodejs.org) **22.12 or newer** (`node -v`).
+**Prerequisite:** [Node.js](https://nodejs.org) **22.13 or newer** (`node -v`).
 
 ```bash
 npm install -g @vladar107/claudescope
@@ -483,7 +483,7 @@ shell, and self-update behavior — and how to report a vulnerability.
   the banner and set them correctly. Any source can be absent; only the present
   ones are indexed.
 - **`Error: listen EADDRINUSE :4317`** — the port is taken; run `claudescope --port <n>`.
-- **Node version errors** — you need Node ≥ 22.12 (`node -v`).
+- **Node version errors** — you need Node ≥ 22.13 (`node -v`).
 - **Stale or wrong data** — delete `~/.claudescope/index.duckdb*` and
   `claudescope restart` to rebuild the index from scratch.
 - **`@duckdb/node-api` install issues** — it ships prebuilt native binaries;

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,10 +1,11 @@
 # Security Policy
 
 Claudescope is a **local, read-only** viewer for your AI coding-agent transcripts
-— Claude Code, OpenAI Codex, JetBrains Junie, pi, opencode, and GitHub Copilot CLI. It runs on your
-machine, binds to loopback only, and is designed to touch as little of your
-system as possible. This document describes exactly what it does so you can audit
-it, and how to report anything that looks wrong.
+— Claude Code, OpenAI Codex, JetBrains Junie, pi, opencode, GitHub Copilot CLI,
+Google Antigravity, and xAI Grok CLI. It runs on your machine, binds to loopback
+only, and is designed to touch as little of your system as possible. This
+document describes exactly what it does so you can audit it, and how to report
+anything that looks wrong.
 
 ## Reporting a vulnerability
 
@@ -37,6 +38,10 @@ None of these are misused; they're listed here so you can verify that.
   - `~/.local/share/opencode/opencode.db` — opencode, a SQLite database opened
     **read-only** via Node's built-in `node:sqlite` (override:
     `$OPENCODE_DATA_DIR` / `$OPENCODE_DB_PATH`)
+  - `~/.gemini/antigravity-cli/brain/**` and `~/.gemini/antigravity/brain/**` —
+    Google Antigravity CLI and desktop (overrides: `$ANTIGRAVITY_CLI_DIR` /
+    `$ANTIGRAVITY_DIR`)
+  - `~/.grok/sessions/**` — xAI Grok CLI (override: `$GROK_SESSIONS_DIR`)
 - **Reads** agent **memory** live (never indexed) from those same read-only home
   dirs — long-lived instruction files and any agent-distilled memory — strictly
   within each agent's own directory, never from your project folders.
@@ -59,8 +64,8 @@ None of these are misused; they're listed here so you can verify that.
   blocks DNS-rebinding attacks, where a malicious site you visit rebinds its own
   hostname to `127.0.0.1` to read your transcripts past the loopback bind. Override
   the allowlist with `CLAUDESCOPE_ALLOWED_HOSTS` for custom local hostnames.
-- Shipped code makes exactly **two kinds of outbound request**, both to
-  hardcoded trusted endpoints:
+- Shipped code makes exactly **two kinds of outbound request**, with these
+  default destinations:
   - a version check against `https://registry.npmjs.org` (cached for 24h) to
     tell you when an update is available; the Settings **Check Update** action
     and `claudescope update` explicitly bypass that cache
@@ -68,8 +73,9 @@ None of these are misused; they're listed here so you can verify that.
   - a daily fetch of model pricing rates from LiteLLM's public table at
     `https://raw.githubusercontent.com/BerriAI/litellm/…/model_prices_and_context_window.json`
     (`packages/server/src/data/pricing-refresh.ts`), validated and written
-    atomically to `~/.claudescope/pricing.fetched.json`. Set
-    `PRICING_REFRESH_INTERVAL_MS=0` to disable it entirely.
+    atomically to `~/.claudescope/pricing.fetched.json`. Override the source
+    with `LITELLM_PRICING_URL`, or set `PRICING_REFRESH_INTERVAL_MS=0` to
+    disable it entirely.
 
   Both are GET requests that **send no data** beyond the request itself.
 - **No telemetry, analytics, or data exfiltration.** Your transcript content

--- a/docs/plans/0071-runtime-and-query-validation.md
+++ b/docs/plans/0071-runtime-and-query-validation.md
@@ -1,0 +1,104 @@
+# 0071 — Runtime and query validation fixes
+
+- **Status:** in-progress <!-- proposed | in-progress | done | superseded | abandoned -->
+- **Date:** 2026-08-18
+- **PR:** <link, once opened>
+
+## Context
+
+A repository review found three correctness gaps and one documentation drift:
+
+1. The npm package advertises Node.js 22.12 support, but the bundled server
+   statically imports `node:sqlite`, which still required
+   `--experimental-sqlite` in Node 22.12 and became unflagged in 22.13. CI's
+   floating `22` entry tests the latest Node 22 rather than the declared floor.
+2. Date-bound validation uses `Date.parse` as a calendar check, but JavaScript
+   normalizes values such as `2026-02-31`. The original invalid string then
+   reaches DuckDB and can produce a conversion error instead of the intended
+   `400`. The activity `today` anchor can similarly normalize to another day.
+3. Analytics and search routes cast arbitrary query strings to TypeScript enum
+   types. Invalid analytics grouping can expose raw project paths, while invalid
+   search type/scope values broaden the result set.
+4. Package/Nix descriptions and `SECURITY.md` do not reflect all current
+   connectors, and the security policy calls default outbound endpoints
+   hardcoded even though the LiteLLM URL is configurable.
+
+The dependency graph and security scanners are currently clean, so dependency
+upgrades and unrelated bundle optimization are deliberately out of scope.
+
+## Goal
+
+Advertise a runtime floor the package actually supports, reject impossible
+dates and unsupported API enum values at the server boundary, and make the
+published/security metadata match the current connector set.
+
+## Decisions
+
+- **Require Node.js 22.13.0** — this is the first Node 22 release where
+  `node:sqlite` no longer needs the experimental flag. Keeping the static import
+  preserves the simple connector registry and makes the package requirement
+  honest.
+- **Test the exact minimum runtime** — CI will use `22.13.0`, not floating `22`,
+  so a future floor regression is observable.
+- **Validate the calendar without normalizing input** — a shared day validator
+  checks month length and leap years, while accepted timestamp strings continue
+  to flow to DuckDB unchanged. Invalid `from`/`to` values remain `400`; invalid
+  optional `today` values remain ignored.
+- **Reject invalid API enums with `400`** — direct HTTP callers receive a useful
+  contract error instead of silently broadened or malformed results. Existing
+  web, CLI, and MCP callers already send allowlisted values.
+- **Prefer connector-neutral package descriptions** — the README and security
+  policy remain the explicit connector inventory, avoiding routine metadata
+  drift when another connector is added.
+
+## Approach
+
+1. Raise the root/package-lock engine floor to `>=22.13.0`; update user,
+   contributor, and plugin requirements; pin CI's floor leg to `22.13.0`.
+2. Add shared calendar and enum validators in `packages/server/src/params.ts`.
+   Use them in analytics and search routes without changing valid-query output.
+3. Extend existing integration tests for month-valid/day-impossible dates,
+   leap-day behavior, the optional `today` fallback, and invalid enum values.
+4. Make package and Nix descriptions connector-neutral, add missing search
+   keywords, and complete/correct the connector and network inventory in
+   `SECURITY.md`.
+5. Run focused tests, then the complete test/typecheck/build/bundle/package,
+   dependency, formatting, and Nix validation sequence. Review the final diff
+   before handoff.
+
+## Files affected
+
+- `package.json`, `package-lock.json` — runtime floor and package metadata.
+- `.github/workflows/ci.yml` — exact minimum-Node CI leg.
+- `README.md`, `CONTRIBUTING.md` — npm runtime requirement.
+- `plugins/claudescope/README.md`, `plugins/claudescope/skills/history/SKILL.md`
+  — keep plugin installation guidance aligned.
+- `packages/server/src/params.ts` — strict calendar and enum validators.
+- `packages/server/src/routes/analytics.ts`, `packages/server/src/routes/search.ts`
+  — validate public query values before use.
+- `packages/server/test/query-params.integration.test.ts` — date and enum
+  regressions.
+- `flake.nix`, `SECURITY.md` — accurate connector-neutral metadata and security
+  inventory.
+- `docs/plans/README.md` — plan index.
+
+## Testing
+
+- Focused: query-parameter integration tests.
+- Full: `npm test`, `npm run typecheck`, `npm run build`, `npm run bundle`,
+  `npm pack --dry-run --json ./dist`, `npm ls --all`, and
+  `npm audit --audit-level=low`.
+- Packaging: verify `dist/package.json` advertises `node >=22.13.0`.
+- Nix: `nix build .#claudescope`; update `npmDepsHash` only if the dependency
+  cache actually changes.
+- Hygiene: Markdown lint where available and `git diff --check`.
+
+## Risks / open questions
+
+- Tightening the minimum Node version intentionally rejects 22.12 instead of
+  requiring users to know about an experimental runtime flag.
+- Invalid enum strings change from silent fallback/broadening to `400`. This is
+  limited to callers already outside the documented typed API contract.
+- Calendar validation must preserve accepted timestamp forms and DuckDB's
+  current timezone semantics; it only rejects impossible date/time values and
+  does not normalize valid input.

--- a/docs/plans/0071-runtime-and-query-validation.md
+++ b/docs/plans/0071-runtime-and-query-validation.md
@@ -1,8 +1,8 @@
 # 0071 — Runtime and query validation fixes
 
-- **Status:** in-progress <!-- proposed | in-progress | done | superseded | abandoned -->
+- **Status:** done <!-- proposed | in-progress | done | superseded | abandoned -->
 - **Date:** 2026-08-18
-- **PR:** <link, once opened>
+- **PR:** https://github.com/vladar107/claudescope/pull/92
 
 ## Context
 

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -95,3 +95,4 @@ decision, or a change worth explaining before doing. Skip it for one-line fixes.
 | 0068 | [Raycast extension and deep-link CLI seam](./0068-raycast-extension.md) | in-progress |
 | 0069 | [Shared Claude Code and Codex plugin](./0069-shared-claude-codex-plugin.md) | done |
 | 0070 | [Reliable update status and identifier search](./0070-update-status-and-identifier-search.md) | done |
+| 0071 | [Runtime and query validation fixes](./0071-runtime-and-query-validation.md) | in-progress |

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -95,4 +95,4 @@ decision, or a change worth explaining before doing. Skip it for one-line fixes.
 | 0068 | [Raycast extension and deep-link CLI seam](./0068-raycast-extension.md) | in-progress |
 | 0069 | [Shared Claude Code and Codex plugin](./0069-shared-claude-codex-plugin.md) | done |
 | 0070 | [Reliable update status and identifier search](./0070-update-status-and-identifier-search.md) | done |
-| 0071 | [Runtime and query validation fixes](./0071-runtime-and-query-validation.md) | in-progress |
+| 0071 | [Runtime and query validation fixes](./0071-runtime-and-query-validation.md) | done |

--- a/flake.nix
+++ b/flake.nix
@@ -1,5 +1,5 @@
 {
-  description = "Local, read-only viewer for AI coding-agent transcripts (Claude Code, Codex, Junie)";
+  description = "Local, read-only viewer for AI coding-agent transcripts";
 
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";

--- a/flake.nix
+++ b/flake.nix
@@ -55,7 +55,7 @@
           # `nix build .#claudescope` and the mismatch error prints the new value.
           npmDeps = pkgs.fetchNpmDeps {
             src = depsLock;
-            hash = "sha256-Spb4aBNAyfdrjZvnC4of2PbKgmkMIt6GpJBIXH6UTNU=";
+            hash = "sha256-kn+cJZ8KPUlAovJji7R/6Nq4DH1VZ8h2FJklxbcMuoc=";
           };
 
           nodejs = node;

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "vitest": "^4.1.9"
       },
       "engines": {
-        "node": ">=22.12"
+        "node": ">=22.13.0"
       }
     },
     "node_modules/@antfu/install-pkg": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "claudescope",
   "version": "0.17.0",
   "private": true,
-  "description": "Local, read-only web app to browse, read, search, and analyze your AI coding-agent transcripts — Claude Code, OpenAI Codex, and JetBrains Junie.",
+  "description": "Local, read-only web app to browse, read, search, and analyze your AI coding-agent transcripts.",
   "keywords": [
     "claude",
     "claude-code",
@@ -11,6 +11,11 @@
     "openai",
     "junie",
     "jetbrains",
+    "pi",
+    "opencode",
+    "copilot",
+    "antigravity",
+    "grok",
     "transcripts",
     "sessions",
     "viewer",
@@ -46,7 +51,7 @@
     "screenshots": "node scripts/screenshots.mjs"
   },
   "engines": {
-    "node": ">=22.12"
+    "node": ">=22.13.0"
   },
   "devDependencies": {
     "concurrently": "^9.2.4",

--- a/packages/server/src/params.ts
+++ b/packages/server/src/params.ts
@@ -23,6 +23,24 @@ export class BadRequestError extends Error {
   }
 }
 
+/** `YYYY-MM-DD`, captured so calendar validity can be checked without coercion. */
+const ISO_DAY_RE = /^(\d{4})-(\d{2})-(\d{2})$/;
+
+/** True only for a real proleptic-Gregorian calendar day. */
+function isCalendarDay(value: string): boolean {
+  const match = ISO_DAY_RE.exec(value);
+  if (!match) return false;
+
+  const year = Number(match[1]);
+  const month = Number(match[2]);
+  const day = Number(match[3]);
+  if (month < 1 || month > 12 || day < 1) return false;
+
+  const leap = year % 4 === 0 && (year % 100 !== 0 || year % 400 === 0);
+  const daysInMonth = [31, leap ? 29 : 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31];
+  return day <= daysInMonth[month - 1]!;
+}
+
 /**
  * Timestamp shapes accepted for a date bound. Covers exactly what the callers
  * send: `YYYY-MM-DD` (the MCP/CLI contract), and a full ISO timestamp with
@@ -38,8 +56,8 @@ const TIMESTAMP_RE =
  *
  * Returns `undefined` for an absent/empty value (the bound is simply not
  * applied) and throws {@link BadRequestError} for anything unusable. The regex
- * checks shape; `Date.parse` then checks the calendar, so `2026-13-45` is
- * rejected here rather than becoming a DuckDB conversion error.
+ * checks shape, {@link isCalendarDay} checks the date without JavaScript's
+ * overflow normalization, and `Date.parse` checks the remaining time/offset.
  *
  * The value is returned unchanged — callers still wrap it in `sqlString` and the
  * cast stays `TIMESTAMP` (not `TIMESTAMPTZ`), so any offset keeps being ignored
@@ -49,16 +67,17 @@ export function timestampParam(raw: string | undefined, field: string): string |
   if (raw === undefined) return undefined;
   const value = raw.trim();
   if (value === '') return undefined;
-  if (!TIMESTAMP_RE.test(value) || Number.isNaN(Date.parse(value))) {
+  if (
+    !TIMESTAMP_RE.test(value) ||
+    !isCalendarDay(value.slice(0, 10)) ||
+    Number.isNaN(Date.parse(value))
+  ) {
     throw new BadRequestError(
       `${field} must be YYYY-MM-DD or an ISO timestamp (got '${value}')`,
     );
   }
   return value;
 }
-
-/** `YYYY-MM-DD` only — the shape the activity punchcard's `today` anchor uses. */
-const ISO_DAY_RE = /^\d{4}-\d{2}-\d{2}$/;
 
 /**
  * Validate a calendar-day param. Unlike {@link timestampParam} an unusable value
@@ -68,6 +87,27 @@ const ISO_DAY_RE = /^\d{4}-\d{2}-\d{2}$/;
 export function isoDayParam(raw: string | undefined): string | undefined {
   if (raw === undefined) return undefined;
   const value = raw.trim();
-  if (!ISO_DAY_RE.test(value) || Number.isNaN(Date.parse(value))) return undefined;
+  if (!isCalendarDay(value)) return undefined;
   return value;
+}
+
+/**
+ * Validate a string-valued enum query param and apply its documented default.
+ * TypeScript's unions disappear at runtime, so public routes must narrow the
+ * arbitrary query string before treating it as one of those values.
+ */
+export function enumParam<const T extends string>(
+  raw: string | undefined,
+  field: string,
+  allowed: readonly T[],
+  fallback: T,
+): T {
+  if (raw === undefined) return fallback;
+  const value = raw.trim();
+  if (!allowed.some((candidate) => candidate === value)) {
+    throw new BadRequestError(
+      `${field} must be one of ${allowed.join(', ')} (got '${value}')`,
+    );
+  }
+  return value as T;
 }

--- a/packages/server/src/routes/analytics.ts
+++ b/packages/server/src/routes/analytics.ts
@@ -25,6 +25,9 @@ import { readRow } from '../db/row.js';
 import { cacheHitRatio } from '../data/analytics-metrics.js';
 import { scopeFilters } from '../data/analytics-scope.js';
 import { projectIdFromCwd } from '../data/project-id.js';
+import { enumParam } from '../params.js';
+
+const ANALYTICS_GROUPS = ['project', 'model', 'day', 'agent'] as const;
 
 /**
  * The grouping key expression plus the FROM clause it needs. Project grouping
@@ -57,7 +60,7 @@ export async function registerAnalyticsRoute(app: FastifyInstance): Promise<void
     Querystring: { groupBy?: string; from?: string; to?: string };
   }>('/api/analytics', async (req): Promise<AnalyticsResponse> => {
     const conn = await getConnection();
-    const groupBy = (req.query.groupBy as AnalyticsGroupBy) ?? 'project';
+    const groupBy = enumParam(req.query.groupBy, 'groupBy', ANALYTICS_GROUPS, 'project');
     const { keyExpr, fromSql } = groupSource(groupBy);
 
     // Bounds go through the shared scope helper (which validates them); this

--- a/packages/server/src/routes/search.ts
+++ b/packages/server/src/routes/search.ts
@@ -13,7 +13,6 @@ import type {
   MemorySearchHit,
   SearchResponse,
   SearchResult,
-  SearchScope,
   SearchType,
   SnippetFormat,
 } from '@claudescope/shared';
@@ -22,10 +21,13 @@ import { readRow } from '../db/row.js';
 import { projectIdFromCwd } from '../data/project-id.js';
 import { projectFilter } from '../data/analytics-scope.js';
 import { collectMemory } from '../data/memory.js';
+import { enumParam } from '../params.js';
 import { makeSnippet } from './snippet.js';
 
 /** Cap on live memory hits returned. */
 const MEMORY_LIMIT = 50;
+const SEARCH_TYPES = ['user', 'assistant', 'all'] as const;
+const SEARCH_SCOPES = ['sessions', 'all', 'memory'] as const;
 
 /** Sessions (BM25) search. Empty unless scope includes sessions. */
 async function searchSessions(
@@ -144,9 +146,9 @@ export async function registerSearchRoute(app: FastifyInstance): Promise<void> {
     if (!q) return { sessions: [], memory: [] };
 
     const terms = q.split(/\s+/).filter(Boolean);
-    const type = (req.query.type as SearchType) ?? 'all';
+    const type = enumParam(req.query.type, 'type', SEARCH_TYPES, 'all');
     const project = req.query.project;
-    const scope = (req.query.scope as SearchScope) ?? 'sessions';
+    const scope = enumParam(req.query.scope, 'scope', SEARCH_SCOPES, 'sessions');
     const format: SnippetFormat = req.query.format === 'plain' ? 'plain' : 'html';
 
     // Each kind is guarded so a failure in one (e.g. an FTS edge case) still

--- a/packages/server/test/query-params.integration.test.ts
+++ b/packages/server/test/query-params.integration.test.ts
@@ -30,6 +30,7 @@ import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import type { FastifyInstance } from 'fastify';
+import { isoDayParam } from '../src/params.js';
 
 // --- temp locations (decided before any server module is imported) ----------
 const work = mkdtempSync(join(tmpdir(), 'claudescope-params-'));
@@ -182,9 +183,28 @@ describe('date bounds are validated at every bounded endpoint', () => {
     expect(res.json().error).toMatch(/^to must be/);
   });
 
-  it('rejects a well-shaped but impossible calendar date', async () => {
-    // Passes a naive regex; DuckDB would have raised a conversion error.
-    const res = await get('/api/analytics?from=2026-13-45');
+  it.each(['2026-13-45', '2026-02-29', '2026-02-30', '2026-04-31'])(
+    'rejects the impossible calendar date %s',
+    async (value) => {
+      // These pass or probe beyond a naive shape check; some are normalized by
+      // Date.parse even though DuckDB rejects the original string.
+      const res = await get(`/api/analytics?from=${value}`);
+      expect(res.statusCode).toBe(400);
+    },
+  );
+
+  it('ignores an impossible optional today anchor instead of normalizing it', () => {
+    expect(isoDayParam('2026-02-31')).toBeUndefined();
+  });
+
+  it('accepts a real leap day', async () => {
+    const res = await get('/api/analytics?from=2028-02-29');
+    expect(res.statusCode).toBe(200);
+    expect(isoDayParam('2028-02-29')).toBe('2028-02-29');
+  });
+
+  it('rejects an impossible calendar date inside a full timestamp', async () => {
+    const res = await get('/api/analytics?from=2026-02-31T12:00:00.000Z');
     expect(res.statusCode).toBe(400);
   });
 
@@ -202,6 +222,23 @@ describe('date bounds are validated at every bounded endpoint', () => {
       expect(res.statusCode).toBe(200);
     },
   );
+});
+
+describe('string enum params are validated at the HTTP boundary', () => {
+  it('rejects an unsupported analytics grouping', async () => {
+    const res = await get('/api/analytics?groupBy=garbage');
+    expect(res.statusCode).toBe(400);
+    expect(res.json().error).toMatch(/^groupBy must be one of/);
+  });
+
+  it.each([
+    ['type', 'garbage'],
+    ['scope', 'garbage'],
+  ])('rejects unsupported search %s=%s', async (field, value) => {
+    const res = await get(`/api/search?q=day&${field}=${value}`);
+    expect(res.statusCode).toBe(400);
+    expect(res.json().error).toMatch(new RegExp(`^${field} must be one of`));
+  });
 });
 
 describe('bound semantics survived the scopeFilters consolidation', () => {

--- a/plugins/claudescope/README.md
+++ b/plugins/claudescope/README.md
@@ -9,7 +9,7 @@ ClaudeScope's existing read-only query CLI.
 - A current Claude Code or Codex version with plugin support.
 - The `claudescope` CLI on `PATH`. Choose npm, Homebrew, or Nix from the
   [ClaudeScope Quick Start](https://github.com/vladar107/claudescope#quick-start).
-  npm requires Node.js 22.12+:
+  npm requires Node.js 22.13+:
 
   ```bash
   npm install -g @vladar107/claudescope

--- a/plugins/claudescope/skills/history/SKILL.md
+++ b/plugins/claudescope/skills/history/SKILL.md
@@ -12,7 +12,7 @@ question.
 1. Check `command -v claudescope >/dev/null 2>&1`. If it is missing, point the
    user to the supported [Quick start](https://github.com/vladar107/claudescope#quick-start)
    options. Mention `npm install -g @vladar107/claudescope` only with its Node.js
-   22.12+ requirement; Homebrew and Nix are alternatives. Then stop.
+   22.13+ requirement; Homebrew and Nix are alternatives. Then stop.
 2. Choose the narrowest read-only query:
    - Prior error, solution, or decision: `claudescope search '<terms>' --limit 5`.
      Add `--project <id>`, `--role user|assistant`, or `--scope sessions|memory|all`


### PR DESCRIPTION
## Summary

- require Node.js 22.13.0, where `node:sqlite` is available without an experimental flag, and test that exact floor in CI
- reject impossible calendar dates before they reach DuckDB while preserving valid timestamp semantics
- validate analytics grouping and search type/scope query values at the HTTP boundary
- align npm/Nix metadata and the security capability inventory with the current connector set

## Why

The package advertised Node 22.12 even though its bundled server statically imports `node:sqlite`, which still required `--experimental-sqlite` in that release. Date validation also relied on `Date.parse`, which normalizes inputs such as `2026-02-31`, and unchecked query-string casts could expose raw project paths or silently broaden search results.

## Validation

- `npm test` — 62 files, 600 tests passed
- focused query-parameter integration tests — 49 tests passed
- `npm run typecheck`
- `npm run build`
- `npm run bundle`
- `npm pack --dry-run --json ./dist`
- generated `dist/package.json` engine/metadata inspection
- `npm ls --all`
- `npm audit --audit-level=low` — 0 vulnerabilities
- Markdown lint
- `git diff --check`

`nix build .#claudescope` could not run locally because Nix is not installed. The initial Ubuntu CI leg produced the fresh `npmDepsHash`, which is applied in this PR; the rerun's Linux/macOS Nix matrix is the authoritative validation for that path.

## Plan

- [`docs/plans/0071-runtime-and-query-validation.md`](https://github.com/vladar107/claudescope/blob/fix/runtime-and-query-validation/docs/plans/0071-runtime-and-query-validation.md)
