### PR TITLE
fix: detect nested Codex file changes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -161,9 +161,12 @@ The CLI `update` command (`cli.ts`) detects the install method and defers to
   `function_call_output` / `custom_tool_call_output` may carry either one string
   or an ordered text-item array; decode the latter before envelope/error parsing
   and keep unknown structured items visible. Direct `apply_patch` calls arrive as
-  `custom_tool_call` records (NOT `function_call`) → parsed V4A envelopes fan out
-  to canonical `Write`/`MultiEdit` per file; rejected patches demote back to raw
-  calls so the Files-changed tab never reports edits that did not happen.
+  `custom_tool_call` records (NOT `function_call`); current Codex may instead
+  wrap one static `tools.apply_patch` call in the JavaScript `exec` custom tool.
+  Both forms parse V4A envelopes and fan out to canonical `Write`/`MultiEdit`
+  per file. Dynamic/ambiguous wrappers stay raw, and rejected or unconfirmed
+  patches demote back to raw calls so Files changed never reports edits that did
+  not happen.
 - **Claude Code subagent correlation** — prefer direct connector linkage when
   available, then metadata-backed description/type matching. If sibling metadata
   is absent or drifted, the shared parser may fall back to an exact full match

--- a/docs/plans/0077-restore-codex-file-change-detection.md
+++ b/docs/plans/0077-restore-codex-file-change-detection.md
@@ -1,0 +1,114 @@
+# 0077 — Restore Codex file-change detection
+
+- **Status:** done
+- **Date:** 2026-08-30
+- **PR:** https://github.com/vladar107/claudescope/pull/99
+
+## Context
+
+ClaudeScope already converts a direct Codex `custom_tool_call` named
+`apply_patch` into canonical `Write`/`Edit`/`MultiEdit` blocks. The shared
+changeset collector and index-time `file_edits` extraction then provide the web
+Files changed view and impact analytics.
+
+Current Codex rollouts instead expose one outer `custom_tool_call` named `exec`.
+Its JavaScript input invokes a nested tool using the generated form
+`const patch = "..."; text(await tools.apply_patch(patch));`. The normalizer
+treats the outer call as an opaque `exec`, so none of the existing patch fan-out
+is reached. A sampled real session contains nine successful nested patches but
+currently reports zero changed files.
+
+This work is intentionally separate from Codex session-title and guardian
+handling. It will use branch `fix/codex-nested-file-changes` and its own PR.
+
+## Goal
+
+Recover statically expressed nested Codex `apply_patch` calls and feed them
+through the existing canonical edit pipeline, so successful edits appear in
+Files changed and indexed impact data while failed, ambiguous, and unrelated
+`exec` calls remain raw.
+
+## Decisions
+
+- **Never evaluate rollout JavaScript** — use a small dependency-free lexical
+  extractor that ignores strings/comments while locating the actual
+  `tools.apply_patch(...)` invocation. Decode only a direct string literal or a
+  local identifier bound to one static string literal.
+- **Fail closed on ambiguity** — interpolation, dynamic expressions,
+  concatenation, computed property access, multiple patch invocations, malformed
+  JavaScript, or an invalid V4A envelope remain an ordinary `exec` block.
+- **Reuse the existing patch pipeline** — recovered patch text goes through the
+  current V4A parser, per-file fan-out, canonical tool names, and per-file status
+  helpers. The shared changeset/UI/index APIs do not change.
+- **Require a successful outer result** — nested edit blocks are provisional
+  until the paired wrapper output explicitly succeeds or matches the observed
+  `Script completed` envelope. Explicit errors, failed/unrecognized envelopes,
+  and missing results demote back to the original raw `exec`, preserving the
+  complete failure text and exposing no `file_path`.
+- **Keep legacy behavior** — direct `apply_patch` rollouts and their existing
+  success/failure envelopes continue to normalize byte-for-byte as before.
+- **No new dependency** — the published bundle remains self-contained apart
+  from its existing DuckDB runtime dependency.
+- **Rebuild derived data once** — advance to schema v18 after plan 0076's v17
+  rebuild so unchanged Codex files are re-normalized and `file_edits` is
+  repopulated.
+
+## Approach
+
+1. Add a narrow static extractor for the observed direct-literal and
+   constant-binding `tools.apply_patch` forms, including escaped quotes and
+   newlines, with explicit rejection of dynamic or multiple-call programs.
+2. Feed a recovered V4A patch through the existing per-file fan-out while
+   retaining the outer tool name/input needed for raw fallback.
+3. Decode the current array-shaped wrapper output, recognize explicit
+   success/failure, attach concise per-file results on success, and demote
+   failed, unconfirmed, or incomplete calls before normalized events are final.
+4. Advance the derived schema version so existing indexes and normalized Codex
+   cache entries rebuild from unchanged source rollouts.
+5. Extend existing Codex and file-edit integration coverage for single/multi-
+   file edits, escaped static strings, rejected patches, unrelated `exec`
+   commands containing patch-like text, malformed/dynamic programs, and indexed
+   path/addition/deletion results.
+6. Run focused and full validation, then use an isolated index plus read-only
+   comparison against an affected real session to confirm its changed files are
+   recovered.
+
+## Files affected
+
+- `packages/server/src/connectors/codex/normalize.ts` — statically recover nested
+  patch payloads, gate fan-out on the paired wrapper result, and preserve raw
+  fallback behavior.
+- `packages/server/src/db/schema.ts` — invalidate unchanged normalized rows and
+  stale `file_edits`.
+- `packages/server/test/codex.integration.test.ts` — current wrapper parsing,
+  rendering, success/failure, and fail-closed regression cases.
+- `packages/server/test/file-edits.integration.test.ts` — indexed edit paths and
+  line statistics for successful nested patches only.
+- `CLAUDE.md` — document both direct and current nested Codex patch forms.
+- `docs/plans/0077-restore-codex-file-change-detection.md` — this plan.
+- `docs/plans/README.md` — plan index entry.
+
+## Testing
+
+- Focused:
+  `npx vitest run packages/server/test/codex.integration.test.ts packages/server/test/file-edits.integration.test.ts`
+- Full: `npm test`
+- Types: `npm run typecheck`
+- Production build: `npm run build`
+- Hygiene: `git diff --check`
+- End-to-end: use the repository `verify` skill with sandboxed fixtures, then
+  perform read-only checks against an affected session. Never write to real
+  agent sources or `~/.claudescope`.
+
+## Risks / open questions
+
+- The wrapper is implementation detail and may change again. Unknown programs
+  deliberately remain raw rather than guessing or reporting false edits.
+- A naive substring/regex search would misclassify commands that merely inspect
+  the text `tools.apply_patch`; lexical recognition must distinguish executable
+  syntax from strings and comments.
+- The outer wrapper currently supplies an explicit success signal and a
+  `Script completed` envelope. If future records omit both, edits stay raw until
+  that result contract is understood.
+- Plan 0076 merged first. This branch was then rebased onto it, retaining both
+  normalizer/test changes and advancing the derived schema from v17 to v18.

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -101,3 +101,4 @@ decision, or a change worth explaining before doing. Skip it for one-line fixes.
 | 0074 | [Timezone-aware analytics](./0074-timezone-aware-analytics.md) | done |
 | 0075 | [Reliable subagent linkage and Codex transcript rendering](./0075-reliable-subagent-linkage-and-codex-rendering.md) | done |
 | 0076 | [Restore Codex session naming](./0076-restore-codex-session-naming.md) | done |
