### PR TITLE
fix: restore Codex session names

### DIFF
--- a/docs/plans/0076-restore-codex-session-naming.md
+++ b/docs/plans/0076-restore-codex-session-naming.md
@@ -1,0 +1,101 @@
+# 0076 — Restore Codex session naming
+
+- **Status:** done
+- **Date:** 2026-08-30
+- **PR:** https://github.com/vladar107/claudescope/pull/98
+
+## Context
+
+Codex still has no stored session title, so ClaudeScope derives one from the
+first genuine user prompt. The bootstrap recognizer currently requires the
+older heading `# AGENTS.md instructions for <path>`. Current rollouts can use
+`# AGENTS.md instructions` without a path; that wrapper is not stripped and
+recent sessions are consequently titled `AGENTS.md instructions`.
+
+The same format generation changed guardian approval-review metadata from
+`thread_source: "subagent"` to `thread_source: "guardian_review"` while retaining
+`source.subagent.other: "guardian"`. The current compound check misses those
+rollouts, so synthetic guardian reviews reappear as top-level sessions with
+prompt-like fallback titles.
+
+This work is intentionally separate from Codex tool/file-change normalization.
+It will use branch `fix/codex-session-names` and its own PR.
+
+## Goal
+
+Derive Codex session names from the first genuine user prompt for both observed
+bootstrap-heading variants, and exclude both legacy and current guardian review
+rollouts without changing transcript fidelity or normal subagent behavior.
+
+## Decisions
+
+- **Recognize only complete known bootstrap shapes** — accept the exact
+  `# AGENTS.md instructions` heading with an optional `for <path>` suffix only
+  when the expected instructions/environment envelopes are well formed. Do not
+  broadly classify arbitrary headings containing “instructions” as bootstrap.
+- **Keep title cleanup and candidate selection aligned** — update both the
+  injected-line cleaner and Codex-specific pre-ranking wrapper removal so a
+  bootstrap-only event is skipped and a coalesced real prompt remains eligible.
+- **Treat the guardian source marker as authoritative** —
+  `source.subagent.other: "guardian"` is stable across both observed
+  `thread_source` values. Filter on that structural marker instead of coupling
+  the exclusion to one generation's thread-source label.
+- **Preserve source records** — title logic changes only the derived title;
+  guardian filtering happens at normalization. No source transcript is edited.
+- **Rebuild derived data once** — advance to the next available schema version
+  at merge time so unchanged rollouts are re-normalized and stale titles and
+  guardian rows disappear.
+
+## Approach
+
+1. Broaden the exact Codex bootstrap-heading recognition in the fallback-title
+   cleaner and SQL candidate preprocessing while retaining complete-envelope
+   and malformed-input safeguards.
+2. Update Codex normalization to exclude a rollout whenever its structural
+   source metadata identifies it as a guardian, covering both legacy and
+   `guardian_review` records.
+3. Advance the derived schema version so installed indexes rebuild from source.
+4. Extend the existing focused title and Codex integration tests for the
+   pathless header, bootstrap-only and coalesced prompt forms, current guardian
+   metadata, and preservation of ordinary top-level/subagent sessions.
+5. Run focused and full validation, then verify the affected real-data shapes
+   read-only through an isolated ClaudeScope fixture/index.
+
+## Files affected
+
+- `packages/server/src/data/title.ts` — recognize the exact pathless Codex
+  bootstrap heading as injected context.
+- `packages/server/src/data/index.ts` — strip both complete Codex bootstrap
+  variants before ranking fallback-title candidates.
+- `packages/server/src/connectors/codex/normalize.ts` — exclude legacy and
+  current guardian review rollouts by their structural source marker.
+- `packages/server/src/db/schema.ts` — invalidate stale derived titles and
+  guardian rows.
+- `packages/server/test/title.test.ts` — focused heading-cleanup cases.
+- `packages/server/test/codex.integration.test.ts` — end-to-end title and
+  guardian-filter regression cases.
+- `docs/plans/0076-restore-codex-session-naming.md` — this plan.
+- `docs/plans/README.md` — plan index entry.
+
+## Testing
+
+- Focused:
+  `npx vitest run packages/server/test/title.test.ts packages/server/test/codex.integration.test.ts`
+- Full: `npm test`
+- Types: `npm run typecheck`
+- Production build: `npm run build`
+- Hygiene: `git diff --check`
+- Isolated verification: confirm affected sessions derive their genuine prompt
+  as the title, guardian IDs are absent, and normal Codex sessions/subagents
+  remain present. Never write to real Codex sources or `~/.claudescope`.
+
+## Risks / open questions
+
+- An overly loose heading match could hide genuine user prose. Requiring the
+  reserved first-line heading plus complete wrapper boundaries keeps the match
+  fail-closed.
+- This branch and plan 0077 both touch the Codex normalizer, schema version,
+  Codex integration fixture, and plan index. Implementation can proceed in
+  parallel worktrees, but the second PR to merge must rebase, resolve those
+  narrow overlaps, and advance the schema version again. Intended merge order:
+  plan 0076 first, then plan 0077.

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -100,3 +100,4 @@ decision, or a change worth explaining before doing. Skip it for one-line fixes.
 | 0073 | [Inclusive analytics end date](./0073-inclusive-analytics-end-date.md) | done |
 | 0074 | [Timezone-aware analytics](./0074-timezone-aware-analytics.md) | done |
 | 0075 | [Reliable subagent linkage and Codex transcript rendering](./0075-reliable-subagent-linkage-and-codex-rendering.md) | done |
