### PR TITLE
fix: restore reliable subagent linkage

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -154,10 +154,21 @@ The CLI `update` command (`cli.ts`) detects the install method and defers to
 - **Codex subagents & apply_patch** — subagent rollouts are separate files whose
   `session_meta` carries `thread_source: "subagent"` + the parent thread id; they
   re-key under their ROOT thread (`is_sidechain`) and nest via a canonical `Task`
-  synthesized from the parent's `spawn_agent` call. File edits arrive as
-  `custom_tool_call` records (NOT `function_call`) named `apply_patch` → parsed
-  V4A envelopes fan out to canonical `Write`/`MultiEdit` per file so the
-  Files-changed tab works.
+  synthesized from the parent's `spawn_agent` call. Legacy output links by
+  `agent_id`; current output links `task_name` to the child's
+  `thread_spawn.agent_path`, retaining the exact spawning call id. Prefer that
+  readable task name over the possibly opaque prompt for the `Task` label.
+  `function_call_output` / `custom_tool_call_output` may carry either one string
+  or an ordered text-item array; decode the latter before envelope/error parsing
+  and keep unknown structured items visible. Direct `apply_patch` calls arrive as
+  `custom_tool_call` records (NOT `function_call`) → parsed V4A envelopes fan out
+  to canonical `Write`/`MultiEdit` per file; rejected patches demote back to raw
+  calls so the Files-changed tab never reports edits that did not happen.
+- **Claude Code subagent correlation** — prefer direct connector linkage when
+  available, then metadata-backed description/type matching. If sibling metadata
+  is absent or drifted, the shared parser may fall back to an exact full match
+  between the spawning `Agent`/`Task.prompt` and the child's first user prompt.
+  Empty or ambiguous matches stay detached; there is no fuzzy prompt matching.
 - **pi connector** (`connectors/pi/`) — JSONL like Claude/Codex but `cwd` is on
   the `session` line and tool results are separate `toolResult` records, so a
   `prepare()` pass normalizes to canonical NDJSON (Codex pattern). `model` comes
@@ -265,4 +276,3 @@ The CLI `update` command (`cli.ts`) detects the install method and defers to
   OIDC). See `CONTRIBUTING.md`.
 
 See `CONTRIBUTING.md` for the full workflow and `README.md` for user-facing docs.
-