+| 0077 | [Restore Codex file-change detection](./0077-restore-codex-file-change-detection.md) | done |

--- a/packages/server/src/connectors/codex/normalize.ts
+++ b/packages/server/src/connectors/codex/normalize.ts
@@ -350,6 +350,7 @@ function stripExecEnvelope(output: string): string {
 /** The `apply_patch`-style custom-tool output envelope (`Exit code: N / Wall
  *  time: … / Output:`) — group 1 is the exit code, group 2 the captured output. */
 const CUSTOM_ENVELOPE_RE = /^Exit code: (-?\d+)\nWall time: [^\n]*\n(?:[^\n]*\n)*?Output:\n?([\s\S]*)$/;
+const SCRIPT_ENVELOPE_RE = /^Script (completed|failed)\nWall time:? [^\n]*\nOutput:\n?([\s\S]*)$/;
 
 /**
  * Strip the custom-tool output envelope down to the captured output on success —
@@ -373,6 +374,193 @@ interface PatchFile {
   op: 'add' | 'update' | 'delete';
   path: string;
   hunks: Hunk[];
+}
+
+interface JsToken {
+  kind: 'identifier' | 'string' | 'punctuation';
+  value: string;
+}
+
+const JS_IDENTIFIER_START = /[A-Za-z_$]/;
+const JS_IDENTIFIER_PART = /[A-Za-z0-9_$]/;
+const HEX = /^[0-9a-f]+$/i;
+
+/** Decode one JavaScript string literal without evaluating rollout code. */
+function readJsString(
+  source: string,
+  start: number,
+): { value: string; end: number } | null {
+  const quote = source[start];
+  if (quote !== '"' && quote !== "'" && quote !== '`') return null;
+
+  let value = '';
+  let i = start + 1;
+  while (i < source.length) {
+    const ch = source[i]!;
+    if (ch === quote) return { value, end: i + 1 };
+    if (quote === '`' && ch === '$' && source[i + 1] === '{') return null;
+    if (ch === '\n' || ch === '\r') {
+      if (quote !== '`') return null;
+      value += ch;
+      i += 1;
+      continue;
+    }
+    if (ch !== '\\') {
+      value += ch;
+      i += 1;
+      continue;
+    }
+
+    i += 1;
+    if (i >= source.length) return null;
+    const escaped = source[i++]!;
+    if (escaped === '\n') continue;
+    if (escaped === '\r') {
+      if (source[i] === '\n') i += 1;
+      continue;
+    }
+    const simple: Record<string, string> = {
+      n: '\n',
+      r: '\r',
+      t: '\t',
+      b: '\b',
+      f: '\f',
+      v: '\v',
+      '\\': '\\',
+      '"': '"',
+      "'": "'",
+      '`': '`',
+    };
+    if (escaped in simple) {
+      value += simple[escaped]!;
+      continue;
+    }
+    if (escaped === '0') {
+      if (/[0-9]/.test(source[i] ?? '')) return null;
+      value += '\0';
+      continue;
+    }
+    if (escaped === 'x') {
+      const digits = source.slice(i, i + 2);
+      if (digits.length !== 2 || !HEX.test(digits)) return null;
+      value += String.fromCharCode(Number.parseInt(digits, 16));
+      i += 2;
+      continue;
+    }
+    if (escaped === 'u') {
+      if (source[i] === '{') {
+        const end = source.indexOf('}', i + 1);
+        if (end < 0) return null;
+        const digits = source.slice(i + 1, end);
+        const point = Number.parseInt(digits, 16);
+        if (!digits || !HEX.test(digits) || point > 0x10ffff) return null;
+        value += String.fromCodePoint(point);
+        i = end + 1;
+      } else {
+        const digits = source.slice(i, i + 4);
+        if (digits.length !== 4 || !HEX.test(digits)) return null;
+        value += String.fromCharCode(Number.parseInt(digits, 16));
+        i += 4;
+      }
+      continue;
+    }
+    // JavaScript treats an unknown escape as the escaped character itself.
+    value += escaped;
+  }
+  return null;
+}
+
+/**
+ * Tokenize only the JavaScript subset needed to recognize a static
+ * `tools.apply_patch` invocation. Regex literals and malformed strings make the
+ * whole program ineligible; falling back to raw `exec` is safer than guessing.
+ */
+function staticJsTokens(source: string): JsToken[] | null {
+  const tokens: JsToken[] = [];
+  let i = 0;
+  let braceDepth = 0;
+  while (i < source.length) {
+    const ch = source[i]!;
+    if (/\s/.test(ch)) {
+      i += 1;
+      continue;
+    }
+    if (ch === '/' && source[i + 1] === '/') {
+      const end = source.indexOf('\n', i + 2);
+      i = end < 0 ? source.length : end + 1;
+      continue;
+    }
+    if (ch === '/' && source[i + 1] === '*') {
+      const end = source.indexOf('*/', i + 2);
+      if (end < 0) return null;
+      i = end + 2;
+      continue;
+    }
+    if (ch === '/') return null;
+    if (ch === '"' || ch === "'" || ch === '`') {
+      const parsed = readJsString(source, i);
+      if (!parsed) return null;
+      tokens.push({ kind: 'string', value: parsed.value });
+      i = parsed.end;
+      continue;
+    }
+    if (JS_IDENTIFIER_START.test(ch)) {
+      const start = i++;
+      while (i < source.length && JS_IDENTIFIER_PART.test(source[i]!)) i += 1;
+      tokens.push({
+        kind: 'identifier',
+        value: source.slice(start, i),
+      });
+      continue;
+    }
+    if (ch === '}') {
+      braceDepth -= 1;
+      if (braceDepth < 0) return null;
+    }
+    tokens.push({ kind: 'punctuation', value: ch });
+    if (ch === '{') braceDepth += 1;
+    i += 1;
+  }
+  return braceDepth === 0 ? tokens : null;
+}
+
+/**
+ * Recover exactly one statically expressed nested patch from the current Codex
+ * `exec` wrapper. Only a direct string argument or a preceding top-level
+ * `const name = <string>` binding is eligible; arbitrary JavaScript is never
+ * evaluated.
+ */
+function nestedApplyPatch(source: string): string | null {
+  const tokens = staticJsTokens(source);
+  if (!tokens) return null;
+  const values = tokens.map((token) => token.value);
+
+  // text(await tools.apply_patch("..."));
+  if (
+    tokens.length === 11 &&
+    values.join('\0') ===
+      ['text', '(', 'await', 'tools', '.', 'apply_patch', '(', tokens[7]!.value, ')', ')', ';'].join('\0') &&
+    tokens[7]!.kind === 'string'
+  ) {
+    return tokens[7]!.value;
+  }
+
+  // const patch = "..."; text(await tools.apply_patch(patch));
+  if (
+    tokens.length === 16 &&
+    tokens[1]!.kind === 'identifier' &&
+    tokens[3]!.kind === 'string' &&
+    tokens[12]!.kind === 'identifier' &&
+    tokens[1]!.value === tokens[12]!.value &&
+    values.join('\0') ===
+      [
+        'const', tokens[1]!.value, '=', tokens[3]!.value, ';',
+        'text', '(', 'await', 'tools', '.', 'apply_patch', '(', tokens[12]!.value, ')', ')', ';',
+      ].join('\0')
+  ) {
+    return tokens[3]!.value;
+  }
+  return null;
 }
 
 /**
@@ -553,11 +741,15 @@ export function parseRollout(path: string): CodexSession | null {
     agentType: string;
     toolUseId: string;
   }>();
-  // apply_patch fan-out: call_id → the fanned block REFERENCES (they stay live
-  // inside the flushed event), per-file statuses, and the raw patch text — so the
-  // (single) custom_tool_call_output can pair a result to every block, or demote
-  // the blocks back to raw passthrough when the patch was rejected.
-  const patchFanout = new Map<string, { blocks: ToolUseBlock[]; statuses: string[]; raw: string }>();
+  // apply_patch fan-out: call_id → live block references plus enough original
+  // call data to demote failed/unconfirmed edits back to raw passthrough.
+  const patchFanout = new Map<string, {
+    blocks: ToolUseBlock[];
+    statuses: string[];
+    passthroughName: string;
+    passthroughInput: Record<string, unknown>;
+    requiresExecSuccess: boolean;
+  }>();
 
   // Open turn buffer; flushed when the conversation side flips.
   let side: 'assistant' | 'user' | null = null;
@@ -687,14 +879,15 @@ export function parseRollout(path: string): CodexSession | null {
         content: stripExecEnvelope(output),
       });
     } else if (kind === 'custom_tool_call') {
-      // Freeform tools (arguments arrive as a raw string). `apply_patch` fans out
-      // to one canonical Write/Edit/MultiEdit block per touched file (mirrors the
-      // opencode connector); other custom tools pass through under their raw name.
+      // Direct apply_patch and the current statically recoverable exec wrapper
+      // fan out to canonical edits; all other custom calls stay raw.
       open('assistant', ts);
       const name = str(pl.name);
       const callId = str(pl.call_id);
       const raw = str(pl.input);
-      const patchFiles = name === 'apply_patch' ? parseApplyPatch(raw) : [];
+      const nestedPatch = name === 'exec' ? nestedApplyPatch(raw) : null;
+      const patch = name === 'apply_patch' ? raw : nestedPatch;
+      const patchFiles = patch ? parseApplyPatch(patch) : [];
       if (patchFiles.length > 0) {
         const fanned = patchFiles.map((f, i) =>
           patchFileToolUse(f, patchFiles.length === 1 ? callId : `${callId}#${i}`),
@@ -703,7 +896,9 @@ export function parseRollout(path: string): CodexSession | null {
         patchFanout.set(callId, {
           blocks: fanned,
           statuses: patchFiles.map(patchFileStatus),
-          raw,
+          passthroughName: name,
+          passthroughInput: { input: raw },
+          requiresExecSuccess: nestedPatch !== null,
         });
       } else {
         blocks.push({ type: 'tool_use', id: callId, name, input: { input: raw } });
@@ -714,18 +909,28 @@ export function parseRollout(path: string): CodexSession | null {
       const output = toolOutputText(pl.output);
       const fan = patchFanout.get(callId);
       const exit = output.match(CUSTOM_ENVELOPE_RE);
+      const script = output.match(SCRIPT_ENVELOPE_RE);
       const isError = pl.is_error === true || (exit !== null && Number(exit[1]) !== 0);
-      if (fan && isError) {
+      const execSucceeded = pl.is_error === false || script?.[1] === 'completed';
+      const execFailed = pl.is_error === true || script?.[1] === 'failed';
+      const shouldDemote = fan?.requiresExecSuccess
+        ? execFailed || !execSucceeded
+        : isError;
+      if (fan && shouldDemote) {
         // The patch was REJECTED — nothing on disk changed. Demote the fanned
-        // canonical blocks back to raw apply_patch passthrough (no `file_path`,
+        // canonical blocks back to their original raw passthrough (no `file_path`,
         // so the Files-changed tab never lists untouched files — the same
         // failed-edit convention as the copilot connector) and surface the full
         // error output on each.
         for (const b of fan.blocks) {
-          b.name = 'apply_patch';
-          b.input = { input: fan.raw };
+          b.name = fan.passthroughName;
+          b.input = fan.passthroughInput;
           blocks.push({ type: 'tool_result', tool_use_id: b.id, content: output, is_error: true });
         }
+      } else if (fan?.requiresExecSuccess) {
+        fan.blocks.forEach((b, i) =>
+          blocks.push({ type: 'tool_result', tool_use_id: b.id, content: fan.statuses[i]! }),
+        );
       } else if (fan && fan.blocks.length > 1) {
         // Per-file status, NOT the shared multi-file summary (which would
         // repeat identically on every fanned-out block).
@@ -740,6 +945,7 @@ export function parseRollout(path: string): CodexSession | null {
           ...(isError ? { is_error: true } : {}),
         });
       }
+      patchFanout.delete(callId);
     } else if (kind === 'tool_search_call') {
       open('assistant', ts);
       blocks.push({ type: 'tool_use', id: str(pl.call_id), name: 'tool_search', input: rec(pl.arguments) });
@@ -754,6 +960,15 @@ export function parseRollout(path: string): CodexSession | null {
       // No call_id and no paired output record — render the query/action alone.
       open('assistant', ts);
       blocks.push({ type: 'tool_use', id: `${sessionId}-ws-${wsSeq++}`, name: 'web_search', input: rec(pl.action) });
+    }
+  }
+  // A live/truncated wrapper without a paired result is not confirmed to have
+  // changed disk. Keep it visible as raw exec, but never report its files.
+  for (const fan of patchFanout.values()) {
+    if (!fan.requiresExecSuccess) continue;
+    for (const b of fan.blocks) {
+      b.name = fan.passthroughName;
+      b.input = fan.passthroughInput;
     }
   }
   flush();

--- a/packages/server/src/db/schema.ts
+++ b/packages/server/src/db/schema.ts
@@ -39,7 +39,8 @@
 //      derived tool errors/file edits, so unchanged normalized rows must rebuild.
 // v17: Codex pathless bootstrap headings and current guardian-review rollouts
 //      change persisted fallback titles and indexed sessions.
-export const SCHEMA_VERSION = 17;
+// v18: current Codex exec-wrapped apply_patch calls populate canonical file edits.
+export const SCHEMA_VERSION = 18;
 
 /** All DDL statements, executed in order at startup. Idempotent. */
 export const SCHEMA_DDL: readonly string[] = [

--- a/packages/server/test/codex.integration.test.ts
+++ b/packages/server/test/codex.integration.test.ts
@@ -43,12 +43,19 @@ const pathlessBootstrap = [
   '  <cwd>/tmp/codexproj</cwd>',
   '</environment_context>',
 ].join('\n');
+const execApplyPatch = (patch: string, direct = false): string =>
+  direct
+    ? `text(await tools.apply_patch(${JSON.stringify(patch)}));`
+    : `const patch = ${JSON.stringify(patch)};\ntext(await tools.apply_patch(patch));`;
 
 /** Write one synthetic rollout under codex/YYYY/MM/DD/. */
 function writeRollout(): string {
   const dir = join(codexDir, '2026', '01', '01');
   mkdirSync(dir, { recursive: true });
   const file = join(dir, 'rollout-2026-01-01T10-00-00-019db3da-f840-7142-a548-5bd30f5fe572.jsonl');
+  const nestedPatch = '*** Begin Patch\n*** Add File: /tmp/codexproj/wrapped.md\n+wrapped\n*** Update File: /tmp/codexproj/wrapped.ts\n@@\n-old wrapped\n+new wrapped\n*** End Patch';
+  const directNestedPatch = '*** Begin Patch\n*** Update File: /tmp/codexproj/direct-wrapped.ts\n@@\n-before\n+after\n*** End Patch';
+  const rejectedNestedPatch = '*** Begin Patch\n*** Update File: /tmp/codexproj/rejected-wrapped.ts\n@@\n-before\n+after\n*** End Patch';
   writeFileSync(
     file,
     jsonl([
@@ -124,6 +131,37 @@ function writeRollout(): string {
       ] } },
       { type: 'response_item', timestamp: ts(31), payload: { type: 'custom_tool_call', name: 'future_tool', call_id: 'call_unknown_output', input: 'opaque input' } },
       { type: 'response_item', timestamp: ts(32), payload: { type: 'custom_tool_call_output', call_id: 'call_unknown_output', output: [{ type: 'future_content', value: 'must-not-vanish' }] } },
+      // Current Codex wraps apply_patch in a JavaScript `exec` custom tool. A
+      // static const-bound patch and a direct string literal both remain safely
+      // recoverable without evaluating the program.
+      { type: 'response_item', timestamp: ts(33), payload: { type: 'custom_tool_call', name: 'exec', call_id: 'call_exec_ap1', input: execApplyPatch(nestedPatch) } },
+      { type: 'response_item', timestamp: ts(34), payload: { type: 'custom_tool_call_output', call_id: 'call_exec_ap1', is_error: false, output: [
+        { type: 'input_text', text: 'Script completed\nWall time 0.1 seconds\nOutput:\n' },
+        { type: 'input_text', text: '{}' },
+      ] } },
+      { type: 'response_item', timestamp: ts(35), payload: { type: 'custom_tool_call', name: 'exec', call_id: 'call_exec_ap2', input: execApplyPatch(directNestedPatch, true) } },
+      { type: 'response_item', timestamp: ts(36), payload: { type: 'custom_tool_call_output', call_id: 'call_exec_ap2', output: [
+        { type: 'input_text', text: 'Script completed\nWall time 0.1 seconds\nOutput:\n' },
+        { type: 'input_text', text: '{}' },
+      ] } },
+      // Failed wrappers demote to raw exec so Files changed never reports them.
+      { type: 'response_item', timestamp: ts(37), payload: { type: 'custom_tool_call', name: 'exec', call_id: 'call_exec_ap3', input: execApplyPatch(rejectedNestedPatch) } },
+      { type: 'response_item', timestamp: ts(38), payload: { type: 'custom_tool_call_output', call_id: 'call_exec_ap3', is_error: true, output: [
+        { type: 'input_text', text: 'Script failed\nWall time 0.1 seconds\nOutput:\n' },
+        { type: 'input_text', text: 'apply_patch verification failed' },
+      ] } },
+      // Patch-like text inside a command string, dynamic input, multiple calls,
+      // and an unconfirmed live call all fail closed as ordinary exec blocks.
+      { type: 'response_item', timestamp: ts(39), payload: { type: 'custom_tool_call', name: 'exec', call_id: 'call_exec_text_only', input: 'const command = "rg tools.apply_patch(patch) ."; text(await tools.exec_command({ cmd: command }));' } },
+      { type: 'response_item', timestamp: ts(40), payload: { type: 'custom_tool_call_output', call_id: 'call_exec_text_only', is_error: false, output: 'Script completed\nWall time 0.1 seconds\nOutput:\nno matches' } },
+      { type: 'response_item', timestamp: ts(41), payload: { type: 'custom_tool_call', name: 'exec', call_id: 'call_exec_dynamic', input: 'const patch = buildPatch(); text(await tools.apply_patch(patch));' } },
+      { type: 'response_item', timestamp: ts(42), payload: { type: 'custom_tool_call_output', call_id: 'call_exec_dynamic', is_error: false, output: 'Script completed\nWall time 0.1 seconds\nOutput:\n{}' } },
+      { type: 'response_item', timestamp: ts(43), payload: { type: 'custom_tool_call', name: 'exec', call_id: 'call_exec_multiple', input: `${execApplyPatch(directNestedPatch, true)}\n${execApplyPatch(directNestedPatch, true)}` } },
+      { type: 'response_item', timestamp: ts(44), payload: { type: 'custom_tool_call_output', call_id: 'call_exec_multiple', is_error: false, output: 'Script completed\nWall time 0.1 seconds\nOutput:\n{}' } },
+      { type: 'response_item', timestamp: ts(45), payload: { type: 'custom_tool_call', name: 'exec', call_id: 'call_exec_concat', input: `const patch = ${JSON.stringify(directNestedPatch)} + suffix; text(await tools.apply_patch(patch));` } },
+      { type: 'response_item', timestamp: ts(46), payload: { type: 'custom_tool_call_output', call_id: 'call_exec_concat', is_error: false, output: 'Script completed\nWall time 0.1 seconds\nOutput:\n{}' } },
+      { type: 'response_item', timestamp: ts(47), payload: { type: 'custom_tool_call', name: 'exec', call_id: 'call_exec_unconfirmed', input: execApplyPatch(directNestedPatch, true) } },
+      { type: 'response_item', timestamp: ts(48), payload: { type: 'message', role: 'assistant', content: [{ type: 'output_text', text: 'waiting for the patch result' }] } },
     ]),
   );
   return file;
@@ -573,6 +611,66 @@ describe('Codex session detail', () => {
     for (const b of canonical) {
       expect((b.input as { file_path: string }).file_path).not.toContain('missing.ts');
       expect((b.input as { file_path: string }).file_path).not.toContain('other.ts');
+    }
+  });
+
+  it('recovers successful nested exec apply_patch calls as canonical edits', async () => {
+    const detail = (await get('/api/sessions/codex-sess-1')).json();
+    const flat = detail.thread.flatMap(
+      (t: { blocks: Record<string, unknown>[] }) => t.blocks,
+    );
+
+    const write = flat.find((b: Record<string, unknown>) => b.id === 'call_exec_ap1#0');
+    expect(write).toMatchObject({ name: 'Write' });
+    expect(write.input).toEqual({ file_path: '/tmp/codexproj/wrapped.md', content: 'wrapped' });
+    expect(write.result.content[0].text).toBe('Created /tmp/codexproj/wrapped.md');
+
+    const edit = flat.find((b: Record<string, unknown>) => b.id === 'call_exec_ap1#1');
+    expect(edit).toMatchObject({ name: 'MultiEdit' });
+    expect(edit.input).toEqual({
+      file_path: '/tmp/codexproj/wrapped.ts',
+      edits: [{ old_string: 'old wrapped', new_string: 'new wrapped' }],
+    });
+    expect(edit.result.content[0].text).toBe('Updated /tmp/codexproj/wrapped.ts');
+
+    const direct = flat.find((b: Record<string, unknown>) => b.id === 'call_exec_ap2');
+    expect(direct).toMatchObject({ name: 'MultiEdit' });
+    expect(direct.input).toEqual({
+      file_path: '/tmp/codexproj/direct-wrapped.ts',
+      edits: [{ old_string: 'before', new_string: 'after' }],
+    });
+    expect(direct.result.content[0].text).toBe('Updated /tmp/codexproj/direct-wrapped.ts');
+  });
+
+  it('fails closed for rejected, dynamic, ambiguous, and unconfirmed exec patches', async () => {
+    const detail = (await get('/api/sessions/codex-sess-1')).json();
+    const flat = detail.thread.flatMap(
+      (t: { blocks: Record<string, unknown>[] }) => t.blocks,
+    );
+
+    const rejected = flat.find((b: Record<string, unknown>) => b.id === 'call_exec_ap3');
+    expect(rejected).toMatchObject({ name: 'exec' });
+    expect((rejected.input as { file_path?: string }).file_path).toBeUndefined();
+    expect(rejected.result.content[0].text).toContain('Script failed');
+    expect(rejected.result.content[0].text).toContain('verification failed');
+
+    for (const id of [
+      'call_exec_text_only',
+      'call_exec_dynamic',
+      'call_exec_multiple',
+      'call_exec_concat',
+      'call_exec_unconfirmed',
+    ]) {
+      const raw = flat.find((b: Record<string, unknown>) => b.id === id);
+      expect(raw).toMatchObject({ name: 'exec' });
+      expect((raw.input as { file_path?: string }).file_path).toBeUndefined();
+    }
+
+    const canonical = flat.filter((b: Record<string, unknown>) =>
+      ['Write', 'Edit', 'MultiEdit'].includes(b.name as string),
+    );
+    for (const block of canonical) {
+      expect((block.input as { file_path: string }).file_path).not.toContain('rejected-wrapped');
     }
   });
 

--- a/packages/server/test/file-edits.integration.test.ts
+++ b/packages/server/test/file-edits.integration.test.ts
@@ -48,6 +48,8 @@ process.env.REINDEX_INTERVAL_MS = '0';
 
 const jsonl = (events: unknown[]): string => events.map((e) => JSON.stringify(e)).join('\n') + '\n';
 const ts = (s: number) => `2026-01-01T10:00:${String(s).padStart(2, '0')}.000Z`;
+const execApplyPatch = (patch: string): string =>
+  `const patch = ${JSON.stringify(patch)};\ntext(await tools.apply_patch(patch));`;
 
 const CWD = '/tmp/feditsproj';
 
@@ -145,8 +147,8 @@ function writeFixtures(): void {
   writeFileSync(join(proj, 'sessOrig.jsonl'), jsonl(claudeLines('sessOrig')));
   writeFileSync(join(proj, 'sessFork.jsonl'), jsonl(claudeLines('sessFork', 'sessOrig')));
 
-  // Codex rollout: one apply_patch fanning out to TWO files (Add + Update) and
-  // a second single-file patch — per-file rows with exact counts.
+  // Codex rollout: one current exec-wrapped apply_patch fanning out to TWO files
+  // (Add + Update) and one legacy direct patch — per-file rows with exact counts.
   const dir = join(codexDir, '2026', '01', '01');
   mkdirSync(dir, { recursive: true });
   writeFileSync(
@@ -155,8 +157,11 @@ function writeFixtures(): void {
       { type: 'session_meta', timestamp: ts(0), payload: { id: 'codex-fe-1', cwd: '/tmp/codexfe', cli_version: '0.122.0', model_provider: 'openai', git: { branch: 'main' } } },
       { type: 'turn_context', timestamp: ts(1), payload: { model: 'gpt-5.4', cwd: '/tmp/codexfe' } },
       { type: 'response_item', timestamp: ts(2), payload: { type: 'message', role: 'user', content: [{ type: 'input_text', text: 'patch things' }] } },
-      { type: 'response_item', timestamp: ts(3), payload: { type: 'custom_tool_call', name: 'apply_patch', call_id: 'call_ap1', input: '*** Begin Patch\n*** Add File: /tmp/codexfe/notes.md\n+hello\n+world\n*** Update File: /tmp/codexfe/src/app.ts\n@@\n context line\n-old value\n+new value\n*** End Patch' } },
-      { type: 'response_item', timestamp: ts(4), payload: { type: 'custom_tool_call_output', call_id: 'call_ap1', output: 'Done!' } },
+      { type: 'response_item', timestamp: ts(3), payload: { type: 'custom_tool_call', name: 'exec', call_id: 'call_ap1', input: execApplyPatch('*** Begin Patch\n*** Add File: /tmp/codexfe/notes.md\n+hello\n+world\n*** Update File: /tmp/codexfe/src/app.ts\n@@\n context line\n-old value\n+new value\n*** End Patch') } },
+      { type: 'response_item', timestamp: ts(4), payload: { type: 'custom_tool_call_output', call_id: 'call_ap1', is_error: false, output: [
+        { type: 'input_text', text: 'Script completed\nWall time 0.1 seconds\nOutput:\n' },
+        { type: 'input_text', text: '{}' },
+      ] } },
       { type: 'response_item', timestamp: ts(5), payload: { type: 'custom_tool_call', name: 'apply_patch', call_id: 'call_ap2', input: '*** Begin Patch\n*** Update File: /tmp/codexfe/single.ts\n@@\n-a\n+b\n*** End Patch' } },
       { type: 'response_item', timestamp: ts(6), payload: { type: 'custom_tool_call_output', call_id: 'call_ap2', output: 'Done!' } },
       { type: 'response_item', timestamp: ts(7), payload: { type: 'message', role: 'assistant', content: [{ type: 'output_text', text: 'patched' }] } },
@@ -257,7 +262,7 @@ afterAll(async () => {
 const get = async (url: string) => app.inject({ method: 'GET', url });
 
 describe('file_edits extraction', () => {
-  it('fans Codex apply_patch out to per-file rows with exact LCS counts', async () => {
+  it('indexes exec-wrapped Codex apply_patch with exact per-file LCS counts', async () => {
     const rows = await queryRows(
       conn,
       `SELECT file_path, tool_name, additions, deletions FROM file_edits


### PR DESCRIPTION
## Summary

- recover the exact static JavaScript wrapper forms current Codex uses for nested apply_patch calls without evaluating rollout code
- reuse canonical Write/Edit/MultiEdit fan-out and fail closed for failed, dynamic, ambiguous, or unconfirmed wrappers
- rebuild derived file edits at schema v18 and cover API rendering plus indexed line statistics

## Plan

[0077 — Restore Codex file-change detection](docs/plans/0077-restore-codex-file-change-detection.md)

## Done

- [x] rebased onto merged [PR #98](https://github.com/vladar107/claudescope/pull/98) with both regression suites retained
- [x] focused combined Codex/title/file-edit suite (41 tests)
- [x] full test suite (630 tests)
- [x] typecheck and production build
- [x] read-only affected-rollout check: 15 canonical edits, 0 unresolved wrappers