### PR TITLE
fix: clear Dependabot alerts #32–#35

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -55,7 +55,7 @@
           # `nix build .#claudescope` and the mismatch error prints the new value.
           npmDeps = pkgs.fetchNpmDeps {
             src = depsLock;
-            hash = "sha256-kn+cJZ8KPUlAovJji7R/6Nq4DH1VZ8h2FJklxbcMuoc=";
+            hash = "sha256-YmSttnRdiuNZOnK8z5YTgendao0e3SM3A09E/KDxkKY=";
           };
 
           nodejs = node;

--- a/package-lock.json
+++ b/package-lock.json
@@ -3080,9 +3080,9 @@
       }
     },
     "node_modules/fast-uri": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
-      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.7.tgz",
+      "integrity": "sha512-dOvZVzjdZdz7phd9v6jCbwxrBW3fK6n8Rc0CtdmM4bumzMnxywBYhuph6J819RRw/ku+rLbelwfMunktuzVVHg==",
       "funding": [
         {
           "type": "github",
@@ -3096,9 +3096,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/fastify": {
-      "version": "5.8.5",
-      "resolved": "https://registry.npmjs.org/fastify/-/fastify-5.8.5.tgz",
-      "integrity": "sha512-Yqptv59pQzPgQUSIm87hMqHJmdkb1+GPxdE6vW6FRyVE9G86mt7rOghitiU4JHRaTyDUk9pfeKmDeu70lAwM4Q==",
+      "version": "5.12.1",
+      "resolved": "https://registry.npmjs.org/fastify/-/fastify-5.12.1.tgz",
+      "integrity": "sha512-FWi+tQvwxR/PeRX7Z2mhfEF5ozJ3jn9asiiclzKXNSzJRHAYcU924aIOKAdHFJ+YIKieh3cqr1IwCOvTr41B3Q==",
       "funding": [
         {
           "type": "github",
@@ -3117,11 +3117,11 @@
         "@fastify/proxy-addr": "^5.0.0",
         "abstract-logging": "^2.0.1",
         "avvio": "^9.0.0",
-        "fast-json-stringify": "^6.0.0",
-        "find-my-way": "^9.0.0",
+        "fast-json-stringify": "^7.0.0",
+        "find-my-way": "^9.6.0",
         "light-my-request": "^6.0.0",
         "pino": "^9.14.0 || ^10.1.0",
-        "process-warning": "^5.0.0",
+        "process-warning": "^5.1.0",
         "rfdc": "^1.3.1",
         "secure-json-parse": "^4.0.0",
         "semver": "^7.6.0",
@@ -3143,6 +3143,46 @@
         }
       ],
       "license": "MIT"
+    },
+    "node_modules/fastify/node_modules/fast-json-stringify": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/fast-json-stringify/-/fast-json-stringify-7.0.1.tgz",
+      "integrity": "sha512-eRSayARSbbwlBjpP4vnTTIRD5QPcIrmihPxDeN1DtKnHPg66UuJLx+8hlK1kaFdjvzyQ/dzALoi4vwAQ+T+iZA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@fastify/merge-json-schemas": "^0.2.0",
+        "ajv": "^8.12.0",
+        "ajv-formats": "^3.0.1",
+        "fast-uri": "^4.0.0",
+        "json-schema-ref-resolver": "^3.0.0",
+        "rfdc": "^1.2.0"
+      }
+    },
+    "node_modules/fastify/node_modules/fast-uri": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-4.1.4.tgz",
+      "integrity": "sha512-dODXrIxlS9JSdgAnhIUKOosKV1oMtU2VtVw87QRaHzyl5jxO290Ii5tEZfCfzfWNHi3jKWwBSdQj0qIyshdZdQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
     },
     "node_modules/fastify/node_modules/semver": {
       "version": "7.8.1",
@@ -5109,9 +5149,9 @@
       }
     },
     "node_modules/process-warning": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-5.0.0.tgz",
-      "integrity": "sha512-a39t9ApHNx2L4+HBnQKqxxHNs1r7KF+Intd8Q/g1bUh6q0WIp9voPXJ/x0j+ZL45KF1pJd9+q2jLIRMfvEshkA==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-5.1.0.tgz",
+      "integrity": "sha512-jQSaVHsPgtyw60e1rQ/A+/ArPEj/S8pS/vFnyGa/gYFXrKk/6RuDkoqVDQ5NI5MmS01698ltlAk0NoDBNLujRw==",
       "funding": [
         {
           "type": "github",
@@ -6399,7 +6439,7 @@
         "@duckdb/node-api": "^1.5.3-r.3",
         "@fastify/static": "^10.1.2",
         "@modelcontextprotocol/server": "^2.0.0",
-        "fastify": "^5.2.0",
+        "fastify": "^5.12.1",
         "zod": "^4.4.3"
       },
       "devDependencies": {

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -14,7 +14,7 @@
     "@duckdb/node-api": "^1.5.3-r.3",
     "@fastify/static": "^10.1.2",
     "@modelcontextprotocol/server": "^2.0.0",
-    "fastify": "^5.2.0",
+    "fastify": "^5.12.1",
     "zod": "^4.4.3"
   },
   "devDependencies": {


### PR DESCRIPTION
Clears all four open Dependabot alerts (#32–#35) in one PR.

| Alert | Severity | Package | Fix |
| --- | --- | --- | --- |
| #35 GHSA-fph4-wmhf-6fwf | high | fast-uri (SSRF via repeated hostname percent-decoding) | 3.1.5 → 3.1.7 |
| #34 GHSA-5jgf-p345-68v8 | high | fast-uri (host confusion via skipped IDN canonicalization) | 3.1.5 → 3.1.7 |
| #33 GHSA-w2qp-rph6-63g4 | moderate | fastify (schema validation bypass via root primitive coercion) | 5.8.5 → 5.12.1 |
| #32 GHSA-3m5p-2c4r-xxw2 | moderate | fastify (X-Forwarded-* spoofing under trustProxy hop-count) | 5.8.5 → 5.12.1 |

- The server manifest floor for fastify moves from `^5.2.0` to `^5.12.1` so a fresh install cannot resolve back below the fix.
- fast-uri is transitive via ajv, so that one is lockfile only. fastify 5.12.1 also brings its own fast-uri 4.1.4 through fast-json-stringify 7.
- None of these are exploitable here: no route declares a schema, trustProxy is off, and the server only listens on `127.0.0.1`. Bumped to clear the alerts.

Verification: `npm audit` reports 0 vulnerabilities with and without `--omit=dev`; typecheck clean; 676 tests pass.

The Nix `npmDepsHash` follows from the CI nix job (Nix is unavailable locally), same as #71 and #80.