+| 0076 | [Restore Codex session naming](./0076-restore-codex-session-naming.md) | done |

--- a/packages/server/src/connectors/codex/normalize.ts
+++ b/packages/server/src/connectors/codex/normalize.ts
@@ -506,10 +506,9 @@ export function parseRollout(path: string): CodexSession | null {
 
   const meta = lines.find((l) => l.type === 'session_meta')?.payload ?? {};
   const subagentSource = rec(rec(meta.source).subagent);
-  // Guardian rollouts contain Codex's synthetic approval-review transcript,
-  // not a user conversation. They have no thread_spawn linkage and otherwise
-  // fall through as top-level sessions whose history looks like one user turn.
-  if (str(meta.thread_source) === 'subagent' && str(subagentSource.other) === 'guardian') {
+  // The structural source marker is stable across Codex's legacy `subagent`
+  // and current `guardian_review` thread-source labels.
+  if (str(subagentSource.other) === 'guardian') {
     return null;
   }
   const sessionId = str(meta.id) || sessionIdFromPath(path);

--- a/packages/server/src/data/index.ts
+++ b/packages/server/src/data/index.ts
@@ -467,7 +467,10 @@ async function applyFallbackTitles(conn: DuckDBConnection): Promise<void> {
           *,
           CASE
             WHEN connector_id = 'codex'
-              AND starts_with(source, '# AGENTS.md instructions for ')
+              AND regexp_matches(
+                source,
+                '^# AGENTS\\.md instructions(?: for [^\\r\\n]+)?\\r?\\n[\\t\\r\\n ]*<INSTRUCTIONS>'
+              )
               AND instructions_start > 0
               AND instructions_end > instructions_start
             THEN substring(source, instructions_end + length('</INSTRUCTIONS>'))
@@ -482,13 +485,22 @@ async function applyFallbackTitles(conn: DuckDBConnection): Promise<void> {
           CASE
             WHEN instructions_remainder IS NOT NULL THEN
               CASE
-                WHEN starts_with(ltrim(instructions_remainder), '<environment_context>') THEN
+                WHEN starts_with(
+                  ltrim(instructions_remainder, chr(9) || chr(10) || chr(13) || ' '),
+                  '<environment_context>'
+                ) THEN
                   CASE
-                    WHEN strpos(ltrim(instructions_remainder), '</environment_context>')
+                    WHEN strpos(
+                      ltrim(instructions_remainder, chr(9) || chr(10) || chr(13) || ' '),
+                      '</environment_context>'
+                    )
                       > length('<environment_context>')
                     THEN substring(
-                      ltrim(instructions_remainder),
-                      strpos(ltrim(instructions_remainder), '</environment_context>')
+                      ltrim(instructions_remainder, chr(9) || chr(10) || chr(13) || ' '),
+                      strpos(
+                        ltrim(instructions_remainder, chr(9) || chr(10) || chr(13) || ' '),
+                        '</environment_context>'
+                      )
                         + length('</environment_context>')
                     )
                     ELSE text_content

--- a/packages/server/src/data/title.ts
+++ b/packages/server/src/data/title.ts
@@ -4,7 +4,8 @@
  * Codex and pi sessions store no title (and a Claude session may never have
  * been auto-titled), so the indexer falls back to the session's first eligible
  * user message. That raw message is often markup or a tool-injected blob — a
- * leading `# AGENTS.md instructions for /…` heading, an
+ * leading `# AGENTS.md instructions` heading (optionally followed by
+ * `for /…`), an
  * `<INSTRUCTIONS>…</INSTRUCTIONS>` wrapper, system reminders — which makes an
  * ugly, leaky title.
  *
@@ -51,7 +52,8 @@ function isSyntheticTurn(raw: string): boolean {
  * actually asked, not the harness scaffolding wrapped around it.
  */
 const INJECTED_LINE = [
-  /^#{1,6}\s*\S.*\b(instructions?|guidelines?)\b.*\bfor\b/i, // "# AGENTS.md instructions for /…"
+  /^# AGENTS\.md instructions(?: for .+)?$/i,
+  /^#{1,6}\s*\S.*\b(instructions?|guidelines?)\b.*\bfor\b/i,
   /^<\/?[a-z][\w-]*>?$/i, // a lone XML-ish tag line: <INSTRUCTIONS> or </INSTRUCTIONS>
   /^<(system|system-reminder|instructions?|context|user[_-]instructions?)\b/i, // opening blob tag
   /^(system reminder|caveat|important):/i, // common injected preambles

--- a/packages/server/src/db/schema.ts
+++ b/packages/server/src/db/schema.ts
@@ -37,7 +37,9 @@
 // v15: Codex guardian approval-review rollouts are excluded from persisted events.
 // v16: Codex current-format subagent linkage and structured tool outputs change
 //      derived tool errors/file edits, so unchanged normalized rows must rebuild.
-export const SCHEMA_VERSION = 16;
+// v17: Codex pathless bootstrap headings and current guardian-review rollouts
+//      change persisted fallback titles and indexed sessions.
+export const SCHEMA_VERSION = 17;
 
 /** All DDL statements, executed in order at startup. Idempotent. */
 export const SCHEMA_DDL: readonly string[] = [

--- a/packages/server/test/codex.integration.test.ts
+++ b/packages/server/test/codex.integration.test.ts
@@ -34,6 +34,15 @@ process.env.REINDEX_INTERVAL_MS = '0';
 
 const jsonl = (events: unknown[]): string => events.map((e) => JSON.stringify(e)).join('\n') + '\n';
 const ts = (s: number) => `2026-01-01T10:00:${String(s).padStart(2, '0')}.000Z`;
+const pathlessBootstrap = [
+  '# AGENTS.md instructions',
+  '<INSTRUCTIONS>',
+  'Follow the repository guide.',
+  '</INSTRUCTIONS>',
+  '<environment_context>',
+  '  <cwd>/tmp/codexproj</cwd>',
+  '</environment_context>',
+].join('\n');
 
 /** Write one synthetic rollout under codex/YYYY/MM/DD/. */
 function writeRollout(): string {
@@ -52,7 +61,7 @@ function writeRollout(): string {
         // redundant `<image …>` placeholder text item that must be dropped.
         { type: 'input_text', text: '<image name=[Image #1] path="/var/tmp/codex-clipboard-xyz.png">' },
         { type: 'input_image', image_url: 'data:image/png;base64,iVBORw0KGgoAAAANS' },
-        { type: 'input_text', text: 'find the needle in this codex haystack' },
+        { type: 'input_text', text: `${pathlessBootstrap}\nfind the needle in this codex haystack` },
       ] } },
       { type: 'response_item', timestamp: ts(3), payload: { type: 'reasoning', summary: [], content: null, encrypted_content: 'enc-abc' } },
       { type: 'response_item', timestamp: ts(4), payload: { type: 'function_call', name: 'exec_command', arguments: '{"cmd":"ls -la"}', call_id: 'call_1' } },
@@ -199,6 +208,63 @@ function writeLocalRollout(): string {
   return file;
 }
 
+/** A pathless bootstrap-only turn followed by the genuine user prompt. */
+function writeBootstrapOnlyRollout(): string {
+  const dir = join(codexDir, '2026', '01', '04');
+  mkdirSync(dir, { recursive: true });
+  const file = join(dir, 'rollout-2026-01-04T09-00-00-019f5555-aaaa-7bbb-8ccc-000000000004.jsonl');
+  writeFileSync(
+    file,
+    jsonl([
+      { type: 'session_meta', timestamp: ts(0), payload: { id: 'codex-title-next', cwd: '/tmp/codexproj' } },
+      { type: 'turn_context', timestamp: ts(1), payload: { model: 'gpt-5.4' } },
+      { type: 'response_item', timestamp: ts(2), payload: { type: 'message', role: 'user', content: [{ type: 'input_text', text: pathlessBootstrap }] } },
+      { type: 'response_item', timestamp: ts(3), payload: { type: 'message', role: 'assistant', content: [{ type: 'output_text', text: 'ready' }] } },
+      { type: 'response_item', timestamp: ts(4), payload: { type: 'message', role: 'user', content: [{ type: 'input_text', text: 'name this session from the genuine prompt' }] } },
+      { type: 'response_item', timestamp: ts(5), payload: { type: 'message', role: 'assistant', content: [{ type: 'output_text', text: 'done' }] } },
+    ]),
+  );
+  return file;
+}
+
+/** A malformed bootstrap must pass through instead of swallowing source text. */
+function writeMalformedBootstrapRollout(): string {
+  const dir = join(codexDir, '2026', '01', '05');
+  mkdirSync(dir, { recursive: true });
+  const file = join(dir, 'rollout-2026-01-05T09-00-00-019f6666-aaaa-7bbb-8ccc-000000000005.jsonl');
+  writeFileSync(
+    file,
+    jsonl([
+      { type: 'session_meta', timestamp: ts(0), payload: { id: 'codex-title-malformed', cwd: '/tmp/codexproj' } },
+      { type: 'turn_context', timestamp: ts(1), payload: { model: 'gpt-5.4' } },
+      { type: 'response_item', timestamp: ts(2), payload: { type: 'message', role: 'user', content: [{ type: 'input_text', text: '# AGENTS.md instructions\n<INSTRUCTIONS>\nKeep this incomplete wrapper visible' }] } },
+      { type: 'response_item', timestamp: ts(2), payload: { type: 'message', role: 'assistant', content: [{ type: 'output_text', text: 'acknowledged' }] } },
+      { type: 'response_item', timestamp: ts(3), payload: { type: 'message', role: 'user', content: [{ type: 'input_text', text: 'do not skip to this later prompt' }] } },
+    ]),
+  );
+  return file;
+}
+
+/** Guardian approval reviews are internal regardless of thread-source generation. */
+function writeGuardianRollouts(): void {
+  const dir = join(codexDir, '2026', '01', '06');
+  mkdirSync(dir, { recursive: true });
+  const variants = [
+    ['codex-guardian-legacy', 'subagent'],
+    ['codex-guardian-current', 'guardian_review'],
+  ] as const;
+  for (const [id, threadSource] of variants) {
+    const file = join(dir, `rollout-2026-01-06T09-00-00-${id}.jsonl`);
+    writeFileSync(
+      file,
+      jsonl([
+        { type: 'session_meta', timestamp: ts(0), payload: { id, cwd: '/tmp/codexproj', thread_source: threadSource, source: { subagent: { other: 'guardian' } } } },
+        { type: 'response_item', timestamp: ts(1), payload: { type: 'message', role: 'user', content: [{ type: 'input_text', text: 'Review this command for approval.' }] } },
+      ]),
+    );
+  }
+}
+
 let app: FastifyInstance;
 let closeConnection: () => Promise<void>;
 
@@ -209,6 +275,9 @@ beforeAll(async () => {
   writeCurrentChildRollout();
   writeOrphanRollout();
   writeLocalRollout();
+  writeBootstrapOnlyRollout();
+  writeMalformedBootstrapRollout();
+  writeGuardianRollouts();
 
   const Fastify = (await import('fastify')).default;
   const { registerRoutes } = await import('../src/routes/index.js');
@@ -234,7 +303,13 @@ describe('Codex session indexing', () => {
     const sessions = (await get('/api/sessions')).json();
     // The child rollout folds into its parent (never its own session); the orphan
     // child indexes under its absent root id `codex-gone`.
-    expect(sessions.map((s: { id: string }) => s.id).sort()).toEqual(['codex-gone', 'codex-local-1', 'codex-sess-1']);
+    expect(sessions.map((s: { id: string }) => s.id).sort()).toEqual([
+      'codex-gone',
+      'codex-local-1',
+      'codex-sess-1',
+      'codex-title-malformed',
+      'codex-title-next',
+    ]);
     const main = sessions.find((s: { id: string }) => s.id === 'codex-sess-1');
     expect(main.models).toContain('gpt-5.4');
     expect(main.connectorId).toBe('codex');
@@ -244,6 +319,29 @@ describe('Codex session indexing', () => {
     expect(main.titleDerived).toBe(true);
     // The re-keyed subagent rollout flips the parent's sidechain flag.
     expect(main.hasSidechain).toBe(true);
+  });
+
+  it('uses the first genuine prompt after a pathless bootstrap-only turn', async () => {
+    const sessions = (await get('/api/sessions')).json();
+    const session = sessions.find((s: { id: string }) => s.id === 'codex-title-next');
+    expect(session.title).toBe('name this session from the genuine prompt');
+    expect(session.titleDerived).toBe(true);
+  });
+
+  it('keeps malformed pathless bootstrap content eligible', async () => {
+    const sessions = (await get('/api/sessions')).json();
+    const session = sessions.find((s: { id: string }) => s.id === 'codex-title-malformed');
+    expect(session.title).toBe('Keep this incomplete wrapper visible');
+  });
+
+  it('filters legacy and current guardian reviews without hiding ordinary sessions', async () => {
+    const sessions = (await get('/api/sessions')).json();
+    const ids = sessions.map((s: { id: string }) => s.id);
+    expect(ids).toContain('codex-sess-1');
+    expect(ids).toContain('codex-gone');
+    expect(ids).not.toContain('codex-guardian-legacy');
+    expect(ids).not.toContain('codex-guardian-current');
+    expect((await get('/api/sessions/codex-guardian-current')).statusCode).toBe(404);
   });
 
   it('tags the project with its agent and groups analytics by agent', async () => {

--- a/packages/server/test/title.test.ts
+++ b/packages/server/test/title.test.ts
@@ -34,6 +34,25 @@ describe('cleanFallbackTitle', () => {
     expect(cleanFallbackTitle(raw)).toBe('Please add a fallback title cleaner');
   });
 
+  it('skips the pathless Codex instructions heading', () => {
+    const raw = [
+      '# AGENTS.md instructions',
+      '<INSTRUCTIONS>',
+      '</INSTRUCTIONS>',
+      'Restore the real session name',
+    ].join('\n');
+    expect(cleanFallbackTitle(raw)).toBe('Restore the real session name');
+  });
+
+  it('does not broadly classify other instruction headings as injected', () => {
+    expect(cleanFallbackTitle('# Project instructions\nKeep this heading visible')).toBe(
+      'Project instructions',
+    );
+    expect(cleanFallbackTitle('# Project instructions for /tmp\nKeep the real prompt')).toBe(
+      'Keep the real prompt',
+    );
+  });
+
   it('skips lone wrapper tag lines and system-reminder preambles', () => {
     const raw = [
       '<system-reminder>',


### PR DESCRIPTION
## Summary

- recognize current pathless Codex AGENTS bootstrap headings while preserving malformed input
- filter both legacy and current guardian review rollouts by their stable source marker
- rebuild derived indexes and cover title selection and guardian filtering with focused regressions

## Plan

[0076 — Restore Codex session naming](docs/plans/0076-restore-codex-session-naming.md)

## Done

- [x] focused title and Codex integration tests
- [x] full test suite (628 tests)
- [x] typecheck and production build
- [x] isolated API verification against scratch-only Codex fixtures