--- a/docs/plans/0075-reliable-subagent-linkage-and-codex-rendering.md
+++ b/docs/plans/0075-reliable-subagent-linkage-and-codex-rendering.md
@@ -1,0 +1,198 @@
+# 0075 — Reliable subagent linkage and Codex transcript rendering
+
+- **Status:** done
+- **Date:** 2026-08-26
+- **PR:** https://github.com/vladar107/claudescope/pull/97
+
+## Context
+
+Real-data inspection found two related classes of subagent failure.
+
+For Codex session `01a0386a-ee8b-7fa0-b5fc-3aaf702f4d3e`, ClaudeScope loads all
+five child rollouts but gives none a `toolUseId`, so the UI lists them under
+"Other subagents" instead of nesting them at their `Task` calls. The connector
+expects the older `spawn_agent` result `{ agent_id }`; current rollouts return
+`{ task_name: "/root/..." }`, while the child records the same value as
+`session_meta.source.subagent.thread_spawn.agent_path`.
+
+The same session also exposes a second Codex format change:
+`custom_tool_call_output.payload.output` is now an array of text items rather
+than always a string. The normalizer's string coercion turns those arrays into
+an empty string, hiding real `exec` output and weakening rejected
+`apply_patch` detection. A child rollout additionally begins with copied parent
+AGENTS/environment/user context; preserving it is useful provenance, but
+rendering the copied turn as ordinary subagent conversation is misleading.
+
+Claude Code still links correctly in the local Claude Code 2.1.246 sample (all
+7 runs in a representative session, and all 25 discovered child files had
+sibling metadata). Its linkage is nevertheless fragile: the shared parser
+matches the parent's `Agent`/`Task` description against
+`agent-<id>.meta.json`. Missing, unreadable, or drifted metadata leaves a valid
+child detached even though the parent's full `prompt` exactly matches the
+child's first user message.
+
+## Goal
+
+Attach current and legacy Codex children deterministically, retain real
+array-shaped tool results and patch failure semantics, provide a safe Claude
+prompt fallback, and present copied Codex parent context as inherited metadata
+rather than ordinary subagent dialogue.
+
+## Decisions
+
+- **Prefer explicit connector linkage over shared heuristics** — extend the
+  internal `SubagentSource` contract with an optional spawning tool id. Codex
+  can recover the exact call from `task_name`/`agent_path` (or legacy
+  `agent_id`), so it should not depend on description equality. The shared
+  description matcher remains for formats that expose no direct key.
+- **Keep both Codex generations supported** — accept legacy `{ agent_id }` and
+  current `{ task_name }` spawn results. Parse the child's canonical
+  `agent_path` and preserve the parent call id in either case.
+- **Use readable task metadata, not opaque payloads** — prefer plaintext
+  `task_name` for the canonical `Task.description`. Retain a plaintext prompt
+  when available, but do not render a long encrypted task payload as if it were
+  a human-readable description; the raw rollout remains untouched.
+- **Decode tool outputs at the format boundary** — one Codex helper accepts the
+  legacy string and current text-item array shapes before envelope stripping or
+  error detection. Known text items are concatenated in order; unfamiliar
+  structured output degrades visibly rather than silently becoming empty.
+- **Claude prompt matching is a guarded fallback** — expose the full first
+  child prompt and compare it exactly with the spawning tool's `prompt` only
+  after direct-id and description matching fail. After type narrowing, the
+  prompt match must identify one unused spawn; no fuzzy text matching is
+  introduced.
+- **Collapse inherited context only in presentation** — a sidechain user turn
+  beginning with a complete recognized Codex startup envelope renders as a
+  collapsed "Inherited parent context" disclosure. Its exact blocks remain
+  available on expansion and unchanged for source/index/export behavior.
+- **Rebuild derived data once** — bump `SCHEMA_VERSION` from 15 to 16. Decoded
+  tool results and correct rejected-patch demotion can change persisted tool
+  errors/file edits, and unchanged source mtimes would otherwise retain stale
+  normalized output.
+- **No new dependencies** — reuse the connector JSON helpers, shared parser,
+  existing context recognizer, and existing test suites.
+
+## Approach
+
+### Wave 1 — shared correlation and presentation
+
+1. **Shared direct/prompt correlation** (Complex; no dependencies)
+   - Add optional `toolUseId` and full `prompt` fields to `SubagentSource`.
+   - Teach `buildSubagentRuns` to resolve an explicit tool id first, then keep
+     Workflow correlation, description/type correlation, and finally exact
+     prompt/type correlation.
+   - Refactor the Claude connector's first-user-message extraction so the full
+     prompt is available for matching while its first line remains the display
+     fallback.
+   - Acceptance: current Claude metadata-backed runs remain unchanged; a child
+     with missing or mismatched metadata links only when its full prompt exactly
+     matches one unused `Agent`/`Task` call; ambiguous/empty children remain
+     detached.
+
+2. **Inherited Codex context presentation** (Simple; no dependencies)
+   - Extend the existing Codex startup-context helper with a fail-closed
+     sidechain classification.
+   - Render a matching sidechain user turn through the existing collapsed
+     system-turn component as "Inherited parent context"; leave top-level
+     session rendering unchanged.
+   - Acceptance: the copied AGENTS/environment/original-prompt turn is compact
+     but fully inspectable, while ordinary subagent user prose remains normal.
+
+### Wave 2 — Codex format compatibility
+
+3. **Deterministic current/legacy spawn linkage** (Complex; depends on task 1)
+   - Parse `thread_spawn.agent_path` on child sessions.
+   - Retain the spawning call id and index spawn metadata by legacy child id and
+     current canonical task path.
+   - Prefer `task_name` for the canonical Task label and pass the exact call id
+     through `SubagentSource` when loading the child.
+   - Acceptance: the five children in the affected session receive the correct
+     `toolUseId`; the linked target nests under
+     `call_Uw4zVlU3fj5jiGTQ3rZ5Wqya`; legacy `{ agent_id }` fixtures still link.
+
+4. **String/array custom-tool results and patch correctness** (Complex;
+   independent within Wave 2 but shares the Codex normalizer)
+   - Normalize string and text-item-array outputs before pairing results.
+   - Run success-envelope stripping and rejected-patch detection on the decoded
+     text, preserving `is_error` and failed-edit demotion.
+   - Keep successful multi-file per-file statuses and unknown-output fallback.
+   - Acceptance: real `exec` output is visible; legacy string output is
+     byte-equivalent; array-shaped successful and rejected patches produce the
+     correct transcript and Files Changed result.
+
+5. **Migration and connector documentation** (Simple; depends on tasks 3–4)
+   - Bump the derived schema to v16.
+   - Update the Codex/Claude subagent gotchas in `CLAUDE.md` with the supported
+     linkage and output shapes.
+
+### Wave 3 — integrated verification
+
+6. Extend existing focused tests (no new test files) for direct tool-id
+   correlation, Claude exact-prompt fallback, current Codex
+   `task_name`/`agent_path`, array tool results, rejected array patch output,
+   legacy compatibility, and inherited-context classification.
+7. Run focused tests, full tests, typecheck, production build, and diff checks.
+8. Use an isolated `CLAUDESCOPE_HOME` fixture run for end-to-end verification,
+   then perform read-only checks against the supplied real session: correct
+   nesting/hash navigation, non-empty tool results, compact inherited context,
+   and accurate Files Changed output. Recheck a known-good Claude session to
+   guard against correlation regressions.
+
+## Files affected
+
+- `packages/server/src/data/session-loader.ts` — optional exact spawn id and
+  prompt signals on the internal subagent source contract.
+- `packages/server/src/data/parser.ts` — direct-id-first correlation plus exact
+  prompt fallback.
+- `packages/server/src/connectors/claude-code/claude-code.ts` — retain the full
+  first child prompt without changing its concise label.
+- `packages/server/src/connectors/codex/normalize.ts` — current/legacy spawn
+  metadata, readable Task mapping, agent path, and structured output decoding.
+- `packages/server/src/connectors/codex/codex.ts` — resolve children by id or
+  canonical task path and pass the exact spawning tool id.
+- `packages/server/src/db/schema.ts` — schema v16 rebuild.
+- `packages/web/src/pages/session/text.ts` — fail-closed inherited-context
+  classification.
+- `packages/web/src/pages/session/ThreadView.tsx` — collapsed inherited-context
+  rendering for sidechain turns.
+- `packages/server/test/parser.test.ts` — shared direct/prompt correlation.
+- `packages/server/test/codex.integration.test.ts` — current and legacy Codex
+  formats, tool output, and patch regression cases.
+- `packages/server/test/api.integration.test.ts` — Claude missing/drifted-meta
+  prompt fallback through the session API, if the parser-level case does not
+  provide sufficient connector coverage.
+- `packages/web/test/text.test.ts` — inherited-context classification edges.
+- `CLAUDE.md` — connector gotcha updates.
+- `docs/plans/README.md` — plan index entry.
+
+## Testing
+
+- Focused:
+  `npx vitest run packages/server/test/parser.test.ts packages/server/test/codex.integration.test.ts packages/server/test/api.integration.test.ts packages/web/test/text.test.ts`
+- Full: `npm test`
+- Types: `npm run typecheck`
+- Production build: `npm run build`
+- Hygiene: `git diff --check`
+- End-to-end: run the repository's `verify` skill against sandboxed fixtures;
+  never point fixture validation at real agent sources or `~/.claudescope`.
+- Read-only real-data checks for session
+  `01a0386a-ee8b-7fa0-b5fc-3aaf702f4d3e` and a known-good Claude session after
+  the isolated suite passes.
+
+## Risks / open questions
+
+- Upstream transcript formats are undocumented and best-effort. Unknown future
+  output items must remain visible/raw rather than throwing or disappearing.
+- Exact prompt fallback can still be ambiguous when two agents receive
+  identical prompts. Type narrowing limits this, and a non-unique fallback must
+  remain visibly unlinked rather than guessing by order.
+- Collapsing inherited context must require both `isSidechain` and a complete
+  recognized Codex envelope so genuine user prose is not hidden.
+- A v16 rebuild can take time on large histories, but the DuckDB index and
+  normalized cache are derived and user settings remain untouched.
+- Recursive nesting of subagents spawned by subagents is not part of this
+  change; this plan fixes attachment to the currently supported parent Task
+  model.
+- Decrypting Codex reasoning/task payloads and parsing arbitrary JavaScript
+  inside the `exec` tool are explicitly out of scope. Empty thinking and raw
+  JavaScript tool inputs remain expected where Codex stores no readable form.

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -99,3 +99,4 @@ decision, or a change worth explaining before doing. Skip it for one-line fixes.
 | 0072 | [Hide Codex guardian sessions](./0072-hide-codex-guardian-sessions.md) | done |
 | 0073 | [Inclusive analytics end date](./0073-inclusive-analytics-end-date.md) | done |
 | 0074 | [Timezone-aware analytics](./0074-timezone-aware-analytics.md) | done |
+| 0075 | [Reliable subagent linkage and Codex transcript rendering](./0075-reliable-subagent-linkage-and-codex-rendering.md) | done |

