### PR TITLE
feat: skill usage card and exact-match search in the web

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Claudescope works whether you use one agent or all eight. Adding another is just
 - **Review changes** via a **Files changed** tab that aggregates every edit/write in the session by file, with per-file diffs and +/− counts (diffs load lazily per file).
 - **Export / share** a session to Markdown — download or copy it, with an optional toggle to **redact** home-dir paths and likely secrets.
 - **Memory** — browse each agent's long-lived **instruction files** (`CLAUDE.md`, `AGENTS.md`, …) and **agent-distilled per-project memory**, read live from each agent's home directory; Claude Code facts deep-link back to the session that produced them.
-- **Search** full-text across all sessions, all agents (DuckDB BM25), with highlighted snippets that deep-link to the exact message.
+- **Search** full-text across all sessions, all agents (DuckDB BM25), with highlighted snippets that deep-link to the exact message; an **Exact** mode matches one substring, newest first, for error lines and identifiers.
 - **Analyze** token usage and cost over time, by project, by model, and **by agent** — including cache-hit ratio.
 - **Light & dark themes** — follows your system appearance, with a manual toggle.
 
@@ -83,7 +83,8 @@ optional redaction) sit in the header.
 
 **Search** — full-text across every session and agent (DuckDB BM25) with
 highlighted snippets and user/assistant filters; each result deep-links to the
-exact message.
+exact message. Flip **Exact** to match one substring instead — an error line,
+an identifier — across transcript text and failed tool results, newest first.
 
 <picture>
   <source media="(prefers-color-scheme: dark)" srcset="docs/screenshots/search-dark.png">
@@ -100,7 +101,8 @@ agent**, with a cache-read breakdown. Click a chart legend to toggle a series.
 
 **Compare** — the Efficiency tab puts every agent head-to-head on one scorecard:
 cost, tokens per response, cache hit ratio, subagent usage, **tool-error rate**,
-and interrupts — honestly. A metric an agent's format can't report shows as
+and interrupts — honestly, plus tool calls by category and **skill usage** by
+skill and agent. A metric an agent's format can't report shows as
 *n/a* with the reason, never a fake 0. Flip the grain to hunt outlier
 **sessions** instead, and a **Digest** view sums up your week (copy it as
 Markdown, or run `claudescope digest` in a terminal).

