### PR TITLE
feat: make analytics timezone-aware

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,8 +245,8 @@ claudescope search "duckdb lock" --limit 5      # where did I hit this before?
 claudescope sessions --agent codex --sort cost  # priciest Codex sessions
 claudescope session <id> --around <uuid>        # open a search hit, windowed
 claudescope open --session <id> --around <uuid> # open that hit in the web app
-claudescope analytics --group-by day --json | jq '.rows[] | [.key, .costUsd]'
-claudescope digest --from 2026-06-23 --to 2026-06-29   # week in review, as Markdown
+claudescope analytics --group-by day --timezone Europe/Amsterdam --json | jq '.rows[] | [.key, .costUsd]'
+claudescope digest --from 2026-06-23 --to 2026-06-29 --timezone Europe/Amsterdam
 ```
 
 `session` prints a pageable window of turns as Markdown (`--offset/--limit`,
@@ -254,6 +254,15 @@ claudescope digest --from 2026-06-23 --to 2026-06-29   # week in review, as Mark
 unredacted. `open` starts the daemon lazily and preserves its configured port;
 session ids and message anchors are URL-encoded before the browser opens. See
 `claudescope help` for the full flag list.
+
+Analytics and digest date-only bounds are inclusive calendar days in the
+selected IANA time zone. The CLI defaults to the machine's time zone (falling
+back to UTC); use `--timezone UTC` or another zone to make a script explicit.
+ISO timestamps with `Z` or an offset always identify exact instants, while the
+time zone still controls day grouping and streaks. The MCP `get_analytics` tool
+accepts the equivalent optional `timeZone` input and has the same local default.
+Claudescope keeps indexed timestamps UTC-normalized; the selected zone changes
+query interpretation, not stored transcript data.
 
 ---
 

--- a/docs/plans/0074-timezone-aware-analytics.md
+++ b/docs/plans/0074-timezone-aware-analytics.md
@@ -1,0 +1,102 @@
+# 0074 — Timezone-aware analytics
+
+- **Status:** done
+- **Date:** 2026-08-25
+- **PR:** https://github.com/vladar107/claudescope/pull/96
+
+## Context
+
+Analytics timestamps are normalized as UTC instants by the connectors, then
+stored in the derived DuckDB index as timezone-naive `TIMESTAMP` values. Date
+filters and calendar grouping do not currently share one timezone contract:
+the web converts date inputs using the browser timezone, day grouping stays in
+UTC, CLI/MCP date-only ranges mean UTC days, and the activity heatmap applies a
+single fixed offset that is incorrect across daylight-saving transitions.
+
+DuckDB's bundled ICU support can interpret IANA timezone names and convert the
+stored UTC-naive values at query time. The index remains fully rebuildable, so
+changing its timestamp types would add migration cost without improving the
+source-of-truth representation.
+
+## Goal
+
+Make every analytics date boundary and calendar grouping use one explicit IANA
+timezone, including correct daylight-saving behavior, while preserving UTC as
+the compatibility default for raw API callers.
+
+## Decisions
+
+- **Keep UTC-naive storage** — connectors already normalize source timestamps to
+  UTC and the derived index consistently treats them as UTC; query-time
+  conversion avoids a schema bump and full rebuild.
+- **Add an explicit `timeZone` query parameter** — first-party clients send an
+  IANA zone, while an omitted parameter means UTC so bare HTTP callers retain
+  deterministic behavior.
+- **Interpret date-only bounds as calendar days in `timeZone`** — the lower
+  bound is local midnight and the upper bound remains half-open at the next
+  local midnight, so 23-hour and 25-hour DST days are handled correctly.
+- **Treat offset-bearing timestamps as absolute instants** — `Z` and numeric
+  offsets are preserved through `TIMESTAMPTZ` parsing instead of being discarded
+  by a naive timestamp cast.
+- **Use the same timezone for grouping and filtering** — day analytics, impact,
+  activity heatmaps and streaks, and digest defaults cannot disagree about which
+  calendar day contains an event.
+- **Retain `tzOffsetMinutes` as an activity fallback** — existing callers keep
+  working when `timeZone` is absent; the web moves to the IANA contract.
+
+## Approach
+
+1. Add shared timezone validation and SQL expressions that reinterpret stored
+   UTC-naive timestamps as instants, convert instants to local calendar values,
+   and build date-only bounds in an IANA zone.
+2. Extend all analytics route query shapes with `timeZone`, route every bound
+   through the shared scope helper, and localize day grouping, activity, streak,
+   impact, and digest calculations.
+3. Have the web send its browser IANA timezone and the original date-only input
+   values to every analytics endpoint.
+4. Add CLI `--timezone` support plus MCP timezone input; first-party agent
+   clients detect the machine IANA timezone when no override is supplied.
+5. Add focused integration coverage for DST boundaries, date-only ranges,
+   offset-bearing instants, invalid zones, and the legacy activity fallback.
+6. Run focused tests, the full test suite, typecheck, build, diff checks, and a
+   final code review before opening the PR.
+
+## Files affected
+
+- `packages/server/src/params.ts` — validate timezone query parameters.
+- `packages/server/src/data/analytics-scope.ts` — centralize timezone-aware
+  bounds and timestamp conversion expressions.
+- `packages/server/src/routes/analytics*.ts` — accept and consistently apply the
+  timezone contract across filters and calendar groupings.
+- `packages/shared/src/api.ts` — expose the timezone in analytics request types.
+- `packages/web/src/api/client.ts` — forward the timezone on analytics requests.
+- `packages/web/src/pages/analytics/AnalyticsPage.tsx` — detect the browser IANA
+  zone and send date-only bounds without pre-converting them to UTC instants.
+- `packages/server/src/agent/{api-client,query,mcp}.ts` and
+  `packages/server/src/cli.ts` — expose CLI/MCP timezone controls.
+- `packages/server/test/*analytics*.test.ts` — cover timezone and DST edges.
+- `README.md` — document date and timezone semantics for agent-facing commands.
+- `docs/plans/README.md` — index this plan.
+
+## Testing
+
+- Focused analytics integration tests covering spring-forward and fall-back
+  calendar boundaries in `Europe/Amsterdam`.
+- Full timestamps with `Z` and numeric offsets resolve to the same instant.
+- Invalid IANA zones return HTTP 400 without exposing DuckDB internals.
+- Existing UTC/default and `tzOffsetMinutes` behavior remains compatible.
+- `npm test`
+- `npm run typecheck`
+- `npm run build`
+- `git diff --check`
+
+## Risks / open questions
+
+- A raw HTTP request carries no browser timezone. The server therefore keeps a
+  deterministic UTC default instead of silently using its process timezone;
+  first-party clients send their detected IANA zone explicitly.
+- IANA timezone data changes occasionally; validation and conversion must use
+  the same runtime database DuckDB uses for query execution.
+- DST gaps and overlaps make local wall-clock timestamps ambiguous, but the
+  stored values are UTC instants; ambiguity exists only for caller-supplied
+  local date boundaries, where midnight is well-defined for normal IANA zones.

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -98,3 +98,4 @@ decision, or a change worth explaining before doing. Skip it for one-line fixes.
 | 0071 | [Runtime and query validation fixes](./0071-runtime-and-query-validation.md) | done |
 | 0072 | [Hide Codex guardian sessions](./0072-hide-codex-guardian-sessions.md) | done |
 | 0073 | [Inclusive analytics end date](./0073-inclusive-analytics-end-date.md) | done |
+| 0074 | [Timezone-aware analytics](./0074-timezone-aware-analytics.md) | done |

--- a/packages/server/src/agent/api-client.ts
+++ b/packages/server/src/agent/api-client.ts
@@ -8,8 +8,9 @@
  */
 
 import type {
-  AnalyticsGroupBy,
+  AnalyticsQuery,
   AnalyticsResponse,
+  DigestQuery,
   DigestResponse,
   HealthResponse,
   MemoryResponse,
@@ -67,11 +68,11 @@ export class ApiClient {
     return this.get(`/api/projects/${encodeURIComponent(projectId)}/memory`);
   }
 
-  analytics(q: { groupBy: AnalyticsGroupBy; from?: string; to?: string }): Promise<AnalyticsResponse> {
-    return this.get('/api/analytics', q);
+  analytics(q: AnalyticsQuery): Promise<AnalyticsResponse> {
+    return this.get('/api/analytics', q as unknown as Params);
   }
 
-  digest(q: { from?: string; to?: string } = {}): Promise<DigestResponse> {
-    return this.get('/api/analytics/digest', q);
+  digest(q: DigestQuery = {}): Promise<DigestResponse> {
+    return this.get('/api/analytics/digest', q as unknown as Params);
   }
 }

--- a/packages/server/src/agent/mcp.ts
+++ b/packages/server/src/agent/mcp.ts
@@ -34,6 +34,7 @@ import {
   shapeSearchResults,
   shapeSessionMarkdown,
 } from './shape.js';
+import { detectedTimeZone } from './query.js';
 
 /** Char cap for memory bodies in `get_memory`. */
 const MEMORY_BODY_CHARS = 2000;
@@ -210,15 +211,25 @@ export function createMcpServer(deps: McpDeps): McpServer {
     {
       description:
         'Aggregated token/cost usage grouped by project, model, day, or agent, with totals. ' +
-        'Cost is a local list-price estimate, not billing. Dates are YYYY-MM-DD.',
+        'Cost is a local list-price estimate, not billing. Date-only bounds are calendar days ' +
+        'in the selected IANA time zone; timestamps with offsets identify exact instants.',
       inputSchema: z.object({
         groupBy: z.enum(['project', 'model', 'day', 'agent']).optional().describe('Grouping (default project)'),
-        from: z.string().optional().describe('Start date (inclusive)'),
-        to: z.string().optional().describe('End date (inclusive)'),
+        from: z.string().optional().describe('Inclusive start date or ISO timestamp'),
+        to: z.string().optional().describe('Inclusive end date or ISO timestamp'),
+        timeZone: z
+          .string()
+          .optional()
+          .describe('IANA time zone for date-only bounds and day grouping (default machine time zone)'),
       }),
     },
-    guarded(async (client, args: { groupBy?: 'project' | 'model' | 'day' | 'agent'; from?: string; to?: string }) => {
-      const res = await client.analytics({ groupBy: args.groupBy ?? 'project', from: args.from, to: args.to });
+    guarded(async (client, args: { groupBy?: 'project' | 'model' | 'day' | 'agent'; from?: string; to?: string; timeZone?: string }) => {
+      const res = await client.analytics({
+        groupBy: args.groupBy ?? 'project',
+        from: args.from,
+        to: args.to,
+        timeZone: args.timeZone ?? detectedTimeZone(),
+      });
       if (res.rows.length === 0) return 'No usage in range.';
       const lines = res.rows.map(
         (row) =>

--- a/packages/server/src/agent/query.ts
+++ b/packages/server/src/agent/query.ts
@@ -25,6 +25,15 @@ import {
 
 const json = (v: unknown): string => JSON.stringify(v, null, 2);
 
+/** Machine-local IANA time zone for user-facing analytics, with a stable fallback. */
+export function detectedTimeZone(): string {
+  try {
+    return Intl.DateTimeFormat().resolvedOptions().timeZone || 'UTC';
+  } catch {
+    return 'UTC';
+  }
+}
+
 /** Cap for free-text columns (titles, cwds) so one long value can't blow up the table. */
 const MAX_CELL = 60;
 
@@ -136,11 +145,17 @@ export interface AnalyticsArgs {
   groupBy?: AnalyticsGroupBy;
   from?: string;
   to?: string;
+  timeZone?: string;
   json?: boolean;
 }
 
 export async function queryAnalytics(client: ApiClient, args: AnalyticsArgs): Promise<string> {
-  const res = await client.analytics({ groupBy: args.groupBy ?? 'project', from: args.from, to: args.to });
+  const res = await client.analytics({
+    groupBy: args.groupBy ?? 'project',
+    from: args.from,
+    to: args.to,
+    timeZone: args.timeZone,
+  });
   if (args.json) return json(res);
   if (res.rows.length === 0) return 'No usage in range.';
   return (
@@ -163,13 +178,14 @@ export async function queryAnalytics(client: ApiClient, args: AnalyticsArgs): Pr
 export interface DigestArgs {
   from?: string;
   to?: string;
+  timeZone?: string;
   json?: boolean;
 }
 
 /** Week-in-review digest — the human output IS the shared Markdown renderer,
  *  so the CLI prints exactly what the web "Copy as Markdown" button copies. */
 export async function queryDigest(client: ApiClient, args: DigestArgs): Promise<string> {
-  const res = await client.digest({ from: args.from, to: args.to });
+  const res = await client.digest({ from: args.from, to: args.to, timeZone: args.timeZone });
   if (args.json) return json(res);
   return digestToMarkdown(res).trimEnd();
 }

--- a/packages/server/src/cli.ts
+++ b/packages/server/src/cli.ts
@@ -49,6 +49,7 @@ import {
 import { runMcpServer } from './agent/mcp.js';
 import { ApiClient } from './agent/api-client.js';
 import {
+  detectedTimeZone,
   queryAnalytics,
   queryDigest,
   queryProjects,
@@ -423,8 +424,10 @@ Query commands (read-only; start the background server on first use):
                    [--offset N] [--limit N] [--around uuid] [--radius N]
                    [--max-tool-chars N] [--redact]
   projects         List projects
-  analytics        Token/cost aggregates [--group-by project|model|day|agent] [--from date] [--to date]
-  digest           Week-in-review Markdown [--from date] [--to date] (default: last 7 days)
+  analytics        Token/cost aggregates [--group-by project|model|day|agent]
+                   [--from date] [--to date] [--timezone IANA]
+  digest           Week-in-review Markdown [--from date] [--to date] [--timezone IANA]
+                   (default: last 7 calendar days in the machine time zone)
   All query commands accept --json for the raw API response (ignores --redact).
 
 Options:
@@ -469,6 +472,7 @@ async function main(): Promise<void> {
       'group-by': { type: 'string' },
       from: { type: 'string' },
       to: { type: 'string' },
+      timezone: { type: 'string' },
     },
   });
 
@@ -554,7 +558,12 @@ async function main(): Promise<void> {
       break;
     case 'digest':
       await runQuery(() => {
-        const args = { from: values.from, to: values.to, json: values.json };
+        const args = {
+          from: values.from,
+          to: values.to,
+          timeZone: values.timezone ?? detectedTimeZone(),
+          json: values.json,
+        };
         return (client) => queryDigest(client, args);
       });
       break;
@@ -564,6 +573,7 @@ async function main(): Promise<void> {
           groupBy: enumFlag('group-by', values['group-by'], ['project', 'model', 'day', 'agent'] as const),
           from: values.from,
           to: values.to,
+          timeZone: values.timezone ?? detectedTimeZone(),
           json: values.json,
         };
         return (client) => queryAnalytics(client, args);

--- a/packages/server/src/data/analytics-scope.ts
+++ b/packages/server/src/data/analytics-scope.ts
@@ -8,7 +8,7 @@
 
 import type { DuckDBConnection } from '@duckdb/node-api';
 import { queryRows, sqlString } from '../db/duckdb.js';
-import { timestampParam } from '../params.js';
+import { BadRequestError, timestampParam } from '../params.js';
 import { projectIdFromCwd } from './project-id.js';
 
 export interface AnalyticsScope {
@@ -17,6 +17,8 @@ export interface AnalyticsScope {
   /** Inclusive ISO bounds on the session start. */
   from?: string;
   to?: string;
+  /** IANA timezone for calendar bounds and local-day analytics. Defaults to UTC. */
+  timeZone?: string;
 }
 
 /** Column names the filters apply to, qualified for the caller's query. */
@@ -34,6 +36,63 @@ export interface ScopeColumns {
  * two-character string `\0` — which no real cwd can be.
  */
 const NEVER_MATCHES = "'\\0'";
+const UTC = 'UTC';
+const OFFSET_SUFFIX_RE = /(?:Z|[+-]\d{2}(?::?\d{2})?)$/i;
+const validatedTimeZones = new Map<string, string>([[UTC.toLowerCase(), UTC]]);
+
+/**
+ * Resolve an optional analytics timezone to the canonical name DuckDB knows.
+ * Validation deliberately uses DuckDB's timezone catalogue: those are the
+ * identifiers the SQL conversion functions will accept, so Node and DuckDB
+ * cannot disagree at runtime. Raw HTTP callers remain UTC by default.
+ */
+export async function analyticsTimeZone(
+  conn: DuckDBConnection,
+  raw: string | undefined,
+): Promise<string> {
+  const value = raw?.trim() || UTC;
+  const cached = validatedTimeZones.get(value.toLowerCase());
+  if (cached) return cached;
+
+  const rows = await queryRows(
+    conn,
+    `SELECT name
+     FROM pg_timezone_names()
+     WHERE lower(name) = lower(${sqlString(value)})
+     ORDER BY name
+     LIMIT 1`,
+  );
+  const name = rows[0]?.name;
+  if (typeof name !== 'string' || name === '') {
+    throw new BadRequestError(`timeZone must be a recognized IANA timezone (got '${value}')`);
+  }
+  validatedTimeZones.set(value.toLowerCase(), name);
+  return name;
+}
+
+/** Treat a UTC-naive stored timestamp as the instant it represents. */
+export function utcInstantSql(timestampSql: string): string {
+  return `timezone('UTC', ${timestampSql})`;
+}
+
+/** Convert a UTC-naive stored timestamp into local wall time for grouping. */
+export function localTimestampSql(timestampSql: string, timeZone: string): string {
+  return `timezone(${sqlString(timeZone)}, ${utcInstantSql(timestampSql)})`;
+}
+
+/**
+ * Turn a validated analytics bound into an absolute instant.
+ *
+ * Offset-bearing timestamps already identify an instant. Date-only values and
+ * offset-less timestamps are local wall times in `timeZone`; applying the zone
+ * after the TIMESTAMP cast lets ICU select the correct DST offset for that day.
+ */
+export function analyticsBoundSql(value: string, timeZone: string): string {
+  if (value.length > 10 && OFFSET_SUFFIX_RE.test(value)) {
+    return `${sqlString(value)}::TIMESTAMPTZ`;
+  }
+  return `timezone(${sqlString(timeZone)}, ${sqlString(value)}::TIMESTAMP)`;
+}
 
 /**
  * Resolve a project slug id to the `project_cwd` it came from, or `null` when no
@@ -92,14 +151,15 @@ export async function scopeFilters(
   const tsCol = cols.ts ?? 'started_at';
   const from = timestampParam(scope.from, 'from');
   const to = timestampParam(scope.to, 'to');
+  const timeZone = await analyticsTimeZone(conn, scope.timeZone);
   const filters: string[] = [];
   if (scope.project) filters.push(await projectFilter(conn, scope.project, cwdCol));
-  if (from) filters.push(`${tsCol} >= ${sqlString(from)}::TIMESTAMP`);
+  if (from) filters.push(`${utcInstantSql(tsCol)} >= ${analyticsBoundSql(from, timeZone)}`);
   if (to) {
     filters.push(
       to.length === 10
-        ? `${tsCol} < (${sqlString(to)}::TIMESTAMP + INTERVAL 1 DAY)`
-        : `${tsCol} <= ${sqlString(to)}::TIMESTAMP`,
+        ? `${utcInstantSql(tsCol)} < timezone(${sqlString(timeZone)}, ${sqlString(to)}::TIMESTAMP + INTERVAL 1 DAY)`
+        : `${utcInstantSql(tsCol)} <= ${analyticsBoundSql(to, timeZone)}`,
     );
   }
   return filters;

--- a/packages/server/src/params.ts
+++ b/packages/server/src/params.ts
@@ -52,16 +52,16 @@ const TIMESTAMP_RE =
   /^\d{4}-\d{2}-\d{2}(?:[T ]\d{2}:\d{2}(?::\d{2}(?:\.\d{1,6})?)?(?:Z|[+-]\d{2}(?::?\d{2})?)?)?$/;
 
 /**
- * Validate an inclusive date-bound param destined for `::TIMESTAMP`.
+ * Validate an inclusive analytics date bound.
  *
  * Returns `undefined` for an absent/empty value (the bound is simply not
  * applied) and throws {@link BadRequestError} for anything unusable. The regex
  * checks shape, {@link isCalendarDay} checks the date without JavaScript's
  * overflow normalization, and `Date.parse` checks the remaining time/offset.
  *
- * The value is returned unchanged — callers still wrap it in `sqlString` and the
- * cast stays `TIMESTAMP` (not `TIMESTAMPTZ`), so any offset keeps being ignored
- * exactly as before. This validates; it does not normalize.
+ * The value is returned unchanged. The analytics scope layer decides whether
+ * it is a calendar day/local wall time or an offset-bearing instant and emits
+ * the corresponding DuckDB cast.
  */
 export function timestampParam(raw: string | undefined, field: string): string | undefined {
   if (raw === undefined) return undefined;

--- a/packages/server/src/routes/analytics-activity.ts
+++ b/packages/server/src/routes/analytics-activity.ts
@@ -2,16 +2,20 @@
  * GET /api/analytics/activity — a punchcard of user prompts by local
  * day-of-week × hour, plus an all-time prompt streak.
  *
- * Local time: `events.ts` is stored UTC-naive, so the client sends its current
- * UTC offset in minutes and the server shifts with `to_minutes()`. This avoids a
- * DuckDB ICU dependency; the (DST-imperfect) fixed offset is fine for a
- * "when do I usually work" view. The heatmap honors the `from`/`to` filter; the
- * streak is always all-time (a current streak only means anything vs. today).
+ * Local time: `events.ts` is stored UTC-naive. An IANA `timeZone` localizes
+ * every event with DuckDB/ICU, including historical DST changes. The old fixed
+ * `tzOffsetMinutes` remains a compatibility fallback when no timezone is sent.
+ * The heatmap honors the `from`/`to` filter; the streak is always all-time (a
+ * current streak only means anything vs. today).
  */
 import type { FastifyInstance } from 'fastify';
 import type { ActivityCell, ActivityResponse, StreakInfo } from '@claudescope/shared';
-import { getConnection, queryRows } from '../db/duckdb.js';
-import { scopeFilters } from '../data/analytics-scope.js';
+import { getConnection, queryRows, sqlString } from '../db/duckdb.js';
+import {
+  analyticsTimeZone,
+  localTimestampSql,
+  scopeFilters,
+} from '../data/analytics-scope.js';
 import { isoDayParam } from '../params.js';
 import { readRow } from '../db/row.js';
 
@@ -54,12 +58,35 @@ function clampOffset(raw: string | undefined): number {
 
 export async function registerActivityRoute(app: FastifyInstance): Promise<void> {
   app.get<{
-    Querystring: { from?: string; to?: string; tzOffsetMinutes?: string; today?: string };
+    Querystring: {
+      from?: string;
+      to?: string;
+      timeZone?: string;
+      tzOffsetMinutes?: string;
+      today?: string;
+    };
   }>('/api/analytics/activity', async (req): Promise<ActivityResponse> => {
     const conn = await getConnection();
+    const hasTimeZone = Boolean(req.query.timeZone?.trim());
+    const timeZone = hasTimeZone
+      ? await analyticsTimeZone(conn, req.query.timeZone)
+      : undefined;
     const offset = clampOffset(req.query.tzOffsetMinutes);
-    const today = isoDayParam(req.query.today) ?? '';
-    const localTs = `(e.ts + to_minutes(${offset}))`;
+    const localTs = timeZone
+      ? localTimestampSql('e.ts', timeZone)
+      : `(e.ts + to_minutes(${offset}))`;
+    let today = isoDayParam(req.query.today);
+    if (!today) {
+      if (timeZone) {
+        const todayRows = await queryRows(
+          conn,
+          `SELECT strftime(timezone(${sqlString(timeZone)}, current_timestamp), '%Y-%m-%d') AS day`,
+        );
+        today = readRow(todayRows[0] ?? {}, 'activity-today').str('day');
+      } else {
+        today = new Date(Date.now() + offset * 60_000).toISOString().slice(0, 10);
+      }
+    }
 
     // Heatmap: honors the date filter (matches the rest of the page).
     // Exclude sidechain rows (subagent-internal user turns) and fork-copy rows
@@ -70,7 +97,11 @@ export async function registerActivityRoute(app: FastifyInstance): Promise<void>
       'NOT e.is_sidechain',
       'e.forked_from_session_id IS NULL',
       // Shared (validated) bounds, on the event timestamp.
-      ...(await scopeFilters(conn, { from: req.query.from, to: req.query.to }, { ts: 'e.ts' })),
+      ...(await scopeFilters(
+        conn,
+        { from: req.query.from, to: req.query.to, timeZone },
+        { ts: 'e.ts' },
+      )),
     ];
     const heatmapRows = await queryRows(
       conn,

--- a/packages/server/src/routes/analytics-agents.ts
+++ b/packages/server/src/routes/analytics-agents.ts
@@ -64,7 +64,7 @@ const AVAILABILITY_NOTES: Record<string, string> = {
 
 export async function registerAgentComparisonRoute(app: FastifyInstance): Promise<void> {
   app.get<{
-    Querystring: { project?: string; from?: string; to?: string };
+    Querystring: { project?: string; from?: string; to?: string; timeZone?: string };
   }>('/api/analytics/agents', async (req): Promise<AgentComparisonResponse> => {
     const conn = await getConnection();
 

--- a/packages/server/src/routes/analytics-digest.ts
+++ b/packages/server/src/routes/analytics-digest.ts
@@ -10,7 +10,7 @@
  *  - Token/cost sums are session-level (already usage-deduped at derivation) —
  *    they naturally cover only agents that report usage.
  *  - Code impact reads canonical `file_edits` rows (fork-deduped at index time).
- *  - The streak is all-time (UTC days) as of the range end — momentum, not a
+ *  - The streak is all-time (local days) as of the range end — momentum, not a
  *    range-bound stat.
  */
 
@@ -21,34 +21,55 @@ import type {
   DigestProjectRow,
   DigestResponse,
 } from '@claudescope/shared';
-import { getConnection, queryRows } from '../db/duckdb.js';
-import { scopeFilters } from '../data/analytics-scope.js';
+import type { DuckDBConnection } from '@duckdb/node-api';
+import { getConnection, queryRows, sqlString } from '../db/duckdb.js';
+import {
+  analyticsBoundSql,
+  analyticsTimeZone,
+  localTimestampSql,
+  scopeFilters,
+} from '../data/analytics-scope.js';
 import { readRow } from '../db/row.js';
 import { projectIdFromCwd } from '../data/project-id.js';
 import { errorSignalsByAgent } from './analytics-errors.js';
 import { computeStreaks } from './analytics-activity.js';
+import { timestampParam } from '../params.js';
 
 const TOP_LIMIT = 5;
 
-/** Default range: the last 7 UTC days ending now. */
-function defaultRange(): { from: string; to: string } {
+/** Default range: the last 7 local calendar days ending now. */
+async function defaultRange(
+  conn: DuckDBConnection,
+  timeZone: string,
+): Promise<{ from: string; to: string }> {
   const now = new Date();
-  const fromDay = new Date(now.getTime() - 6 * 86_400_000).toISOString().slice(0, 10);
-  return { from: `${fromDay}T00:00:00.000Z`, to: now.toISOString() };
+  const rows = await queryRows(
+    conn,
+    `SELECT strftime(
+       timezone(${sqlString(timeZone)}, ${sqlString(now.toISOString())}::TIMESTAMPTZ)
+         - INTERVAL 6 DAY,
+       '%Y-%m-%d'
+     ) AS day`,
+  );
+  return {
+    from: readRow(rows[0] ?? {}, 'digest-default-range').str('day'),
+    to: now.toISOString(),
+  };
 }
 
 export async function registerDigestRoute(app: FastifyInstance): Promise<void> {
   app.get<{
-    Querystring: { from?: string; to?: string };
+    Querystring: { from?: string; to?: string; timeZone?: string };
   }>('/api/analytics/digest', async (req): Promise<DigestResponse> => {
     const conn = await getConnection();
-    const range = defaultRange();
-    const from = req.query.from || range.from;
-    const to = req.query.to || range.to;
+    const timeZone = await analyticsTimeZone(conn, req.query.timeZone);
+    const range = await defaultRange(conn, timeZone);
+    const from = timestampParam(req.query.from, 'from') ?? range.from;
+    const to = timestampParam(req.query.to, 'to') ?? range.to;
 
     // Shared (validated) bounds on the session start — a session belongs to the
     // range its START falls in. Both bounds are always present (defaultRange).
-    const filters = await scopeFilters(conn, { from, to });
+    const filters = await scopeFilters(conn, { from, to, timeZone });
     const whereSql = filters.length > 0 ? `WHERE ${filters.join(' AND ')}` : '';
     const scopedCte = `WITH scoped AS (SELECT * FROM sessions ${whereSql})`;
 
@@ -154,16 +175,23 @@ export async function registerDigestRoute(app: FastifyInstance): Promise<void> {
         })()
       : null;
 
-    // All-time prompt streak (UTC days) as of the range end.
+    // All-time prompt streak (local days) as of the range end.
     const dayRows = await queryRows(
       conn,
-      `SELECT DISTINCT strftime(e.ts, '%Y-%m-%d') AS day
+      `SELECT DISTINCT strftime(${localTimestampSql('e.ts', timeZone)}, '%Y-%m-%d') AS day
        FROM events e
        WHERE e.type = 'user' AND NOT e.is_sidechain AND e.forked_from_session_id IS NULL`,
     );
+    const todayRows = await queryRows(
+      conn,
+      `SELECT strftime(
+         timezone(${sqlString(timeZone)}, ${analyticsBoundSql(to, timeZone)}),
+         '%Y-%m-%d'
+       ) AS day`,
+    );
     const streak = computeStreaks(
       dayRows.map((r) => readRow(r, 'digest-days').str('day')).filter(Boolean),
-      to.slice(0, 10),
+      readRow(todayRows[0] ?? {}, 'digest-today').str('day'),
     );
 
     // Code impact over canonical file_edits (session-atomic, like everything else).
@@ -199,7 +227,7 @@ export async function registerDigestRoute(app: FastifyInstance): Promise<void> {
 
     // Reliability — roll up the shared per-agent aggregation. Agents whose
     // formats carry no error signal are listed, not zero-counted.
-    const signals = await errorSignalsByAgent(conn, { from, to });
+    const signals = await errorSignalsByAgent(conn, { from, to, timeZone });
     const known = signals.filter((s) => s.toolErrors !== null);
     const errors: DigestErrors | null = known.length
       ? {

--- a/packages/server/src/routes/analytics-errors.ts
+++ b/packages/server/src/routes/analytics-errors.ts
@@ -41,6 +41,7 @@ export interface ErrorScope {
   project?: string;
   from?: string;
   to?: string;
+  timeZone?: string;
 }
 
 /** Raw per-agent aggregates, before n/a shaping. */
@@ -103,7 +104,7 @@ export async function errorSignalsByAgent(
 
 export async function registerErrorsRoute(app: FastifyInstance): Promise<void> {
   app.get<{
-    Querystring: { project?: string; from?: string; to?: string };
+    Querystring: { project?: string; from?: string; to?: string; timeZone?: string };
   }>('/api/analytics/errors', async (req): Promise<ErrorAnalyticsResponse> => {
     const conn = await getConnection();
     const signals = await errorSignalsByAgent(conn, req.query);

--- a/packages/server/src/routes/analytics-impact.ts
+++ b/packages/server/src/routes/analytics-impact.ts
@@ -18,15 +18,19 @@ import type { FastifyInstance } from 'fastify';
 import type { ImpactGroupBy, ImpactResponse, ImpactRow, ImpactTotals } from '@claudescope/shared';
 import { getConnection, queryRows } from '../db/duckdb.js';
 import { readRow } from '../db/row.js';
-import { scopeFilters } from '../data/analytics-scope.js';
+import {
+  analyticsTimeZone,
+  localTimestampSql,
+  scopeFilters,
+} from '../data/analytics-scope.js';
 
 /** Cap for `groupBy=file` — the long tail of one-touch files isn't informative. */
 const FILE_ROW_LIMIT = 200;
 
-function keyExpr(groupBy: ImpactGroupBy): string {
+function keyExpr(groupBy: ImpactGroupBy, timeZone: string): string {
   switch (groupBy) {
     case 'day':
-      return "strftime(COALESCE(fe.ts, s.started_at), '%Y-%m-%d')";
+      return `strftime(${localTimestampSql('COALESCE(fe.ts, s.started_at)', timeZone)}, '%Y-%m-%d')`;
     case 'file':
       return 'fe.file_path';
     case 'agent':
@@ -37,9 +41,16 @@ function keyExpr(groupBy: ImpactGroupBy): string {
 
 export async function registerImpactRoute(app: FastifyInstance): Promise<void> {
   app.get<{
-    Querystring: { groupBy?: string; project?: string; from?: string; to?: string };
+    Querystring: {
+      groupBy?: string;
+      project?: string;
+      from?: string;
+      to?: string;
+      timeZone?: string;
+    };
   }>('/api/analytics/impact', async (req): Promise<ImpactResponse> => {
     const conn = await getConnection();
+    const timeZone = await analyticsTimeZone(conn, req.query.timeZone);
     const groupBy: ImpactGroupBy = ['agent', 'day', 'file'].includes(req.query.groupBy ?? '')
       ? (req.query.groupBy as ImpactGroupBy)
       : 'agent';
@@ -59,7 +70,7 @@ export async function registerImpactRoute(app: FastifyInstance): Promise<void> {
     const rowsRaw = await queryRows(
       conn,
       `SELECT
-         ${keyExpr(groupBy)} AS group_key,
+         ${keyExpr(groupBy, timeZone)} AS group_key,
          sum(fe.additions) AS additions,
          sum(fe.deletions) AS deletions,
          count(*) AS edits,

--- a/packages/server/src/routes/analytics-sessions.ts
+++ b/packages/server/src/routes/analytics-sessions.ts
@@ -50,6 +50,7 @@ export async function registerSessionEfficiencyRoute(app: FastifyInstance): Prom
       project?: string;
       from?: string;
       to?: string;
+      timeZone?: string;
       sort?: string;
       dir?: string;
       limit?: string;

--- a/packages/server/src/routes/analytics-tools.ts
+++ b/packages/server/src/routes/analytics-tools.ts
@@ -14,7 +14,7 @@ import { scopeFilters } from '../data/analytics-scope.js';
 
 export async function registerToolsRoute(app: FastifyInstance): Promise<void> {
   app.get<{
-    Querystring: { project?: string; from?: string; to?: string };
+    Querystring: { project?: string; from?: string; to?: string; timeZone?: string };
   }>('/api/analytics/tools', async (req): Promise<ToolUsageResponse> => {
     const conn = await getConnection();
     const filters: string[] = ["e.type = 'assistant'", 'e.usage_canonical', "e.tool_names <> ''"];

--- a/packages/server/src/routes/analytics.ts
+++ b/packages/server/src/routes/analytics.ts
@@ -23,7 +23,11 @@ import type {
 import { getConnection, queryRows } from '../db/duckdb.js';
 import { readRow } from '../db/row.js';
 import { cacheHitRatio } from '../data/analytics-metrics.js';
-import { scopeFilters } from '../data/analytics-scope.js';
+import {
+  analyticsTimeZone,
+  localTimestampSql,
+  scopeFilters,
+} from '../data/analytics-scope.js';
 import { projectIdFromCwd } from '../data/project-id.js';
 import { enumParam } from '../params.js';
 
@@ -35,12 +39,18 @@ const ANALYTICS_GROUPS = ['project', 'model', 'day', 'agent'] as const;
  * canonical modal project_cwd — matching the project ids returned by
  * /api/projects — rather than fragmenting across mid-session sub-directory cwds.
  */
-function groupSource(groupBy: AnalyticsGroupBy): { keyExpr: string; fromSql: string } {
+function groupSource(
+  groupBy: AnalyticsGroupBy,
+  timeZone: string,
+): { keyExpr: string; fromSql: string } {
   switch (groupBy) {
     case 'model':
       return { keyExpr: "COALESCE(e.model, 'unknown')", fromSql: 'FROM events e' };
     case 'day':
-      return { keyExpr: "strftime(e.ts, '%Y-%m-%d')", fromSql: 'FROM events e' };
+      return {
+        keyExpr: `strftime(${localTimestampSql('e.ts', timeZone)}, '%Y-%m-%d')`,
+        fromSql: 'FROM events e',
+      };
     case 'agent':
       return {
         keyExpr: "COALESCE(s.connector_id, 'unknown')",
@@ -57,18 +67,23 @@ function groupSource(groupBy: AnalyticsGroupBy): { keyExpr: string; fromSql: str
 
 export async function registerAnalyticsRoute(app: FastifyInstance): Promise<void> {
   app.get<{
-    Querystring: { groupBy?: string; from?: string; to?: string };
+    Querystring: { groupBy?: string; from?: string; to?: string; timeZone?: string };
   }>('/api/analytics', async (req): Promise<AnalyticsResponse> => {
     const conn = await getConnection();
     const groupBy = enumParam(req.query.groupBy, 'groupBy', ANALYTICS_GROUPS, 'project');
-    const { keyExpr, fromSql } = groupSource(groupBy);
+    const timeZone = await analyticsTimeZone(conn, req.query.timeZone);
+    const { keyExpr, fromSql } = groupSource(groupBy, timeZone);
 
     // Bounds go through the shared scope helper (which validates them); this
     // route filters the EVENT timestamp, not the session start, hence the `ts`
     // override. No project filter here — only the bounds are shared.
     const filters: string[] = [
       "e.type = 'assistant'",
-      ...(await scopeFilters(conn, { from: req.query.from, to: req.query.to }, { ts: 'e.ts' })),
+      ...(await scopeFilters(
+        conn,
+        { from: req.query.from, to: req.query.to, timeZone },
+        { ts: 'e.ts' },
+      )),
     ];
     const whereSql = `WHERE ${filters.join(' AND ')}`;
 

--- a/packages/server/test/analytics-timezone.integration.test.ts
+++ b/packages/server/test/analytics-timezone.integration.test.ts
@@ -1,0 +1,218 @@
+/**
+ * Timezone-aware analytics integration edges. The fixture straddles both 2026
+ * Europe/Amsterdam DST transitions so a fixed offset cannot satisfy these
+ * assertions: the spring day is 23 hours, and the fall overlap contains two
+ * distinct UTC instants with the same local wall-clock hour.
+ */
+
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import type { FastifyInstance } from 'fastify';
+
+const work = mkdtempSync(join(tmpdir(), 'claudescope-timezone-'));
+const projectsDir = join(work, 'projects');
+
+process.env.CLAUDE_PROJECTS_DIR = projectsDir;
+for (const variable of [
+  'CODEX_SESSIONS_DIR',
+  'JUNIE_SESSIONS_DIR',
+  'PI_SESSIONS_DIR',
+  'OPENCODE_DATA_DIR',
+  'COPILOT_SESSIONS_DIR',
+  'ANTIGRAVITY_CLI_DIR',
+  'ANTIGRAVITY_DIR',
+  'GROK_SESSIONS_DIR',
+]) {
+  process.env[variable] = join(work, `${variable.toLowerCase()}-empty`);
+}
+process.env.DUCKDB_PATH = join(work, 'index.duckdb');
+process.env.CLAUDESCOPE_HOME = join(work, 'home');
+process.env.REINDEX_INTERVAL_MS = '0';
+
+const CWD = '/tmp/timezone-analytics';
+const ZONE = 'Europe/Amsterdam';
+
+const fixtures = [
+  { id: 'spring-before', timestamp: '2026-03-28T22:59:00.000Z', input: 1 },
+  { id: 'spring-start', timestamp: '2026-03-28T23:00:00.000Z', input: 2 },
+  { id: 'spring-end', timestamp: '2026-03-29T21:59:00.000Z', input: 4 },
+  { id: 'spring-after', timestamp: '2026-03-29T22:00:00.000Z', input: 8 },
+  { id: 'fall-first', timestamp: '2026-10-25T00:30:00.000Z', input: 16 },
+  { id: 'fall-second', timestamp: '2026-10-25T01:30:00.000Z', input: 32 },
+] as const;
+
+function writeFixtures(): void {
+  const project = join(projectsDir, 'enc-timezone');
+  mkdirSync(project, { recursive: true });
+
+  for (const fixture of fixtures) {
+    const base = {
+      sessionId: fixture.id,
+      cwd: CWD,
+      gitBranch: 'main',
+      timestamp: fixture.timestamp,
+      isSidechain: false,
+    };
+    const rows = [
+      {
+        ...base,
+        type: 'user',
+        uuid: `${fixture.id}-user`,
+        parentUuid: null,
+        message: { role: 'user', content: fixture.id },
+      },
+      {
+        ...base,
+        type: 'assistant',
+        uuid: `${fixture.id}-assistant`,
+        parentUuid: `${fixture.id}-user`,
+        message: {
+          role: 'assistant',
+          id: `message-${fixture.id}`,
+          model: 'claude-opus-4-8',
+          content: [
+            {
+              type: 'tool_use',
+              id: `tool-${fixture.id}`,
+              name: 'Edit',
+              input: {
+                file_path: `${CWD}/${fixture.id}.txt`,
+                old_string: fixture.id,
+                new_string: `${fixture.id}-changed`,
+              },
+            },
+          ],
+          usage: { input_tokens: fixture.input, output_tokens: 1 },
+        },
+      },
+    ];
+    writeFileSync(
+      join(project, `${fixture.id}.jsonl`),
+      rows.map((row) => JSON.stringify(row)).join('\n') + '\n',
+    );
+  }
+}
+
+let app: FastifyInstance;
+let closeConnection: () => Promise<void>;
+
+beforeAll(async () => {
+  writeFixtures();
+  const Fastify = (await import('fastify')).default;
+  const { registerRoutes } = await import('../src/routes/index.js');
+  const { reindex } = await import('../src/data/index.js');
+  ({ closeConnection } = await import('../src/db/duckdb.js'));
+
+  app = Fastify();
+  await registerRoutes(app);
+  await reindex();
+  await app.ready();
+});
+
+afterAll(async () => {
+  await app?.close();
+  await closeConnection?.();
+  rmSync(work, { recursive: true, force: true });
+});
+
+const get = (url: string) => app.inject({ method: 'GET', url });
+const zone = `timeZone=${encodeURIComponent(ZONE)}`;
+
+describe('timezone-aware analytics', () => {
+  it('groups the same UTC instants into local IANA calendar days', async () => {
+    const utc = await get('/api/analytics?groupBy=day');
+    expect(utc.statusCode).toBe(200);
+    expect(utc.json().rows.map((row: { key: string }) => row.key).sort()).toEqual([
+      '2026-03-28',
+      '2026-03-29',
+      '2026-10-25',
+    ]);
+
+    const local = await get(`/api/analytics?groupBy=day&${zone}`);
+    expect(local.statusCode).toBe(200);
+    expect(local.json().rows.map((row: { key: string }) => row.key).sort()).toEqual([
+      '2026-03-28',
+      '2026-03-29',
+      '2026-03-30',
+      '2026-10-25',
+    ]);
+  });
+
+  it('uses local midnights for a date-only range across spring-forward', async () => {
+    const res = await get(
+      `/api/analytics?groupBy=day&from=2026-03-29&to=2026-03-29&${zone}`,
+    );
+    expect(res.statusCode).toBe(200);
+    expect(res.json().rows).toHaveLength(1);
+    expect(res.json().rows[0]).toMatchObject({ key: '2026-03-29', inputTokens: 6 });
+    expect(res.json().totals.messageCount).toBe(2);
+
+    const digest = await get(
+      `/api/analytics/digest?from=2026-03-29&to=2026-03-29&${zone}`,
+    );
+    expect(digest.statusCode).toBe(200);
+    expect(digest.json().totals.sessions).toBe(2);
+    expect(digest.json().totals.totalTokens).toBe(8);
+  });
+
+  it('preserves a numeric-offset timestamp as an exact instant', async () => {
+    const instant = encodeURIComponent('2026-03-29T01:00:00+02:00');
+    const res = await get(`/api/analytics?groupBy=day&from=${instant}&to=${instant}&${zone}`);
+    expect(res.statusCode).toBe(200);
+    expect(res.json().rows).toHaveLength(1);
+    expect(res.json().rows[0]).toMatchObject({ key: '2026-03-29', inputTokens: 2 });
+    expect(res.json().totals.messageCount).toBe(1);
+  });
+
+  it('buckets both fall-back instants into the repeated local hour', async () => {
+    const res = await get(
+      `/api/analytics/activity?from=2026-10-25&to=2026-10-25&${zone}&today=2026-10-25`,
+    );
+    expect(res.statusCode).toBe(200);
+    const hourTwo = res
+      .json()
+      .heatmap.filter((cell: { hour: number }) => cell.hour === 2)
+      .reduce((count: number, cell: { count: number }) => count + cell.count, 0);
+    expect(hourTwo).toBe(2);
+  });
+
+  it('uses the timezone for code-impact day grouping', async () => {
+    const res = await get(
+      `/api/analytics/impact?groupBy=day&from=2026-03-29&to=2026-03-29&${zone}`,
+    );
+    expect(res.statusCode).toBe(200);
+    expect(res.json().rows).toHaveLength(1);
+    expect(res.json().rows[0]).toMatchObject({ key: '2026-03-29', edits: 2 });
+  });
+
+  it('retains the fixed-offset activity fallback for existing callers', async () => {
+    const instant = encodeURIComponent('2026-03-28T23:00:00.000Z');
+    const res = await get(
+      `/api/analytics/activity?from=${instant}&to=${instant}&tzOffsetMinutes=120&today=2026-03-29`,
+    );
+    expect(res.statusCode).toBe(200);
+    expect(res.json().heatmap).toEqual([{ dow: 7, hour: 1, count: 1 }]);
+  });
+});
+
+describe('timezone validation', () => {
+  const boundedEndpoints = [
+    '/api/analytics',
+    '/api/analytics/sessions',
+    '/api/analytics/agents',
+    '/api/analytics/activity',
+    '/api/analytics/tools',
+    '/api/analytics/impact',
+    '/api/analytics/errors',
+    '/api/analytics/digest',
+  ];
+
+  it.each(boundedEndpoints)('%s rejects an unknown IANA timezone', async (path) => {
+    const res = await get(`${path}?timeZone=Mars%2FOlympus`);
+    expect(res.statusCode).toBe(400);
+    expect(res.json().error).toMatch(/^timeZone must be a recognized IANA timezone/);
+    expect(res.body).not.toMatch(/SELECT|pg_timezone_names|Catalog Error/i);
+  });
+});

--- a/packages/shared/src/api.ts
+++ b/packages/shared/src/api.ts
@@ -170,13 +170,29 @@ export interface SearchQuery {
 
 export type AnalyticsGroupBy = 'project' | 'model' | 'day' | 'agent';
 
-export interface AnalyticsQuery {
-  groupBy: AnalyticsGroupBy;
-  /** Inclusive ISO date/time lower bound. */
+/** Shared date-range semantics for every analytics endpoint. */
+export interface AnalyticsDateRangeQuery {
+  /**
+   * Inclusive ISO date/time lower bound. Date-only values are interpreted as
+   * calendar days in `timeZone`; timestamps with an offset identify an instant.
+   */
   from?: string;
-  /** Inclusive ISO date/time upper bound. */
+  /**
+   * Inclusive ISO date/time upper bound. A date-only value includes the whole
+   * calendar day in `timeZone`.
+   */
   to?: string;
+  /** IANA time zone for date-only bounds and local-day grouping (default UTC at the raw HTTP API). */
+  timeZone?: string;
 }
+
+/** GET /api/analytics query parameters; bounds filter event timestamps. */
+export interface AnalyticsQuery extends AnalyticsDateRangeQuery {
+  groupBy: AnalyticsGroupBy;
+}
+
+/** GET /api/analytics/digest query parameters; bounds filter session start timestamps. */
+export type DigestQuery = AnalyticsDateRangeQuery;
 
 // ---------------------------------------------------------------------------
 // Session efficiency (per-session ratios)
@@ -198,11 +214,8 @@ export type SessionEfficiencySort =
 /** Sort direction. */
 export type SortDir = 'asc' | 'desc';
 
-export interface SessionEfficiencyQuery {
-  /** Inclusive ISO lower bound on session START. */
-  from?: string;
-  /** Inclusive ISO upper bound on session START. */
-  to?: string;
+/** GET /api/analytics/sessions query parameters; bounds filter session start timestamps. */
+export interface SessionEfficiencyQuery extends AnalyticsDateRangeQuery {
   /** Sort column (default 'cost'). */
   sort?: SessionEfficiencySort;
   /** Sort direction (default 'desc'). */
@@ -813,7 +826,7 @@ export interface DigestResponse {
   /** Sessions per agent. */
   agents: DigestCountRow[];
   biggestSession: DigestBiggestSession | null;
-  /** All-time prompt streak (UTC days) as of the range end. */
+  /** All-time prompt streak (local days in the selected time zone) as of the range end. */
   streak: StreakInfo;
   impact: DigestImpact;
   /** null when no agent in range records tool errors. */
@@ -888,13 +901,10 @@ export interface PrLinkedStats {
   costPerPrSession: number | null;
 }
 
-export interface AgentComparisonQuery {
+/** GET /api/analytics/agents query parameters; bounds filter session start timestamps. */
+export interface AgentComparisonQuery extends AnalyticsDateRangeQuery {
   /** Project slug id (as returned by /api/projects); omit for the whole corpus. */
   project?: string;
-  /** Inclusive ISO lower bound on session START. */
-  from?: string;
-  /** Inclusive ISO upper bound on session START. */
-  to?: string;
 }
 
 /** GET /api/analytics/agents */

--- a/packages/web/src/api/client.ts
+++ b/packages/web/src/api/client.ts
@@ -106,12 +106,14 @@ export interface AnalyticsParams {
   groupBy: AnalyticsGroupBy;
   from?: string;
   to?: string;
+  timeZone?: string;
 }
 
 export interface SessionEfficiencyParams {
   project?: string;
   from?: string;
   to?: string;
+  timeZone?: string;
   sort?: SessionEfficiencySort;
   dir?: SortDir;
   limit?: number;
@@ -163,53 +165,83 @@ export const api = {
     );
   },
 
-  /** GET /api/analytics?groupBy=&from=&to= */
+  /** GET /api/analytics?groupBy=&from=&to=&timeZone= */
   analytics(params: AnalyticsParams, signal?: AbortSignal): Promise<AnalyticsResponse> {
     return request<AnalyticsResponse>(
-      `/analytics${qs({ groupBy: params.groupBy, from: params.from, to: params.to })}`,
+      `/analytics${qs({
+        groupBy: params.groupBy,
+        from: params.from,
+        to: params.to,
+        timeZone: params.timeZone,
+      })}`,
       { signal },
     );
   },
 
-  /** GET /api/analytics/activity?from=&to=&tzOffsetMinutes=&today= */
+  /** GET /api/analytics/activity?from=&to=&timeZone=&today= */
   analyticsActivity(
-    params: { from?: string; to?: string; tzOffsetMinutes: number; today: string },
+    params: { from?: string; to?: string; timeZone?: string; today: string },
     signal?: AbortSignal,
   ): Promise<ActivityResponse> {
     return request<ActivityResponse>(
-      `/analytics/activity${qs({ from: params.from, to: params.to, tzOffsetMinutes: params.tzOffsetMinutes, today: params.today })}`,
+      `/analytics/activity${qs({
+        from: params.from,
+        to: params.to,
+        timeZone: params.timeZone,
+        today: params.today,
+      })}`,
       { signal },
     );
   },
 
-  /** GET /api/analytics/tools?from=&to= */
+  /** GET /api/analytics/tools?from=&to=&timeZone= */
   analyticsTools(
-    params: { project?: string; from?: string; to?: string },
+    params: { project?: string; from?: string; to?: string; timeZone?: string },
     signal?: AbortSignal,
   ): Promise<ToolUsageResponse> {
     return request<ToolUsageResponse>(
-      `/analytics/tools${qs({ project: params.project, from: params.from, to: params.to })}`,
+      `/analytics/tools${qs({
+        project: params.project,
+        from: params.from,
+        to: params.to,
+        timeZone: params.timeZone,
+      })}`,
       { signal },
     );
   },
 
-  /** GET /api/analytics/agents?project=&from=&to= */
+  /** GET /api/analytics/agents?project=&from=&to=&timeZone= */
   analyticsAgents(
-    params: { project?: string; from?: string; to?: string } = {},
+    params: { project?: string; from?: string; to?: string; timeZone?: string } = {},
     signal?: AbortSignal,
   ): Promise<AgentComparisonResponse> {
     return request<AgentComparisonResponse>(
-      `/analytics/agents${qs({ project: params.project, from: params.from, to: params.to })}`,
+      `/analytics/agents${qs({
+        project: params.project,
+        from: params.from,
+        to: params.to,
+        timeZone: params.timeZone,
+      })}`,
       { signal },
     );
   },
 
-  /** GET /api/analytics/digest?from=&to= */
-  analyticsDigest(params: { from?: string; to?: string }, signal?: AbortSignal): Promise<DigestResponse> {
-    return request<DigestResponse>(`/analytics/digest${qs({ from: params.from, to: params.to })}`, { signal });
+  /** GET /api/analytics/digest?from=&to=&timeZone= */
+  analyticsDigest(
+    params: { from?: string; to?: string; timeZone?: string },
+    signal?: AbortSignal,
+  ): Promise<DigestResponse> {
+    return request<DigestResponse>(
+      `/analytics/digest${qs({
+        from: params.from,
+        to: params.to,
+        timeZone: params.timeZone,
+      })}`,
+      { signal },
+    );
   },
 
-  /** GET /api/analytics/sessions?from=&to=&sort=&dir=&limit=&minResponses= */
+  /** GET /api/analytics/sessions?from=&to=&timeZone=&sort=&dir=&limit=&minResponses= */
   sessionEfficiency(
     params: SessionEfficiencyParams = {},
     signal?: AbortSignal,
@@ -219,6 +251,7 @@ export const api = {
         project: params.project,
         from: params.from,
         to: params.to,
+        timeZone: params.timeZone,
         sort: params.sort,
         dir: params.dir,
         limit: params.limit,

--- a/packages/web/src/pages/analytics/AnalyticsPage.tsx
+++ b/packages/web/src/pages/analytics/AnalyticsPage.tsx
@@ -57,6 +57,32 @@ const SORT_OPTIONS: { value: BreakdownSort; label: string }[] = [
   { value: 'cost', label: 'Cost' },
 ];
 
+function browserTimeZone(): string {
+  try {
+    return Intl.DateTimeFormat().resolvedOptions().timeZone || 'UTC';
+  } catch {
+    return 'UTC';
+  }
+}
+
+const TIME_ZONE = browserTimeZone();
+
+function todayInTimeZone(): string {
+  try {
+    const parts = new Intl.DateTimeFormat('en-US', {
+      timeZone: TIME_ZONE,
+      year: 'numeric',
+      month: '2-digit',
+      day: '2-digit',
+    }).formatToParts(new Date());
+    const part = (type: Intl.DateTimeFormatPartTypes) =>
+      parts.find((candidate) => candidate.type === type)?.value ?? '';
+    return `${part('year')}-${part('month')}-${part('day')}`;
+  } catch {
+    return new Date().toISOString().slice(0, 10);
+  }
+}
+
 /** Fetch state for one analytics query. */
 interface QueryState {
   data: AnalyticsResponse | null;
@@ -117,11 +143,9 @@ export function AnalyticsPage() {
   const [activity, setActivity] = useState<{ data: ActivityResponse | null; loading: boolean; error: unknown }>({ data: null, loading: true, error: null });
   const [tools, setTools] = useState<{ data: ToolUsageResponse | null; loading: boolean; error: unknown }>({ data: null, loading: true, error: null });
 
-  // Convert the date inputs (YYYY-MM-DD, local) into inclusive ISO bounds.
+  // Keep calendar dates intact so the server can interpret them in TIME_ZONE.
   const range = useMemo(() => {
-    const fromIso = from ? new Date(`${from}T00:00:00`).toISOString() : undefined;
-    const toIso = to ? new Date(`${to}T23:59:59.999`).toISOString() : undefined;
-    return { from: fromIso, to: toIso };
+    return { from: from || undefined, to: to || undefined };
   }, [from, to]);
 
   const load = useCallback(() => {
@@ -130,7 +154,7 @@ export function AnalyticsPage() {
     setSeries((s) => ({ ...s, loading: true, error: null }));
 
     api
-      .analytics({ groupBy, from: range.from, to: range.to }, ctrl.signal)
+      .analytics({ groupBy, from: range.from, to: range.to, timeZone: TIME_ZONE }, ctrl.signal)
       .then((data) => setBreakdown({ data, loading: false, error: null }))
       .catch((error) => {
         if (ctrl.signal.aborted) return;
@@ -138,7 +162,10 @@ export function AnalyticsPage() {
       });
 
     api
-      .analytics({ groupBy: 'day', from: range.from, to: range.to }, ctrl.signal)
+      .analytics(
+        { groupBy: 'day', from: range.from, to: range.to, timeZone: TIME_ZONE },
+        ctrl.signal,
+      )
       .then((data) => setSeries({ data, loading: false, error: null }))
       .catch((error) => {
         if (ctrl.signal.aborted) return;
@@ -156,7 +183,15 @@ export function AnalyticsPage() {
     setEff((s) => ({ ...s, loading: true, error: null }));
     api
       .sessionEfficiency(
-        { project: effProject || undefined, from: range.from, to: range.to, sort: effSort, dir: effDir, limit: 50 },
+        {
+          project: effProject || undefined,
+          from: range.from,
+          to: range.to,
+          timeZone: TIME_ZONE,
+          sort: effSort,
+          dir: effDir,
+          limit: 50,
+        },
         ctrl.signal,
       )
       .then((data) => setEff({ data, loading: false, error: null }))
@@ -172,7 +207,15 @@ export function AnalyticsPage() {
     const ctrl = new AbortController();
     setAgents((s) => ({ ...s, loading: true, error: null }));
     api
-      .analyticsAgents({ project: effProject || undefined, from: range.from, to: range.to }, ctrl.signal)
+      .analyticsAgents(
+        {
+          project: effProject || undefined,
+          from: range.from,
+          to: range.to,
+          timeZone: TIME_ZONE,
+        },
+        ctrl.signal,
+      )
       .then((data) => setAgents({ data, loading: false, error: null }))
       .catch((error) => {
         if (ctrl.signal.aborted) return;
@@ -186,7 +229,7 @@ export function AnalyticsPage() {
     const ctrl = new AbortController();
     setDigest((s) => ({ ...s, loading: true, error: null }));
     api
-      .analyticsDigest({ from: range.from, to: range.to }, ctrl.signal)
+      .analyticsDigest({ from: range.from, to: range.to, timeZone: TIME_ZONE }, ctrl.signal)
       .then((data) => setDigest({ data, loading: false, error: null }))
       .catch((error) => {
         if (ctrl.signal.aborted) return;
@@ -198,14 +241,13 @@ export function AnalyticsPage() {
   useEffect(() => {
     if (view !== 'overview') return;
     const ctrl = new AbortController();
-    const tzOffsetMinutes = -new Date().getTimezoneOffset(); // east-of-UTC positive
-    const today = (() => {
-      const d = new Date();
-      return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`;
-    })();
+    const today = todayInTimeZone();
     setActivity((s) => ({ ...s, loading: true }));
     api
-      .analyticsActivity({ from: range.from, to: range.to, tzOffsetMinutes, today }, ctrl.signal)
+      .analyticsActivity(
+        { from: range.from, to: range.to, timeZone: TIME_ZONE, today },
+        ctrl.signal,
+      )
       .then((data) => setActivity({ data, loading: false, error: null }))
       .catch((error) => {
         if (ctrl.signal.aborted) return;
@@ -219,7 +261,15 @@ export function AnalyticsPage() {
     const ctrl = new AbortController();
     setTools((s) => ({ ...s, loading: true }));
     api
-      .analyticsTools({ project: effProject || undefined, from: range.from, to: range.to }, ctrl.signal)
+      .analyticsTools(
+        {
+          project: effProject || undefined,
+          from: range.from,
+          to: range.to,
+          timeZone: TIME_ZONE,
+        },
+        ctrl.signal,
+      )
       .then((data) => setTools({ data, loading: false, error: null }))
       .catch((error) => {
         if (ctrl.signal.aborted) return;


### PR DESCRIPTION
## Summary

- keep UTC-normalized derived storage while applying explicit IANA timezone semantics at query time
- make date-only filters, day grouping, activity, impact, and digest calculations DST-aware
- send timezone context from the web, CLI, and MCP while preserving UTC and fixed-offset compatibility defaults

## Plan

- [0074 — Timezone-aware analytics](https://github.com/vladar107/claudescope/blob/feat/timezone-aware-analytics/docs/plans/0074-timezone-aware-analytics.md)

## Testing

- npm test (63 files, 615 tests)
- npm run typecheck
- npm run build
- git diff --check