### PR TITLE
fix: hide Codex guardian sessions

### DIFF
--- a/docs/plans/0072-hide-codex-guardian-sessions.md
+++ b/docs/plans/0072-hide-codex-guardian-sessions.md
@@ -1,0 +1,75 @@
+# 0072 — Hide Codex guardian sessions
+
+- **Status:** done
+- **Date:** 2026-08-18
+- **PR:** pending
+
+## Context
+
+Recent Codex versions persist internal approval-review conversations as separate
+rollouts with `thread_source: "subagent"` and
+`source.subagent.other: "guardian"`. Unlike user-spawned subagents, these
+rollouts have no `thread_spawn` linkage. ClaudeScope currently falls through to
+normal-session handling, so each guardian appears as a top-level session whose
+synthetic transcript history is rendered as a large user message.
+
+The other connectors use agent-specific linkage (nested paths, parent session
+ids, inline agent ids, or explicit spawn records) and do not consume Codex
+rollouts, so this schema and failure mode are Codex-specific.
+
+## Goal
+
+Exclude Codex guardian approval-review rollouts from indexing while preserving
+normal top-level Codex sessions, linked spawned subagents, and orphan handling
+for spawned subagents whose parent rollout is missing.
+
+## Decisions
+
+- **Filter by the explicit guardian source marker** —
+  `source.subagent.other: "guardian"` is the stable structural distinction in
+  the observed rollout metadata. Content matching would be brittle and could
+  hide legitimate user text.
+- **Filter during normalization** — returning no canonical rows prevents the
+  internal rollout from entering session lists, search, analytics, or detail
+  views while retaining ordinary source discovery and cache pruning behavior.
+- **Bump the index schema version** — source mtimes do not change on upgrade, so
+  existing derived indexes must rebuild once to remove guardian rows indexed by
+  earlier ClaudeScope versions.
+- **Keep the change Codex-only** — no other connector recognizes this source
+  schema, and the repository audit found no equivalent fallback requiring a
+  shared abstraction.
+
+## Approach
+
+1. Detect the guardian marker immediately after reading Codex `session_meta`.
+2. Skip normalization for guardian rollouts without changing normal spawned or
+   orphaned-subagent behavior.
+3. Bump the derived-index schema version so existing installations rebuild.
+4. Rebuild an isolated local index from the real transcript set and verify the
+   reported guardian session disappears while its reviewed user session remains.
+5. Run the existing test and typecheck suites, then review the final diff.
+
+## Files affected
+
+- `packages/server/src/connectors/codex/normalize.ts` — identify and skip Codex
+  guardian rollouts.
+- `packages/server/src/db/schema.ts` — invalidate existing derived indexes so
+  previously indexed guardian rows are removed on upgrade.
+- `docs/plans/0072-hide-codex-guardian-sessions.md` — record the scoped plan and
+  evidence.
+- `docs/plans/README.md` — index this plan.
+
+## Testing
+
+- `npm test`
+- `npm run typecheck`
+- Isolated real-data reindex: confirm guardian IDs are absent from session APIs
+  and their parent user sessions remain present.
+
+## Risks / open questions
+
+- Codex may add other `source.subagent.other` roles later. This fix intentionally
+  matches only `guardian`; unknown roles remain visible until their semantics are
+  understood rather than being silently discarded.
+- Repository and real-data audits found no equivalent internal-session schema in
+  the other supported connectors, so no cross-connector change is needed.

--- a/docs/plans/0072-hide-codex-guardian-sessions.md
+++ b/docs/plans/0072-hide-codex-guardian-sessions.md
@@ -2,7 +2,7 @@
 
 - **Status:** done
 - **Date:** 2026-08-18
-- **PR:** pending
+- **PR:** https://github.com/vladar107/claudescope/pull/93
 
 ## Context
 

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -96,3 +96,4 @@ decision, or a change worth explaining before doing. Skip it for one-line fixes.
 | 0069 | [Shared Claude Code and Codex plugin](./0069-shared-claude-codex-plugin.md) | done |
 | 0070 | [Reliable update status and identifier search](./0070-update-status-and-identifier-search.md) | done |
 | 0071 | [Runtime and query validation fixes](./0071-runtime-and-query-validation.md) | done |