--- a/docs/plans/0081-web-skill-usage-and-exact-search.md
+++ b/docs/plans/0081-web-skill-usage-and-exact-search.md
@@ -1,0 +1,103 @@
+# 0081 — Skill usage and exact-match search in the web
+
+- **Status:** done
+- **Date:** 2026-09-03
+- **PR:** https://github.com/vladar107/claudescope/pull/104
+
+## Context
+
+Plans 0078–0080 (issue #100) added two things to the API that only the CLI and
+MCP expose: `kind=skill` on `/api/analytics/tools` and `literal=true` on
+`/api/search`. In the web:
+
+- The Efficiency view's "Tool usage" card calls the tools endpoint for
+  `kind=tool` only and buckets by category (`ToolUsageChart`), so `Skill`
+  calls fold into one bar and skill names never appear.
+- The Search page (`SearchPage.tsx`) keeps its state in the URL
+  (`?q=&project=&type=&scope=`) and is BM25 only, so an error line pasted
+  there gets the ranking noise the issue complained about.
+
+The web's tests are pure helpers under `packages/web/test` (no DOM), and
+Playwright is a dev dependency used by the perf suite; the `verify` skill
+documents a sandboxed launch against fixture transcripts.
+
+## Goal
+
+From the web, see which skills were used how often, per agent, under the same
+project and date scope as the rest of the Efficiency view; and search an exact
+string (an error line, an identifier) with results that open the session at
+the matching message. Demonstrated with screenshots of the running app.
+
+## Decisions
+
+- **A second card, not a mode on "Tool usage"** — a `SkillUsageChart` card
+  under "Tool usage" in the same `tv-analytics__charts` column, one bar per
+  skill name, tooltip with the per-agent split (the `ToolUsageChart` tooltip
+  pattern, without its category bucketing). Reusing `ToolUsageChart` with a
+  switch was rejected: categories are meaningless for skills, and the two
+  charts answer different questions side by side.
+- **Own fetch, same scope** — a second `api.analyticsTools({ kind: 'skill' })`
+  call under the same conditions as the tools fetch (`view === 'efficiency'`,
+  `grain === 'agents'`, project scope, date range), in its own state so one
+  failing does not blank the other. The client gains `kind`.
+- **`exact=1` in the URL** — the toggle joins the existing URL-state pattern
+  (`patchParams`), so an exact search is shareable and survives reload. Sent
+  as `literal: true`; `SearchParams` gains `literal`.
+- **Toggle plus a one-line hint** — a checkbox labelled "Exact" after the
+  role select; when on, a muted line under the controls says the query is
+  matched as one case-insensitive substring over transcript text, failed
+  tool results, tool and skill names, newest first. The empty state reads
+  "No exact matches for …". The memory half of a search stays ranked (the
+  route only switches the transcript half); the hint says so.
+- **No new unit tests** — the change is wiring and rendering with no
+  bug-prone logic of its own; the server behaviour it reads is already
+  covered by the literal-search and tools-endpoint integration tests.
+  Verification is typecheck, build, and driving the built app.
+
+## Approach
+
+1. `packages/web/src/api/client.ts`: `kind` on `analyticsTools`, `literal` on
+   `SearchParams` / `search`.
+2. Analytics: `skills` state and fetch in `AnalyticsPage.tsx`; new
+   `SkillUsageChart.tsx`; a `ChartCard` titled "Skill usage" with hint
+   "calls by skill".
+3. Search: `exact` read from the URL, checkbox in `tv-search__controls`, hint
+   line and empty-state wording, `literal` passed to the API; a few lines in
+   `search.css` for the checkbox.
+4. Docs: one sentence each in the README's analytics and search descriptions;
+   this plan + index row.
+5. Verify: `npm run typecheck`, `npm test`, `npm run build`; then the demo
+   below.
+
+## Files affected
+
+- `packages/web/src/api/client.ts` — `kind` param, `literal` param.
+- `packages/web/src/pages/analytics/AnalyticsPage.tsx` — skills fetch + card.
+- `packages/web/src/pages/analytics/SkillUsageChart.tsx` — new.
+- `packages/web/src/pages/search/SearchPage.tsx`, `search.css` — exact
+  toggle, hint, empty state.
+- `README.md`, `docs/plans/README.md`.
+
+## Testing
+
+- `npm run typecheck`, `npm test`, `npm run build`.
+- **Demo (sandboxed, per the `verify` skill):** launch the built server on a
+  scratch port with `CLAUDESCOPE_HOME` and every source dir pointed at a
+  temp dir; write Claude Code fixture sessions with `Skill` calls for three
+  skills across two sessions (one of them a split message, so the corrected
+  counting shows) and a failed `Bash` result whose error line recurs in two
+  sessions. Drive the built app with Playwright: Analytics → Efficiency →
+  screenshot the "Skill usage" card; Search with the error line and
+  `exact=1` → screenshot the results; click through to the session. Present
+  the screenshots in the conversation. Kill the server afterwards.
+
+## Risks / open questions
+
+- Long skill names (`plugin:skill`) need a wider Y axis than tool categories;
+  set from the longest label, capped.
+- Exact mode applies to transcripts only; memory hits stay ranked. Stated in
+  the hint rather than hidden.
+- A "recurring failures" aggregate (top error lines across sessions) is out
+  of scope; it needs a new endpoint and the error-line heuristic from plan
+  0080, and is worth adding only if exact search turns out to be used for it
+  repeatedly.

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -105,3 +105,4 @@ decision, or a change worth explaining before doing. Skip it for one-line fixes.
 | 0078 | [Proactive history context](./0078-proactive-history-context.md) | done |
 | 0079 | [Literal search and tool/skill analytics](./0079-literal-search-and-skill-analytics.md) | done |
 | 0080 | [Tool-failure history hook](./0080-tool-failure-history-hook.md) | abandoned |
+| 0081 | [Skill usage and exact-match search in the web](./0081-web-skill-usage-and-exact-search.md) | done |

--- a/packages/web/src/api/client.ts
+++ b/packages/web/src/api/client.ts
@@ -32,6 +32,7 @@ import type {
   SessionsResponse,
   SourcesResponse,
   SystemInfoResponse,
+  ToolUsageKind,
   ToolUsageResponse,
   DigestResponse,
 } from '@claudescope/shared';
@@ -100,6 +101,8 @@ export interface SearchParams {
   project?: string;
   type?: SearchType;
   scope?: SearchScope;
+  /** Exact mode: one case-insensitive substring, newest first (`literal=true`). */
+  literal?: boolean;
 }
 
 export interface AnalyticsParams {
@@ -157,10 +160,16 @@ export const api = {
     );
   },
 
-  /** GET /api/search?q=&project=&type= */
+  /** GET /api/search?q=&project=&type=&scope=&literal= */
   search(params: SearchParams, signal?: AbortSignal): Promise<SearchResponse> {
     return request<SearchResponse>(
-      `/search${qs({ q: params.q, project: params.project, type: params.type, scope: params.scope })}`,
+      `/search${qs({
+        q: params.q,
+        project: params.project,
+        type: params.type,
+        scope: params.scope,
+        literal: params.literal ? 'true' : undefined,
+      })}`,
       { signal },
     );
   },
@@ -194,13 +203,14 @@ export const api = {
     );
   },
 