--- a/packages/server/src/connectors/claude-code/claude-code.ts
+++ b/packages/server/src/connectors/claude-code/claude-code.ts
@@ -270,11 +270,8 @@ function workflowIdFromPath(path: string): string | undefined {
   return m ? m[1] : undefined;
 }
 
-/**
- * A readable label for a subagent that lacks a meta description (e.g. workflow
- * agents): the first line of its first user message, truncated.
- */
-function deriveLabel(events: RawEvent[]): string {
+/** Full text of the first non-empty user message, if one is available. */
+function firstUserPrompt(events: RawEvent[]): string | undefined {
   for (const e of events) {
     if (e.type !== 'user') continue;
     const content = (e as { message?: { content?: unknown } }).message?.content;
@@ -287,10 +284,15 @@ function deriveLabel(events: RawEvent[]): string {
       );
       text = first?.text ?? '';
     }
-    const line = text.trim().split('\n')[0]?.trim() ?? '';
-    if (line) return line.length > 80 ? `${line.slice(0, 80)}…` : line;
+    if (text.trim().length > 0) return text;
   }
-  return '';
+  return undefined;
+}
+
+/** A concise display label derived from a subagent's full first prompt. */
+function deriveLabel(prompt: string): string {
+  const line = prompt.trim().split('\n')[0]?.trim() ?? '';
+  return line.length > 80 ? `${line.slice(0, 80)}…` : line;
 }
 
 /**
@@ -316,13 +318,15 @@ async function loadSession(sessionId: string, paths: string[]): Promise<SessionD
     const meta = readSubagentMeta(p);
     const slug = firstSlug(events);
     const workflowId = workflowIdFromPath(p);
+    const prompt = firstUserPrompt(events);
     // Workflow agents have no meta description; fall back to their first prompt.
-    const description = meta.description || deriveLabel(events);
+    const description = meta.description || (prompt ? deriveLabel(prompt) : '');
     subagents.push({
       agentId: agentIdFromPath(p),
       agentType: meta.agentType,
       description,
       ...(slug ? { slug } : {}),
+      ...(prompt ? { prompt } : {}),
       ...(workflowId ? { workflowId } : {}),
       events,
     });

--- a/packages/server/src/connectors/codex/codex.ts
+++ b/packages/server/src/connectors/codex/codex.ts
@@ -53,9 +53,9 @@ function auxProjections(_filePath: string): AuxProjections {
 /**
  * Load a session's events, splitting the resolved rollouts into the main thread
  * (its own thread id equals the session id) and one subagent per re-keyed child
- * rollout. A child's `description`/`agentType` come from the parent's matching
- * `spawn_agent` call (correlated via the spawn output's `agent_id`), so the run
- * anchors to the canonical `Task` block.
+ * rollout. A child's metadata comes from the parent's matching `spawn_agent`
+ * call, correlated by the legacy child `agent_id` or current canonical
+ * `task_name`/`agent_path`, so the run anchors to the exact canonical `Task`.
  */
 async function loadSession(sessionId: string, paths: string[]): Promise<SessionData> {
   const sessions = paths
@@ -65,11 +65,14 @@ async function loadSession(sessionId: string, paths: string[]): Promise<SessionD
   const subagents: SubagentSource[] = [];
   for (const s of sessions) {
     if (s === main) continue;
-    const meta = main?.spawnedAgents.get(s.sessionId);
+    const meta =
+      (s.agentPath ? main?.spawnedAgents.get(s.agentPath) : undefined) ??
+      main?.spawnedAgents.get(s.sessionId);
     subagents.push({
       agentId: s.sessionId,
       agentType: meta?.agentType ?? s.agentRole ?? '',
-      description: meta?.description ?? '',
+      description: meta?.description ?? s.agentPath ?? '',
+      toolUseId: meta?.toolUseId,
       events: s.events,
     });
   }

--- a/packages/server/src/connectors/codex/normalize.ts
+++ b/packages/server/src/connectors/codex/normalize.ts
@@ -52,15 +52,17 @@ export interface CodexSession {
   isSidechain: boolean;
   /** `thread_spawn.agent_role` for a subagent rollout (fallback agentType). */
   agentRole?: string;
+  /** Current Codex's canonical task path from `thread_spawn.agent_path`. */
+  agentPath?: string;
   cwd: string;
   gitBranch?: string;
   /** `model_provider` from session_meta — session-level, applied to every
    *  assistant row (e.g. 'openai'). */
   modelProvider?: string;
   events: (UserEvent | AssistantEvent)[];
-  /** Spawned child thread id → Task correlation meta, from this rollout's
-   *  `spawn_agent` calls (description must equal the Task block's). */
-  spawnedAgents: Map<string, { description: string; agentType: string }>;
+  /** Legacy child thread id OR current canonical task path → exact Task
+   *  correlation meta, recovered from this rollout's `spawn_agent` calls. */
+  spawnedAgents: Map<string, { description: string; agentType: string; toolUseId: string }>;
 }
 
 /** Mutable per-turn token accumulator (assignable to {@link MessageUsage}). */
@@ -281,21 +283,53 @@ function codexToolUse(name: string, input: unknown, id: string): ToolUseBlock {
   }
   if (name === 'spawn_agent') {
     const args = argsRecord(input);
+    const taskName = str(args.task_name);
     const message = str(args.message);
-    if (message) {
+    if (taskName || message) {
       return {
         type: 'tool_use',
         id,
         name: 'Task',
         input: {
-          description: subagentLabel(message),
+          description: taskName || subagentLabel(message),
           subagent_type: str(args.agent_type),
-          prompt: message,
+          ...(message ? { prompt: message } : {}),
         },
       };
     }
   }
   return { type: 'tool_use', id, name, input };
+}
+
+/**
+ * Decode Codex tool output at the format boundary. Older rollouts store one
+ * string; current rollouts store an ordered array of text items. Preserve text
+ * bytes exactly, while keeping unfamiliar structured items visible as JSON
+ * instead of silently coercing them to an empty string.
+ */
+function toolOutputText(output: unknown): string {
+  if (typeof output === 'string') return output;
+  if (Array.isArray(output)) {
+    return output
+      .map((item) => {
+        const obj = rec(item);
+        const type = str(obj.type);
+        if (['text', 'input_text', 'output_text'].includes(type) && typeof obj.text === 'string') {
+          return obj.text;
+        }
+        try {
+          return JSON.stringify(item, null, 2);
+        } catch {
+          return String(item);
+        }
+      })
+      .join('');
+  }
+  try {
+    return JSON.stringify(output, null, 2) ?? String(output);
+  } catch {
+    return String(output);
+  }
 }
 
 /**
@@ -490,10 +524,12 @@ export function parseRollout(path: string): CodexSession | null {
   let indexSessionId = sessionId;
   let isSidechain = false;
   let agentRole: string | undefined;
+  let agentPath: string | undefined;
   if (str(meta.thread_source) === 'subagent') {
     const spawn = rec(subagentSource.thread_spawn);
     const parentId = str(spawn.parent_thread_id);
     agentRole = str(spawn.agent_role) || undefined;
+    agentPath = str(spawn.agent_path) || undefined;
     if (parentId) {
       isSidechain = true;
       indexSessionId = rootThreadId(parentId, getCodexContext().parents);
@@ -508,8 +544,16 @@ export function parseRollout(path: string): CodexSession | null {
 
   // spawn_agent correlation: call_id → Task meta (set at the call), promoted to
   // spawnedAgents keyed by the child thread id when the output names it.
-  const pendingSpawns = new Map<string, { description: string; agentType: string }>();
-  const spawnedAgents = new Map<string, { description: string; agentType: string }>();
+  const pendingSpawns = new Map<string, {
+    block: ToolUseBlock;
+    description: string;
+    agentType: string;
+  }>();
+  const spawnedAgents = new Map<string, {
+    description: string;
+    agentType: string;
+    toolUseId: string;
+  }>();
   // apply_patch fan-out: call_id → the fanned block REFERENCES (they stay live
   // inside the flushed event), per-file statuses, and the raw patch text — so the
   // (single) custom_tool_call_output can pair a result to every block, or demote
@@ -607,6 +651,7 @@ export function parseRollout(path: string): CodexSession | null {
       if (str(pl.name) === 'spawn_agent' && block.name === 'Task') {
         const taskInput = block.input as { description: string; subagent_type: string };
         pendingSpawns.set(block.id, {
+          block,
           description: taskInput.description,
           agentType: taskInput.subagent_type,
         });
@@ -615,13 +660,24 @@ export function parseRollout(path: string): CodexSession | null {
     } else if (kind === 'function_call_output') {
       open('user', ts);
       const callId = str(pl.call_id);
-      const output = str(pl.output);
+      const output = toolOutputText(pl.output);
       const spawn = pendingSpawns.get(callId);
       if (spawn) {
-        // The output names the spawned child thread: `{"agent_id": …, "nickname": …}`.
+        // Legacy output names the child thread by `agent_id`; current output
+        // returns the canonical task path as `task_name`, which the child stores
+        // in `thread_spawn.agent_path`.
         try {
-          const agentId = str(rec(JSON.parse(output)).agent_id);
-          if (agentId) spawnedAgents.set(agentId, spawn);
+          const result = rec(JSON.parse(output));
+          const agentId = str(result.agent_id);
+          const taskName = str(result.task_name);
+          const description = taskName || spawn.description;
+          if (taskName) {
+            const input = argsRecord(spawn.block.input);
+            spawn.block.input = { ...input, description: taskName };
+          }
+          const linked = { description, agentType: spawn.agentType, toolUseId: callId };
+          if (agentId) spawnedAgents.set(agentId, linked);
+          if (taskName) spawnedAgents.set(taskName, linked);
         } catch {
           /* unparseable spawn output — the child will render detached */
         }
