### PR TITLE
feat: literal search and tool/skill call analytics

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,10 +202,10 @@ claude mcp add claudescope -- claudescope mcp
 first use if it isn't already running. Tools: `search_transcripts` (full-text
 search with snippet hits), `list_sessions` / `list_projects` (compact listings),
 `get_session` (a windowed Markdown slice of one session — pageable, tool
-payloads truncated), `get_analytics` (token/cost aggregates), and `get_memory`
-(instruction files + distilled agent memory). Output is plain text sized for an
-agent's context window; pass `redact: true` to mask home paths and likely
-secrets. Everything stays read-only and on localhost.
+payloads truncated), `get_analytics` (token/cost aggregates, or tool/skill call
+counts), and `get_memory` (instruction files + distilled agent memory). Output is
+plain text sized for an agent's context window; pass `redact: true` to mask home
+paths and likely secrets. Everything stays read-only and on localhost.
 
 ### Claude Code and Codex plugin
 
@@ -244,6 +244,7 @@ start the background server on first use and print tables (or raw JSON with
 
 ```bash
 claudescope search "duckdb lock" --limit 5      # where did I hit this before?
+claudescope search --literal "ENOENT: no such file" --limit 5  # exact string, no ranking
 claudescope sessions --agent codex --sort cost  # priciest Codex sessions
 claudescope sessions --cwd "$PWD" --branch "$(git rev-parse --abbrev-ref HEAD)" # this project + branch
 claudescope session <id> --around <uuid>        # open a search hit, windowed
@@ -252,6 +253,10 @@ claudescope open --session <id> --around <uuid> # open that hit in the web app
 claudescope analytics --group-by day --timezone Europe/Amsterdam --json | jq '.rows[] | [.key, .costUsd]'
 claudescope digest --from 2026-06-23 --to 2026-06-29 --timezone Europe/Amsterdam
 ```
+
+`--literal` matches the query as one case-insensitive substring over transcript
+text, failed tool-result bodies, tool names and skill names (newest first, no
+ranking) — the way to find an error message the agent never restated in prose.
 
 `sessions --cwd <path>` resolves to the project for that working directory
 locally, without a separate `projects` lookup, and is exclusive with

--- a/docs/plans/0079-literal-search-and-skill-analytics.md
+++ b/docs/plans/0079-literal-search-and-skill-analytics.md
@@ -1,0 +1,103 @@
+# 0079 — Literal search and tool/skill analytics
+
+- **Status:** done
+- **Date:** 2026-09-02
+- **PR:** https://github.com/vladar107/claudescope/pull/102
+
+## Context
+
+Second half of issue
+[#100](https://github.com/vladar107/claudescope/issues/100) (first half: plan
+0078). When an agent does consult history for an error message or identifier,
+BM25 is the wrong tool: two of the three sessions that used the skill abandoned
+`search` for grep because ranking returned noise. Worse, the index stores only
+`text` / `thinking` blocks, so a tool error that the assistant never restated is
+unfindable by any search. Measuring skill adoption today means dumping every
+session and post-processing with jq, because `tool_use.input` is never
+persisted and `tool_names` only says `Skill`.
+
+## Goal
+
+`search --literal` finds exact strings across transcript text, failed tool
+results, tool names and skill names; `analytics --group-by tool|skill` answers
+"how often was X used" in one command. Default search ranking is untouched
+(issue non-goal).
+
+## Decisions
+
+- **Schema v19 with two narrow columns** — `tool_error_text` (failed
+  `tool_result` bodies only, capped per event) and `skill_names` (CSV of the
+  `skill` argument on canonical `Skill` calls, shaped like `tool_names`).
+  Indexing all tool-result bodies was rejected: file reads would bloat the
+  index for little search value. FTS stays on `text_content` only.
+- **Literal mode is a filter, not a ranking** — `contains(lower(col), lower(q))`
+  over the four columns, newest first, same 50 cap and the same snippet
+  renderer (already plain substring). No change to the BM25 path or its
+  identifier heuristic.
+- **Tool/skill grouping reuses the tools endpoint** — `/api/analytics/tools`
+  gains `kind=tool|skill`; the CLI's `analytics --group-by tool|skill` routes
+  there and prints `KEY, AGENT, COUNT`. Extending the token analytics route was
+  rejected: one event carries several tool calls, so token sums per tool would
+  double-count.
+- **Call counts exclude fork copies, not non-canonical rows** — review fix.
+  `usage_canonical` elects ONE row per billed `message.id` for token sums, but
+  tool_use blocks sit on whichever row carries them. Measured over 38 real Claude
+  Code transcripts: 1022 of 1451 message ids span several rows with identical
+  usage (the election falls to the uuid tiebreak), leaving 876 of 1312 tool-call
+  rows and 9 of 15 Skill rows on a non-elected row and invisible to this
+  endpoint. The filter is therefore `forked_from_session_id IS NULL` — the same
+  fork exclusion `routes/analytics-errors.ts` uses, and the marker sits on every
+  copied row, so a fork still cannot double-count. The web's tool-usage chart
+  reads the same endpoint and now shows the corrected, higher counts.
+- **`skill_names` is best-effort per connector** — populated where a canonical
+  `Skill` tool_use exists (Claude Code, Grok); Codex injects skills as message
+  content, not tool calls, and stays empty.
+
+## Approach
+
+1. Index derivation (schema v19): columns in `schema.ts` + changelog; the
+   Claude Code lateral pass derives both (string vs text-block-array
+   `tool_result` content); `connectors/tool-errors.ts` gains `toolErrorText`,
+   new `connectors/skill-names.ts`; `CANONICAL_COLUMNS` /
+   `canonicalProjectionSql`; every cache-backed normalizer emits the two
+   fields; staging list in `data/index.ts`.
+2. Tools endpoint `kind` param; `ApiClient.toolUsage`; CLI
+   `analytics --group-by tool|skill` (+ `--project`); MCP `get_analytics`
+   values.
+3. `search --literal`: `SearchQuery.literal`, route branch, CLI flag, MCP
+   param.
+4. Docs: this plan, README scripting section, SKILL.md (`--literal` for errors
+   and identifiers).
+5. Review, tests, typecheck, build.
+
+## Files affected
+
+- `packages/server/src/db/schema.ts` — v19, two columns.
+- `packages/server/src/connectors/claude-code/claude-code.ts` — lateral
+  derivation.
+- `packages/server/src/connectors/tool-errors.ts`,
+  `connectors/skill-names.ts` (new), `connectors/canonical.ts`, each
+  `connectors/*/normalize.ts`.
+- `packages/server/src/data/index.ts` — staging columns.
+- `packages/server/src/routes/search.ts` — literal branch.
+- `packages/server/src/routes/analytics-tools.ts` — `kind`.
+- `packages/shared/src/api.ts` — `SearchQuery.literal`, tool-usage query kind.
+- `packages/server/src/agent/{query,api-client,mcp}.ts`, `cli.ts`.
+- `README.md`, `plugins/claudescope/skills/history/SKILL.md`,
+  `docs/plans/README.md`.
+- Tests: literal search integration (punctuation string BM25 loses; hit only in
+  `tool_error_text`; empty wording), tools endpoint `kind=skill`, Claude Code
+  array-form error result, one normalizer's `tool_error_text`.
+
+## Testing
+
+`npm test`, `npm run typecheck`, `npm run build`; the schema bump is covered by
+the existing stale-signature rebuild test.
+
+## Risks / open questions
+
+- The schema bump forces a full rebuild on upgrade (routine; v18 did the same).
+- `tool_error_text` is verbatim transcript data like `text_content`; `--redact`
+  applies to session output, not search snippets, as today.
+- Rebase onto plan 0078's branch: both touch `api.ts`, `cli.ts`, `mcp.ts`,
+  `SKILL.md`, and the plans index — small, mechanical conflicts.

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -103,3 +103,4 @@ decision, or a change worth explaining before doing. Skip it for one-line fixes.
 | 0076 | [Restore Codex session naming](./0076-restore-codex-session-naming.md) | done |
 | 0077 | [Restore Codex file-change detection](./0077-restore-codex-file-change-detection.md) | done |
 | 0078 | [Proactive history context](./0078-proactive-history-context.md) | done |
+| 0079 | [Literal search and tool/skill analytics](./0079-literal-search-and-skill-analytics.md) | done |

--- a/packages/server/src/agent/api-client.ts
+++ b/packages/server/src/agent/api-client.ts
@@ -22,6 +22,8 @@ import type {
   SessionDetailResponse,
   SessionMeta,
   SessionsQuery,
+  ToolUsageQuery,
+  ToolUsageResponse,
 } from '@claudescope/shared';
 
 /** Query-param bag: undefined/empty values are omitted from the URL. */
@@ -74,5 +76,9 @@ export class ApiClient {
 
   digest(q: DigestQuery = {}): Promise<DigestResponse> {
     return this.get('/api/analytics/digest', q as unknown as Params);
+  }
+
+  toolUsage(q: ToolUsageQuery): Promise<ToolUsageResponse> {
+    return this.get('/api/analytics/tools', q as unknown as Params);
   }
 }

--- a/packages/server/src/agent/mcp.ts
+++ b/packages/server/src/agent/mcp.ts
@@ -34,6 +34,7 @@ import {
   resolveWindowArgs,
   shapeSearchResults,
   shapeSessionMarkdown,
+  shapeToolUsage,
 } from './shape.js';
 import { detectedTimeZone } from './query.js';
 
@@ -119,10 +120,17 @@ export function createMcpServer(deps: McpDeps): McpServer {
           .enum(['sessions', 'memory', 'all'])
           .optional()
           .describe('What to search: transcripts, agent memory, or both (default sessions)'),
+        literal: z
+          .boolean()
+          .optional()
+          .describe(
+            'Match the query as an exact case-insensitive substring instead of ranked full-text; ' +
+              'use for error messages, identifiers, tool or skill names',
+          ),
         limit: z.number().int().min(1).max(50).optional().describe(`Max hits (default ${DEFAULT_LIMIT})`),
       }),
     },
