### PR TITLE
fix: include analytics end date

### DIFF
--- a/docs/plans/0073-inclusive-analytics-end-date.md
+++ b/docs/plans/0073-inclusive-analytics-end-date.md
@@ -1,0 +1,68 @@
+# 0073 — Inclusive analytics end date
+
+- **Status:** done
+- **Date:** 2026-08-25
+- **PR:** https://github.com/vladar107/claudescope/pull/95
+
+## Context
+
+Issue #94 reports that date-only `to` bounds exclude nearly all activity on the
+named day. DuckDB casts `YYYY-MM-DD` to midnight, while the shared analytics
+scope currently compares timestamps with `<=`. The public CLI and MCP contract
+describes the bound as inclusive.
+
+Analytics timestamps are stored as UTC-naive DuckDB `TIMESTAMP` values. This fix
+preserves the current UTC calendar-day meaning for date-only CLI/MCP bounds;
+making analytics consistently timezone-aware remains a separate follow-up.
+
+## Goal
+
+Make a date-only `to` bound include the entire named UTC day without changing
+the inclusive semantics of full timestamp bounds or the existing `from` bound.
+
+## Decisions
+
+- **Use a half-open next-midnight comparison for date-only upper bounds** —
+  `< date + INTERVAL 1 DAY` includes every representable timestamp on the day
+  without relying on an end-of-day fractional precision.
+- **Keep full timestamps inclusive with `<=`** — callers that provide an exact
+  instant, including the web UI's local-day-to-UTC conversion, keep their
+  existing contract.
+- **Do not add implicit local-time interpretation** — the daemon timezone is not
+  a stable API contract; filtering and day grouping need one explicit timezone
+  in a future, separately scoped change.
+
+## Approach
+
+1. Update the shared analytics scope filter to distinguish date-only upper
+   bounds from full ISO timestamps after validation.
+2. Extend the existing query-parameter integration suite to cover same-day
+   analytics, date-only digest ranges, and exact timestamp inclusivity.
+3. Run focused and full validation, then review the complete diff.
+
+## Files affected
+
+- `packages/server/src/data/analytics-scope.ts` — implement the date-only upper
+  bound semantics.
+- `packages/server/test/query-params.integration.test.ts` — add regression
+  coverage at the shared HTTP boundary.
+- `CLAUDE.md` — retain the explicit timezone-aware analytics follow-up.
+- `docs/plans/0073-inclusive-analytics-end-date.md` — record the implementation
+  decisions and verification.
+- `docs/plans/README.md` — index this plan.
+
+## Testing
+
+- `npm test -- packages/server/test/query-params.integration.test.ts`
+- `npm test`
+- `npm run typecheck`
+- `git diff --check`
+- Review the final diff for range regressions and unrelated changes.
+
+## Risks / open questions
+
+- Date-only CLI/MCP ranges remain UTC calendar days. Fully timezone-aware range
+  filtering and day grouping are a required follow-up, not part of issue #94.
+- The shared helper serves eight analytics endpoints, so the regression tests
+  must prove both event-timestamp and session-start consumers retain their
+  intended scope.

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -97,3 +97,4 @@ decision, or a change worth explaining before doing. Skip it for one-line fixes.
 | 0070 | [Reliable update status and identifier search](./0070-update-status-and-identifier-search.md) | done |
 | 0071 | [Runtime and query validation fixes](./0071-runtime-and-query-validation.md) | done |
 | 0072 | [Hide Codex guardian sessions](./0072-hide-codex-guardian-sessions.md) | done |
+| 0073 | [Inclusive analytics end date](./0073-inclusive-analytics-end-date.md) | done |

--- a/packages/server/src/data/analytics-scope.ts
+++ b/packages/server/src/data/analytics-scope.ts
@@ -95,6 +95,12 @@ export async function scopeFilters(
   const filters: string[] = [];
   if (scope.project) filters.push(await projectFilter(conn, scope.project, cwdCol));
   if (from) filters.push(`${tsCol} >= ${sqlString(from)}::TIMESTAMP`);
-  if (to) filters.push(`${tsCol} <= ${sqlString(to)}::TIMESTAMP`);
+  if (to) {
+    filters.push(
+      to.length === 10
+        ? `${tsCol} < (${sqlString(to)}::TIMESTAMP + INTERVAL 1 DAY)`
+        : `${tsCol} <= ${sqlString(to)}::TIMESTAMP`,
+    );
+  }
   return filters;
 }

--- a/packages/server/test/query-params.integration.test.ts
+++ b/packages/server/test/query-params.integration.test.ts
@@ -250,11 +250,20 @@ describe('bound semantics survived the scopeFilters consolidation', () => {
     // Two distinct days of assistant events across both sessions.
     expect(all.json().rows.map((r: { key: string }) => r.key).sort()).toEqual([DAY1, DAY2]);
 
-    const day2 = await get(`/api/analytics?groupBy=day&from=${DAY2}`);
+    const day2 = await get(`/api/analytics?groupBy=day&from=${DAY2}&to=${DAY2}`);
+    expect(day2.statusCode).toBe(200);
     expect(day2.json().rows.map((r: { key: string }) => r.key)).toEqual([DAY2]);
     // sOld's DAY2 event is included even though sOld STARTED on DAY1 — that is
     // the event-level semantics this route must keep.
     expect(day2.json().totals.messageCount).toBe(2);
+  });
+
+  it('keeps a full timestamp upper bound inclusive', async () => {
+    const to = encodeURIComponent(`${DAY1}T12:00:00.000Z`);
+    const res = await get(`/api/analytics?groupBy=day&to=${to}`);
+    expect(res.statusCode).toBe(200);
+    expect(res.json().rows.map((r: { key: string }) => r.key)).toEqual([DAY1]);
+    expect(res.json().totals.messageCount).toBe(1);
   });
 
   it('/api/analytics/sessions bounds the SESSION START', async () => {
@@ -287,10 +296,11 @@ describe('bound semantics survived the scopeFilters consolidation', () => {
   });
 
   it('/api/analytics/digest bounds the SESSION START', async () => {
-    const all = await get(`/api/analytics/digest?from=${DAY1}&to=${DAY2}T23:59:59.999Z`);
+    const all = await get(`/api/analytics/digest?from=${DAY1}&to=${DAY2}`);
     expect(all.json().totals.sessions).toBe(2);
 
-    const day2 = await get(`/api/analytics/digest?from=${DAY2}&to=${DAY2}T23:59:59.999Z`);
+    const day2 = await get(`/api/analytics/digest?from=${DAY2}&to=${DAY2}`);
+    expect(day2.statusCode).toBe(200);
     expect(day2.json().totals.sessions).toBe(1);
   });
 });


### PR DESCRIPTION
## Summary
- treat a date-only analytics to bound as an inclusive UTC calendar day
- preserve inclusive semantics for exact timestamp bounds
- add regressions for same-day analytics, digest ranges, and exact timestamps
- record timezone-aware analytics as an explicit follow-up

Closes #94

## Definition of done
- [x] focused query-parameter integration tests pass
- [x] full test suite passes: 601 tests across 62 files
- [x] TypeScript typecheck passes
- [x] diff review completed with no findings
- [x] no schema bump or reindex required

Plan: docs/plans/0073-inclusive-analytics-end-date.md