@@ -656,10 +712,11 @@ export function parseRollout(path: string): CodexSession | null {
     } else if (kind === 'custom_tool_call_output') {
       open('user', ts);
       const callId = str(pl.call_id);
-      const output = str(pl.output);
+      const output = toolOutputText(pl.output);
       const fan = patchFanout.get(callId);
       const exit = output.match(CUSTOM_ENVELOPE_RE);
-      if (fan && exit && Number(exit[1]) !== 0) {
+      const isError = pl.is_error === true || (exit !== null && Number(exit[1]) !== 0);
+      if (fan && isError) {
         // The patch was REJECTED — nothing on disk changed. Demote the fanned
         // canonical blocks back to raw apply_patch passthrough (no `file_path`,
         // so the Files-changed tab never lists untouched files — the same
@@ -681,6 +738,7 @@ export function parseRollout(path: string): CodexSession | null {
           type: 'tool_result',
           tool_use_id: callId,
           content: stripCustomEnvelope(output),
+          ...(isError ? { is_error: true } : {}),
         });
       }
     } else if (kind === 'tool_search_call') {
@@ -701,7 +759,18 @@ export function parseRollout(path: string): CodexSession | null {
   }
   flush();
 
-  return { sessionId, indexSessionId, isSidechain, agentRole, cwd, gitBranch, modelProvider, events, spawnedAgents };
+  return {
+    sessionId,
+    indexSessionId,
+    isSidechain,
+    agentRole,
+    agentPath,
+    cwd,
+    gitBranch,
+    modelProvider,
+    events,
+    spawnedAgents,
+  };
 }
 
 

--- a/packages/server/src/data/parser.ts
+++ b/packages/server/src/data/parser.ts
@@ -138,6 +138,7 @@ interface SpawnPoint {
   spawnUuid: string;
   description?: string;
   subagentType?: string;
+  prompt?: string;
   used: boolean;
 }
 