-    guarded(async (client, args: { query: string; project?: string; role?: 'user' | 'assistant' | 'all'; scope?: 'sessions' | 'memory' | 'all'; limit?: number }) => {
+    guarded(async (client, args: { query: string; project?: string; role?: 'user' | 'assistant' | 'all'; scope?: 'sessions' | 'memory' | 'all'; literal?: boolean; limit?: number }) => {
       const limit = args.limit ?? DEFAULT_LIMIT;
       const res = await client.search({
         q: args.query,
@@ -130,6 +138,7 @@ export function createMcpServer(deps: McpDeps): McpServer {
         type: args.role ?? 'all',
         scope: args.scope ?? 'sessions',
         format: 'plain',
+        literal: args.literal,
       });
       return shapeSearchResults(res, limit);
     }),
@@ -237,11 +246,17 @@ export function createMcpServer(deps: McpDeps): McpServer {
     'get_analytics',
     {
       description:
-        'Aggregated token/cost usage grouped by project, model, day, or agent, with totals. ' +
-        'Cost is a local list-price estimate, not billing. Date-only bounds are calendar days ' +
-        'in the selected IANA time zone; timestamps with offsets identify exact instants.',
+        'Aggregated token/cost usage grouped by project, model, day, or agent, with totals; ' +
+        'or (tool/skill) a call-count breakdown of canonical tool calls or the skills they ' +
+        'invoked, which accepts an optional project filter instead of totals. Cost is a local ' +
+        'list-price estimate, not billing. Date-only bounds are calendar days in the selected ' +
+        'IANA time zone; timestamps with offsets identify exact instants.',
       inputSchema: z.object({
-        groupBy: z.enum(['project', 'model', 'day', 'agent']).optional().describe('Grouping (default project)'),
+        groupBy: z
+          .enum(['project', 'model', 'day', 'agent', 'tool', 'skill'])
+          .optional()
+          .describe('Grouping (default project)'),
+        project: z.string().optional().describe('Project id (from list_projects); only used by tool/skill grouping'),
         from: z.string().optional().describe('Inclusive start date or ISO timestamp'),
         to: z.string().optional().describe('Inclusive end date or ISO timestamp'),
         timeZone: z
@@ -250,24 +265,47 @@ export function createMcpServer(deps: McpDeps): McpServer {
           .describe('IANA time zone for date-only bounds and day grouping (default machine time zone)'),
       }),
     },
-    guarded(async (client, args: { groupBy?: 'project' | 'model' | 'day' | 'agent'; from?: string; to?: string; timeZone?: string }) => {
-      const res = await client.analytics({
-        groupBy: args.groupBy ?? 'project',
-        from: args.from,
-        to: args.to,
-        timeZone: args.timeZone ?? detectedTimeZone(),
-      });
-      if (res.rows.length === 0) return 'No usage in range.';
-      const lines = res.rows.map(
-        (row) =>
-          `- ${row.key}: ${fmtTokens(row.totalTokens)} tok ` +
-          `(in ${fmtTokens(row.inputTokens)}, out ${fmtTokens(row.outputTokens)}, ` +
-          `cache r/w ${fmtTokens(row.cacheReadTokens)}/${fmtTokens(row.cacheCreationTokens)}) · ` +
-          `${fmtCost(row.costUsd)} · ${row.messageCount} responses`,
-      );
-      lines.push(analyticsTotalsLine(res.totals));
-      return lines.join('\n');
-    }),
+    guarded(
+      async (
+        client,
+        args: {
+          groupBy?: 'project' | 'model' | 'day' | 'agent' | 'tool' | 'skill';
+          project?: string;
+          from?: string;
+          to?: string;
+          timeZone?: string;
+        },
+      ) => {
+        const groupBy = args.groupBy ?? 'project';
+        if (groupBy === 'tool' || groupBy === 'skill') {
+          const res = await client.toolUsage({
+            kind: groupBy,
+            project: args.project,
+            from: args.from,
+            to: args.to,
+            timeZone: args.timeZone ?? detectedTimeZone(),
+          });
+          return shapeToolUsage(res, groupBy);
+        }
+
+        const res = await client.analytics({
+          groupBy,
+          from: args.from,
+          to: args.to,
+          timeZone: args.timeZone ?? detectedTimeZone(),
+        });
+        if (res.rows.length === 0) return 'No usage in range.';
+        const lines = res.rows.map(
+          (row) =>
+            `- ${row.key}: ${fmtTokens(row.totalTokens)} tok ` +
+            `(in ${fmtTokens(row.inputTokens)}, out ${fmtTokens(row.outputTokens)}, ` +
+            `cache r/w ${fmtTokens(row.cacheReadTokens)}/${fmtTokens(row.cacheCreationTokens)}) · ` +
+            `${fmtCost(row.costUsd)} · ${row.messageCount} responses`,
+        );
+        lines.push(analyticsTotalsLine(res.totals));
+        return lines.join('\n');
+      },
+    ),
   );
 
   server.registerTool(

--- a/packages/server/src/agent/query.ts
+++ b/packages/server/src/agent/query.ts
@@ -22,6 +22,8 @@ import {
   resolveWindowArgs,
   shapeSearchResults,
   shapeSessionMarkdown,
+  shapeToolUsage,
+  table,
 } from './shape.js';
 
 const json = (v: unknown): string => JSON.stringify(v, null, 2);
@@ -40,26 +42,12 @@ const MAX_CELL = 60;
 
 const clip = (s: string): string => (s.length > MAX_CELL ? `${s.slice(0, MAX_CELL - 1)}…` : s);
 
-/**
- * Dependency-free aligned table: pad each column to its widest cell (header
- * included); `right` marks numeric columns for right-alignment. Widths are
- * code-unit based — good enough for a terminal listing.
- */
-export function table(headers: string[], rows: string[][], right: boolean[] = []): string {
-  const widths = headers.map((h, i) => Math.max(h.length, ...rows.map((r) => (r[i] ?? '').length)));
-  const line = (cells: string[]): string =>
-    cells
-      .map((c, i) => (right[i] ? c.padStart(widths[i] ?? 0) : c.padEnd(widths[i] ?? 0)))
-      .join('  ')
-      .trimEnd();
-  return [line(headers), ...rows.map(line)].join('\n');
-}
-
 export interface SearchArgs {
   query: string;
   project?: string;
   role?: SearchType;
   scope?: SearchScope;
+  literal?: boolean;
   limit?: number;
   json?: boolean;
 }
@@ -71,6 +59,7 @@ export async function querySearch(client: ApiClient, args: SearchArgs): Promise<
     type: args.role ?? 'all',
     scope: args.scope ?? 'sessions',
     format: 'plain',
+    literal: args.literal,
   });
   if (args.json) return json(res);
   return shapeSearchResults(res, args.limit ?? DEFAULT_LIMIT);
@@ -156,7 +145,8 @@ export async function queryProjects(client: ApiClient, args: { json?: boolean })
 }
 
 export interface AnalyticsArgs {
-  groupBy?: AnalyticsGroupBy;
+  groupBy?: AnalyticsGroupBy | 'tool' | 'skill';
+  project?: string;
   from?: string;
   to?: string;
   timeZone?: string;
@@ -164,8 +154,21 @@ export interface AnalyticsArgs {
 }
 
 export async function queryAnalytics(client: ApiClient, args: AnalyticsArgs): Promise<string> {
+  const groupBy = args.groupBy ?? 'project';
+  if (groupBy === 'tool' || groupBy === 'skill') {
+    const res = await client.toolUsage({
+      kind: groupBy,
+      project: args.project,
+      from: args.from,
+      to: args.to,
+      timeZone: args.timeZone,
+    });
+    if (args.json) return json(res);
+    return shapeToolUsage(res, groupBy);
+  }
+
   const res = await client.analytics({
-    groupBy: args.groupBy ?? 'project',
+    groupBy,
     from: args.from,
     to: args.to,
     timeZone: args.timeZone,

--- a/packages/server/src/agent/shape.ts
+++ b/packages/server/src/agent/shape.ts
@@ -6,7 +6,13 @@
  */
 
 import { isAbsolute, resolve } from 'node:path';
-import type { AnalyticsResponse, SearchResponse, SessionDetailResponse } from '@claudescope/shared';
+import type {
+  AnalyticsResponse,
+  SearchResponse,
+  SessionDetailResponse,
+  ToolUsageKind,
+  ToolUsageResponse,
+} from '@claudescope/shared';
 import { redactText, threadItemsToMarkdown } from '@claudescope/shared';
 import { projectIdFromCwd } from '../data/project-id.js';
 
@@ -20,6 +26,21 @@ export const DEFAULT_TURNS = 20;
 export const fmtCost = (usd: number): string => `$${usd.toFixed(2)}`;
 export const fmtTokens = (n: number): string => n.toLocaleString('en-US');
 export const day = (iso: string): string => iso.slice(0, 10);
+
+/**
+ * Dependency-free aligned table: pad each column to its widest cell (header
+ * included); `right` marks numeric columns for right-alignment. Widths are
+ * code-unit based — good enough for a terminal listing.
+ */
+export function table(headers: string[], rows: string[][], right: boolean[] = []): string {
+  const widths = headers.map((h, i) => Math.max(h.length, ...rows.map((r) => (r[i] ?? '').length)));
+  const line = (cells: string[]): string =>
+    cells
+      .map((c, i) => (right[i] ? c.padStart(widths[i] ?? 0) : c.padEnd(widths[i] ?? 0)))
+      .join('  ')
+      .trimEnd();
+  return [line(headers), ...rows.map(line)].join('\n');
+}
 
 /** Windowing params a session request may carry. */
 export interface WindowArgs {
@@ -139,4 +160,20 @@ export function shapeSessionMarkdown(data: SessionDetailResponse, redact: boolea
     );
   }
   return parts.join('\n\n');
+}
+
+/**
+ * Tool/skill usage breakdown as a `KEY, AGENT, COUNT` table. Shared by the CLI
+ * `analytics --group-by tool|skill` command and the MCP `get_analytics` tool so
+ * neither can drift from the other's column layout or empty-state wording.
+ */
+export function shapeToolUsage(res: ToolUsageResponse, kind: ToolUsageKind): string {
+  if (res.rows.length === 0) {
+    return kind === 'skill' ? 'No skill calls in range.' : 'No tool calls in range.';
+  }
+  return table(
+    ['KEY', 'AGENT', 'COUNT'],
+    res.rows.map((r) => [r.tool, r.agent, String(r.count)]),
+    [false, false, true],
+  );
 }

--- a/packages/server/src/cli.ts
+++ b/packages/server/src/cli.ts
@@ -422,14 +422,16 @@ Commands:
 Query commands (read-only; start the background server on first use):
   search "<query>" Full-text search across transcripts and agent memory
                    [--project id] [--role user|assistant] [--scope sessions|memory|all] [--limit N]
+                   [--literal] (exact substring, for errors/identifiers)
   sessions         List sessions [--project id] [--cwd path] [--agent id] [--branch name]
                    [--sort recent|oldest|tokens|cost|messages] [--q substr] [--limit N]
   session <id>     One session as Markdown — a window of turns, pageable
                    [--offset N] [--limit N] [--around uuid] [--radius N] [--tail N]
                    [--max-tool-chars N] [--redact]
   projects         List projects
-  analytics        Token/cost aggregates [--group-by project|model|day|agent]
+  analytics        Token/cost aggregates [--group-by project|model|day|agent|tool|skill]
                    [--from date] [--to date] [--timezone IANA]
+                   (tool|skill accept --project too; count calls, not tokens/cost)
   digest           Week-in-review Markdown [--from date] [--to date] [--timezone IANA]
                    (default: last 7 calendar days in the machine time zone)
   All query commands accept --json for the raw API response (ignores --redact).
@@ -465,6 +467,7 @@ async function main(): Promise<void> {
       branch: { type: 'string' },
       role: { type: 'string' },
       scope: { type: 'string' },
+      literal: { type: 'boolean' },
       sort: { type: 'string' },
       q: { type: 'string' },
       limit: { type: 'string' },
@@ -519,12 +522,13 @@ async function main(): Promise<void> {
     case 'search':
       await runQuery(() => {
         const query = positionals[1];
-        if (!query) throw new UsageError('usage: claudescope search "<query>" [--project id] [--role user|assistant] [--scope sessions|memory|all] [--limit N] [--json]');
+        if (!query) throw new UsageError('usage: claudescope search "<query>" [--project id] [--role user|assistant] [--scope sessions|memory|all] [--literal] [--limit N] [--json]');
         const args = {
           query,
           project: values.project,
           role: enumFlag('role', values.role, ['user', 'assistant', 'all'] as const),
           scope: enumFlag('scope', values.scope, ['sessions', 'memory', 'all'] as const),
+          literal: values.literal,
           limit: intFlag('limit', values.limit),
           json: values.json,
         };
@@ -596,7 +600,8 @@ async function main(): Promise<void> {
     case 'analytics':
       await runQuery(() => {
         const args = {
-          groupBy: enumFlag('group-by', values['group-by'], ['project', 'model', 'day', 'agent'] as const),
+          groupBy: enumFlag('group-by', values['group-by'], ['project', 'model', 'day', 'agent', 'tool', 'skill'] as const),
+          project: values.project,
           from: values.from,
           to: values.to,
           timeZone: values.timezone ?? detectedTimeZone(),

--- a/packages/server/src/connectors/antigravity/normalize.ts
+++ b/packages/server/src/connectors/antigravity/normalize.ts
@@ -40,6 +40,7 @@ import type {
 } from '@claudescope/shared';
 import { resolveImageWithin } from '../safe-image.js';
 import { toolNamesCsv } from '../tool-names.js';
+import { skillNamesCsv } from '../skill-names.js';
 import type { CanonicalRow } from '../canonical.js';
 import { rec, str } from '../json.js';
 
@@ -616,6 +617,8 @@ export function toCanonicalRows(session: AntigravitySession, filePath: string): 
       tool_use_count: content.filter((b) => b.type === 'tool_use').length,
       tool_names: toolNamesCsv(content),
       tool_error_count: null, // Antigravity's typed result records carry no error signal
+      tool_error_text: null,
+      skill_names: skillNamesCsv(content),
       text_content: text,
     };
   });

--- a/packages/server/src/connectors/canonical.ts
+++ b/packages/server/src/connectors/canonical.ts
@@ -47,6 +47,8 @@ export const CANONICAL_COLUMNS = {
   tool_use_count: 'INTEGER',
   tool_names: 'VARCHAR',
   tool_error_count: 'INTEGER',
+  tool_error_text: 'VARCHAR',
+  skill_names: 'VARCHAR',
   text_content: 'VARCHAR',
 } as const;
 
@@ -81,6 +83,9 @@ export interface CanonicalRow {
   tool_names: string;
   /** NULL when the source format carries no error signal — distinct from 0. */
   tool_error_count: number | null;
+  /** Failed tool_result bodies, newline-joined; NULL when the row has none. */
+  tool_error_text: string | null;
+  skill_names: string;
   text_content: string;
   /** Session title; read by the aux projection, ignored by the events one. */
   title?: string;

--- a/packages/server/src/connectors/claude-code/claude-code.ts
+++ b/packages/server/src/connectors/claude-code/claude-code.ts
@@ -17,6 +17,7 @@ import { claudeProjectsDir } from '../../settings.js';
 import { sqlString } from '../../db/duckdb.js';
 import type { SessionData, SubagentSource } from '../../data/session-loader.js';
 import type { AgentConnector, AuxProjections, DiscoveredFile } from '../types.js';
+import { MAX_TOOL_ERROR_TEXT } from '../tool-errors.js';
 import { globalMemory, projectMemory } from './memory.js';
 
 /**
@@ -29,14 +30,36 @@ import { globalMemory, projectMemory } from './memory.js';
 const READ_OPTS = `union_by_name=true, format='newline_delimited', maximum_object_size=268435456, ignore_errors=true`;
 
 /**
+ * One failed tool_result's body. `content` is either a plain string or an array
+ * of blocks (a tool returning an image alongside its message), and DuckDB
+ * reports those as json_type 'VARCHAR' and 'ARRAY' respectively; the array form
+ * keeps its text items only. Any other shape yields NULL, which `string_agg`
+ * then skips.
+ */
+const ERROR_BODY = `
+        CASE json_type(b.value, '$.content')
+          WHEN 'VARCHAR' THEN json_extract_string(b.value, '$.content')
+          WHEN 'ARRAY' THEN array_to_string(
+            list_filter(
+              list_transform(
+                CAST(json_extract(b.value, '$.content') AS JSON[]),
+                x -> CASE WHEN json_extract_string(x, '$.type') = 'text'
+                          THEN json_extract_string(x, '$.text') END
+              ),
+              t -> t IS NOT NULL
+            ), chr(10))
+        END`;
+
+/**
  * One shared pass over a message's content blocks, as a LATERAL join: plain
- * text (text/thinking bodies for FTS), tool_use count + names, and the count
- * of tool_results flagged `is_error` — four aggregates from a single
- * `json_each` scan per row (correlated subqueries would re-scan the array per
- * aggregate, which measurably slows cold indexing). For a plain-string
- * `content` the scan yields scalar rows no block filter matches, so every
- * aggregate comes back empty and the CASEs in the SELECT keep the original
- * per-shape semantics (string content → its text, zero tools).
+ * text (text/thinking bodies for FTS), tool_use count + names, the skill
+ * argument of `Skill` calls, and the count and bodies of tool_results flagged
+ * `is_error` — six aggregates from a single `json_each` scan per row
+ * (correlated subqueries would re-scan the array per aggregate, which
+ * measurably slows cold indexing). For a plain-string `content` the scan yields
+ * scalar rows no block filter matches, so every aggregate comes back empty and
+ * the CASEs in the SELECT keep the original per-shape semantics (string
+ * content → its text, zero tools).
  */
 const BLOCK_AGG_LATERAL = `
   LEFT JOIN LATERAL (
@@ -52,6 +75,16 @@ const BLOCK_AGG_LATERAL = `
         WHERE json_extract_string(b.value, '$.type') = 'tool_result'
           AND json_extract_string(b.value, '$.is_error') = 'true'
       ) AS tool_error_count,
+      string_agg(${ERROR_BODY}, chr(10)) FILTER (
+        WHERE json_extract_string(b.value, '$.type') = 'tool_result'
+          AND json_extract_string(b.value, '$.is_error') = 'true'
+      ) AS tool_error_text,
+      string_agg(json_extract_string(b.value, '$.input.skill'), ',') FILTER (
+        WHERE json_extract_string(b.value, '$.type') = 'tool_use'
+          AND json_extract_string(b.value, '$.name') = 'Skill'
+          AND json_type(b.value, '$.input.skill') = 'VARCHAR'
+          AND json_extract_string(b.value, '$.input.skill') <> ''
+      ) AS skill_names,
       string_agg(
         coalesce(
           json_extract_string(b.value, '$.text'),
@@ -101,6 +134,24 @@ const TOOL_NAMES_EXPR = `
   CASE
     WHEN message IS NULL OR ${STRING_CONTENT} THEN ''
     ELSE COALESCE(blocks.tool_names, '')
+  END`;
+
+/**
+ * Newline-joined bodies of the failed tool_results, capped per event so a single
+ * multi-megabyte failure (a truncated build log) can't bloat the index. NULL
+ * when the row has no failed result — this is search material, not a count.
+ */
+const TOOL_ERROR_TEXT_EXPR = `
+  CASE
+    WHEN message IS NULL OR ${STRING_CONTENT} THEN NULL
+    ELSE left(blocks.tool_error_text, ${MAX_TOOL_ERROR_TEXT})
+  END`;
+
+/** Comma-joined `$.input.skill` of `Skill` tool_use blocks ('' when none). */
+const SKILL_NAMES_EXPR = `
+  CASE
+    WHEN message IS NULL OR ${STRING_CONTENT} THEN ''
+    ELSE COALESCE(blocks.skill_names, '')
   END`;
 
 /**
@@ -168,6 +219,8 @@ function eventsProjectionSql(filePath: string): string {
       ${TOOL_USE_COUNT_EXPR} AS tool_use_count,
       ${TOOL_NAMES_EXPR} AS tool_names,
       ${TOOL_ERROR_COUNT_EXPR} AS tool_error_count,
+      ${TOOL_ERROR_TEXT_EXPR} AS tool_error_text,
+      ${SKILL_NAMES_EXPR} AS skill_names,
       ${TEXT_CONTENT_EXPR} AS text_content,
       json_extract_string(message, '$.id') AS message_id,
       json_extract_string(forkedFrom, '$.sessionId') AS forked_from_session_id

--- a/packages/server/src/connectors/codex/normalize.ts
+++ b/packages/server/src/connectors/codex/normalize.ts
@@ -33,7 +33,8 @@ import type {
 } from '@claudescope/shared';
 import { codexSessionsDir } from '../../settings.js';
 import { toolNamesCsv } from '../tool-names.js';
-import { toolErrorCount } from '../tool-errors.js';
+import { skillNamesCsv } from '../skill-names.js';
+import { toolErrorCount, toolErrorText } from '../tool-errors.js';
 import type { CanonicalRow } from '../canonical.js';
 import { num, rec, str } from '../json.js';
 
@@ -1023,6 +1024,8 @@ export function toCanonicalRows(session: CodexSession, filePath: string): Canoni
       tool_use_count: arr.filter((b) => b.type === 'tool_use').length,
       tool_names: toolNamesCsv(arr),
       tool_error_count: toolErrorCount(arr),
+      tool_error_text: toolErrorText(arr),
+      skill_names: skillNamesCsv(arr),
       text_content: text,
     };
   });

--- a/packages/server/src/connectors/copilot/normalize.ts
+++ b/packages/server/src/connectors/copilot/normalize.ts
@@ -50,7 +50,8 @@ import type {
 } from '@claudescope/shared';
 import { resolveImageWithin } from '../safe-image.js';
 import { toolNamesCsv } from '../tool-names.js';
-import { toolErrorCount } from '../tool-errors.js';
+import { skillNamesCsv } from '../skill-names.js';
+import { toolErrorCount, toolErrorText } from '../tool-errors.js';
 import type { CanonicalRow } from '../canonical.js';
 import { num, rec, str } from '../json.js';
 
@@ -497,6 +498,8 @@ export function toCanonicalRows(session: CopilotSession, filePath: string): Cano
       tool_use_count: content.filter((b) => b.type === 'tool_use').length,
       tool_names: toolNamesCsv(content),
       tool_error_count: toolErrorCount(content),
+      tool_error_text: toolErrorText(content),
+      skill_names: skillNamesCsv(content),
       text_content: text,
       title: session.title,
     };

--- a/packages/server/src/connectors/grok/normalize.ts
+++ b/packages/server/src/connectors/grok/normalize.ts
@@ -36,6 +36,7 @@ import { existsSync, readdirSync, readFileSync, statSync } from 'node:fs';
 import { basename, dirname, join } from 'node:path';
 import type { AssistantEvent, ContentBlock, MessageUsage, UserEvent } from '@claudescope/shared';
 import { toolNamesCsv } from '../tool-names.js';
+import { skillNamesCsv } from '../skill-names.js';
 import type { CanonicalRow } from '../canonical.js';
 import { num, rec, str } from '../json.js';
 
@@ -630,6 +631,8 @@ export function toCanonicalRows(session: GrokSession, filePath: string): Canonic
       tool_use_count: content.filter((b) => b.type === 'tool_use').length,
       tool_names: toolNamesCsv(content),
       tool_error_count: null,
+      tool_error_text: null,
+      skill_names: skillNamesCsv(content),
       text_content: text,
       // A sidechain file's rows carry the PARENT's session_id — emitting the
       // child's own title there would overwrite the parent's in the titles

--- a/packages/server/src/connectors/junie/normalize.ts
+++ b/packages/server/src/connectors/junie/normalize.ts
@@ -36,6 +36,7 @@ import type {
 import { junieHome } from '../../settings.js';
 import { resolveImageWithin } from '../safe-image.js';
 import { toolNamesCsv } from '../tool-names.js';
+import { skillNamesCsv } from '../skill-names.js';
 import type { CanonicalRow } from '../canonical.js';
 import { num, str } from '../json.js';
 
@@ -453,6 +454,8 @@ export function toCanonicalRows(session: JunieSession, filePath: string): Canoni
       tool_use_count: arr.filter((b) => b.type === 'tool_use').length,
       tool_names: toolNamesCsv(arr),
       tool_error_count: null, // Junie results are 'modified: path' strings — no error signal
+      tool_error_text: null,
+      skill_names: skillNamesCsv(arr),
       text_content: text,
       title: session.title,
     };

--- a/packages/server/src/connectors/opencode/normalize.ts
+++ b/packages/server/src/connectors/opencode/normalize.ts
@@ -34,7 +34,8 @@ import type {
 } from '@claudescope/shared';
 import type { OpencodeRawSession } from './db.js';
 import { toolNamesCsv } from '../tool-names.js';
-import { toolErrorCount } from '../tool-errors.js';
+import { skillNamesCsv } from '../skill-names.js';
+import { toolErrorCount, toolErrorText } from '../tool-errors.js';
 import type { CanonicalRow } from '../canonical.js';
 import { num, str } from '../json.js';
 
@@ -416,6 +417,8 @@ export function toCanonicalRows(session: OpencodeRawSession, filePath: string): 
       tool_use_count: content.filter((b) => b.type === 'tool_use').length,
       tool_names: toolNamesCsv(content),
       tool_error_count: toolErrorCount(content),
+      tool_error_text: toolErrorText(content),
+      skill_names: skillNamesCsv(content),
       text_content: text,
       // A child's title must not clobber the parent's via the titles projection
       // (both files now share one session_id) — emit none for sidechain rows.

--- a/packages/server/src/connectors/pi/normalize.ts
+++ b/packages/server/src/connectors/pi/normalize.ts
@@ -36,7 +36,8 @@ import { existsSync, readFileSync, statSync } from 'node:fs';
 import { basename, dirname } from 'node:path';
 import type { AssistantEvent, ContentBlock, MessageUsage, UserEvent } from '@claudescope/shared';
 import { toolNamesCsv } from '../tool-names.js';
-import { toolErrorCount } from '../tool-errors.js';
+import { skillNamesCsv } from '../skill-names.js';
+import { toolErrorCount, toolErrorText } from '../tool-errors.js';
 import type { CanonicalRow } from '../canonical.js';
 import { num, rec, str } from '../json.js';
 
@@ -487,6 +488,8 @@ export function toCanonicalRows(session: PiSession, filePath: string): Canonical
       tool_use_count: content.filter((b) => b.type === 'tool_use').length,
       tool_names: toolNamesCsv(content),
       tool_error_count: toolErrorCount(content),
+      tool_error_text: toolErrorText(content),
+      skill_names: skillNamesCsv(content),
       text_content: text,
     };
   });

--- a/packages/server/src/connectors/skill-names.ts
+++ b/packages/server/src/connectors/skill-names.ts
@@ -1,0 +1,16 @@
+/**
+ * Comma-joined `skill` argument of a message's canonical `Skill` tool calls, in
+ * order (empty string when there are none). Stored in the `events.skill_names`
+ * column and shaped exactly like `events.tool_names`, which on its own only ever
+ * says "Skill" — the skill actually invoked lives in the call's input. Skill
+ * names never contain commas, so the join is unambiguous.
+ */
+export function skillNamesCsv(
+  blocks: ReadonlyArray<{ type: string; name?: string; input?: unknown }>,
+): string {
+  return blocks
+    .filter((b) => b.type === 'tool_use' && b.name === 'Skill')
+    .map((b) => (b.input as { skill?: unknown } | null | undefined)?.skill)
+    .filter((s): s is string => typeof s === 'string' && s !== '')
+    .join(',');
+}

--- a/packages/server/src/connectors/tool-errors.ts
+++ b/packages/server/src/connectors/tool-errors.ts
@@ -10,3 +10,48 @@ export function toolErrorCount(
 ): number {
   return blocks.filter((b) => b.type === 'tool_result' && b.is_error === true).length;
 }
+
+/**
+ * Per-event cap on {@link toolErrorText}, so a single multi-megabyte failure (a
+ * truncated build log, a stack trace with an embedded payload) can't bloat the
+ * index. Shared with the Claude Code SQL projection, which derives the same
+ * column in DuckDB.
+ */
+export const MAX_TOOL_ERROR_TEXT = 4000;
+
+/**
+ * Bodies of the failed `tool_result` blocks on a canonical row, newline-joined
+ * and capped — the searchable half of {@link toolErrorCount}. Stored in
+ * `events.tool_error_text` so a literal search finds an error message the
+ * assistant never restated in prose. NULL when the row has no failed result.
+ */
+export function toolErrorText(
+  blocks: ReadonlyArray<{ type: string; is_error?: boolean; content?: unknown }>,
+): string | null {
+  const bodies = blocks
+    .filter((b) => b.type === 'tool_result' && b.is_error === true)
+    .map((b) => resultText(b.content))
+    .filter((t): t is string => t !== null);
+  if (bodies.length === 0) return null;
+  const capped = bodies.join('\n').slice(0, MAX_TOOL_ERROR_TEXT);
+  // Slicing by UTF-16 unit can cut a surrogate pair in half, and DuckDB's JSON
+  // reader nulls out every column of a cache line carrying a lone surrogate —
+  // losing the whole event, not just its error text. Drop the orphan half.
+  return /[\uD800-\uDBFF]$/.test(capped) ? capped.slice(0, -1) : capped;
+}
+
+/**
+ * A `tool_result.content` as searchable text. It is usually a plain string, but
+ * can also be an array of blocks (a tool returning an image beside its message)
+ * — only the text items of that form count. Any other shape has no body at all.
+ */
+function resultText(content: unknown): string | null {
+  if (typeof content === 'string') return content;
+  if (!Array.isArray(content)) return null;
+  return content
+    .filter((b): b is { type: string; text: string } =>
+      (b as { type?: unknown })?.type === 'text' && typeof (b as { text?: unknown }).text === 'string',
+    )
+    .map((b) => b.text)
+    .join('\n');
+}

--- a/packages/server/src/data/index.ts
+++ b/packages/server/src/data/index.ts
@@ -232,7 +232,7 @@ async function loadFile(
       ${costExpr} AS cost_usd,
       ev.text_content,
       ev.message_id, ev.forked_from_session_id, TRUE AS usage_canonical,
-      ev.tool_error_count
+      ev.tool_error_count, ev.tool_error_text, ev.skill_names
     FROM (
       ${connector.eventsProjectionSql(file.path)}
     ) AS ev

--- a/packages/server/src/db/schema.ts
+++ b/packages/server/src/db/schema.ts
@@ -40,7 +40,9 @@
 // v17: Codex pathless bootstrap headings and current guardian-review rollouts
 //      change persisted fallback titles and indexed sessions.
 // v18: current Codex exec-wrapped apply_patch calls populate canonical file edits.
-export const SCHEMA_VERSION = 18;
+// v19: per-event tool_error_text (failed tool_result bodies) and skill_names,
+//      indexed for literal search and the skill-usage breakdown.
+export const SCHEMA_VERSION = 19;
 
 /** All DDL statements, executed in order at startup. Idempotent. */
 export const SCHEMA_DDL: readonly string[] = [
@@ -87,7 +89,14 @@ export const SCHEMA_DDL: readonly string[] = [
      usage_canonical BOOLEAN DEFAULT TRUE,
      -- Failed tool calls on the row (tool_result blocks with is_error). NULL when
      -- the source format has no error signal (Junie, Antigravity) — not 0.
-     tool_error_count INTEGER
+     tool_error_count INTEGER,
+     -- Bodies of those failed tool_results, newline-joined and capped per event.
+     -- Indexed so a literal search finds an error the assistant never restated;
+     -- NULL when the row carries no failed result.
+     tool_error_text VARCHAR,
+     -- Comma-joined skill argument of canonical Skill tool calls, shaped like
+     -- tool_names, which on its own only ever says "Skill".
+     skill_names     VARCHAR DEFAULT ''
    )`,
 
   `CREATE TABLE IF NOT EXISTS sessions (

--- a/packages/server/src/params.ts
+++ b/packages/server/src/params.ts
@@ -103,6 +103,12 @@ export function enumParam<const T extends string>(
   fallback: T,
 ): T {
   if (raw === undefined) return fallback;
+  // A repeated query param (`?kind=a&kind=b`) arrives as an array, which the
+  // route's `string | undefined` typing does not admit — reject it here rather
+  // than let `trim()` throw a 500.
+  if (typeof raw !== 'string') {
+    throw new BadRequestError(`${field} must be a single value (got '${String(raw)}')`);
+  }
   const value = raw.trim();
   if (!allowed.some((candidate) => candidate === value)) {
     throw new BadRequestError(

--- a/packages/server/src/routes/analytics-tools.ts
+++ b/packages/server/src/routes/analytics-tools.ts
@@ -1,23 +1,39 @@
 /**
  * GET /api/analytics/tools — count of tool calls by raw (canonical) tool name
  * AND the agent that emitted it (joined from `sessions.connector_id`), descending.
- * Unnests the `events.tool_names` CSV. Filters on `usage_canonical` to match the
- * "tool calls" semantics of the session-efficiency table (a fork copy / multi-block
- * split must not multiply-count a call). The web maps raw names → categories via
- * `toolCategory()` and surfaces the per-agent attribution in the tooltip.
+ * Unnests the `events.tool_names` CSV. Duplicates are dropped by excluding fork
+ * copies (`forked_from_session_id`, set on every copied row), NOT by
+ * `usage_canonical`: that elects one row per billed message for token sums, while
+ * a split message keeps its tool_use blocks on specific rows — most of which lose
+ * the election, so filtering on it hides the majority of real calls. The web maps
+ * raw names → categories via `toolCategory()` and surfaces the per-agent
+ * attribution in the tooltip.
+ *
+ * `kind=skill` swaps the source column to `events.skill_names` — the `skill`
+ * argument of each canonical `Skill` tool_use call — so the same `tool` field
+ * carries a skill name instead of a tool name.
  */
 import type { FastifyInstance } from 'fastify';
-import type { ToolUsageResponse, ToolUsageRow } from '@claudescope/shared';
+import type { ToolUsageKind, ToolUsageResponse, ToolUsageRow } from '@claudescope/shared';
 import { getConnection, queryRows } from '../db/duckdb.js';
 import { readRow } from '../db/row.js';
 import { scopeFilters } from '../data/analytics-scope.js';
+import { enumParam } from '../params.js';
+
+const TOOL_USAGE_KINDS = ['tool', 'skill'] as const;
 
 export async function registerToolsRoute(app: FastifyInstance): Promise<void> {
   app.get<{
-    Querystring: { project?: string; from?: string; to?: string; timeZone?: string };
+    Querystring: { kind?: string; project?: string; from?: string; to?: string; timeZone?: string };
   }>('/api/analytics/tools', async (req): Promise<ToolUsageResponse> => {
     const conn = await getConnection();
-    const filters: string[] = ["e.type = 'assistant'", 'e.usage_canonical', "e.tool_names <> ''"];
+    const kind: ToolUsageKind = enumParam(req.query.kind, 'kind', TOOL_USAGE_KINDS, 'tool');
+    const column = kind === 'skill' ? 'skill_names' : 'tool_names';
+    const filters: string[] = [
+      "e.type = 'assistant'",
+      'e.forked_from_session_id IS NULL',
+      `e.${column} <> ''`,
+    ];
     // Project scope resolves like every other analytics route; date bounds stay
     // on the event timestamp (a call belongs to the day it happened).
     filters.push(...(await scopeFilters(conn, req.query, { cwd: 's.project_cwd', ts: 'e.ts' })));
@@ -26,7 +42,7 @@ export async function registerToolsRoute(app: FastifyInstance): Promise<void> {
       conn,
       `SELECT tool, agent, count(*) AS count
        FROM (
-         SELECT unnest(string_split(e.tool_names, ',')) AS tool, s.connector_id AS agent
+         SELECT unnest(string_split(e.${column}, ',')) AS tool, s.connector_id AS agent
          FROM events e
          JOIN sessions s ON e.session_id = s.id
          WHERE ${filters.join(' AND ')}

--- a/packages/server/src/routes/search.ts
+++ b/packages/server/src/routes/search.ts
@@ -6,6 +6,10 @@
  * which: `sessions` (default), `all` (both), or `memory` (memory only). Both
  * kinds carry a snippet with matched terms highlighted via `<mark>`. Optional
  * filters: `project` (slug) and `type` (user|assistant|all; sessions only).
+ *
+ * `literal=true` swaps the transcript half for an exact substring match over
+ * text, failed tool-result bodies, tool names and skill names (newest first);
+ * memory search is unaffected.
  */
 
 import type { FastifyInstance } from 'fastify';
@@ -92,6 +96,85 @@ async function searchSessions(
   });
 }
 
+/**
+ * Sessions (literal) search: the whole query as one case-insensitive substring,
+ * newest first, no ranking. It also reaches the columns FTS does not index —
+ * failed tool-result bodies, tool names and skill names — so an error the
+ * assistant never restated in prose, or a tool/skill invocation, is findable.
+ */
+async function searchLiteral(
+  q: string,
+  type: SearchType,
+  project: string | undefined,
+  format: SnippetFormat,
+): Promise<SearchResult[]> {
+  const conn = await getConnection();
+  // Case-fold in ONE engine: DuckDB's `lower()` and JavaScript's `toLowerCase()`
+  // disagree on dozens of code points (U+0130 `İ`, final sigma, …), so a needle
+  // lowered here could miss rows the SQL filter matches — and vice versa.
+  const lit = `lower(${sqlString(q)})`;
+
+  const filters: string[] = [
+    `(contains(lower(coalesce(e.text_content, '')), ${lit})
+      OR contains(lower(coalesce(e.tool_error_text, '')), ${lit})
+      OR contains(lower(e.tool_names), ${lit})
+      OR contains(lower(e.skill_names), ${lit}))`,
+  ];
+  if (type === 'user' || type === 'assistant') filters.push(`e.role = ${sqlString(type)}`);
+  if (project) filters.push(await projectFilter(conn, project, 's.project_cwd'));
+
+  const rows = await queryRows(
+    conn,
+    `SELECT
+       e.uuid AS message_uuid,
+       e.session_id AS session_id,
+       e.role AS role,
+       e.text_content AS text_content,
+       e.tool_error_text AS tool_error_text,
+       e.tool_names AS tool_names,
+       e.skill_names AS skill_names,
+       s.project_cwd AS project_cwd,
+       s.title AS title,
+       CASE
+         WHEN contains(lower(coalesce(e.text_content, '')), ${lit}) THEN 'text'
+         WHEN contains(lower(coalesce(e.tool_error_text, '')), ${lit}) THEN 'error'
+         WHEN contains(lower(e.skill_names), ${lit}) THEN 'skill'
+         ELSE 'tool'
+       END AS matched
+     FROM events e
+     JOIN sessions s ON s.id = e.session_id
+     WHERE ${filters.join(' AND ')}
+     ORDER BY e.ts DESC NULLS LAST
+     LIMIT 50`,
+  );
+
+  return rows.map((r): SearchResult => {
+    const rd = readRow(r, 'search-literal');
+    const cwd = rd.str('project_cwd');
+    // Which column matched is decided by the same SQL that filtered, never
+    // re-tested here. The match may live in a column with no prose to quote, so
+    // those synthesize a line that still shows what it matched.
+    const matched = rd.str('matched');
+    const source =
+      matched === 'text'
+        ? rd.str('text_content')
+        : matched === 'error'
+          ? rd.str('tool_error_text')
+          : matched === 'skill'
+            ? `Skills: ${rd.str('skill_names')}`
+            : `Tools: ${rd.str('tool_names')}`;
+    return {
+      sessionId: rd.str('session_id'),
+      projectId: cwd ? projectIdFromCwd(cwd) : '',
+      title: rd.str('title'),
+      snippet: makeSnippet(source, [q], format),
+      score: 0,
+      messageUuid: rd.str('message_uuid'),
+      role: rd.str('role'),
+    };
+  });
+}
+
 /** Live memory search. Empty unless scope includes memory. */
 async function searchMemory(
   terms: string[],
@@ -140,7 +223,14 @@ async function searchMemory(
 
 export async function registerSearchRoute(app: FastifyInstance): Promise<void> {
   app.get<{
-    Querystring: { q?: string; project?: string; type?: string; scope?: string; format?: string };
+    Querystring: {
+      q?: string;
+      project?: string;
+      type?: string;
+      scope?: string;
+      format?: string;
+      literal?: string;
+    };
   }>('/api/search', async (req): Promise<SearchResponse> => {
     const q = (req.query.q ?? '').trim();
     if (!q) return { sessions: [], memory: [] };
@@ -150,13 +240,17 @@ export async function registerSearchRoute(app: FastifyInstance): Promise<void> {
     const project = req.query.project;
     const scope = enumParam(req.query.scope, 'scope', SEARCH_SCOPES, 'sessions');
     const format: SnippetFormat = req.query.format === 'plain' ? 'plain' : 'html';
+    const literal = req.query.literal === 'true' || req.query.literal === '1';
 
     // Each kind is guarded so a failure in one (e.g. an FTS edge case) still
     // returns the other rather than 500-ing the whole request.
     const sessions =
       scope === 'memory'
         ? []
-        : await searchSessions(q, terms, type, project, format).catch((err) => {
+        : await (literal
+            ? searchLiteral(q, type, project, format)
+            : searchSessions(q, terms, type, project, format)
+          ).catch((err) => {
             // Don't 500 the whole request, but don't let a real FTS regression
             // silently look like "no results" either — leave a trace.
             req.log.warn({ err }, 'session search failed');

--- a/packages/server/test/analytics-tools.integration.test.ts
+++ b/packages/server/test/analytics-tools.integration.test.ts
@@ -40,8 +40,8 @@ beforeAll(async () => {
     ]),
   );
   // Fork-copy session: same message.id 'm1', same tool_use blocks, carrying forkedFrom.
-  // The canonical-usage election prefers the original (forked_from_session_id IS NULL)
-  // and marks this copy non-canonical — proving usage_canonical is load-bearing.
+  // Every copied row keeps the marker, so the fork filter drops the whole copy —
+  // proving the fork exclusion is load-bearing.
   const forkBase = { sessionId: 'sTF', cwd: '/tmp/tools', gitBranch: 'main', version: '2.1.0' };
   const forkFrom = { sessionId: 'sT', messageUuid: 'a1' };
   writeFileSync(
@@ -55,6 +55,51 @@ beforeAll(async () => {
       ], usage: { input_tokens: 1, output_tokens: 1 } } },
     ]),
   );
+
+  // Session with one Skill call, plus a fork copy sharing message.id 'm2'.
+  // Same fork-dedup story as the tools case above: kind=skill must still count
+  // the skill once, not twice.
+  const skillBase = { sessionId: 'sS', cwd: '/tmp/tools', gitBranch: 'main', version: '2.1.0' };
+  writeFileSync(
+    join(projA, 'sS.jsonl'),
+    jsonl([
+      { ...skillBase, type: 'user', uuid: 'su1', parentUuid: null, timestamp: '2026-06-01T11:00:00.000Z', isSidechain: false, message: { role: 'user', content: 'search history' } },
+      { ...skillBase, type: 'assistant', uuid: 'sa1', parentUuid: 'su1', timestamp: '2026-06-01T11:00:01.000Z', isSidechain: false, message: { role: 'assistant', model: 'claude-opus-4-8', id: 'm2', content: [
+        { type: 'tool_use', id: 't4', name: 'Skill', input: { skill: 'claudescope:history' } },
+      ], usage: { input_tokens: 1, output_tokens: 1 } } },
+    ]),
+  );
+  const skillForkBase = { sessionId: 'sSF', cwd: '/tmp/tools', gitBranch: 'main', version: '2.1.0' };
+  const skillForkFrom = { sessionId: 'sS', messageUuid: 'sa1' };
+  writeFileSync(
+    join(projA, 'sSF.jsonl'),
+    jsonl([
+      { ...skillForkBase, type: 'user', uuid: 'su1', parentUuid: null, timestamp: '2026-06-01T11:00:00.000Z', isSidechain: false, forkedFrom: skillForkFrom, message: { role: 'user', content: 'search history' } },
+      { ...skillForkBase, type: 'assistant', uuid: 'sa1', parentUuid: 'su1', timestamp: '2026-06-01T11:00:01.000Z', isSidechain: false, forkedFrom: skillForkFrom, message: { role: 'assistant', model: 'claude-opus-4-8', id: 'm2', content: [
+        { type: 'tool_use', id: 't4', name: 'Skill', input: { skill: 'claudescope:history' } },
+      ], usage: { input_tokens: 1, output_tokens: 1 } } },
+    ]),
+  );
+  // Split message: two assistant rows share message.id 'm3' with identical usage,
+  // so the canonical election falls to the uuid tiebreak and 'sp-a' (text only)
+  // wins. The tool_use blocks live on the non-canonical 'sp-b' — the common shape
+  // in real transcripts, and invisible to this endpoint under a usage_canonical filter.
+  const splitBase = { sessionId: 'sP', cwd: '/tmp/tools', gitBranch: 'main', version: '2.1.0' };
+  const splitUsage = { input_tokens: 3, output_tokens: 2 };
+  writeFileSync(
+    join(projA, 'sP.jsonl'),
+    jsonl([
+      { ...splitBase, type: 'user', uuid: 'spu1', parentUuid: null, timestamp: '2026-06-01T12:00:00.000Z', isSidechain: false, message: { role: 'user', content: 'find it' } },
+      { ...splitBase, type: 'assistant', uuid: 'sp-a', parentUuid: 'spu1', timestamp: '2026-06-01T12:00:01.000Z', isSidechain: false, message: { role: 'assistant', model: 'claude-opus-4-8', id: 'm3', content: [
+        { type: 'text', text: 'Looking for the config.' },
+      ], usage: splitUsage } },
+      { ...splitBase, type: 'assistant', uuid: 'sp-b', parentUuid: 'sp-a', timestamp: '2026-06-01T12:00:02.000Z', isSidechain: false, message: { role: 'assistant', model: 'claude-opus-4-8', id: 'm3', content: [
+        { type: 'tool_use', id: 't5', name: 'Glob', input: {} },
+        { type: 'tool_use', id: 't6', name: 'Skill', input: { skill: 'claudescope:verify' } },
+      ], usage: splitUsage } },
+    ]),
+  );
+
   const Fastify = (await import('fastify')).default;
   const { registerRoutes } = await import('../src/routes/index.js');
   const { reindex } = await import('../src/data/index.js');
@@ -88,13 +133,41 @@ describe('GET /api/analytics/tools', () => {
     const body = res.json() as { rows: { tool: string; agent: string; count: number }[] };
     const sumTool = (t: string) => body.rows.filter((r) => r.tool === t).reduce((n, r) => n + r.count, 0);
     // The fork-copy row shares message.id 'm1' and carries the same [Edit, Edit, Bash]
-    // blocks, but is marked non-canonical by usage_canonical election. Counts must
-    // remain Edit=2 and Bash=1, not 4 and 2 — proving usage_canonical is load-bearing.
+    // blocks, but is excluded as a fork copy. Counts must remain Edit=2 and Bash=1,
+    // not 4 and 2 — proving the fork exclusion is load-bearing.
     expect(sumTool('Edit')).toBe(2);
     expect(sumTool('Bash')).toBe(1);
     // Each row is attributed to the agent that emitted it (here, all Claude Code).
     expect(body.rows.every((r) => r.agent === 'claude-code')).toBe(true);
     // descending
     expect(body.rows[0]?.count).toBeGreaterThanOrEqual(body.rows[body.rows.length - 1]?.count ?? 0);
+  });
+
+  it('kind=skill counts the skill argument of Skill calls, deduped across a fork', async () => {
+    const res = await app.inject({ method: 'GET', url: '/api/analytics/tools?kind=skill' });
+    const body = res.json() as { rows: { tool: string; agent: string; count: number }[] };
+    // The fork-copy session shares message.id 'm2' and the same Skill call, but
+    // carries the fork marker — the count must stay 1, not 2.
+    expect(body.rows.filter((r) => r.tool === 'claudescope:history')).toEqual([
+      { tool: 'claudescope:history', agent: 'claude-code', count: 1 },
+    ]);
+  });
+
+  it('counts calls that sit on the non-canonical row of a split message', async () => {
+    const tools = (await app.inject({ method: 'GET', url: '/api/analytics/tools' })).json() as { rows: { tool: string; count: number }[] };
+    const skills = (await app.inject({ method: 'GET', url: '/api/analytics/tools?kind=skill' })).json() as { rows: { tool: string; count: number }[] };
+    // Both blocks live on 'sp-b', the row the usage election did NOT pick.
+    expect(tools.rows.find((r) => r.tool === 'Glob')?.count).toBe(1);
+    expect(skills.rows.find((r) => r.tool === 'claudescope:verify')?.count).toBe(1);
+  });
+
+  it('kind=bogus is rejected', async () => {
+    const res = await app.inject({ method: 'GET', url: '/api/analytics/tools?kind=bogus' });
+    expect(res.statusCode).toBe(400);
+  });
+
+  it('a repeated kind param is rejected (an array, not a string)', async () => {
+    const res = await app.inject({ method: 'GET', url: '/api/analytics/tools?kind=tool&kind=skill' });
+    expect(res.statusCode).toBe(400);
   });
 });

--- a/packages/server/test/cli-query.test.ts
+++ b/packages/server/test/cli-query.test.ts
@@ -59,7 +59,7 @@ function writeFixtures(): void {
     jsonl([
       { type: 'ai-title', sessionId: 'sessQ2', aiTitle: '🚀 déjà-vu — fix résumé parsing' },
       { ...base2, type: 'user', uuid: 'q2u1', parentUuid: null, timestamp: '2026-01-03T09:00:00.000Z', isSidechain: false, message: { role: 'user', content: 'unrelated haystack chatter' } },
-      { ...base2, type: 'assistant', uuid: 'q2a1', parentUuid: 'q2u1', timestamp: '2026-01-03T09:00:04.000Z', isSidechain: false, message: { role: 'assistant', model: 'claude-opus-4-8', content: [{ type: 'text', text: 'ok' }], usage } },
+      { ...base2, type: 'assistant', uuid: 'q2a1', parentUuid: 'q2u1', timestamp: '2026-01-03T09:00:04.000Z', isSidechain: false, message: { role: 'assistant', model: 'claude-opus-4-8', content: [{ type: 'text', text: 'ok' }, { type: 'tool_use', id: 't1', name: 'Bash', input: {} }], usage } },
     ]),
   );
 }
@@ -131,6 +131,13 @@ describe('cli query subcommands', () => {
     expect(miss).toBe('No matches.');
   });
 
+  it('search --literal survives the boolean→query-param hop', async () => {
+    const hit = await query.querySearch(client, { query: 'secret/needle.txt', literal: true });
+    expect(hit).toContain('sessQ1');
+    const miss = await query.querySearch(client, { query: 'zzz-none', literal: true });
+    expect(miss).toBe('No matches.');
+  });
+
   it('session --redact masks home paths in Markdown, while --json stays raw', async () => {
     const plain = await query.querySession(client, 'sessQ1', {});
     expect(plain).toContain('/Users/testuser/secret/needle.txt');
@@ -150,5 +157,12 @@ describe('cli query subcommands', () => {
     const out = await query.queryAnalytics(client, { groupBy: 'agent' });
     expect(out).toContain('claude-code');
     expect(out).toMatch(/Total: [\d,]+ tok · \$\d/u);
+  });
+
+  it('analytics --group-by tool renders a KEY/AGENT/COUNT table, no totals line', async () => {
+    const out = await query.queryAnalytics(client, { groupBy: 'tool' });
+    expect(out).toMatch(/^KEY\s+AGENT\s+COUNT$/mu);
+    expect(out).toContain('claude-code');
+    expect(out).not.toContain('Total:');
   });
 });

--- a/packages/server/test/index-error-text.integration.test.ts
+++ b/packages/server/test/index-error-text.integration.test.ts
@@ -1,0 +1,141 @@
+/**
+ * Schema v19's two derived columns, end to end.
+ *
+ * `tool_error_text` is the one derivation whose source shape is genuinely
+ * polymorphic: `tool_result.content` is usually a string but can be an array of
+ * blocks, and Claude Code derives the column in SQL (a DuckDB `json_type` switch)
+ * while every other connector derives it in TypeScript — two implementations that
+ * have to agree. `skill_names` reaches into `tool_use.input`, which nothing else
+ * in the index does, so a Skill call without a `skill` argument must not poison it.
+ */
+
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+const work = mkdtempSync(join(tmpdir(), 'claudescope-errtext-'));
+const projectsDir = join(work, 'projects');
+const codexDir = join(work, 'codex');
+process.env.CLAUDE_PROJECTS_DIR = projectsDir;
+process.env.CODEX_SESSIONS_DIR = codexDir;
+process.env.JUNIE_SESSIONS_DIR = join(work, 'junie-empty');
+process.env.PI_SESSIONS_DIR = join(work, 'pi-empty');
+process.env.OPENCODE_DATA_DIR = join(work, 'opencode-empty');
+process.env.COPILOT_SESSIONS_DIR = join(work, 'copilot-empty');
+process.env.ANTIGRAVITY_CLI_DIR = join(work, 'antigravity-empty');
+process.env.ANTIGRAVITY_DIR = join(work, 'antigravity-empty-desktop');
+process.env.GROK_SESSIONS_DIR = join(work, 'grok-empty');
+process.env.DUCKDB_PATH = join(work, 'index.duckdb');
+process.env.CLAUDESCOPE_HOME = join(work, 'home');
+process.env.REINDEX_INTERVAL_MS = '0';
+
+const jsonl = (events: unknown[]): string => events.map((e) => JSON.stringify(e)).join('\n') + '\n';
+
+/** Longer than the 4000-char per-event cap. */
+const HUGE = 'stack frame\n'.repeat(900);
+
+let getConnection: typeof import('../src/db/duckdb.js').getConnection;
+let queryRows: typeof import('../src/db/duckdb.js').queryRows;
+let closeConnection: typeof import('../src/db/duckdb.js').closeConnection;
+
+const row = async (uuid: string): Promise<Record<string, unknown>> => {
+  const conn = await getConnection();
+  const rows = await queryRows(
+    conn,
+    `SELECT tool_error_count, tool_error_text, skill_names FROM events WHERE uuid = '${uuid}'`,
+  );
+  return rows[0]!;
+};
+
+beforeAll(async () => {
+  const projA = join(projectsDir, 'enc-errtext');
+  mkdirSync(projA, { recursive: true });
+  const base = { sessionId: 'sErr', cwd: '/tmp/errtext', gitBranch: 'main', version: '2.1.0' };
+  const at = (n: number) => `2026-06-02T10:00:${String(n).padStart(2, '0')}.000Z`;
+  writeFileSync(
+    join(projA, 'sErr.jsonl'),
+    jsonl([
+      { ...base, type: 'user', uuid: 'u1', parentUuid: null, timestamp: at(0), isSidechain: false, message: { role: 'user', content: 'build it' } },
+      { ...base, type: 'assistant', uuid: 'a1', parentUuid: 'u1', timestamp: at(1), isSidechain: false, message: { role: 'assistant', model: 'claude-opus-4-8', id: 'm1', content: [{ type: 'tool_use', id: 't1', name: 'Bash', input: { command: 'npm run build' } }], usage: { input_tokens: 5, output_tokens: 5 } } },
+      // String-form failed result.
+      { ...base, type: 'user', uuid: 'r1', parentUuid: 'a1', timestamp: at(2), isSidechain: false, message: { role: 'user', content: [{ type: 'tool_result', tool_use_id: 't1', is_error: true, content: 'ENOENT: no such file or directory' }] } },
+      // Array-form failed result: only the text item is searchable, the image is not.
+      { ...base, type: 'user', uuid: 'r2', parentUuid: 'r1', timestamp: at(3), isSidechain: false, message: { role: 'user', content: [{ type: 'tool_result', tool_use_id: 't2', is_error: true, content: [{ type: 'image', source: { type: 'base64', media_type: 'image/png', data: 'AAAA' } }, { type: 'text', text: 'TS2339: Property foo does not exist' }] }] } },
+      // Successful result — must stay NULL, not ''.
+      { ...base, type: 'user', uuid: 'r3', parentUuid: 'r2', timestamp: at(4), isSidechain: false, message: { role: 'user', content: [{ type: 'tool_result', tool_use_id: 't3', content: 'Build succeeded' }] } },
+      // Oversized failure body.
+      { ...base, type: 'user', uuid: 'r4', parentUuid: 'r3', timestamp: at(5), isSidechain: false, message: { role: 'user', content: [{ type: 'tool_result', tool_use_id: 't4', is_error: true, content: HUGE }] } },
+      { ...base, type: 'assistant', uuid: 'a2', parentUuid: 'r4', timestamp: at(6), isSidechain: false, message: { role: 'assistant', model: 'claude-opus-4-8', id: 'm2', content: [
+        { type: 'tool_use', id: 's1', name: 'Skill', input: { skill: 'claudescope:history' } },
+        { type: 'tool_use', id: 's2', name: 'Skill', input: { command: 'no skill argument' } },
+        { type: 'tool_use', id: 's3', name: 'Skill', input: { skill: '' } },
+      ], usage: { input_tokens: 5, output_tokens: 5 } } },
+    ]),
+  );
+
+  // Codex: the same column, derived by a normalizer and round-tripped through the
+  // canonical NDJSON cache instead of read straight out of the source JSONL.
+  mkdirSync(codexDir, { recursive: true });
+  writeFileSync(
+    join(codexDir, 'rollout-2026-06-02T10-00-00-019db3da-f840-7142-a548-5bd30f5fe573.jsonl'),
+    jsonl([
+      { type: 'session_meta', timestamp: at(0), payload: { id: 'codex-err-1', cwd: '/tmp/codexerr', cli_version: '0.122.0', model_provider: 'openai', git: { branch: 'main' } } },
+      { type: 'turn_context', timestamp: at(1), payload: { model: 'gpt-5.4', cwd: '/tmp/codexerr' } },
+      { type: 'response_item', timestamp: at(2), payload: { type: 'message', role: 'user', content: [{ type: 'input_text', text: 'build it' }] } },
+      { type: 'response_item', timestamp: at(3), payload: { type: 'custom_tool_call', name: 'exec', input: 'npm run build', call_id: 'c1' } },
+      { type: 'response_item', timestamp: at(4), payload: { type: 'custom_tool_call_output', call_id: 'c1', output: 'bash: vitest: command not found', is_error: true } },
+    ]),
+  );
+
+  ({ getConnection, queryRows, closeConnection } = await import('../src/db/duckdb.js'));
+  const { reindex } = await import('../src/data/index.js');
+  await reindex();
+});
+
+afterAll(async () => {
+  await closeConnection?.();
+  rmSync(work, { recursive: true, force: true });
+});
+
+describe('tool_error_text indexing', () => {
+  it('indexes a string-form failed result verbatim', async () => {
+    expect((await row('r1')).tool_error_text).toBe('ENOENT: no such file or directory');
+  });
+
+  it('keeps only the text items of an array-form failed result', async () => {
+    expect((await row('r2')).tool_error_text).toBe('TS2339: Property foo does not exist');
+  });
+
+  it('leaves a successful result NULL (distinct from an empty body)', async () => {
+    const r3 = await row('r3');
+    expect(r3.tool_error_text).toBeNull();
+    expect(Number(r3.tool_error_count)).toBe(0);
+  });
+
+  it('caps an oversized failure body per event', async () => {
+    expect((await row('r4')).tool_error_text).toBe(HUGE.slice(0, 4000));
+  });
+
+  it('survives the canonical NDJSON round trip (Codex)', async () => {
+    const conn = await getConnection();
+    const rows = await queryRows(
+      conn,
+      `SELECT tool_error_text, skill_names FROM events
+       WHERE session_id = 'codex-err-1' AND tool_error_text IS NOT NULL`,
+    );
+    expect(rows.map((r) => r.tool_error_text)).toEqual(['bash: vitest: command not found']);
+    expect(rows[0]?.skill_names).toBe('');
+  });
+});
+
+describe('skill_names indexing', () => {
+  it('records the skill argument and skips a Skill call with none or an empty one', async () => {
+    // An empty `skill` would otherwise land as a stray '' member of the CSV.
+    expect((await row('a2')).skill_names).toBe('claudescope:history');
+  });
+
+  it('stays empty for a non-Skill tool call', async () => {
+    expect((await row('a1')).skill_names).toBe('');
+  });
+});

--- a/packages/server/test/search-literal.integration.test.ts
+++ b/packages/server/test/search-literal.integration.test.ts
@@ -1,0 +1,204 @@
+/**
+ * `GET /api/search?literal=true` — exact substring search.
+ *
+ * The BM25 path answers a different question than an agent asking "have I seen
+ * THIS string before?": it tokenizes, so punctuation-heavy error messages and
+ * identifiers dissolve into common words, and it only ever looks at
+ * `events.text_content` — a tool failure the assistant never restated in prose
+ * is not in the index it searches at all. The literal branch therefore also
+ * covers `tool_error_text`, `tool_names` and `skill_names`, and interpolates the
+ * query into SQL, so the quoting has to survive a string full of quotes.
+ */
+
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import type { FastifyInstance } from 'fastify';
+
+// --- temp locations (decided before any server module is imported) ----------
+const work = mkdtempSync(join(tmpdir(), 'claudescope-searchlit-'));
+const projectsDir = join(work, 'projects');
+
+process.env.CLAUDE_PROJECTS_DIR = projectsDir;
+for (const v of [
+  'CODEX_SESSIONS_DIR',
+  'JUNIE_SESSIONS_DIR',
+  'PI_SESSIONS_DIR',
+  'OPENCODE_DATA_DIR',
+  'COPILOT_SESSIONS_DIR',
+  'ANTIGRAVITY_CLI_DIR',
+  'ANTIGRAVITY_DIR',
+  'GROK_SESSIONS_DIR',
+]) {
+  process.env[v] = join(work, `${v.toLowerCase()}-empty`);
+}
+process.env.DUCKDB_PATH = join(work, 'index.duckdb');
+process.env.CLAUDESCOPE_HOME = join(work, 'home');
+process.env.REINDEX_INTERVAL_MS = '0';
+
+/** Assistant prose carrying an error verbatim — quotes, colons and all. */
+const ENOENT = `Error: ENOENT: no such file or directory, open '/tmp/x.json'`;
+/** Body of a failed tool_result; no assistant message repeats it. */
+const LOCK_ERROR =
+  'IO Error: Could not set lock on file "/tmp/lit/index.duckdb": Conflicting lock is held';
+
+function writeFixtures(): void {
+  const proj = join(projectsDir, 'enc-lit');
+  mkdirSync(proj, { recursive: true });
+  const base = { sessionId: 'sLit', cwd: '/tmp/lit', gitBranch: 'main', version: '2.1.0' };
+
+  const rows = [
+    {
+      ...base,
+      type: 'user',
+      uuid: 'u-go',
+      parentUuid: null,
+      timestamp: '2026-05-02T09:00:00.000Z',
+      isSidechain: false,
+      message: { role: 'user', content: 'rebuild the index' },
+    },
+    {
+      ...base,
+      type: 'assistant',
+      uuid: 'a-enoent',
+      parentUuid: 'u-go',
+      timestamp: '2026-05-02T09:00:01.000Z',
+      isSidechain: false,
+      message: {
+        role: 'assistant',
+        id: 'm1',
+        model: 'claude-opus-4-8',
+        content: [{ type: 'text', text: `The rebuild failed: ${ENOENT} — retrying once.` }],
+        usage: { input_tokens: 10, output_tokens: 5 },
+      },
+    },
+    {
+      // Only the failed result carries the message: no text/thinking block, so
+      // this row has no text_content and cannot be found by the BM25 path.
+      ...base,
+      type: 'user',
+      uuid: 'u-lock',
+      parentUuid: 'a-enoent',
+      timestamp: '2026-05-02T09:00:02.000Z',
+      isSidechain: false,
+      message: {
+        role: 'user',
+        content: [{ type: 'tool_result', tool_use_id: 't1', is_error: true, content: LOCK_ERROR }],
+      },
+    },
+    {
+      // The skill name lives in the call's input; tool_names only says "Skill"
+      // and the prose never mentions it.
+      ...base,
+      type: 'assistant',
+      uuid: 'a-skill',
+      parentUuid: 'u-lock',
+      timestamp: '2026-05-02T09:00:03.000Z',
+      isSidechain: false,
+      message: {
+        role: 'assistant',
+        id: 'm2',
+        model: 'claude-opus-4-8',
+        content: [
+          { type: 'text', text: 'Let me check what happened last time.' },
+          { type: 'tool_use', id: 't2', name: 'Skill', input: { skill: 'claudescope:history' } },
+        ],
+        usage: { input_tokens: 8, output_tokens: 4 },
+      },
+    },
+    {
+      // `İ` (U+0130) lowercases to two code points in JavaScript and to one
+      // in DuckDB, so lowering the needle on the JS side loses this row entirely.
+      ...base,
+      type: 'user',
+      uuid: 'u-turkish',
+      parentUuid: 'a-skill',
+      timestamp: '2026-05-02T09:00:04.000Z',
+      isSidechain: false,
+      message: { role: 'user', content: 'Config for İnfo service' },
+    },
+  ];
+
+  writeFileSync(join(proj, 'sLit.jsonl'), rows.map((r) => JSON.stringify(r)).join('\n') + '\n');
+}
+
+let app: FastifyInstance;
+let closeConnection: () => Promise<void>;
+
+/** Run a search; `literal` and `type` are opt-in so the BM25 default is testable too. */
+async function search(
+  q: string,
+  extra: Record<string, string> = {},
+): Promise<{ messageUuid: string; role: string; snippet: string }[]> {
+  const params = new URLSearchParams({ q, ...extra });
+  const res = await app.inject({ method: 'GET', url: `/api/search?${params}` });
+  expect(res.statusCode).toBe(200);
+  return res.json().sessions;
+}
+
+beforeAll(async () => {
+  writeFixtures();
+  const Fastify = (await import('fastify')).default;
+  const { registerRoutes } = await import('../src/routes/index.js');
+  const { reindex } = await import('../src/data/index.js');
+  ({ closeConnection } = await import('../src/db/duckdb.js'));
+  app = Fastify();
+  await registerRoutes(app);
+  await reindex();
+  await app.ready();
+});
+
+afterAll(async () => {
+  await app?.close();
+  await closeConnection?.();
+  rmSync(work, { recursive: true, force: true });
+});
+
+describe('GET /api/search?literal=true', () => {
+  it('matches a punctuated error string including its quotes', async () => {
+    const hits = await search(ENOENT, { literal: 'true' });
+    expect(hits.map((h) => h.messageUuid)).toEqual(['a-enoent']);
+    expect(hits[0].snippet).toContain('<mark>');
+  });
+
+  it('reaches a failed tool_result the assistant never restated', async () => {
+    const hits = await search('IO Error: Could not set lock on file', { literal: 'true' });
+    expect(hits.map((h) => h.messageUuid)).toEqual(['u-lock']);
+    expect(hits[0].role).toBe('user');
+    expect(hits[0].snippet).toContain('Conflicting lock is held');
+  });
+
+  it('is the only path that finds it — the BM25 default cannot', async () => {
+    const hits = await search('IO Error: Could not set lock on file');
+    expect(hits.map((h) => h.messageUuid)).not.toContain('u-lock');
+  });
+
+  it('matches a Skill call by the skill it invoked, naming it in the snippet', async () => {
+    const hits = await search('claudescope:history', { literal: 'true' });
+    expect(hits.map((h) => h.messageUuid)).toEqual(['a-skill']);
+    expect(hits[0].snippet).toBe('Skills: <mark>claudescope:history</mark>');
+  });
+
+  it('case-folds only in DuckDB, so a code point JS lowercases differently still hits', async () => {
+    const hits = await search('for İnfo service', { literal: 'true' });
+    expect(hits.map((h) => h.messageUuid)).toEqual(['u-turkish']);
+    // Snippet drawn from the matched text, not the synthetic tool-name fallback.
+    expect(hits[0].snippet).toBe('Config <mark>for İnfo service</mark>');
+  });
+
+  it('honors format=plain', async () => {
+    const hits = await search(ENOENT, { literal: 'true', format: 'plain' });
+    expect(hits).toHaveLength(1);
+    expect(hits[0].snippet).not.toContain('<mark>');
+    expect(hits[0].snippet).toContain(ENOENT);
+  });
+
+  it('honors the role filter — type=assistant drops the user-row error hit', async () => {
+    const hits = await search('IO Error: Could not set lock on file', {
+      literal: 'true',
+      type: 'assistant',
+    });
+    expect(hits).toHaveLength(0);
+  });
+});

--- a/packages/server/test/skill-names.test.ts
+++ b/packages/server/test/skill-names.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest';
+import { skillNamesCsv } from '../src/connectors/skill-names.js';
+
+describe('skillNamesCsv', () => {
+  it('joins the skill argument of Skill calls in order', () => {
+    const blocks = [
+      { type: 'tool_use', name: 'Bash', input: { command: 'ls' } },
+      { type: 'tool_use', name: 'Skill', input: { skill: 'claudescope:history' } },
+      { type: 'tool_use', name: 'Skill', input: { skill: 'now' } },
+    ];
+    expect(skillNamesCsv(blocks)).toBe('claudescope:history,now');
+  });
+
+  it('skips a Skill call whose skill argument is missing or not a string', () => {
+    const blocks = [
+      { type: 'tool_use', name: 'Skill', input: { command: 'no skill argument' } },
+      { type: 'tool_use', name: 'Skill', input: { skill: { name: 'now' } } },
+      { type: 'tool_use', name: 'Skill', input: null },
+      { type: 'tool_use', name: 'Skill' },
+      { type: 'tool_use', name: 'Skill', input: { skill: 'review' } },
+    ];
+    expect(skillNamesCsv(blocks)).toBe('review');
+  });
+
+  it('ignores a Skill-named tool_result (only calls count)', () => {
+    expect(skillNamesCsv([{ type: 'tool_result', name: 'Skill', input: { skill: 'now' } }])).toBe('');
+  });
+});

--- a/packages/server/test/tool-errors.test.ts
+++ b/packages/server/test/tool-errors.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest';
+import { MAX_TOOL_ERROR_TEXT, toolErrorText } from '../src/connectors/tool-errors.js';
+
+describe('toolErrorText', () => {
+  it('keeps only the text items of an array-form result body', () => {
+    const blocks = [
+      { type: 'tool_result', is_error: true, content: [
+        { type: 'image', source: { type: 'base64', media_type: 'image/png', data: 'AAAA' } },
+        { type: 'text', text: 'first' },
+        { type: 'text', text: 'second' },
+      ] },
+    ];
+    expect(toolErrorText(blocks)).toBe('first\nsecond');
+  });
+
+  it('ignores results that did not fail', () => {
+    expect(toolErrorText([{ type: 'tool_result', content: 'fine' }])).toBeNull();
+    expect(toolErrorText([{ type: 'text' } as never])).toBeNull();
+  });
+
+  it('drops a failed result whose body is neither a string nor a block array', () => {
+    // The SQL derivation yields NULL for such a body and string_agg skips it;
+    // an all-unknown event therefore has no text at all, not an empty one.
+    expect(toolErrorText([{ type: 'tool_result', is_error: true, content: { code: 1 } }])).toBeNull();
+    expect(
+      toolErrorText([
+        { type: 'tool_result', is_error: true, content: { code: 1 } },
+        { type: 'tool_result', is_error: true, content: 'boom' },
+      ]),
+    ).toBe('boom');
+  });
+
+  it('never leaves a surrogate half at the cap (it would null the cached row)', () => {
+    const body = 'x'.repeat(MAX_TOOL_ERROR_TEXT - 1) + '\u{1F4A5}' + 'tail';
+    const out = toolErrorText([{ type: 'tool_result', is_error: true, content: body }])!;
+    expect(out).toBe('x'.repeat(MAX_TOOL_ERROR_TEXT - 1));
+  });
+
+  it('caps the joined bodies per event', () => {
+    const body = 'x'.repeat(MAX_TOOL_ERROR_TEXT + 500);
+    expect(toolErrorText([{ type: 'tool_result', is_error: true, content: body }])?.length).toBe(
+      MAX_TOOL_ERROR_TEXT,
+    );
+  });
+});

--- a/packages/shared/src/api.ts
+++ b/packages/shared/src/api.ts
@@ -77,7 +77,7 @@ export interface SearchResult {
   title: string;
   /** Snippet with matched terms highlighted (HTML `<mark>`), or raw text with `format=plain`. */
   snippet: string;
-  /** BM25 relevance score. */
+  /** BM25 relevance score; 0 for `literal` hits, which are ordered by recency. */
   score: number;
   messageUuid: string;
   role: string;
@@ -170,6 +170,13 @@ export interface SearchQuery {
   type?: SearchType;
   scope?: SearchScope;
   format?: SnippetFormat;
+  /**
+   * Exact mode: a case-insensitive substring match of the whole query over
+   * transcript text, failed tool-result text, tool names and skill names,
+   * newest first. No BM25 ranking — for error messages and identifiers that
+   * tokenized search dilutes, and for the columns FTS doesn't index.
+   */
+  literal?: boolean;
 }
 
 export type AnalyticsGroupBy = 'project' | 'model' | 'day' | 'agent';
@@ -718,6 +725,18 @@ export interface StreakInfo {
 export interface ActivityResponse {
   heatmap: ActivityCell[];
   streak: StreakInfo;
+}
+
+/** Which breakdown `/api/analytics/tools` computes: raw tool calls, or (`skill`)
+ *  canonical `Skill` tool_use calls counted by the skill they invoked. */
+export type ToolUsageKind = 'tool' | 'skill';
+
+/** GET /api/analytics/tools query parameters; bounds filter event timestamps. */
+export interface ToolUsageQuery extends AnalyticsDateRangeQuery {
+  /** Which breakdown to compute (default 'tool'). */
+  kind?: ToolUsageKind;
+  /** Project slug id (as returned by /api/projects); omit for the whole corpus. */
+  project?: string;
 }
 
 /** One bar of the tool-usage breakdown: a raw (pre-categorization) tool name,

--- a/plugins/claudescope/skills/history/SKILL.md
+++ b/plugins/claudescope/skills/history/SKILL.md
@@ -23,6 +23,9 @@ command it gives instead of listing sessions.
      only when relevant. `claudescope search` snippets are unredacted and enter
      the current conversation context, so use the fewest distinctive terms and
      results needed.
+   - Exact error message, identifier, tool or skill name: `claudescope search
+     --literal '<exact string>' --limit 5` (case-insensitive substring over
+     transcript text, failed tool results, tool and skill names; no ranking).
    - Search hit context: `claudescope session <session-id> --around <message-uuid>
      --radius 4 --max-tool-chars 1200 --redact`.
    - Recent, expensive, or project/agent-specific sessions: `claudescope sessions
@@ -30,9 +33,11 @@ command it gives instead of listing sessions.
    - Project lookup: `claudescope projects`, only when project IDs are needed;
      this listing can cover the full corpus.
    - Token/cost comparison: `claudescope analytics --group-by
-     project|model|day|agent`, with `--from YYYY-MM-DD --to YYYY-MM-DD` for a
-     relevant period. Without dates, analytics covers the full corpus, so omit
-     them only for an all-time question.
+     project|model|day|agent|tool|skill`, with `--from YYYY-MM-DD --to
+     YYYY-MM-DD` for a relevant period and `--project <id>` when relevant;
+     `tool|skill` report call counts rather than tokens and cost. Without dates,
+     analytics covers the full corpus, so omit them only for an all-time
+     question.
    - Work summary: `claudescope digest --from YYYY-MM-DD --to YYYY-MM-DD`.
 3. Inspect only the context needed. For paging without a search hit, use
    `claudescope session <session-id> --offset <n> --limit 10 --max-tool-chars
@@ -52,9 +57,10 @@ Only run the ClaudeScope subcommands `search`, `sessions`, `session`, `projects`
 ClaudeScope HTTP endpoints, or run ClaudeScope lifecycle, MCP, update, or
 pricing commands.
 
-`No matches.`, `No sessions match.`, `No projects indexed.`, and `No usage in
-range.` are successful empty results. Refine a search once with shorter,
-distinctive terms when useful. If the command just started the daemon and an
-empty result is unexpected, wait a few seconds and retry once because the index
-may still be building. For any nonzero exit or other error, report the error
-concisely and do not invent an answer.
+`No matches.`, `No sessions match.`, `No projects indexed.`, `No usage in
+range.`, `No tool calls in range.`, and `No skill calls in range.` are successful
+empty results. Refine a search once with shorter, distinctive terms when useful.
+If the command just started the daemon and an empty result is unexpected, wait a
+few seconds and retry once because the index may still be building. For any
+nonzero exit or other error, report the error concisely and do not invent an
+answer.


### PR DESCRIPTION
Part 2 of #100 (plan: `docs/plans/0079-literal-search-and-skill-analytics.md`). Follows #101, now rebased onto `main`.

## What

- **Schema v19**: two narrow event columns — `tool_error_text` (bodies of failed `tool_result` blocks, capped at 4000 chars per event) and `skill_names` (CSV of the `skill` argument on canonical `Skill` calls, shaped like `tool_names`). Derived in the Claude Code lateral pass (string and text-block-array results) and emitted by every cache-backed normalizer. FTS stays on `text_content`; the bump forces a full index rebuild on upgrade, as v18 did.
- **`search --literal`** (route `literal=true`, MCP `literal`): the whole query as one case-insensitive substring over transcript text, failed tool results, tool names and skill names, newest first, same 50 cap and snippet renderer, score 0. The BM25 path and its ranking are untouched.
- **`analytics --group-by tool|skill`** (plus `--project`; MCP `get_analytics` enum): routes to `/api/analytics/tools?kind=` and prints `KEY, AGENT, COUNT`. The endpoint now counts calls on every non-fork row (`forked_from_session_id IS NULL`) instead of `usage_canonical` rows: on 38 real Claude Code transcripts, 876 of 1312 tool-call rows and 9 of 15 `Skill` rows sat on a non-elected split-message row and were invisible. The web tool-usage chart reads the same endpoint and now shows the corrected counts.
- `enumParam` answers a repeated query param with 400 instead of coercing the array.
- Docs: README scripting section, history skill `SKILL.md` (`--literal` for errors and identifiers, tool/skill grouping), MCP blurb.

## Verification

- `npm test` (676), `npm run typecheck`, `npm run build`, after the rebase onto `main`.
- Review pass with reproduced findings; each fix has a test that fails with the fix reverted (split-message fixture for call counts, `İ` case folding in literal search, array-form error results, repeated `kind` param).

## Notes

- `skill_names` is best-effort per connector: Codex injects skills as message content rather than tool calls, so it stays empty there.
- Call counts changed for existing users of `/api/analytics/tools` (higher, and correct); token analytics are unaffected.