-  /** GET /api/analytics/tools?from=&to=&timeZone= */
+  /** GET /api/analytics/tools?kind=&project=&from=&to=&timeZone= */
   analyticsTools(
-    params: { project?: string; from?: string; to?: string; timeZone?: string },
+    params: { kind?: ToolUsageKind; project?: string; from?: string; to?: string; timeZone?: string },
     signal?: AbortSignal,
   ): Promise<ToolUsageResponse> {
     return request<ToolUsageResponse>(
       `/analytics/tools${qs({
+        kind: params.kind,
         project: params.project,
         from: params.from,
         to: params.to,

--- a/packages/web/src/pages/analytics/AnalyticsPage.tsx
+++ b/packages/web/src/pages/analytics/AnalyticsPage.tsx
@@ -35,6 +35,7 @@ import { AgentComparisonTable } from './AgentComparisonTable.js';
 import { DigestView } from './DigestView.js';
 import { BreakdownChart } from './BreakdownChart.js';
 import { ToolUsageChart } from './ToolUsageChart.js';
+import { SkillUsageChart } from './SkillUsageChart.js';
 import type { BreakdownMetric, BreakdownSort } from './BreakdownChart.js';
 import { TimeSeriesChart } from './TimeSeriesChart.js';
 import { formatCount, formatCost, formatPct } from './format.js';
@@ -142,6 +143,9 @@ export function AnalyticsPage() {
   const [series, setSeries] = useState<QueryState>(INITIAL);
   const [activity, setActivity] = useState<{ data: ActivityResponse | null; loading: boolean; error: unknown }>({ data: null, loading: true, error: null });
   const [tools, setTools] = useState<{ data: ToolUsageResponse | null; loading: boolean; error: unknown }>({ data: null, loading: true, error: null });
+  // Same endpoint as `tools` with kind=skill, in its own state so one card's
+  // failure never blanks the other.
+  const [skills, setSkills] = useState<{ data: ToolUsageResponse | null; loading: boolean; error: unknown }>({ data: null, loading: true, error: null });
 
   // Keep calendar dates intact so the server can interpret them in TIME_ZONE.
   const range = useMemo(() => {
@@ -274,6 +278,29 @@ export function AnalyticsPage() {
       .catch((error) => {
         if (ctrl.signal.aborted) return;
         setTools({ data: null, loading: false, error });
+      });
+    return () => ctrl.abort();
+  }, [view, grain, effProject, range.from, range.to]);
+
+  useEffect(() => {
+    if (view !== 'efficiency' || grain !== 'agents') return;
+    const ctrl = new AbortController();
+    setSkills((s) => ({ ...s, loading: true }));
+    api
+      .analyticsTools(
+        {
+          kind: 'skill',
+          project: effProject || undefined,
+          from: range.from,
+          to: range.to,
+          timeZone: TIME_ZONE,
+        },
+        ctrl.signal,
+      )
+      .then((data) => setSkills({ data, loading: false, error: null }))
+      .catch((error) => {
+        if (ctrl.signal.aborted) return;
+        setSkills({ data: null, loading: false, error });
       });
     return () => ctrl.abort();
   }, [view, grain, effProject, range.from, range.to]);
@@ -543,6 +570,14 @@ export function AnalyticsPage() {
                 empty={!tools.data || tools.data.rows.length === 0}
               >
                 {tools.data && <ToolUsageChart rows={tools.data.rows} />}
+              </ChartCard>
+              <ChartCard
+                title="Skill usage"
+                hint="calls by skill"
+                loading={skills.loading}
+                empty={!skills.data || skills.data.rows.length === 0}
+              >
+                {skills.data && <SkillUsageChart rows={skills.data.rows} />}
               </ChartCard>
             </div>
           </>

--- a/packages/web/src/pages/analytics/SkillUsageChart.tsx
+++ b/packages/web/src/pages/analytics/SkillUsageChart.tsx
@@ -1,0 +1,65 @@
+import { Bar, BarChart, CartesianGrid, ResponsiveContainer, Tooltip, XAxis, YAxis } from 'recharts';
+import type { ToolUsageRow } from '@claudescope/shared';
+import { useTheme } from '../../theme/ThemeProvider.js';
+import { axisTick, getChartColors, TooltipCard } from './chart-common.js';
+import { formatCount } from './format.js';
+import { agentLabel } from '../../components/index.js';
+
+interface SkillBar {
+  skill: string;
+  count: number;
+  /** Per-agent split of the calls, for the tooltip. */
+  agents: { agent: string; count: number }[];
+}
+
+/** Rows arrive one per (skill, agent); fold them to one bar per skill. */
+function bySkill(rows: ToolUsageRow[]): SkillBar[] {
+  const map = new Map<string, SkillBar>();
+  for (const r of rows) {
+    const b = map.get(r.tool) ?? { skill: r.tool, count: 0, agents: [] };
+    b.count += r.count;
+    b.agents.push({ agent: r.agent, count: r.count });
+    map.set(r.tool, b);
+  }
+  return [...map.values()].sort((a, b) => b.count - a.count);
+}
+
+/** Skill names are `plugin:skill` and can be long; size the axis to the
+ *  longest label instead of clipping it, within a cap. */
+function yAxisWidth(data: SkillBar[]): number {
+  const longest = Math.max(0, ...data.map((d) => d.skill.length));
+  return Math.min(240, Math.max(84, 16 + longest * 7));
+}
+
+export function SkillUsageChart({ rows }: { rows: ToolUsageRow[] }) {
+  const { resolvedTheme } = useTheme();
+  const colors = getChartColors(resolvedTheme);
+  const data = bySkill(rows);
+  const tick = axisTick(colors);
+  const height = Math.max(140, data.length * 34 + 24);
+
+  return (
+    <ResponsiveContainer width="100%" height={height}>
+      <BarChart layout="vertical" data={data} margin={{ top: 8, right: 24, left: 8, bottom: 8 }}>
+        <CartesianGrid stroke={colors.grid} horizontal={false} />
+        <XAxis type="number" allowDecimals={false} tick={tick} tickLine={false} axisLine={{ stroke: colors.grid }} tickFormatter={(v: number) => formatCount(v)} />
+        <YAxis type="category" dataKey="skill" tick={tick} tickLine={false} axisLine={{ stroke: colors.grid }} width={yAxisWidth(data)} interval={0} />
+        <Tooltip cursor={{ fill: colors.cursor }} content={<SkillTip color={colors.output} />} />
+        <Bar dataKey="count" name="Calls" fill={colors.output} radius={[0, 2, 2, 0]} isAnimationActive={false} />
+      </BarChart>
+    </ResponsiveContainer>
+  );
+}
+
+function SkillTip(props: { active?: boolean; payload?: ReadonlyArray<{ payload?: SkillBar }>; color: string }) {
+  if (!props.active || !props.payload?.length) return null;
+  const b = props.payload[0]?.payload;
+  if (!b) return null;
+  const agents = [...b.agents].sort((a, z) => z.count - a.count);
+  return (
+    <TooltipCard
+      title={`${b.skill} — ${formatCount(b.count)} calls`}
+      rows={agents.map((a) => ({ label: agentLabel(a.agent), value: formatCount(a.count), color: props.color }))}
+    />
+  );
+}

--- a/packages/web/src/pages/search/SearchPage.tsx
+++ b/packages/web/src/pages/search/SearchPage.tsx
@@ -11,8 +11,13 @@
  * The scope control selects where search looks: transcripts only (`sessions`,
  * the default), transcripts plus agent memory (`all`), or memory only (`memory`).
  *
- * Query state lives in the URL (?q=&project=&type=&scope=) so searches are
- * shareable and survive reloads.
+ * "Exact" (`exact=1`) swaps ranking for one case-insensitive substring match
+ * over transcript text, failed tool results, tool and skill names, newest
+ * first (`literal=true` on the API) — for error lines and identifiers that
+ * tokenized search dilutes. Memory hits stay ranked either way.
+ *
+ * Query state lives in the URL (?q=&project=&type=&scope=&exact=) so searches
+ * are shareable and survive reloads.
  */
 
 import { useEffect, useMemo, useRef, useState } from 'react';
@@ -67,10 +72,13 @@ function SearchGroup({
   group,
   projectName,
   maxScore,
+  showRelevance,
 }: {
   group: SessionGroup;
   projectName?: string;
   maxScore: number;
+  /** Off in exact mode, where hits are ordered by recency and carry no score. */
+  showRelevance: boolean;
 }) {
   const [expanded, setExpanded] = useState(false);
   const shown = expanded ? group.matches : group.matches.slice(0, GROUP_COLLAPSE);
@@ -107,7 +115,7 @@ function SearchGroup({
               // Server snippet is HTML-escaped except <mark> wraps (safe).
               dangerouslySetInnerHTML={{ __html: m.snippet }}
             />
-            <RelevanceBar ratio={m.score / maxScore} />
+            {showRelevance ? <RelevanceBar ratio={m.score / maxScore} /> : null}
           </Link>
         ))}
         {hidden > 0 ? (
@@ -169,6 +177,9 @@ export function SearchPage() {
   const project = searchParams.get('project') ?? '';
   const type = asSearchType(searchParams.get('type'));
   const scope = asSearchScope(searchParams.get('scope'));
+  // Exact mode only reaches the transcript half of a search, so in memory-only
+  // scope the switch is hidden and the flag is inert.
+  const exact = searchParams.get('exact') === '1' && scope !== 'memory';
 
   const [sessions, setSessions] = useState<SearchResult[]>([]);
   const [memory, setMemory] = useState<MemorySearchHit[]>([]);
@@ -233,7 +244,7 @@ export function SearchPage() {
     debounceRef.current = setTimeout(() => {
       api
         .search(
-          { q: trimmed, project: project || undefined, type, scope },
+          { q: trimmed, project: project || undefined, type, scope, literal: exact },
           controller.signal,
         )
         .then((res) => {
@@ -254,7 +265,7 @@ export function SearchPage() {
       controller.abort();
       if (debounceRef.current) clearTimeout(debounceRef.current);
     };
-  }, [query, project, type, scope]);
+  }, [query, project, type, scope, exact]);
 
   const hasQuery = query.trim() !== '';
 
@@ -342,7 +353,26 @@ export function SearchPage() {
             ))}
           </select>
         ) : null}
+        {showRoleFilter ? (
+          <label className="tv-search__toggle">
+            <input
+              type="checkbox"
+              className="tv-switch__input"
+              checked={exact}
+              onChange={(e) => patchParams({ exact: e.target.checked ? '1' : '' })}
+            />
+            <span className="tv-switch" aria-hidden="true" />
+            Exact
+          </label>
+        ) : null}
       </div>
+      {exact ? (
+        <p className="tv-search__hint">
+          Exact: the query is matched as one case-insensitive substring over transcript
+          text, failed tool results, tool and skill names, newest first. Memory results
+          stay ranked.
+        </p>
+      ) : null}
 
       {error ? (
         <ErrorBox error={error} title="Search failed" onRetry={() => patchParams({ q: query })} />
@@ -352,7 +382,7 @@ export function SearchPage() {
         <p className="tv-search__empty">Type a query above to search across all transcripts.</p>
       ) : searched && totalCount === 0 ? (
         <p className="tv-search__empty">
-          No matches for <strong>{query}</strong>
+          No {exact ? 'exact ' : ''}matches for <strong>{query}</strong>
           {project ? ' in this project' : ''}.
         </p>
       ) : (
@@ -382,6 +412,7 @@ export function SearchPage() {
                     group={g}
                     projectName={projectNameById.get(g.projectId)}
                     maxScore={maxScore}
+                    showRelevance={!exact}
                   />
                 ))}
               </div>

--- a/packages/web/src/pages/search/search.css
+++ b/packages/web/src/pages/search/search.css
@@ -42,6 +42,21 @@
   color: var(--tv-fg-faint);
 }
 
+.tv-search__toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--tv-space-2);
+  font-size: var(--tv-fs-sm);
+  color: var(--tv-fg-muted);
+  cursor: pointer;
+  user-select: none;
+}
+.tv-search__hint {
+  font-size: var(--tv-fs-sm);
+  color: var(--tv-fg-muted);
+  margin: calc(-1 * var(--tv-space-2)) 0 var(--tv-space-4);
+}
+
 .tv-search__meta {
   font-size: var(--tv-fs-sm);
   color: var(--tv-fg-muted);


### PR DESCRIPTION
Plan: `docs/plans/0081-web-skill-usage-and-exact-search.md`. Follows #100's CLI/MCP work (#101–#103) by exposing the two new API capabilities in the web.

## What

- **Skill usage card** in the Efficiency view, under "Tool usage": one bar per skill name, tooltip with the per-agent split, same project scope and date range. Own fetch (`/api/analytics/tools?kind=skill`) in its own state so one card's failure never blanks the other. Integer-only axis ticks (three calls no longer render a duplicated "2").
- **Exact switch** on the Search page, kept in the URL as `exact=1` like the other filters and sent as `literal=true`. When on, a muted hint states what is matched (one case-insensitive substring over transcript text, failed tool results, tool and skill names, newest first; memory hits stay ranked), the empty state reads "No exact matches for …", and relevance bars are hidden since exact hits carry no score. The switch hides itself in memory-only scope, where it would be inert.
- Client: `kind` on `analyticsTools`, `literal` on `search`. README sentences for both.

## Verification

- `npm run typecheck`, `npm test` (676), `npm run build`, markdownlint.
- Demo on sandboxed fixtures (verify skill, scratch port, no real agent dirs): three sessions with `Skill` calls (one inside a split message) and a Bash failure whose error line recurs in two sessions. Playwright screenshots: the Skill usage card shows history 3 / verify 1 / review 1 with the split-message call counted; the same error line searched ranked returns two prose matches in one session, while Exact returns the two failed tool results in both sessions with the match highlighted; clicking a hit lands on the session.