+| 0072 | [Hide Codex guardian sessions](./0072-hide-codex-guardian-sessions.md) | done |

--- a/packages/server/src/connectors/codex/normalize.ts
+++ b/packages/server/src/connectors/codex/normalize.ts
@@ -18,7 +18,8 @@
  * its parent via `source.subagent.thread_spawn.parent_thread_id`; it is re-keyed
  * to the ROOT thread id (`is_sidechain: true`) so it folds into the parent
  * session, and the parent's `spawn_agent` call becomes a canonical `Task` block
- * the nested run anchors to.
+ * the nested run anchors to. Internal approval-review rollouts marked as
+ * `source.subagent.other: "guardian"` are omitted entirely.
  */
 
 import { closeSync, openSync, readFileSync, readSync, readdirSync, statSync } from 'node:fs';
@@ -470,6 +471,13 @@ export function parseRollout(path: string): CodexSession | null {
   }
 
   const meta = lines.find((l) => l.type === 'session_meta')?.payload ?? {};
+  const subagentSource = rec(rec(meta.source).subagent);
+  // Guardian rollouts contain Codex's synthetic approval-review transcript,
+  // not a user conversation. They have no thread_spawn linkage and otherwise
+  // fall through as top-level sessions whose history looks like one user turn.
+  if (str(meta.thread_source) === 'subagent' && str(subagentSource.other) === 'guardian') {
+    return null;
+  }
   const sessionId = str(meta.id) || sessionIdFromPath(path);
   const cwd = str(meta.cwd);
   const git = meta.git as Record<string, unknown> | undefined;
@@ -483,7 +491,7 @@ export function parseRollout(path: string): CodexSession | null {
   let isSidechain = false;
   let agentRole: string | undefined;
   if (str(meta.thread_source) === 'subagent') {
-    const spawn = rec(rec(rec(meta.source).subagent).thread_spawn);
+    const spawn = rec(subagentSource.thread_spawn);
     const parentId = str(spawn.parent_thread_id);
     agentRole = str(spawn.agent_role) || undefined;
     if (parentId) {

--- a/packages/server/src/db/schema.ts
+++ b/packages/server/src/db/schema.ts
@@ -34,7 +34,8 @@
 // v12: Codex fallback titles skip the injected AGENTS/environment bootstrap.
 // v13: fallback titles skip complete synthetic command/system turns for every connector.
 // v14: FTS retains numeric terms for versions, issue keys, and other identifiers.
-export const SCHEMA_VERSION = 14;
+// v15: Codex guardian approval-review rollouts are excluded from persisted events.
+export const SCHEMA_VERSION = 15;
 
 /** All DDL statements, executed in order at startup. Idempotent. */
 export const SCHEMA_DDL: readonly string[] = [


### PR DESCRIPTION
## Summary

- exclude Codex approval-review rollouts marked as internal `guardian` subagents
- bump the derived index schema so existing installations remove stale guardian rows automatically
- document the Codex-specific scope and cross-connector audit in plan 0072

## Root cause

Codex persists approval reviews as separate `thread_source: "subagent"` rollouts, but identifies them with `source.subagent.other: "guardian"` instead of the `thread_spawn` linkage used by normal spawned agents. ClaudeScope treated an unlinked subagent as a top-level session, so the guardian's synthetic review history rendered as one large user message.

## User impact

Internal approval-review sessions no longer appear in session lists, search, analytics, or detail views. Normal Codex conversations and spawned subagents are unchanged.

## Validation

- `npm test` — 62 files, 600 tests passed
- `npm run typecheck`
- `npm run build`
- migrated a real v14 index containing the reported guardian session to v15; the guardian disappeared while its reviewed session remained
- verified all 19 local guardian rollout IDs are absent and a normal Codex session with three spawned subagents still nests correctly

## Plan

- [0072 — Hide Codex guardian sessions](https://github.com/vladar107/claudescope/blob/fix/hide-codex-guardian-sessions/docs/plans/0072-hide-codex-guardian-sessions.md)