@@ -181,6 +182,7 @@ export function buildSubagentRuns(
           spawnUuid: item.uuid,
           description: typeof input.description === 'string' ? input.description : undefined,
           subagentType: typeof input.subagent_type === 'string' ? input.subagent_type : undefined,
+          prompt: typeof input.prompt === 'string' ? input.prompt : undefined,
           used: false,
         });
       } else if (block.name === 'Workflow') {
@@ -202,10 +204,16 @@ export function buildSubagentRuns(
     );
     const totalTokens = thread.reduce((n, t) => n + usageTokens(t.usage), 0);
 
-    // Workflow agents: link all of a run's agents to the Workflow tool call
-    // whose result references the run id (a one-to-many spawn; not consumed).
     let match: { toolUseId: string; spawnUuid: string } | undefined;
-    if (src.workflowId) {
+    const directSpawn = src.toolUseId
+      ? spawns.find((s) => !s.used && s.toolUseId === src.toolUseId)
+      : undefined;
+    if (directSpawn) {
+      directSpawn.used = true;
+      match = directSpawn;
+    } else if (src.workflowId) {
+      // Workflow agents: link all of a run's agents to the Workflow tool call
+      // whose result references the run id (a one-to-many spawn; not consumed).
       match = workflowSpawns.find((w) => w.resultText.includes(src.workflowId as string));
     } else {
       // Agent/Task: match description (+ type), earliest unused. Require a
@@ -222,6 +230,25 @@ export function buildSubagentRuns(
         if (sp) {
           sp.used = true;
           match = sp;
+        }
+      }
+
+      // Missing or stale Claude metadata can leave description matching with
+      // no candidate. Fall back only when the complete child prompt identifies
+      // exactly one unused, type-compatible spawn.
+      if (!match && src.prompt && src.prompt.trim().length > 0) {
+        const promptMatches = spawns.filter(
+          (s) =>
+            !s.used &&
+            s.prompt === src.prompt &&
+            (!s.subagentType || !src.agentType || s.subagentType === src.agentType),
+        );
+        if (promptMatches.length === 1) {
+          const [sp] = promptMatches;
+          if (sp) {
+            sp.used = true;
+            match = sp;
+          }
         }
       }
     }

--- a/packages/server/src/data/session-loader.ts
+++ b/packages/server/src/data/session-loader.ts
@@ -19,6 +19,10 @@ export interface SubagentSource {
   agentType: string;
   description: string;
   slug?: string;
+  /** Exact id of the Agent/Task call that spawned this run, when known. */
+  toolUseId?: string;
+  /** Full first user prompt, retained for guarded exact-match correlation. */
+  prompt?: string;
   /**
    * Workflow run id (e.g. `wf_…`) when this agent was spawned by a `Workflow`
    * tool call — derived from its `subagents/workflows/<wfId>/` path. Lets the

--- a/packages/server/src/db/schema.ts
+++ b/packages/server/src/db/schema.ts
@@ -35,7 +35,9 @@
 // v13: fallback titles skip complete synthetic command/system turns for every connector.
 // v14: FTS retains numeric terms for versions, issue keys, and other identifiers.
 // v15: Codex guardian approval-review rollouts are excluded from persisted events.
-export const SCHEMA_VERSION = 15;
+// v16: Codex current-format subagent linkage and structured tool outputs change
+//      derived tool errors/file edits, so unchanged normalized rows must rebuild.
+export const SCHEMA_VERSION = 16;
 
 /** All DDL statements, executed in order at startup. Idempotent. */
 export const SCHEMA_DDL: readonly string[] = [

--- a/packages/server/test/api.integration.test.ts
+++ b/packages/server/test/api.integration.test.ts
@@ -53,7 +53,7 @@ function writeFixtures(): string[] {
       { type: 'ai-title', sessionId: 'sessA', aiTitle: 'Session A' },
       { ...baseA, type: 'user', uuid: 'u1', parentUuid: null, timestamp: '2026-01-01T10:00:00.000Z', isSidechain: false, message: { role: 'user', content: 'please find the needle in this haystack' } },
       { ...baseA, type: 'assistant', uuid: 'a1', parentUuid: 'u1', timestamp: '2026-01-01T10:00:05.000Z', isSidechain: false, message: { role: 'assistant', model: 'claude-opus-4-8', content: [{ type: 'thinking', thinking: '', signature: 's' }, { type: 'text', text: 'on it' }], usage: { input_tokens: 100, output_tokens: 50, cache_read_input_tokens: 10, cache_creation_input_tokens: 5 } } },
-      { ...baseA, type: 'assistant', uuid: 'a2', parentUuid: 'a1', timestamp: '2026-01-01T10:00:10.000Z', isSidechain: false, message: { role: 'assistant', model: 'claude-opus-4-8', content: [{ type: 'tool_use', id: 'tu_agent', name: 'Agent', input: { description: 'Explore the code', subagent_type: 'Explore' } }], usage: { input_tokens: 20, output_tokens: 10 } } },
+      { ...baseA, type: 'assistant', uuid: 'a2', parentUuid: 'a1', timestamp: '2026-01-01T10:00:10.000Z', isSidechain: false, message: { role: 'assistant', model: 'claude-opus-4-8', content: [{ type: 'tool_use', id: 'tu_agent', name: 'Agent', input: { description: 'Explore the code', subagent_type: 'Explore', prompt: 'explore please' } }, { type: 'tool_use', id: 'tu_prompt', name: 'Task', input: { description: 'Inspect fallback', subagent_type: 'Explore', prompt: 'inspect through exact prompt\nwith full details' } }], usage: { input_tokens: 20, output_tokens: 10 } } },
       { ...baseA, type: 'user', uuid: 'u2', parentUuid: 'a2', timestamp: '2026-01-01T10:00:30.000Z', isSidechain: false, message: { role: 'user', content: [{ type: 'tool_result', tool_use_id: 'tu_agent', content: 'exploration finished' }] } },
       { ...baseA, type: 'assistant', uuid: 'a3', parentUuid: 'u2', timestamp: '2026-01-01T10:00:35.000Z', isSidechain: false, message: { role: 'assistant', model: 'claude-opus-4-8', content: [{ type: 'tool_use', id: 'tu_wf', name: 'Workflow', input: { script: '...' } }], usage: { input_tokens: 30, output_tokens: 15 } } },
       { ...baseA, type: 'user', uuid: 'u3', parentUuid: 'a3', timestamp: '2026-01-01T10:02:00.000Z', isSidechain: false, message: { role: 'user', content: [{ type: 'tool_result', tool_use_id: 'tu_wf', content: 'Workflow launched. Run ID: wf_int1 — done.' }] } },
@@ -74,6 +74,13 @@ function writeFixtures(): string[] {
     { ...subBase, type: 'assistant', uuid: 'sa-a1', parentUuid: 'sa-u1', agentId: 'aaaa', timestamp: '2026-01-01T10:00:20.000Z', message: { role: 'assistant', model: 'claude-opus-4-8', content: [{ type: 'tool_use', id: 'g1', name: 'Grep', input: {} }], usage: { input_tokens: 40, output_tokens: 20 } } },
   ]));
   writeFileSync(join(subA, 'agent-aaaa.meta.json'), JSON.stringify({ agentType: 'Explore', description: 'Explore the code' }));
+
+  // Missing metadata: correlates by its complete first prompt instead.
+  const agentP = join(subA, 'agent-pppp.jsonl');
+  writeFileSync(agentP, jsonl([
+    { ...subBase, type: 'user', uuid: 'sp-u1', parentUuid: null, agentId: 'pppp', timestamp: '2026-01-01T10:00:13.000Z', message: { role: 'user', content: 'inspect through exact prompt\nwith full details' } },
+    { ...subBase, type: 'assistant', uuid: 'sp-a1', parentUuid: 'sp-u1', agentId: 'pppp', timestamp: '2026-01-01T10:00:21.000Z', message: { role: 'assistant', model: 'claude-opus-4-8', content: [{ type: 'text', text: 'inspected' }], usage: { input_tokens: 15, output_tokens: 5 } } },
+  ]));
 
   // Workflow-spawned subagent (correlates by run id, no meta description).
   const agentW = join(wfA, 'agent-wwww.jsonl');
@@ -97,7 +104,7 @@ function writeFixtures(): string[] {
   ];
   writeFileSync(sessB, sessBLines.join('\n') + '\n');
 
-  return [sessA, agentA, join(subA, 'agent-aaaa.meta.json'), agentW, join(wfA, 'agent-wwww.meta.json'), sessB];
+  return [sessA, agentA, join(subA, 'agent-aaaa.meta.json'), agentP, agentW, join(wfA, 'agent-wwww.meta.json'), sessB];
 }
 
 let app: FastifyInstance;
@@ -187,13 +194,17 @@ describe('GET /api/sessions/:id', () => {
     expect(detail.thread.every((t: { isSidechain: boolean }) => !t.isSidechain)).toBe(true);
   });
 
-  it('returns subagents linked to their spawn points (Agent + Workflow)', async () => {
+  it('returns subagents linked to their spawn points (Agent + Task + Workflow)', async () => {
     const detail = (await get('/api/sessions/sessA')).json();
-    expect(detail.subagents).toHaveLength(2);
+    expect(detail.subagents).toHaveLength(3);
 
     const explore = detail.subagents.find((s: { agentType: string }) => s.agentType === 'Explore');
     expect(explore.toolUseId).toBe('tu_agent');
     expect(explore.description).toBe('Explore the code');
+
+    const promptFallback = detail.subagents.find((s: { agentId: string }) => s.agentId === 'pppp');
+    expect(promptFallback.toolUseId).toBe('tu_prompt');
+    expect(promptFallback.description).toBe('inspect through exact prompt');
 
     const wf = detail.subagents.find((s: { agentType: string }) => s.agentType === 'workflow-subagent');
     expect(wf.toolUseId).toBe('tu_wf');
@@ -223,7 +234,7 @@ describe('GET /api/sessions/:id — windowing (agent/CLI consumers)', () => {
   it('no windowing params → full thread and no window object (the web path)', async () => {
     const detail = (await get('/api/sessions/sessA')).json();
     expect(detail.window).toBeUndefined();
-    expect(detail.subagents).toHaveLength(2);
+    expect(detail.subagents).toHaveLength(3);
   });
 
   it('windows around a uuid and keeps only subagents spawned inside the slice', async () => {

--- a/packages/server/test/codex.integration.test.ts
+++ b/packages/server/test/codex.integration.test.ts
@@ -88,14 +88,33 @@ function writeRollout(): string {
       // Single-file patch: block keeps the bare call_id and the result is the
       // envelope-stripped tool output.
       { type: 'response_item', timestamp: ts(22), payload: { type: 'custom_tool_call', name: 'apply_patch', call_id: 'call_ap2', input: '*** Begin Patch\n*** Update File: /tmp/codexproj/single.ts\n@@\n-a\n+b\n*** End Patch' } },
-      { type: 'response_item', timestamp: ts(23), payload: { type: 'custom_tool_call_output', call_id: 'call_ap2', output: 'Exit code: 0\nWall time: 0.0 seconds\nOutput:\nSuccess. Updated the following files:\nM /tmp/codexproj/single.ts' } },
+      { type: 'response_item', timestamp: ts(23), payload: { type: 'custom_tool_call_output', call_id: 'call_ap2', output: [
+        { type: 'input_text', text: 'Exit code: 0\nWall time: 0.0 seconds\nOutput:\n' },
+        { type: 'input_text', text: 'Success. Updated the following files:\nM /tmp/codexproj/single.ts' },
+      ] } },
       // web_search_call has no call_id and no paired output record.
       { type: 'response_item', timestamp: ts(24), payload: { type: 'web_search_call', status: 'completed', action: { type: 'search', query: 'codex docs' } } },
       // A REJECTED two-file patch (non-zero exit): nothing on disk changed, so the
       // fanned canonical blocks must demote back to raw apply_patch (no file_path)
       // and the real error text must survive on every result.
       { type: 'response_item', timestamp: ts(25), payload: { type: 'custom_tool_call', name: 'apply_patch', call_id: 'call_ap3', input: '*** Begin Patch\n*** Update File: /tmp/codexproj/missing.ts\n@@\n-x\n+y\n*** Update File: /tmp/codexproj/other.ts\n@@\n-p\n+q\n*** End Patch' } },
-      { type: 'response_item', timestamp: ts(26), payload: { type: 'custom_tool_call_output', call_id: 'call_ap3', output: 'Exit code: 1\nWall time: 0.0 seconds\nOutput:\napply_patch: /tmp/codexproj/missing.ts: No such file or directory' } },
+      { type: 'response_item', timestamp: ts(26), payload: { type: 'custom_tool_call_output', call_id: 'call_ap3', output: [
+        { type: 'input_text', text: 'Exit code: 1\nWall time: 0.0 seconds\nOutput:\n' },
+        { type: 'input_text', text: 'apply_patch: /tmp/codexproj/missing.ts: No such file or directory' },
+      ] } },
+      // Current Codex spawn format: task_name is readable while the message may
+      // be opaque; the output's canonical path matches the child's agent_path.
+      { type: 'response_item', timestamp: ts(27), payload: { type: 'function_call', name: 'spawn_agent', namespace: 'collaboration', arguments: '{"agent_type":"context_explorer","fork_turns":"all","message":"encrypted-task-payload","task_name":"locate_analytics_range"}', call_id: 'call_spawn2' } },
+      { type: 'response_item', timestamp: ts(28), payload: { type: 'function_call_output', call_id: 'call_spawn2', output: '{"task_name":"/root/locate_analytics_range"}' } },
+      // Current custom outputs are arrays of ordered input_text items. An exec
+      // result must concatenate them, while an unfamiliar item remains visible.
+      { type: 'response_item', timestamp: ts(29), payload: { type: 'custom_tool_call', name: 'exec', call_id: 'call_exec_current', input: 'const result = await tools.exec_command({ cmd: "pwd" }); text(result.output);' } },
+      { type: 'response_item', timestamp: ts(30), payload: { type: 'custom_tool_call_output', call_id: 'call_exec_current', output: [
+        { type: 'input_text', text: 'Script completed\nWall time: 0.1 seconds\nOutput:\n' },
+        { type: 'input_text', text: '/tmp/codexproj\n' },
+      ] } },
+      { type: 'response_item', timestamp: ts(31), payload: { type: 'custom_tool_call', name: 'future_tool', call_id: 'call_unknown_output', input: 'opaque input' } },
+      { type: 'response_item', timestamp: ts(32), payload: { type: 'custom_tool_call_output', call_id: 'call_unknown_output', output: [{ type: 'future_content', value: 'must-not-vanish' }] } },
     ]),
   );
   return file;
@@ -115,6 +134,23 @@ function writeChildRollout(): string {
       { type: 'response_item', timestamp: ts(33), payload: { type: 'message', role: 'assistant', content: [{ type: 'output_text', text: 'zebranugget report from the child' }] } },
       // Child usage folds into the parent session's totals (claude-code precedent).
       { type: 'event_msg', timestamp: ts(34), payload: { type: 'token_count', info: { last_token_usage: { input_tokens: 100, cached_input_tokens: 0, output_tokens: 50 } }, rate_limits: {} } },
+    ]),
+  );
+  return file;
+}
+
+/** A current-format child correlated by canonical agent_path, not its thread id. */
+function writeCurrentChildRollout(): string {
+  const dir = join(codexDir, '2026', '01', '01');
+  mkdirSync(dir, { recursive: true });
+  const file = join(dir, 'rollout-2026-01-01T10-02-00-019f2222-aaaa-7bbb-8ccc-000000000002.jsonl');
+  writeFileSync(
+    file,
+    jsonl([
+      { type: 'session_meta', timestamp: ts(35), payload: { id: '019f2222-aaaa-7bbb-8ccc-000000000002', cwd: '/tmp/codexproj', thread_source: 'subagent', source: { subagent: { thread_spawn: { parent_thread_id: 'codex-sess-1', depth: 1, agent_path: '/root/locate_analytics_range', agent_nickname: 'Cartographer', agent_role: 'context_explorer' } } }, git: { branch: 'main' } } },
+      { type: 'turn_context', timestamp: ts(36), payload: { model: 'gpt-5.4' } },
+      { type: 'response_item', timestamp: ts(37), payload: { type: 'message', role: 'user', content: [{ type: 'input_text', text: 'copied parent context, not the task label' }] } },
+      { type: 'response_item', timestamp: ts(38), payload: { type: 'message', role: 'assistant', content: [{ type: 'output_text', text: 'current-format child report' }] } },
     ]),
   );
   return file;
@@ -170,6 +206,7 @@ beforeAll(async () => {
   mkdirSync(claudeDir, { recursive: true });
   writeRollout();
   writeChildRollout();
+  writeCurrentChildRollout();
   writeOrphanRollout();
   writeLocalRollout();
 
@@ -331,8 +368,10 @@ describe('Codex session detail', () => {
       subagent_type: 'explorer',
     });
 
-    expect(detail.subagents).toHaveLength(1);
-    const run = detail.subagents[0];
+    expect(detail.subagents).toHaveLength(2);
+    const run = detail.subagents.find(
+      (candidate: { agentId: string }) => candidate.agentId === '019f2222-aaaa-7bbb-8ccc-000000000001',
+    );
     expect(run).toMatchObject({
       agentId: '019f2222-aaaa-7bbb-8ccc-000000000001',
       agentType: 'explorer',
@@ -346,6 +385,24 @@ describe('Codex session detail', () => {
     // wait_agent is not a spawn — it stays under its raw name.
     const wait = flat.find((b: Record<string, unknown>) => b.id === 'call_wait1');
     expect(wait.name).toBe('wait_agent');
+
+    // Current format links by output task_name ↔ child agent_path, while the
+    // canonical task path replaces the opaque message as the readable label.
+    const currentTask = flat.find((b: Record<string, unknown>) => b.id === 'call_spawn2');
+    expect(currentTask).toMatchObject({ name: 'Task' });
+    expect(currentTask.input).toMatchObject({
+      description: '/root/locate_analytics_range',
+      subagent_type: 'context_explorer',
+    });
+    const currentRun = detail.subagents.find(
+      (candidate: { agentId: string }) => candidate.agentId === '019f2222-aaaa-7bbb-8ccc-000000000002',
+    );
+    expect(currentRun).toMatchObject({
+      agentType: 'context_explorer',
+      description: '/root/locate_analytics_range',
+      toolUseId: 'call_spawn2',
+    });
+    expect(JSON.stringify(currentRun.thread)).toContain('current-format child report');
   });
 
   it('fans apply_patch out to canonical Write/Edit blocks the changeset keys off', async () => {
@@ -380,6 +437,15 @@ describe('Codex session detail', () => {
     expect(search.result).toBeTruthy();
     const web = flat.find((b: Record<string, unknown>) => b.name === 'web_search');
     expect((web.input as { query: string }).query).toBe('codex docs');
+
+    const currentExec = flat.find((b: Record<string, unknown>) => b.id === 'call_exec_current');
+    expect(currentExec.result.content[0].text).toBe(
+      'Script completed\nWall time: 0.1 seconds\nOutput:\n/tmp/codexproj\n',
+    );
+
+    const unknown = flat.find((b: Record<string, unknown>) => b.id === 'call_unknown_output');
+    expect(unknown.result.content[0].text).toContain('future_content');
+    expect(unknown.result.content[0].text).toContain('must-not-vanish');
   });
 
   it('demotes a REJECTED apply_patch to raw blocks so Files-changed never sees it', async () => {

--- a/packages/server/test/parser.test.ts
+++ b/packages/server/test/parser.test.ts
@@ -153,7 +153,11 @@ function mainThreadWithSpawns(): ThreadItem[] {
           kind: 'tool',
           id: 'tu_agent',
           name: 'Agent',
-          input: { description: 'Explore X', subagent_type: 'Explore' },
+          input: {
+            description: 'Explore X',
+            subagent_type: 'Explore',
+            prompt: 'Investigate the complete prompt\nincluding every detail.',
+          },
         },
         {
           kind: 'tool',
@@ -192,6 +196,20 @@ describe('buildSubagentRuns', () => {
     expect(run?.spawnUuid).toBe('m1');
   });
 
+  it('prefers an exact tool id over mismatched description and prompt metadata', () => {
+    const [run] = buildSubagentRuns(mainThreadWithSpawns(), [
+      source({
+        agentId: 'a',
+        agentType: 'Other',
+        description: 'stale description',
+        prompt: 'stale prompt',
+        toolUseId: 'tu_agent',
+      }),
+    ]);
+    expect(run?.toolUseId).toBe('tu_agent');
+    expect(run?.spawnUuid).toBe('m1');
+  });
+
   it('falls back to description-only when type differs', () => {
     const [run] = buildSubagentRuns(mainThreadWithSpawns(), [
       source({ agentId: 'a', agentType: 'general-purpose', description: 'Explore X' }),
@@ -209,6 +227,68 @@ describe('buildSubagentRuns', () => {
   it('does NOT link a run whose description matches nothing', () => {
     const [run] = buildSubagentRuns(mainThreadWithSpawns(), [
       source({ agentId: 'a', description: 'totally different' }),
+    ]);
+    expect(run?.toolUseId).toBeUndefined();
+  });
+
+  it('falls back to a unique exact full prompt when description metadata is stale', () => {
+    const [run] = buildSubagentRuns(mainThreadWithSpawns(), [
+      source({
+        agentId: 'a',
+        agentType: 'Explore',
+        description: 'stale description',
+        prompt: 'Investigate the complete prompt\nincluding every detail.',
+      }),
+    ]);
+    expect(run?.toolUseId).toBe('tu_agent');
+  });
+
+  it('uses subagent type to narrow otherwise-identical prompt matches', () => {
+    const main: ThreadItem[] = [
+      {
+        uuid: 'm1',
+        parentUuid: null,
+        role: 'assistant',
+        timestamp: ts(),
+        isSidechain: false,
+        blocks: [
+          {
+            kind: 'tool',
+            id: 'tu_explore',
+            name: 'Task',
+            input: { prompt: 'same prompt', subagent_type: 'Explore' },
+          },
+          {
+            kind: 'tool',
+            id: 'tu_plan',
+            name: 'Task',
+            input: { prompt: 'same prompt', subagent_type: 'Plan' },
+          },
+        ],
+      },
+    ];
+    const [run] = buildSubagentRuns(main, [
+      source({ agentId: 'a', agentType: 'Plan', prompt: 'same prompt' }),
+    ]);
+    expect(run?.toolUseId).toBe('tu_plan');
+  });
+
+  it('does NOT guess when an exact prompt matches multiple unused spawns', () => {
+    const main: ThreadItem[] = [
+      {
+        uuid: 'm1',
+        parentUuid: null,
+        role: 'assistant',
+        timestamp: ts(),
+        isSidechain: false,
+        blocks: [
+          { kind: 'tool', id: 'tu1', name: 'Task', input: { prompt: 'same prompt' } },
+          { kind: 'tool', id: 'tu2', name: 'Task', input: { prompt: 'same prompt' } },
+        ],
+      },
+    ];
+    const [run] = buildSubagentRuns(main, [
+      source({ agentId: 'a', prompt: 'same prompt' }),
     ]);
     expect(run?.toolUseId).toBeUndefined();
   });

--- a/packages/web/src/pages/session/ThreadView.tsx
+++ b/packages/web/src/pages/session/ThreadView.tsx
@@ -4,7 +4,12 @@ import type { SubagentRun, ThreadBlock, ThreadItem } from '@claudescope/shared';
 import { ClampedText, Collapsible, ErrorBoundary, ErrorBox, TokenChips } from '../../components';
 import { formatDateTime, shortModel } from '../browse/format.js';
 import { ThreadBlockView, hasRenderableContent } from './blocks.js';
-import { classifySystemText, parseCommandTurn, type CommandTurn } from './text.js';
+import {
+  classifySystemText,
+  isInheritedCodexContext,
+  parseCommandTurn,
+  type CommandTurn,
+} from './text.js';
 import { SessionSearchContext } from './SearchContext.js';
 import { blockRevealId } from './search.js';
 
@@ -149,7 +154,14 @@ function turnText(item: ThreadItem): string {
 function classifySystemTurn(item: ThreadItem): string | null {
   // Only plain-text turns (no tools/attachments) qualify.
   if (item.blocks.some((b) => b.kind === 'tool' || b.kind === 'attachment')) return null;
-  return classifySystemText(turnText(item));
+  const text = turnText(item);
+  if (
+    item.blocks.every((block) => block.kind === 'text') &&
+    isInheritedCodexContext(text, item.isSidechain)
+  ) {
+    return 'Inherited parent context';
+  }
+  return classifySystemText(text);
 }
 
 /** Compact, collapsed-by-default rendering for a harness/system user turn. */

--- a/packages/web/src/pages/session/text.ts
+++ b/packages/web/src/pages/session/text.ts
@@ -92,6 +92,15 @@ export function splitCodexSessionContext(text: string): CodexSessionContext | nu
   };
 }
 
+/**
+ * Whether a sidechain user turn starts with a complete Codex startup envelope
+ * copied from its parent. Top-level and malformed turns fail closed so genuine
+ * user prose keeps its normal presentation.
+ */
+export function isInheritedCodexContext(text: string, isSidechain: boolean): boolean {
+  return isSidechain && splitCodexSessionContext(text) !== null;
+}
+
 /** Leading tags that mark a user turn as harness/system-injected, not a person. */
 export const SYSTEM_TURN_TAGS: { tag: string; label: string }[] = [
   { tag: '<task-notification>', label: 'Task notification' },

--- a/packages/web/test/text.test.ts
+++ b/packages/web/test/text.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import {
   classifySystemText,
+  isInheritedCodexContext,
   parseCommandTurn,
   stripAnsi,
   stripImageMarkers,
@@ -47,6 +48,43 @@ describe('classifySystemText', () => {
   it('returns null for ordinary user text', () => {
     expect(classifySystemText('please fix the bug')).toBeNull();
     expect(classifySystemText('here is some <html> in my message')).toBeNull();
+  });
+});
+
+describe('isInheritedCodexContext', () => {
+  const inheritedTurn = `# AGENTS.md instructions for /repo
+
+<INSTRUCTIONS>
+Parent instructions
+</INSTRUCTIONS>
+<environment_context>
+  <cwd>/repo</cwd>
+</environment_context>
+
+Original parent prompt`;
+
+  it('classifies a complete Codex startup envelope on a sidechain', () => {
+    expect(isInheritedCodexContext(inheritedTurn, true)).toBe(true);
+  });
+
+  it('leaves the same startup envelope unchanged on a top-level turn', () => {
+    expect(isInheritedCodexContext(inheritedTurn, false)).toBe(false);
+  });
+
+  it('leaves ordinary sidechain user prose unchanged', () => {
+    expect(isInheritedCodexContext('Please inspect the parser.', true)).toBe(false);
+  });
+
+  it('fails closed when a startup wrapper is incomplete', () => {
+    expect(
+      isInheritedCodexContext(
+        '# AGENTS.md instructions for /repo\n<INSTRUCTIONS>Parent instructions',
+        true,
+      ),
+    ).toBe(false);
+    expect(
+      isInheritedCodexContext('<environment_context><cwd>/repo</cwd>', true),
+    ).toBe(false);
   });
 });
 


### PR DESCRIPTION
## Summary

- link current and legacy Codex subagents deterministically to their spawning Task calls
- preserve array-shaped tool outputs and rejected apply_patch semantics
- add guarded Claude prompt fallback and collapse inherited Codex parent context

## Verification

- [x] Focused suite: 99 tests
- [x] Full suite: 623 tests
- [x] Typecheck
- [x] Production build
- [x] Sandboxed API and UI verification against the affected Codex session
- [x] Known-good Claude regression check

## Definition of done

- [x] Current task_name / agent_path and legacy agent_id formats are covered
- [x] Derived schema bumped to v16
- [x] Connector documentation updated
- [x] Implementation plan completed: [plan 0075](docs/plans/0075-reliable-subagent-linkage-and-codex-rendering.md)