### PR TITLE
feat: context size and compaction count per session

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -270,6 +270,26 @@ The CLI `update` command (`cli.ts`) detects the install method and defers to
   **prospectively** — cost is stamped per event at index time, so only an index
   rebuild re-prices already-indexed history. Rates are interpolated into SQL, so
   `loadPricing` validates them — an unusable rate is dropped, not passed through.
+- **Context & compactions come from the index, not from a live process.**
+  `sessions.context_tokens` is the prompt size (input + cache read + cache
+  write) of the LAST main-thread assistant row, and `compaction_count` counts
+  main-thread rows of the file-keyed `compactions` aux table. The API reports
+  both as *absent* (not 0) for agents whose format never records them — decided
+  in `data/agent-capabilities.ts`, never inferred from the data. Context needs
+  **prompt-sized** rows (Claude Code, Codex, pi, opencode): Junie sums every LLM
+  call of a turn into one row and Grok records one total per user turn, so a
+  "context" read from them would be a fabrication, not merely session-level
+  like Copilot's. Compaction
+  markers differ per agent: Claude Code's is a `system`/`compact_boundary` row
+  (the 2025 format flagged the summary user turn `isCompactSummary`; mid-period
+  files carry both, so boundaries win and summaries are only counted in files
+  with no boundary); Codex's is the top-level `compacted` record (the
+  `compaction` item and `context_compacted` event belong to the same
+  compaction — never count them); pi's is the `compaction` entry; Copilot's is
+  `session.context_changed` with reason `compaction`. Normalizers synthesize
+  the Claude Code system-row shape so the parser and the aux projection have one
+  path; the window percentage is best-effort from pricing (`contextWindow`,
+  LiteLLM `max_input_tokens`) and is never stored.
 - **`loadFile` stages, then swaps — keep it that way.** It materializes the
   projection into temp tables *before* deleting the file's existing rows, so a
   failure while projecting (unreadable source, a bad rate reaching the

--- a/docs/plans/0083-context-window-and-compactions.md
+++ b/docs/plans/0083-context-window-and-compactions.md
@@ -1,0 +1,169 @@
+# 0083 — Context size and compaction count per session
+
+- **Status:** done
+- **Date:** 2026-09-04
+- **PR:** [#107](https://github.com/vladar107/claudescope/pull/107)
+
+## Context
+
+Looking at [cctop](https://github.com/stefanprodan/cctop) for ideas, most of it
+is live process monitoring, which does not fit a history tool. Its CTX column
+does: context size is a property of the transcript, not of a running process,
+and Claudescope already indexes the per-turn usage it is derived from. What the
+history could not answer until now:
+
+- how large the context was when a session stopped (does resuming it have room,
+  or will the first thing it does be a compaction?);
+- how many times a session was compacted, and where in the transcript;
+- which sessions in a date range ran hot.
+
+How the sources record a compaction, checked against real local data:
+
+| Agent       | Marker                                                                                              |
+| ----------- | --------------------------------------------------------------------------------------------------- |
+| Claude Code | `system` row, `subtype: "compact_boundary"`, `compactMetadata: {trigger, preTokens, postTokens}` (current); a `user` row flagged `isCompactSummary: true` (2025 format); mid-period files carry **both** for one compaction. Subagent files compact too. |
+| Codex       | top-level `compacted` record (`payload.message` = plaintext summary, `replacement_history`); one compaction also writes an encrypted `compaction` response item and, in current versions, a `context_compacted` event — only `compacted` is counted. |
+| pi          | `compaction` entry: `summary`, `tokensBefore`, `firstKeptEntryId`.                                   |
+| Copilot     | `session.context_changed` event with `reason: "compaction"` (already in the fixture, previously skipped). |
+| others      | opencode, Grok, Antigravity, Junie: no known marker → reported as unavailable, not 0.                |
+
+Context at a turn = `input + cache_read + cache_write` on the assistant row (the
+full prompt) — for connectors whose row IS one prompt (Claude Code, Codex, pi,
+opencode). Copilot (session-level usage), Antigravity (none), and Junie/Grok
+(one row sums a whole turn) do not get it.
+
+## Goal
+
+Every session shows its context size at the last main-thread turn (with a
+percent of the model's window when known) and its compaction count; the
+transcript shows a divider where each compaction happened; the efficiency table
+sorts by both. No live machinery — everything comes from the index.
+
+## Decisions
+
+- **Context at the last turn, not the peak.** Without a compaction the two are
+  the same number (context only grows within a segment). With compactions the
+  peak is roughly the window edge for every session, which the compaction count
+  already says — while "context now" is the actionable figure before resuming,
+  and doubles as cctop's CTX for a session that is still running (meta is
+  ≤15 s stale). The sawtooth stays visible in the transcript dividers.
+- **Compactions live in their own aux table, not an events column.** Claude
+  Code's marker is a `system` row, which `events` excludes by design (message
+  counts, FTS, analytics all assume conversational rows). A file-keyed
+  `compactions` table follows the `titles`/`pr_links` pattern; the canonical
+  events contract (`CANONICAL_COLUMNS`) is untouched. Cache-backed connectors
+  write `type: 'compaction'` rows into the NDJSON cache they already have; the
+  events projection filters them out by type, a shared aux projection reads
+  them back. Rejected: including system rows in `events` (changes its
+  semantics for every consumer); per-event `is_compaction` (needs window
+  functions over file order in the Claude Code projection).
+- **Claude Code counts boundaries, falling back to flagged summaries** only in
+  files with no boundary row, so the mid-period format is not double counted.
+  The parser applies the same rule (one divider, merged).
+- **Session count = main thread only.** A subagent compacting is visible in its
+  own thread but would inflate the session's number confusingly.
+- **One synthetic event shape for every agent.** Normalizers emit the Claude
+  Code `system`/`compact_boundary` event (plus a `summary` field Claude Code
+  does not have), so the parser has one path and pi summaries become readable
+  in the transcript. Codex's `compacted.payload.message` is empty in every
+  local sample, so Codex dividers usually carry sizes only (an empty summary
+  is never emitted).
+- **Divider numbers are derived when the agent does not record them.** Claude
+  Code's `preTokens`/`postTokens` are used verbatim; otherwise the parser takes
+  the previous and next assistant turns' prompt sizes — but only for agents
+  with per-response usage (`assembleThread`'s `deriveContextSizes`, set by the
+  route from the capability map). Copilot pins its session total to the last
+  turn, so a derived "after" figure there would measure nothing.
+- **Window size is best effort and resolved at read time.** `mapLiteLLM` keeps
+  `max_input_tokens` as an optional `contextWindow` on `ModelRates`; the user
+  `pricing.json` may set it on `models`/`families`; resolution is exact id →
+  family → unknown, and the UI shows a percent only when known. Nothing about
+  the window is stored in the index. Rejected: shipping family windows in the
+  default `pricing.json` (Anthropic ids with 1M-context variants make a
+  substring family wrong too often).
+- **Capability map.** `data/agent-capabilities.ts` owns the per-connector
+  usage granularity (moved from the comparison route), the compaction-signal
+  set, and a separate **prompt-sized usage** set (Claude Code, Codex, pi,
+  opencode) that gates the context figure: per-response granularity is not
+  enough, because Junie sums every LLM call of an agentic loop into the turn's
+  one row and Grok records one `turn_completed` total per user turn — a
+  "context" read from either would routinely exceed the model's window. So
+  `0` vs "unavailable" is decided in one place, never inferred from the data.
+- **Schema v20** — forces a rebuild (derived cache).
+
+## Approach
+
+1. Shared contract: `SessionMeta.contextTokens/contextWindow/compactionCount`
+   (optional = unavailable), `SessionSort 'context'`, efficiency row/sort/stats
+   columns, `ThreadItem.compaction: CompactionInfo`, `SystemEvent.compactMetadata
+   /summary`, `UserEvent.isCompactSummary`, `ModelRates.contextWindow`.
+2. Index: `compactions` table + `sessions.context_tokens/context_model/
+   compaction_count`; `AuxProjections.compactions` staged and swapped per file in
+   `loadFile`; `rebuildSessions` derives the three columns (newest main-thread
+   assistant row with a prompt, `row_number` with a `uuid` tie-break like
+   `modal_cwd`; count of main-thread compaction rows).
+   Claude Code aux SQL with the boundary-or-summary rule; `canonical.ts` gains
+   `compactionRow`, `COMPACTION_ROW_TYPE`, `compactionsProjectionSql`, and the
+   events projection's type filter.
+3. Parser: stamp `compaction` on the first conversational item after a boundary
+   (merge with a flagged summary turn), then fill missing pre/post from adjacent
+   usage. Subagent runs go through the same path.
+4. Normalizers: Codex (`compacted` → boundary with summary; skip the
+   `compaction` item and `context_compacted`), pi (`compaction` entry →
+   boundary with summary + `preTokens`), Copilot (`session.context_changed`
+   reason `compaction` → boundary). Each connector's `auxProjections` returns the
+   shared compactions projection.
+5. Pricing: keep the window through refresh and sanitize; `contextWindowFor`.
+6. Routes: session meta mapping gated by the capability map, `context` sort,
+   efficiency columns/sorts/quantiles, CLI/MCP session header line.
+7. Web: header (`142K context (71%)`, amber ≥ 80 %, red ≥ 95 %, tooltip with
+   the definition and "N at last turn"), tier-two `⟲ N compactions`, list row
+   `ctx` + compaction chip, sort option, transcript divider with the summary
+   collapsible, efficiency columns.
+8. Docs: CLAUDE.md gotcha, README feature line.
+
+## Files affected
+
+- `packages/shared/src/{api,events,thread,pricing}.ts` — contract (step 1).
+- `packages/server/src/db/schema.ts` — v20, `compactions`, session columns.
+- `packages/server/src/connectors/{canonical,types}.ts` — cache row + projection.
+- `packages/server/src/data/agent-capabilities.ts` — new; `routes/analytics-agents.ts` imports it.
+- `packages/server/src/data/index.ts` — aux staging/swap, rebuild aggregates.
+- `packages/server/src/connectors/claude-code/claude-code.ts` — compactions aux SQL.
+- `packages/server/src/connectors/{codex,pi,copilot}/{normalize,*}.ts` — synthetic boundary + wiring.
+- `packages/server/src/data/parser.ts` — stamping + derivation.
+- `packages/server/src/data/{pricing,pricing-refresh}.ts` — window.
+- `packages/server/src/routes/{sessions,analytics-sessions}.ts`, `agent/shape.ts`.
+- `packages/web/src/pages/session/{SessionPage,ThreadView}.tsx`, `session.css`,
+  `pages/browse/SessionList.tsx`, `browse.css`, `pages/analytics/SessionEfficiencyTable.tsx`.
+- `CLAUDE.md`, `README.md`, this plan.
+
+## Testing
+
+- `npm test`, `npm run typecheck`.
+- Index: boundary-only file, boundary + flagged summary (counted once), flagged
+  summary only, subagent boundary excluded from the session count, context =
+  last turn with block-duplicated rows and a sidechain excluded, reload of one
+  file replaces only its compaction rows.
+- Normalizers: one compaction each for Codex/pi/Copilot → boundary event and
+  cache row; the Codex `compaction` item stays out of the thread.
+- Parser: stamp lands on the next item; merge with a flagged summary; derived
+  pre/post from adjacent usage; no stamp when nothing follows.
+- Pricing: `max_input_tokens` kept / invalid dropped without dropping the rates;
+  user override wins; family fallback.
+- Routes: Copilot session → no `contextTokens`; opencode session → no
+  `compactionCount`; `sort=context`; efficiency columns and quantiles.
+
+## Risks / open questions
+
+- The Claude Code 2025 format is inferred from one local file; the rule is
+  conservative (boundaries win) so a wrong guess under-counts, never doubles.
+- The Codex `compaction` response item is only ever seen nested inside
+  `compacted.replacement_history` locally, never as its own line; the explicit
+  skip is forward-looking and covered by the fixture anyway.
+- opencode very likely records compactions (an assistant `summary` message);
+  add once verified against real data.
+- Codex reports its own effective window (`model_context_window` on
+  `token_count`, e.g. 258 400 for gpt-5.x-codex) which differs from LiteLLM's;
+  a follow-up could prefer it.
+- Per-turn context on every assistant turn was deliberately left out (noise).

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -107,3 +107,4 @@ decision, or a change worth explaining before doing. Skip it for one-line fixes.
 | 0080 | [Tool-failure history hook](./0080-tool-failure-history-hook.md) | abandoned |
 | 0081 | [Skill usage and exact-match search in the web](./0081-web-skill-usage-and-exact-search.md) | done |
 | 0082 | [Brew release waits for the npm tarball](./0082-brew-release-waits-for-npm-tarball.md) | done |
+| 0083 | [Context size and compaction count per session](./0083-context-window-and-compactions.md) | done |

--- a/packages/server/src/agent/shape.ts
+++ b/packages/server/src/agent/shape.ts
@@ -10,6 +10,7 @@ import type {
   AnalyticsResponse,
   SearchResponse,
   SessionDetailResponse,
+  SessionMeta,
   ToolUsageKind,
   ToolUsageResponse,
 } from '@claudescope/shared';
@@ -129,6 +130,23 @@ export function shapeSearchResults(res: SearchResponse, limit: number): string {
 }
 
 /**
+ * ` · ctx 142K (71%) · 2 compactions` for the session header — each part only
+ * when the agent records it (see data/agent-capabilities.ts), so an absent
+ * figure reads as unknown rather than 0.
+ */
+function contextSuffix(meta: SessionMeta): string {
+  const parts: string[] = [];
+  if (meta.contextTokens !== undefined) {
+    const pct = meta.contextWindow ? ` (${Math.round((meta.contextTokens / meta.contextWindow) * 100)}%)` : '';
+    parts.push(`ctx ${fmtTokens(meta.contextTokens)}${pct}`);
+  }
+  if (meta.compactionCount !== undefined) {
+    parts.push(`${meta.compactionCount} compaction${meta.compactionCount === 1 ? '' : 's'}`);
+  }
+  return parts.map((p) => ` · ${p}`).join('');
+}
+
+/**
  * One session (or a window of it) as compact Markdown: a header with ids and
  * totals, the paging line when the response is windowed, then the turns and
  * any subagent runs inside the window. `redact` masks home paths and likely
@@ -140,7 +158,8 @@ export function shapeSessionMarkdown(data: SessionDetailResponse, redact: boolea
   const head = [
     `# ${r(meta.title)}`,
     `session ${meta.id} [${meta.connectorId}] · project ${meta.projectDisplayName} · ` +
-      `${meta.startedAt} → ${meta.endedAt} · ${fmtTokens(meta.totalTokens)} tok · ${fmtCost(meta.totalCostUsd)}`,
+      `${meta.startedAt} → ${meta.endedAt} · ${fmtTokens(meta.totalTokens)} tok · ${fmtCost(meta.totalCostUsd)}` +
+      contextSuffix(meta),
   ];
   if (window) {
     const end = window.offset + window.limit;

--- a/packages/server/src/connectors/canonical.ts
+++ b/packages/server/src/connectors/canonical.ts
@@ -89,6 +89,53 @@ export interface CanonicalRow {
   text_content: string;
   /** Session title; read by the aux projection, ignored by the events one. */
   title?: string;
+  /**
+   * Compaction metadata, set only on {@link COMPACTION_ROW_TYPE} rows (see
+   * {@link compactionRow}); read by {@link compactionsProjectionSql}, ignored by
+   * the events projection, which filters those rows out.
+   */
+  compaction_trigger?: string | null;
+  compaction_pre_tokens?: number | null;
+  compaction_post_tokens?: number | null;
+}
+
+/**
+ * `type` of a cache row that records a context compaction rather than a
+ * conversational event. Cache-internal: it is neither a Claude Code event type
+ * nor an `events` row — the events projection excludes it by type.
+ */
+export const COMPACTION_ROW_TYPE = 'compaction';
+
+/**
+ * A cache row marking one context compaction (the normalizer's synthetic
+ * `system`/`compact_boundary` event). Token/text columns are the canonical
+ * zeros so the row is shape-identical to an event row in the NDJSON file.
+ */
+export function compactionRow(
+  base: Pick<CanonicalRow, 'file_path' | 'session_id' | 'uuid' | 'parent_uuid' | 'ts' | 'cwd' | 'is_sidechain'>,
+  meta: { trigger?: string; preTokens?: number; postTokens?: number } = {},
+): CanonicalRow {
+  return {
+    ...base,
+    role: 'system',
+    type: COMPACTION_ROW_TYPE,
+    git_branch: null,
+    model: null,
+    input_tokens: 0,
+    output_tokens: 0,
+    cache_read_tokens: 0,
+    cache_write_tokens: 0,
+    service_tier: null,
+    tool_use_count: 0,
+    tool_names: '',
+    tool_error_count: null,
+    tool_error_text: null,
+    skill_names: '',
+    text_content: '',
+    compaction_trigger: meta.trigger ?? null,
+    compaction_pre_tokens: meta.preTokens ?? null,
+    compaction_post_tokens: meta.postTokens ?? null,
+  };
 }
 
 /**
@@ -122,11 +169,32 @@ export function canonicalProjectionSql(cachePath: string, opts: { provider: bool
   const selected = Object.keys(CANONICAL_COLUMNS).map((n) =>
     n === 'provider' && !opts.provider ? 'CAST(NULL AS VARCHAR) AS provider' : n,
   );
+  // Compaction rows share the file (see compactionRow) but are not events.
+  // This filter is the contract: a `toCanonicalRows` must only ever emit
+  // user/assistant rows plus COMPACTION_ROW_TYPE — any other `type` would
+  // silently vanish from `events` here rather than fail.
   return `
     SELECT
       ${selected.join(', ')},
       CAST(NULL AS VARCHAR) AS message_id, CAST(NULL AS VARCHAR) AS forked_from_session_id
-    FROM read_ndjson(${sqlString(cachePath)}, ${READ_OPTS}, ${columnsMap(names)})`;
+    FROM read_ndjson(${sqlString(cachePath)}, ${READ_OPTS}, ${columnsMap(names)})
+    WHERE type IN ('user', 'assistant')`;
+}
+
+/**
+ * The `compactions` aux projection for a cache-backed connector: the
+ * {@link compactionRow}s of the file, in the `compactions` table's column order.
+ */
+export function compactionsProjectionSql(cachePath: string): string {
+  return `
+      SELECT file_path, session_id, uuid, ts, COALESCE(is_sidechain, FALSE) AS is_sidechain,
+             compaction_trigger AS trigger, compaction_pre_tokens AS pre_tokens,
+             compaction_post_tokens AS post_tokens
+      FROM read_ndjson(${sqlString(cachePath)}, ${READ_OPTS},
+        columns={file_path:'VARCHAR', session_id:'VARCHAR', uuid:'VARCHAR', type:'VARCHAR',
+                 ts:'TIMESTAMP', is_sidechain:'BOOLEAN', compaction_trigger:'VARCHAR',
+                 compaction_pre_tokens:'BIGINT', compaction_post_tokens:'BIGINT'})
+      WHERE type = '${COMPACTION_ROW_TYPE}' AND session_id IS NOT NULL`;
 }
 
 /**

--- a/packages/server/src/connectors/claude-code/claude-code.ts
+++ b/packages/server/src/connectors/claude-code/claude-code.ts
@@ -229,12 +229,19 @@ function eventsProjectionSql(filePath: string): string {
     WHERE type IN ('user', 'assistant')`;
 }
 
-/** ai-title and pr-link projections, keyed by session. */
+/** ai-title and pr-link projections (session-keyed) plus compactions (file-keyed). */
 function auxProjections(filePath: string): AuxProjections {
   const path = sqlString(filePath);
   const readFn = `read_ndjson(${path}, ${READ_OPTS}, columns={
     type:'VARCHAR', sessionId:'VARCHAR', aiTitle:'VARCHAR',
     prNumber:'BIGINT', prRepository:'VARCHAR', prUrl:'VARCHAR'
+  })`;
+  // Compaction markers live on records the events projection filters out
+  // (`system`) or on a flagged user turn, so they need their own column map.
+  const compactionReadFn = `read_ndjson(${path}, ${READ_OPTS}, columns={
+    type:'VARCHAR', subtype:'VARCHAR', isCompactSummary:'BOOLEAN', uuid:'VARCHAR',
+    sessionId:'VARCHAR', timestamp:'VARCHAR', isSidechain:'BOOLEAN',
+    compactMetadata:'JSON'
   })`;
   return {
     // ai-title: latest non-null title in the file wins.
@@ -256,6 +263,32 @@ function auxProjections(filePath: string): AuxProjections {
       FROM ${readFn}
       WHERE type = 'pr-link' AND sessionId IS NOT NULL AND prUrl IS NOT NULL
       GROUP BY sessionId`,
+    // One row per compaction. Current Claude Code writes a `compact_boundary`
+    // system record; the 2025 format instead flagged the summary user turn with
+    // `isCompactSummary`, and files from the transition carry BOTH for a single
+    // compaction. So flagged summaries only count in a file with no boundary at
+    // all — the conservative direction, where a wrong guess under-counts rather
+    // than doubling. `MATERIALIZED` keeps the NOT EXISTS check from reading the
+    // transcript a second time.
+    compactions: `
+      WITH marks AS MATERIALIZED (
+        SELECT type, uuid, sessionId, timestamp, isSidechain, compactMetadata
+        FROM ${compactionReadFn}
+        WHERE sessionId IS NOT NULL
+          AND ((type = 'system' AND subtype = 'compact_boundary')
+               OR (type = 'user' AND COALESCE(isCompactSummary, FALSE)))
+      )
+      SELECT
+        ${path} AS file_path,
+        sessionId AS session_id,
+        uuid,
+        try_cast(timestamp AS TIMESTAMP) AS ts,
+        COALESCE(isSidechain, FALSE) AS is_sidechain,
+        json_extract_string(compactMetadata, '$.trigger') AS trigger,
+        try_cast(json_extract(compactMetadata, '$.preTokens') AS BIGINT) AS pre_tokens,
+        try_cast(json_extract(compactMetadata, '$.postTokens') AS BIGINT) AS post_tokens
+      FROM marks
+      WHERE type = 'system' OR NOT EXISTS (SELECT 1 FROM marks WHERE type = 'system')`,
   };
 }
 

--- a/packages/server/src/connectors/codex/codex.ts
+++ b/packages/server/src/connectors/codex/codex.ts
@@ -18,7 +18,7 @@
 import { codexSessionsDir } from '../../settings.js';
 import type { SessionData, SubagentSource } from '../../data/session-loader.js';
 import type { AgentConnector, AuxProjections, DiscoveredFile } from '../types.js';
-import { canonicalProjectionSql } from '../canonical.js';
+import { canonicalProjectionSql, compactionsProjectionSql } from '../canonical.js';
 import { ndjsonCache } from '../ndjson-cache.js';
 import { codexGlobalMemory } from './memory.js';
 import { listRollouts, parseRollout, toCanonicalRows, type CodexSession } from './normalize.js';
@@ -46,8 +46,10 @@ function eventsProjectionSql(filePath: string): string {
   return canonicalProjectionSql(cache.path(filePath), { provider: true });
 }
 
-function auxProjections(_filePath: string): AuxProjections {
-  return {}; // Codex has no ai-title / pr-link records
+/** Codex has no ai-title / pr-link records — only the compaction markers the
+ *  normalizer wrote into the cache. */
+function auxProjections(filePath: string): AuxProjections {
+  return { compactions: compactionsProjectionSql(cache.path(filePath)) };
 }
 
 /**

--- a/packages/server/src/connectors/codex/normalize.ts
+++ b/packages/server/src/connectors/codex/normalize.ts
@@ -3,7 +3,8 @@
  *
  * A Codex session (`rollout-*.jsonl`) spreads its data across record types:
  * `session_meta` (id, cwd), `turn_context` (model, per turn), `response_item`
- * (the transcript), and `event_msg/token_count` (per-turn token usage). This
+ * (the transcript), `event_msg/token_count` (per-turn token usage), and
+ * `compacted` (a context compaction → a synthetic `compact_boundary`). This
  * parses one rollout into Claude-shaped `RawEvent[]` — assistant/user turns whose
  * `message.content` carries text / thinking / tool_use / tool_result blocks — so
  * the existing thread assembler and the canonical index row builder both reuse it.
@@ -28,6 +29,7 @@ import type {
   AssistantEvent,
   ContentBlock,
   MessageUsage,
+  SystemEvent,
   ToolUseBlock,
   UserEvent,
 } from '@claudescope/shared';
@@ -35,7 +37,7 @@ import { codexSessionsDir } from '../../settings.js';
 import { toolNamesCsv } from '../tool-names.js';
 import { skillNamesCsv } from '../skill-names.js';
 import { toolErrorCount, toolErrorText } from '../tool-errors.js';
-import type { CanonicalRow } from '../canonical.js';
+import { compactionRow, type CanonicalRow } from '../canonical.js';
 import { num, rec, str } from '../json.js';
 
 interface CodexLine {
@@ -43,6 +45,12 @@ interface CodexLine {
   payload?: Record<string, unknown>;
   timestamp?: string;
 }
+
+/**
+ * One normalized event: a conversational turn, or the synthetic
+ * `compact_boundary` marker a top-level `compacted` record becomes.
+ */
+export type CodexEvent = UserEvent | AssistantEvent | SystemEvent;
 
 export interface CodexSession {
   /** Own thread id — the correlation key `loadSession` splits files by. */
@@ -60,7 +68,7 @@ export interface CodexSession {
   /** `model_provider` from session_meta — session-level, applied to every
    *  assistant row (e.g. 'openai'). */
   modelProvider?: string;
-  events: (UserEvent | AssistantEvent)[];
+  events: CodexEvent[];
   /** Legacy child thread id OR current canonical task path → exact Task
    *  correlation meta, recovered from this rollout's `spawn_agent` calls. */
   spawnedAgents: Map<string, { description: string; agentType: string; toolUseId: string }>;
@@ -724,7 +732,7 @@ export function parseRollout(path: string): CodexSession | null {
     }
   }
 
-  const events: (UserEvent | AssistantEvent)[] = [];
+  const events: CodexEvent[] = [];
   let seq = 0;
   let wsSeq = 0;
   let prevUuid: string | null = null;
@@ -818,8 +826,33 @@ export function parseRollout(path: string): CodexSession | null {
       continue;
     }
 
+    // A context compaction. Codex writes it three times over — this top-level
+    // record, an encrypted `compaction` response item, and (current versions) a
+    // `context_compacted` event — so ONLY this one becomes the marker.
+    if (line.type === 'compacted') {
+      flush();
+      const summary = str(pl.message);
+      events.push({
+        uuid: `${sessionId}-${seq++}`,
+        // Deliberately NOT advancing prevUuid: the boundary sits beside the
+        // conversation, so the next turn still chains to the previous one.
+        parentUuid: prevUuid,
+        sessionId,
+        timestamp: ts,
+        cwd,
+        isSidechain,
+        type: 'system',
+        subtype: 'compact_boundary',
+        ...(summary ? { summary } : {}),
+      } as SystemEvent);
+      continue;
+    }
+
     if (line.type !== 'response_item') continue;
     const kind = str(pl.type);
+    // The encrypted twin of the `compacted` record above — bookkeeping, never a
+    // transcript block.
+    if (kind === 'compaction') continue;
 
     if (kind === 'message') {
       const role = str(pl.role);
@@ -992,6 +1025,18 @@ export function parseRollout(path: string): CodexSession | null {
 /** Flatten a parsed session into canonical index rows for one file. */
 export function toCanonicalRows(session: CodexSession, filePath: string): CanonicalRow[] {
   return session.events.map((e) => {
+    if (e.type === 'system') {
+      // The synthetic compaction marker: a `compactions` cache row, not an event.
+      return compactionRow({
+        file_path: filePath,
+        session_id: session.indexSessionId,
+        uuid: e.uuid,
+        parent_uuid: e.parentUuid,
+        ts: e.timestamp,
+        cwd: session.cwd,
+        is_sidechain: session.isSidechain,
+      });
+    }
     const msg = (e as AssistantEvent | UserEvent).message;
     const content = msg.content;
     const arr = Array.isArray(content) ? content : [];

--- a/packages/server/src/connectors/copilot/copilot.ts
+++ b/packages/server/src/connectors/copilot/copilot.ts
@@ -19,7 +19,7 @@ import { join } from 'node:path';
 import { copilotSessionsDir } from '../../settings.js';
 import type { SessionData, SubagentSource } from '../../data/session-loader.js';
 import type { AgentConnector, AuxProjections, DiscoveredFile } from '../types.js';
-import { canonicalProjectionSql, titlesProjectionSql } from '../canonical.js';
+import { canonicalProjectionSql, compactionsProjectionSql, titlesProjectionSql } from '../canonical.js';
 import { ndjsonCache } from '../ndjson-cache.js';
 import { parseCopilotSession, toCanonicalRows, type CopilotSession } from './normalize.js';
 import { copilotGlobalMemory } from './memory.js';
@@ -61,10 +61,14 @@ function eventsProjectionSql(filePath: string): string {
 }
 
 /** Copilot carries a real session title (workspace.yaml `name`), threaded through
- *  the cache NDJSON; the first-user-message fallback applies when it's empty. */
+ *  the cache NDJSON alongside its compaction markers; the first-user-message
+ *  fallback applies when the title is empty. */
 function auxProjections(filePath: string): AuxProjections {
   if (!existsSync(cache.path(filePath))) return {};
-  return { titles: titlesProjectionSql(cache.path(filePath)) };
+  return {
+    titles: titlesProjectionSql(cache.path(filePath)),
+    compactions: compactionsProjectionSql(cache.path(filePath)),
+  };
 }
 
 async function loadSession(_sessionId: string, paths: string[]): Promise<SessionData> {

--- a/packages/server/src/connectors/copilot/normalize.ts
+++ b/packages/server/src/connectors/copilot/normalize.ts
@@ -6,8 +6,9 @@
  * `{type, data, id, timestamp, parentId}`. The transcript is spread across record
  * types: `session.start` carries cwd/branch/repository, `session.model_change`
  * the model, `assistant.message` the text + tool calls (+ encrypted reasoning),
- * `tool.execution_complete` the tool results, and `session.shutdown` the ONLY
- * token counts (session-level — there is no per-message usage). The sibling
+ * `tool.execution_complete` the tool results, `session.context_changed` a
+ * context compaction (→ a synthetic `compact_boundary`), and `session.shutdown`
+ * the ONLY token counts (session-level — there is no per-message usage). The sibling
  * `workspace.yaml` carries the session title; `files/<displayName>` holds persisted
  * attachments (screenshots) when saving is enabled.
  *
@@ -45,6 +46,7 @@ import type {
   AssistantEvent,
   ContentBlock,
   MessageUsage,
+  SystemEvent,
   ToolResultBlock,
   UserEvent,
 } from '@claudescope/shared';
@@ -52,8 +54,15 @@ import { resolveImageWithin } from '../safe-image.js';
 import { toolNamesCsv } from '../tool-names.js';
 import { skillNamesCsv } from '../skill-names.js';
 import { toolErrorCount, toolErrorText } from '../tool-errors.js';
-import type { CanonicalRow } from '../canonical.js';
+import { compactionRow, type CanonicalRow } from '../canonical.js';
 import { num, rec, str } from '../json.js';
+
+/**
+ * One normalized thread event: a conversational turn, or the synthetic
+ * `compact_boundary` marker a `session.context_changed` compaction becomes.
+ * (`CopilotEvent` below is the raw on-disk line, not this.)
+ */
+export type CopilotThreadEvent = UserEvent | AssistantEvent | SystemEvent;
 
 /** One inline subagent run, segmented out of the parent's event stream. */
 export interface CopilotSubagent {
@@ -64,7 +73,7 @@ export interface CopilotSubagent {
   /** The `task` call's `arguments.description` — same string the canonical
    *  `Task` block carries, so the run anchors to its spawn point. */
   description: string;
-  events: (UserEvent | AssistantEvent)[];
+  events: CopilotThreadEvent[];
 }
 
 export interface CopilotSession {
@@ -72,7 +81,7 @@ export interface CopilotSession {
   cwd: string;
   branch: string | null;
   title: string;
-  events: (UserEvent | AssistantEvent)[];
+  events: CopilotThreadEvent[];
   subagents: CopilotSubagent[];
 }
 
@@ -210,7 +219,7 @@ interface CopilotEvent {
 /** Per-thread turn buffer: the main transcript and each subagent run get their
  *  own event list, uuid chain, and running model. */
 interface TurnStream {
-  events: (UserEvent | AssistantEvent)[];
+  events: CopilotThreadEvent[];
   seq: number;
   prevUuid: string | null;
   uuidPrefix: string;
@@ -362,6 +371,19 @@ export function parseCopilotSession(
     s.prevUuid = uuid;
   };
 
+  /** A context compaction marker for the stream it appeared in. It carries no
+   *  metadata or summary, and deliberately does NOT advance `prevUuid` — the
+   *  next turn still chains to the previous one. */
+  const pushCompaction = (s: TurnStream, ts: string): void => {
+    s.events.push({
+      uuid: `${s.uuidPrefix}-${s.seq++}`,
+      parentUuid: s.prevUuid,
+      ...envelope(ts, s.sidechain),
+      type: 'system',
+      subtype: 'compact_boundary',
+    } as SystemEvent);
+  };
+
   /** One `assistant.message` → an assistant turn (+ a tool-result user turn). */
   const assistantTurn = (s: TurnStream, d: Record<string, unknown>, ts: string): void => {
     if (str(d.model)) s.model = str(d.model);
@@ -430,6 +452,10 @@ export function parseCopilotSession(
       pushUser(stream, ts, userBlocks(d, sessionDir, resolveImages));
     } else if (ev.type === 'assistant.message') {
       assistantTurn(stream, d, ts);
+    } else if (ev.type === 'session.context_changed') {
+      // The ONLY compaction signal Copilot writes. Other reasons for a context
+      // change are not compactions and stay skipped.
+      if (str(d.reason) === 'compaction') pushCompaction(stream, ts);
     } else if (ev.type === 'session.shutdown') {
       shutdown = shutdownUsage(d);
     }
@@ -471,6 +497,18 @@ export function parseCopilotSession(
 export function toCanonicalRows(session: CopilotSession, filePath: string): CanonicalRow[] {
   const all = [...session.events, ...session.subagents.flatMap((s) => s.events)];
   return all.map((e) => {
+    if (e.type === 'system') {
+      // The synthetic compaction marker: a `compactions` cache row, not an event.
+      return compactionRow({
+        file_path: filePath,
+        session_id: session.sessionId,
+        uuid: e.uuid,
+        parent_uuid: e.parentUuid,
+        ts: e.timestamp,
+        cwd: session.cwd,
+        is_sidechain: e.isSidechain === true,
+      });
+    }
     const msg = e.message;
     const content = Array.isArray(msg.content) ? msg.content : [];
     const usage = (msg as { usage?: MessageUsage }).usage;

--- a/packages/server/src/connectors/pi/normalize.ts
+++ b/packages/server/src/connectors/pi/normalize.ts
@@ -4,9 +4,10 @@
  * A pi session (`<ts>_<uuid>.jsonl`) is a flat, threaded record stream: a
  * `session` line (carrying `cwd` + the session id), `message` records
  * (`role: user | assistant | toolResult`), and `model_change` /
- * `thinking_level_change` records. The conversation lives entirely in the
- * `message` records; the model and usage ride the assistant message itself, and
- * `cwd` ride the single `session` line.
+ * `thinking_level_change` records, plus a `compaction` entry per context
+ * compaction (→ a synthetic `compact_boundary`). The conversation lives entirely
+ * in the `message` records; the model and usage ride the assistant message
+ * itself, and `cwd` ride the single `session` line.
  *
  * This parses one session into Claude-shaped `RawEvent[]` — assistant/user turns
  * whose `message.content` carries text / thinking / tool_use / tool_result blocks
@@ -34,12 +35,18 @@
 
 import { existsSync, readFileSync, statSync } from 'node:fs';
 import { basename, dirname } from 'node:path';
-import type { AssistantEvent, ContentBlock, MessageUsage, UserEvent } from '@claudescope/shared';
+import type { AssistantEvent, ContentBlock, MessageUsage, SystemEvent, UserEvent } from '@claudescope/shared';
 import { toolNamesCsv } from '../tool-names.js';
 import { skillNamesCsv } from '../skill-names.js';
 import { toolErrorCount, toolErrorText } from '../tool-errors.js';
-import type { CanonicalRow } from '../canonical.js';
+import { compactionRow, type CanonicalRow } from '../canonical.js';
 import { num, rec, str } from '../json.js';
+
+/**
+ * One normalized event: a conversational turn, or the synthetic
+ * `compact_boundary` marker a `compaction` entry becomes.
+ */
+export type PiEvent = UserEvent | AssistantEvent | SystemEvent;
 
 export interface PiSession {
   /** Indexing key: the parent's session id for a nested subagent, else the own id. */
@@ -49,7 +56,7 @@ export interface PiSession {
   /** True for a nested subagent transcript (re-keyed to the parent session). */
   isSidechain: boolean;
   cwd: string;
-  events: (UserEvent | AssistantEvent)[];
+  events: PiEvent[];
 }
 
 
@@ -230,6 +237,9 @@ interface PiLine {
   };
   id?: string;
   cwd?: string;
+  /** `compaction` entries only: the plaintext summary and the pre-compaction size. */
+  summary?: string;
+  tokensBefore?: number;
 }
 
 /** Tolerantly read a pi JSONL file, or null if unreadable. */
@@ -309,7 +319,7 @@ export function parsePiSession(path: string): PiSession | null {
   const sessionId = parentFile ? sessionIdOf(parentFile) : ownId;
   const isSidechain = parentFile !== null;
 
-  const events: (UserEvent | AssistantEvent)[] = [];
+  const events: PiEvent[] = [];
   let seq = 0;
   let prevUuid: string | null = null;
   const nextUuid = (): string => `${ownId}-${seq++}`;
@@ -336,6 +346,28 @@ export function parsePiSession(path: string): PiSession | null {
   };
 
   for (const line of lines) {
+    // A context compaction. `branch_summary` entries look similar but record a
+    // branch digest, not a compaction, so only this type is a marker.
+    if (line.type === 'compaction') {
+      flushToolResults();
+      const summary = str(line.summary);
+      const preTokens = num(line.tokensBefore);
+      events.push({
+        // Deliberately NOT advancing prevUuid: the boundary sits beside the
+        // conversation, so the next turn still chains to the previous one.
+        uuid: nextUuid(),
+        parentUuid: prevUuid,
+        sessionId,
+        timestamp: str(line.timestamp),
+        cwd,
+        isSidechain,
+        type: 'system',
+        subtype: 'compact_boundary',
+        ...(summary ? { summary } : {}),
+        ...(preTokens > 0 ? { compactMetadata: { preTokens } } : {}),
+      } as SystemEvent);
+      continue;
+    }
     if (line.type !== 'message' || !line.message) continue;
     const msg = line.message;
     const role = str(msg.role);
@@ -460,6 +492,21 @@ export function subagentRuns(path: string): PiSubagentRun[] {
 /** Flatten a parsed session into canonical index rows for one file. */
 export function toCanonicalRows(session: PiSession, filePath: string): CanonicalRow[] {
   return session.events.map((e) => {
+    if (e.type === 'system') {
+      // The synthetic compaction marker: a `compactions` cache row, not an event.
+      return compactionRow(
+        {
+          file_path: filePath,
+          session_id: session.sessionId,
+          uuid: e.uuid,
+          parent_uuid: e.parentUuid,
+          ts: e.timestamp,
+          cwd: session.cwd,
+          is_sidechain: session.isSidechain,
+        },
+        e.compactMetadata?.preTokens !== undefined ? { preTokens: e.compactMetadata.preTokens } : {},
+      );
+    }
     const msg = e.message;
     const content = Array.isArray(msg.content) ? msg.content : [];
     const usage = (msg as { usage?: MessageUsage }).usage;

--- a/packages/server/src/connectors/pi/pi.ts
+++ b/packages/server/src/connectors/pi/pi.ts
@@ -23,7 +23,7 @@ import { basename, dirname, join } from 'node:path';
 import { piSessionsDir } from '../../settings.js';
 import type { SessionData, SubagentSource } from '../../data/session-loader.js';
 import type { AgentConnector, AuxProjections, DiscoveredFile } from '../types.js';
-import { canonicalProjectionSql } from '../canonical.js';
+import { canonicalProjectionSql, compactionsProjectionSql } from '../canonical.js';
 import { ndjsonCache } from '../ndjson-cache.js';
 import { parentSessionFile, parsePiSession, subagentRuns, toCanonicalRows } from './normalize.js';
 
@@ -75,8 +75,10 @@ function eventsProjectionSql(filePath: string): string {
   return canonicalProjectionSql(cache.path(filePath), { provider: true });
 }
 
-function auxProjections(_filePath: string): AuxProjections {
-  return {}; // pi has no ai-title / pr-link records (first-user-message title fallback applies)
+/** pi has no ai-title / pr-link records (the first-user-message title fallback
+ *  applies) — only the compaction markers the normalizer wrote into the cache. */
+function auxProjections(filePath: string): AuxProjections {
+  return { compactions: compactionsProjectionSql(cache.path(filePath)) };
 }
 
 async function loadSession(_sessionId: string, paths: string[]): Promise<SessionData> {

--- a/packages/server/src/connectors/types.ts
+++ b/packages/server/src/connectors/types.ts
@@ -33,15 +33,20 @@ export interface DiscoveredFile {
  */
 
 /**
- * Optional auxiliary, session-keyed projections. Each value is a `SELECT` body
- * the indexer wraps with `INSERT OR REPLACE INTO <table> (...)`:
- *   - `titles` → `(session_id, title)`
- *   - `prLinks` → `(session_id, pr_number, pr_repository, pr_url)`
- * Agents without these (e.g. Codex) simply omit them.
+ * Optional auxiliary projections. Each value is a `SELECT` body the indexer
+ * stages and inserts into the matching table:
+ *   - `titles` → `(session_id, title)` (session-keyed, INSERT OR REPLACE)
+ *   - `prLinks` → `(session_id, pr_number, pr_repository, pr_url)` (same)
+ *   - `compactions` → `(file_path, session_id, uuid, ts, is_sidechain, trigger,
+ *     pre_tokens, post_tokens)` — one row per context compaction in the file;
+ *     file-keyed (rows of the reloaded file are replaced). Cache-backed
+ *     connectors get it from `canonical.ts:compactionsProjectionSql`.
+ * Agents without these simply omit them.
  */
 export interface AuxProjections {
   titles?: string;
   prLinks?: string;
+  compactions?: string;
 }
 
 /** A source of agent transcripts. One implementation per supported agent. */

--- a/packages/server/src/data/agent-capabilities.ts
+++ b/packages/server/src/data/agent-capabilities.ts
@@ -1,0 +1,69 @@
+/**
+ * What each agent's source format can and cannot tell us — properties of the
+ * CONNECTOR, not of the data (see the per-connector gotchas in CLAUDE.md).
+ * Consulted wherever a metric must read "unavailable" rather than 0 for an
+ * agent that never records it.
+ */
+
+import type { AgentUsageGranularity } from '@claudescope/shared';
+
+/**
+ * How each agent records token usage:
+ * - copilot: tokens live only in `session.shutdown`, attached to the last
+ *   assistant row — session totals are real, per-response ratios are not, and
+ *   crashed/still-running sessions (no shutdown) carry no usage at all.
+ * - antigravity: transcripts carry no token counts by design.
+ * Unknown connectors default to per-response (the canonical event contract
+ * carries per-event tokens).
+ */
+const USAGE_GRANULARITY: Record<string, AgentUsageGranularity> = {
+  'claude-code': 'per-response',
+  codex: 'per-response',
+  pi: 'per-response',
+  opencode: 'per-response',
+  junie: 'per-response',
+  copilot: 'session-level',
+  antigravity: 'none',
+  grok: 'per-response',
+};
+
+export function usageGranularity(connectorId: string): AgentUsageGranularity {
+  return USAGE_GRANULARITY[connectorId] ?? 'per-response';
+}
+
+/**
+ * Agents whose assistant rows carry ONE prompt's usage, so a row's
+ * `input + cache read + cache write` is a context size. Not the same thing as
+ * per-response granularity: Junie sums every LLM call of an agentic loop into
+ * the turn's single row, and Grok attaches one `turn_completed` total per user
+ * turn — real totals, but a "context" read from them would be a fabrication
+ * (a long Junie turn exceeds any model's window). Unknown connectors are NOT
+ * assumed to qualify: a wrong absence is a missing figure, a wrong presence is
+ * a wrong one.
+ */
+const PROMPT_SIZED_USAGE = new Set(['claude-code', 'codex', 'pi', 'opencode']);
+
+export function hasPromptSizedUsage(connectorId: string): boolean {
+  return PROMPT_SIZED_USAGE.has(connectorId);
+}
+
+export function connectorsWithPromptSizedUsage(): string[] {
+  return [...PROMPT_SIZED_USAGE];
+}
+
+/**
+ * Agents whose format records a context-compaction marker: Claude Code
+ * (`system`/`compact_boundary`, or the 2025 `isCompactSummary` user turn),
+ * Codex (`compacted` rollout record), pi (`compaction` entry), Copilot
+ * (`session.context_changed` with reason `compaction`). For every other agent
+ * a compaction count of 0 means "unknown", so the API omits it.
+ */
+const COMPACTION_SIGNAL = new Set(['claude-code', 'codex', 'pi', 'copilot']);
+
+export function hasCompactionSignal(connectorId: string): boolean {
+  return COMPACTION_SIGNAL.has(connectorId);
+}
+
+export function connectorsWithCompactionSignal(): string[] {
+  return [...COMPACTION_SIGNAL];
+}

--- a/packages/server/src/data/file-edits.ts
+++ b/packages/server/src/data/file-edits.ts
@@ -80,7 +80,7 @@ export async function refreshFileEdits(
     try {
       const { mainEvents, subagents } = await loadSessionData(sessionId);
       if (mainEvents.length === 0 && subagents.length === 0) continue;
-      const thread = assembleThread(mainEvents);
+      const thread = assembleThread(mainEvents, { deriveContextSizes: false });
       const runs = buildSubagentRuns(thread, subagents);
 
       const values: string[] = [];

--- a/packages/server/src/data/index.ts
+++ b/packages/server/src/data/index.ts
@@ -97,7 +97,7 @@ const RATES_ALIAS = 'pr';
 /**
  * Suffix for {@link loadFile}'s staging temp tables. Constant (not per-file):
  * only one pass runs at a time (see {@link inFlight}) and it loads files
- * sequentially, so `CREATE OR REPLACE` reuses the same three tables instead of
+ * sequentially, so `CREATE OR REPLACE` reuses the same staging tables instead of
  * leaking one set per indexed file. Temp tables are connection-scoped, so this
  * can never collide with a route's query.
  */
@@ -217,6 +217,7 @@ async function loadFile(
   const stagedEvents = `stage_events_${STAGE_SUFFIX}`;
   const stagedTitles = `stage_titles_${STAGE_SUFFIX}`;
   const stagedPrLinks = `stage_pr_links_${STAGE_SUFFIX}`;
+  const stagedCompactions = `stage_compactions_${STAGE_SUFFIX}`;
 
   // The cost expression references the projected token/model columns plus the
   // pricing_rates join (aliased `pr` — see buildCostExpr). LEFT JOIN on the
@@ -248,6 +249,9 @@ async function loadFile(
   if (aux.prLinks) {
     await conn.run(`CREATE OR REPLACE TEMP TABLE ${stagedPrLinks} AS ${aux.prLinks}`);
   }
+  if (aux.compactions) {
+    await conn.run(`CREATE OR REPLACE TEMP TABLE ${stagedCompactions} AS ${aux.compactions}`);
+  }
 
   // Swap. From here the statements are table-to-table copies — no source file,
   // no interpolated pricing, nothing left that can realistically fail.
@@ -259,6 +263,10 @@ async function loadFile(
   await conn.run(`DELETE FROM titles   WHERE session_id IN (SELECT DISTINCT session_id FROM events WHERE file_path = ${path})`);
   await conn.run(`DELETE FROM pr_links WHERE session_id IN (SELECT DISTINCT session_id FROM events WHERE file_path = ${path})`);
   await conn.run(`DELETE FROM events WHERE file_path = ${path}`);
+  // Compactions are keyed by FILE, not by session (unlike titles/pr_links): a
+  // subagent transcript shares its parent's session id, so a session-keyed
+  // delete here would drop the sibling file's rows on every parent reload.
+  await conn.run(`DELETE FROM compactions WHERE file_path = ${path}`);
   await conn.run(`INSERT INTO events SELECT * FROM ${stagedEvents}`);
   if (aux.titles) {
     await conn.run(`INSERT OR REPLACE INTO titles (session_id, title) SELECT * FROM ${stagedTitles}`);
@@ -267,6 +275,9 @@ async function loadFile(
     await conn.run(
       `INSERT OR REPLACE INTO pr_links (session_id, pr_number, pr_repository, pr_url) SELECT * FROM ${stagedPrLinks}`,
     );
+  }
+  if (aux.compactions) {
+    await conn.run(`INSERT INTO compactions SELECT * FROM ${stagedCompactions}`);
   }
 }
 
@@ -317,10 +328,10 @@ async function electCanonicalUsage(conn: DuckDBConnection): Promise<void> {
 }
 
 /**
- * Recompute the derived `sessions` table from `events`, `titles`, and
- * `pr_links`. Cheap full recompute (no per-file partial maintenance needed at
- * this scale). `project_cwd` is the modal (most frequent) cwd of the session's
- * events — robust to subdirectory cwds appearing mid-session.
+ * Recompute the derived `sessions` table from `events`, `titles`, `pr_links`,
+ * and `compactions`. Cheap full recompute (no per-file partial maintenance
+ * needed at this scale). `project_cwd` is the modal (most frequent) cwd of the
+ * session's events — robust to subdirectory cwds appearing mid-session.
  */
 async function rebuildSessions(conn: DuckDBConnection): Promise<void> {
   await conn.run('DELETE FROM sessions');
@@ -345,6 +356,34 @@ async function rebuildSessions(conn: DuckDBConnection): Promise<void> {
                row_number() OVER (PARTITION BY session_id ORDER BY count(*) DESC, cwd) AS rn
         FROM events WHERE cwd IS NOT NULL GROUP BY session_id, cwd
       ) WHERE rn = 1
+    ),
+    last_turn AS (
+      -- Context at the session's last main-thread turn: the prompt size
+      -- (input + cache read + cache write) of the newest assistant row that
+      -- carries one, and that row's model. Deliberately NOT filtered by
+      -- usage_canonical — context is the size of ONE prompt, not a sum, and the
+      -- per-content-block rows of a single call all repeat the same usage, so
+      -- the uuid tie-break below picks an identical value either way. (The
+      -- tie-break is lexicographic; it only has to be deterministic, because a
+      -- ts tie between DIFFERENT calls needs a connector with no real clock,
+      -- and those have no prompt-sized usage to read a context from anyway.)
+      SELECT session_id, context_tokens, context_model FROM (
+        SELECT session_id,
+               input_tokens + cache_read_tokens + cache_write_tokens AS context_tokens,
+               model AS context_model,
+               row_number() OVER (
+                 PARTITION BY session_id ORDER BY ts DESC NULLS LAST, uuid DESC
+               ) AS rn
+        FROM events
+        WHERE type = 'assistant' AND NOT is_sidechain
+          AND input_tokens + cache_read_tokens + cache_write_tokens > 0
+      ) WHERE rn = 1
+    ),
+    compaction_counts AS (
+      -- Main thread only: a subagent compacting is visible in its own thread,
+      -- but counting it would inflate the session's number confusingly.
+      SELECT session_id, count(*) AS compaction_count
+      FROM compactions WHERE NOT is_sidechain GROUP BY session_id
     ),
     agg AS (
       SELECT
@@ -389,13 +428,18 @@ async function rebuildSessions(conn: DuckDBConnection): Promise<void> {
       p.pr_url,
       COALESCE(fs.size_bytes, 0) AS size_bytes,
       a.has_sidechain,
-      sc.connector_id
+      sc.connector_id,
+      lt.context_tokens,
+      lt.context_model,
+      COALESCE(cc.compaction_count, 0) AS compaction_count
     FROM agg a
     LEFT JOIN modal_cwd mc ON mc.session_id = a.session_id
     LEFT JOIN titles t ON t.session_id = a.session_id
     LEFT JOIN pr_links p ON p.session_id = a.session_id
     LEFT JOIN file_size fs ON fs.session_id = a.session_id
     LEFT JOIN session_connector sc ON sc.session_id = a.session_id
+    LEFT JOIN last_turn lt ON lt.session_id = a.session_id
+    LEFT JOIN compaction_counts cc ON cc.session_id = a.session_id
   `);
 
   // git_branch: most recent non-null branch seen for the session.
@@ -737,6 +781,7 @@ async function doReindex(): Promise<ReindexResponse> {
       await conn.run(`DELETE FROM titles   WHERE session_id IN (SELECT DISTINCT session_id FROM events WHERE file_path = ${sqlString(path)})`);
       await conn.run(`DELETE FROM pr_links WHERE session_id IN (SELECT DISTINCT session_id FROM events WHERE file_path = ${sqlString(path)})`);
       await conn.run(`DELETE FROM events WHERE file_path = ${sqlString(path)}`);
+      await conn.run(`DELETE FROM compactions WHERE file_path = ${sqlString(path)}`);
       await conn.run(`DELETE FROM files WHERE path = ${sqlString(path)}`);
       removed += 1;
     }

--- a/packages/server/src/data/parser.ts
+++ b/packages/server/src/data/parser.ts
@@ -8,7 +8,8 @@
  *   - pairing each `tool_use` with its later `tool_result` (by `tool_use_id`),
  *     even when the result arrives in a subsequent user turn;
  *   - attachment events;
- *   - the `isSidechain` flag and usage/model/timestamp metadata.
+ *   - the `isSidechain` flag and usage/model/timestamp metadata;
+ *   - stamping a context compaction onto the turn that follows it.
  *
  * The pairing is done in a second pass: tool_use blocks are emitted inline in
  * the assistant turn where they occur, and the matching tool_result (which the
@@ -18,10 +19,12 @@
 
 import type {
   AssistantEvent,
+  CompactionInfo,
   ContentBlock,
   MessageUsage,
   RawEvent,
   SubagentRun,
+  SystemEvent,
   ThreadBlock,
   ThreadItem,
   ToolInteraction,
@@ -32,6 +35,77 @@ import type { SubagentSource } from './session-loader.js';
 /** Narrow a raw event to a conversational (user/assistant) event. */
 function isConversational(e: RawEvent): e is UserEvent | AssistantEvent {
   return e.type === 'user' || e.type === 'assistant';
+}
+
+/**
+ * A compaction marker: Claude Code writes it natively, the Codex/pi/Copilot
+ * normalizers synthesize the same shape.
+ */
+function isCompactBoundary(e: RawEvent): e is SystemEvent {
+  return e.type === 'system' && e.subtype === 'compact_boundary';
+}
+
+/** Token counts on disk are unvalidated — only keep a sane number. */
+function tokenCount(value: unknown): number | undefined {
+  return typeof value === 'number' && Number.isFinite(value) && value >= 0 ? value : undefined;
+}
+
+/** Build the display info for a compaction from its boundary event. */
+function compactionFrom(event: SystemEvent): CompactionInfo {
+  const info: CompactionInfo = {};
+  const meta = event.compactMetadata;
+  if (meta) {
+    if (typeof meta.trigger === 'string') info.trigger = meta.trigger;
+    const pre = tokenCount(meta.preTokens);
+    if (pre !== undefined) info.preTokens = pre;
+    const post = tokenCount(meta.postTokens);
+    if (post !== undefined) info.postTokens = post;
+  }
+  if (typeof event.summary === 'string' && event.summary.length > 0) info.summary = event.summary;
+  return info;
+}
+
+/**
+ * Context size (the full prompt) at an assistant turn, or 0 when the turn
+ * carries no usage — which is what "unknown" looks like here.
+ */
+function promptTokens(item: ThreadItem | undefined): number {
+  const usage = item?.role === 'assistant' ? item.usage : undefined;
+  if (!usage) return 0;
+  return (
+    (usage.input_tokens ?? 0) +
+    (usage.cache_read_input_tokens ?? 0) +
+    (usage.cache_creation_input_tokens ?? 0)
+  );
+}
+
+/** Walk `items` from `from` in `step` direction for the first known context size. */
+function nearestPromptTokens(items: ThreadItem[], from: number, step: -1 | 1): number {
+  for (let i = from; i >= 0 && i < items.length; i += step) {
+    const tokens = promptTokens(items[i]);
+    if (tokens > 0) return tokens;
+  }
+  return 0;
+}
+
+/**
+ * Fill in the context sizes the agent did not record on the boundary itself,
+ * from the turns around the compaction: the last prompt before it and the
+ * first one after it (the stamped turn counts when it is an assistant turn).
+ */
+function deriveCompactionTokens(items: ThreadItem[]): void {
+  for (const [index, item] of items.entries()) {
+    const { compaction } = item;
+    if (!compaction) continue;
+    if (compaction.preTokens === undefined) {
+      const pre = nearestPromptTokens(items, index - 1, -1);
+      if (pre > 0) compaction.preTokens = pre;
+    }
+    if (compaction.postTokens === undefined) {
+      const post = nearestPromptTokens(items, index, 1);
+      if (post > 0) compaction.postTokens = post;
+    }
+  }
 }
 
 /**
@@ -68,7 +142,19 @@ function normalizeResultContent(content: string | ContentBlock[]): ContentBlock[
  * Sidechain events should already be merged into `events` by the caller; their
  * `isSidechain` flag is preserved on each item.
  */
-export function assembleThread(events: RawEvent[]): ThreadItem[] {
+/** Options for {@link assembleThread} / {@link buildSubagentRuns}. */
+export interface AssembleOptions {
+  /**
+   * Fill a compaction's missing before/after sizes from the adjacent assistant
+   * turns' usage. Default true; the caller turns it off for an agent whose
+   * per-turn usage is not a prompt size (Copilot attaches its session total to
+   * the last turn — see data/agent-capabilities.ts), where a derived figure
+   * would be a real-looking number that measures nothing.
+   */
+  deriveContextSizes?: boolean;
+}
+
+export function assembleThread(events: RawEvent[], opts: AssembleOptions = {}): ThreadItem[] {
   const convo = events.filter(isConversational);
 
   // Pass 1: index every tool_result by tool_use_id so tool_use blocks can be
@@ -91,8 +177,32 @@ export function assembleThread(events: RawEvent[]): ThreadItem[] {
   }
 
   const items: ThreadItem[] = [];
+  // A compaction seen in the stream but not yet attached to a rendered turn.
+  // Turns that produce no blocks never consume it, so it lands on the first
+  // turn the transcript actually shows after the boundary.
+  let pending: CompactionInfo | undefined;
+  // The flagged summary turn just pushed, until another turn follows it. A
+  // mid-period Claude Code file writes BOTH a boundary and a flagged summary
+  // for ONE compaction, and subagent files are timestamp-sorted on load, which
+  // can put the summary (stamped a few hundred ms earlier) BEFORE its boundary
+  // — so the merge has to work in either order.
+  let openSummary: ThreadItem | undefined;
 
-  for (const event of convo) {
+  // Pass 2 walks the FULL stream: the compaction markers are `system` rows,
+  // which sit between the conversational ones.
+  for (const event of events) {
+    if (isCompactBoundary(event)) {
+      const info = compactionFrom(event);
+      if (openSummary) {
+        openSummary.compaction = { ...openSummary.compaction, ...info };
+        openSummary = undefined;
+      } else {
+        pending = info;
+      }
+      continue;
+    }
+    if (!isConversational(event)) continue;
+
     const blocks = parseBlocks(event, resultsByToolUseId);
 
     // Skip turns that contain only tool_result blocks (those are folded into
@@ -113,8 +223,21 @@ export function assembleThread(events: RawEvent[]): ThreadItem[] {
       if (event.message.model !== undefined) item.model = event.message.model;
       if (event.message.usage !== undefined) item.usage = event.message.usage;
     }
+    if (event.type === 'user' && event.isCompactSummary === true) {
+      item.compaction = { ...pending, isSummaryTurn: true };
+      pending = undefined;
+      openSummary = item;
+    } else {
+      openSummary = undefined;
+      if (pending) {
+        item.compaction = pending;
+        pending = undefined;
+      }
+    }
     items.push(item);
   }
+
+  if (opts.deriveContextSizes !== false) deriveCompactionTokens(items);
 
   return items;
 }
@@ -169,6 +292,7 @@ function resultText(tool: ToolInteraction): string {
 export function buildSubagentRuns(
   mainThread: ThreadItem[],
   sources: SubagentSource[],
+  opts: AssembleOptions = {},
 ): SubagentRun[] {
   const spawns: SpawnPoint[] = [];
   const workflowSpawns: WorkflowSpawn[] = [];
@@ -197,7 +321,7 @@ export function buildSubagentRuns(
 
   const runs: SubagentRun[] = [];
   for (const src of sources) {
-    const thread = assembleThread(src.events);
+    const thread = assembleThread(src.events, opts);
     const toolCallCount = thread.reduce(
       (n, t) => n + t.blocks.filter((b) => b.kind === 'tool').length,
       0,

--- a/packages/server/src/data/pricing-refresh.ts
+++ b/packages/server/src/data/pricing-refresh.ts
@@ -58,6 +58,7 @@ interface LiteLLMEntry {
   output_cost_per_token?: unknown;
   cache_creation_input_token_cost?: unknown;
   cache_read_input_token_cost?: unknown;
+  max_input_tokens?: unknown;
 }
 
 /** A finite, non-negative number within the sanity cap, else `null`. */
@@ -74,6 +75,15 @@ function toCacheRate(value: unknown): number | null {
 }
 
 /**
+ * The model's context window (`max_input_tokens`), or `undefined` when absent
+ * or not a positive integer. Not a rate: it never reaches SQL, so a bad value
+ * just leaves the window unknown instead of dropping the entry.
+ */
+function toWindow(value: unknown): number | undefined {
+  return typeof value === 'number' && Number.isInteger(value) && value > 0 ? value : undefined;
+}
+
+/**
  * Map a parsed LiteLLM JSON object to our per-MTok rate table. Pure; exported
  * for tests.
  *
@@ -82,7 +92,7 @@ function toCacheRate(value: unknown): number | null {
  * — transcripts store bare model ids, and the bare id is present for these
  * providers. Individual entries with missing/invalid input or output cost (or
  * any rate over the sanity cap) are skipped, not fatal. Missing cache fields
- * default to 0.
+ * default to 0. `max_input_tokens` rides along as `contextWindow` when present.
  */
 export function mapLiteLLM(json: unknown): Record<string, ModelRates> {
   const out: Record<string, ModelRates> = {};
@@ -108,7 +118,8 @@ export function mapLiteLLM(json: unknown): Record<string, ModelRates> {
       continue;
     }
 
-    out[id] = { input, output, cacheWrite, cacheRead };
+    const contextWindow = toWindow(entry.max_input_tokens);
+    out[id] = { input, output, cacheWrite, cacheRead, ...(contextWindow ? { contextWindow } : {}) };
   }
 
   return out;

--- a/packages/server/src/data/pricing.ts
+++ b/packages/server/src/data/pricing.ts
@@ -4,8 +4,9 @@
  * Loads a layered {@link PricingConfig}: a base layer (the user-editable
  * {@link PRICING_PATH}, falling back to the shipped {@link DEFAULT_PRICING_PATH})
  * with an optional overlay of runtime-fetched rates from
- * {@link FETCHED_PRICING_PATH}. Fetched rates win per exact model id; `families`
- * and `default` always come from the base layer (LiteLLM has no such concepts).
+ * {@link FETCHED_PRICING_PATH}. Fetched rates win per exact model id (a
+ * user-set `contextWindow` on that id survives); `families` and `default`
+ * always come from the base layer (LiteLLM has no such concepts).
  *
  * The result is cached and keyed on the (mtime, existence) of both files, so an
  * edit to either — e.g. a `claudescope pricing update` rewriting the fetched
@@ -32,7 +33,11 @@ function rateOrNull(value: unknown): number | null {
   return typeof value === 'number' && Number.isFinite(value) && value >= 0 ? value : null;
 }
 
-/** A fully-valid {@link ModelRates}, or `null` if any field is unusable. */
+/**
+ * A fully-valid {@link ModelRates}, or `null` if any rate is unusable. The
+ * optional `contextWindow` is not a rate (it never reaches SQL): it is kept
+ * when a positive integer and silently left out otherwise.
+ */
 function ratesOrNull(value: unknown): ModelRates | null {
   if (value === null || typeof value !== 'object') return null;
   const raw = value as Record<string, unknown>;
@@ -42,7 +47,27 @@ function ratesOrNull(value: unknown): ModelRates | null {
     if (n === null) return null;
     out[field] = n;
   }
+  const window = raw.contextWindow;
+  if (typeof window === 'number' && Number.isInteger(window) && window > 0) out.contextWindow = window;
   return out;
+}
+
+/**
+ * The context window (tokens) pricing knows for a model id: the exact-id entry
+ * first, then the first substring family that defines one — the same
+ * `models` → `families` chain the cost expression uses (`data/index.ts:
+ * buildCostExpr`), minus the default, which has no window. `undefined` when
+ * unknown; the UI then shows the absolute context size without a percentage.
+ */
+export function contextWindowFor(model: string | null | undefined, pricing: PricingConfig): number | undefined {
+  if (!model) return undefined;
+  const exact = pricing.models[model]?.contextWindow;
+  if (exact !== undefined) return exact;
+  const id = model.toLowerCase();
+  for (const [family, rates] of Object.entries(pricing.families ?? {})) {
+    if (rates.contextWindow !== undefined && id.includes(family.toLowerCase())) return rates.contextWindow;
+  }
+  return undefined;
 }
 
 /**
@@ -169,7 +194,16 @@ export function loadPricing(): PricingConfig {
         'fetched.models',
         [],
       );
-      config = { ...base, models: { ...base.models, ...overlay } };
+      const models = { ...base.models, ...overlay };
+      // Rates come from the feed, but a window the user wrote on an exact id in
+      // pricing.json is a deliberate override (e.g. a 1M-context variant LiteLLM
+      // lists under another id): keep it on top of the fetched entry.
+      for (const [id, rates] of Object.entries(base.models)) {
+        if (rates.contextWindow !== undefined && id in overlay) {
+          models[id] = { ...models[id]!, contextWindow: rates.contextWindow };
+        }
+      }
+      config = { ...base, models };
     }
   }
 

--- a/packages/server/src/db/schema.ts
+++ b/packages/server/src/db/schema.ts
@@ -42,7 +42,10 @@
 // v18: current Codex exec-wrapped apply_patch calls populate canonical file edits.
 // v19: per-event tool_error_text (failed tool_result bodies) and skill_names,
 //      indexed for literal search and the skill-usage breakdown.
-export const SCHEMA_VERSION = 19;
+// v20: context & compactions — `compactions` aux table (one row per context
+//      compaction, per file) + sessions.context_tokens / context_model /
+//      compaction_count derived at rebuild.
+export const SCHEMA_VERSION = 20;
 
 /** All DDL statements, executed in order at startup. Idempotent. */
 export const SCHEMA_DDL: readonly string[] = [
@@ -122,7 +125,15 @@ export const SCHEMA_DDL: readonly string[] = [
      pr_url        VARCHAR,
      size_bytes    BIGINT DEFAULT 0,
      has_sidechain BOOLEAN DEFAULT FALSE,
-     connector_id  VARCHAR
+     connector_id  VARCHAR,
+     -- Prompt size (input + cache read + cache write) of the LAST main-thread
+     -- assistant row with usage — the session's context as of that turn — and
+     -- that row's model (for the window lookup). NULL when no such row.
+     context_tokens BIGINT,
+     context_model  VARCHAR,
+     -- Main-thread rows in the compactions table. 0 for agents with no marker: the API
+     -- layer turns that into "unavailable" via the connector capability map.
+     compaction_count BIGINT DEFAULT 0
    )`,
 
   `CREATE TABLE IF NOT EXISTS pr_links (
@@ -135,6 +146,23 @@ export const SCHEMA_DDL: readonly string[] = [
   `CREATE TABLE IF NOT EXISTS titles (
      session_id VARCHAR PRIMARY KEY,
      title      VARCHAR
+   )`,
+
+  // One row per context compaction, filled by each connector's `compactions`
+  // aux projection (Claude Code reads its raw `compact_boundary` system rows;
+  // cache-backed connectors write `type: 'compaction'` rows into their NDJSON
+  // cache). Keyed by FILE, like events: a reload of one file replaces exactly
+  // its rows, so a subagent file's compactions survive the parent's reload.
+  // trigger/pre/post are NULL when the agent records no metadata.
+  `CREATE TABLE IF NOT EXISTS compactions (
+     file_path    VARCHAR NOT NULL,
+     session_id   VARCHAR NOT NULL,
+     uuid         VARCHAR,
+     ts           TIMESTAMP,
+     is_sidechain BOOLEAN DEFAULT FALSE,
+     trigger      VARCHAR,
+     pre_tokens   BIGINT,
+     post_tokens  BIGINT
    )`,
 
   // One row per edit-bearing tool call (canonical Edit/MultiEdit/Write),
@@ -160,4 +188,5 @@ export const SCHEMA_DDL: readonly string[] = [
   `CREATE INDEX IF NOT EXISTS idx_events_cwd ON events (cwd)`,
   `CREATE INDEX IF NOT EXISTS idx_events_ts ON events (ts)`,
   `CREATE INDEX IF NOT EXISTS idx_file_edits_session ON file_edits (session_id)`,
+  `CREATE INDEX IF NOT EXISTS idx_compactions_session ON compactions (session_id)`,
 ];

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -30,15 +30,18 @@ import { openBrowser } from './util/open-browser.js';
 const PRICING_STALE_MS = 24 * 60 * 60 * 1000;
 
 /**
- * Whether the fetched-pricing snapshot is missing, unparsable, or older than
- * {@link PRICING_STALE_MS} — i.e. worth refreshing on boot.
+ * Whether the fetched-pricing snapshot is missing, unparsable, older than
+ * {@link PRICING_STALE_MS}, or written by a version that kept no context
+ * windows (every session would show a bare context size for up to a day after
+ * upgrading otherwise) — i.e. worth refreshing on boot.
  */
 function pricingSnapshotIsStale(): boolean {
   try {
     const snapshot = JSON.parse(readFileSync(FETCHED_PRICING_PATH, 'utf8')) as FetchedPricing;
     const fetchedAt = Date.parse(snapshot?.fetchedAt ?? '');
     if (!Number.isFinite(fetchedAt)) return true;
-    return Date.now() - fetchedAt > PRICING_STALE_MS;
+    if (Date.now() - fetchedAt > PRICING_STALE_MS) return true;
+    return !Object.values(snapshot.models ?? {}).some((m) => m?.contextWindow !== undefined);
   } catch {
     return true; // missing or corrupt → refresh
   }

--- a/packages/server/src/routes/analytics-agents.ts
+++ b/packages/server/src/routes/analytics-agents.ts
@@ -11,7 +11,7 @@
  * different granularities (see AgentUsageGranularity), so metrics an agent
  * cannot honestly report are `null` ("not available") — NEVER 0. The
  * granularity is a per-connector property of the source format, declared in
- * USAGE_GRANULARITY below, not inferred from the data (a zero-usage corpus is
+ * `data/agent-capabilities.ts`, not inferred from the data (a zero-usage corpus is
  * still a real 0 for a per-response agent).
  *
  * Ride-along: PR-linked session stats (count + cost per PR-linked session).
@@ -22,35 +22,14 @@ import type { FastifyInstance } from 'fastify';
 import type {
   AgentComparisonResponse,
   AgentComparisonRow,
-  AgentUsageGranularity,
   PrLinkedStats,
 } from '@claudescope/shared';
 import { getConnection, queryRows } from '../db/duckdb.js';
 import { readRow } from '../db/row.js';
 import { cacheHitRatio } from '../data/analytics-metrics.js';
 import { scopeFilters } from '../data/analytics-scope.js';
+import { usageGranularity } from '../data/agent-capabilities.js';
 import { errorSignalsByAgent } from './analytics-errors.js';
-
-/**
- * How each agent's source format records token usage. A property of the
- * connector (see the per-connector gotchas in CLAUDE.md), not of the data:
- * - copilot: tokens live only in `session.shutdown`, attached to the last
- *   assistant row — session totals are real, per-response ratios are not, and
- *   crashed/still-running sessions (no shutdown) carry no usage at all.
- * - antigravity: transcripts carry no token counts by design.
- * Unknown connectors default to per-response (the canonical event contract
- * carries per-event tokens).
- */
-const USAGE_GRANULARITY: Record<string, AgentUsageGranularity> = {
-  'claude-code': 'per-response',
-  codex: 'per-response',
-  pi: 'per-response',
-  opencode: 'per-response',
-  junie: 'per-response',
-  copilot: 'session-level',
-  antigravity: 'none',
-  grok: 'per-response',
-};
 
 /** Human notes behind the n/a markers, keyed by connector id. */
 const AVAILABILITY_NOTES: Record<string, string> = {
@@ -126,7 +105,7 @@ export async function registerAgentComparisonRoute(app: FastifyInstance): Promis
     const rows: AgentComparisonRow[] = rowsRaw.map((r) => {
       const rd = readRow(r, 'agent-comparison');
       const connectorId = rd.str('connector_id', 'unknown');
-      const granularity = USAGE_GRANULARITY[connectorId] ?? 'per-response';
+      const granularity = usageGranularity(connectorId);
       const sessions = rd.num('sessions');
       const responses = rd.num('responses');
       const toolCalls = rd.num('tool_calls');

--- a/packages/server/src/routes/analytics-sessions.ts
+++ b/packages/server/src/routes/analytics-sessions.ts
@@ -17,9 +17,14 @@ import type {
   SessionEfficiencyRow,
   SessionEfficiencySort,
 } from '@claudescope/shared';
-import { getConnection, queryRows } from '../db/duckdb.js';
+import { getConnection, queryRows, sqlString } from '../db/duckdb.js';
 import { scopeFilters } from '../data/analytics-scope.js';
 import { cacheHitRatioSql } from '../data/analytics-metrics.js';
+import {
+  connectorsWithCompactionSignal,
+  connectorsWithPromptSizedUsage,
+} from '../data/agent-capabilities.js';
+import { contextWindowFor, loadPricing } from '../data/pricing.js';
 import { readRow } from '../db/row.js';
 import { projectIdFromCwd, displayNameFromCwd } from '../data/project-id.js';
 import { toIso } from './projects.js';
@@ -36,7 +41,12 @@ const SORT_EXPR: Record<SessionEfficiencySort, string> = {
   tokensPerResponse: 'tokens_per_response',
   toolCallCount: 'tool_call_count',
   toolCallsPerResponse: 'tool_calls_per_response',
+  contextTokens: 'context_tokens',
+  compactionCount: 'compaction_count',
 };
+
+/** `'a', 'b'` for an `IN (...)` list; `''` never happens (both sets are non-empty). */
+const sqlList = (ids: string[]): string => ids.map(sqlString).join(', ');
 
 function clampInt(raw: string | undefined, dflt: number, min: number, max: number): number {
   const n = raw === undefined ? dflt : Number.parseInt(raw, 10);
@@ -71,6 +81,14 @@ export async function registerSessionEfficiencyRoute(app: FastifyInstance): Prom
     // Optional project + inclusive date bounds (shared resolution/semantics).
     const scoped = await scopeFilters(conn, req.query, { cwd: 's.project_cwd', ts: 's.started_at' });
     const scopeClause = scoped.map((f) => `AND ${f}`).join('\n          ');
+
+    // Context/compactions are NULL (not 0) for agents whose format never records
+    // them, so they sort last and stay out of the quantiles.
+    // COALESCE mirrors rowToSessionMeta's default so both routes agree on a
+    // (theoretical) NULL connector_id.
+    const connector = "COALESCE(s.connector_id, 'claude-code')";
+    const withContext = sqlList(connectorsWithPromptSizedUsage());
+    const withCompactions = sqlList(connectorsWithCompactionSignal());
 
     // Shared CTE: per-session deduped sums -> derived ratios, filtered.
     const cte = `
@@ -115,7 +133,10 @@ export async function registerSessionEfficiencyRoute(app: FastifyInstance): Prom
             WHEN s.ended_at IS NOT NULL AND s.started_at IS NOT NULL
             THEN epoch_ms(s.ended_at) - epoch_ms(s.started_at)
             ELSE 0
-          END AS duration_ms
+          END AS duration_ms,
+          CASE WHEN ${connector} IN (${withContext}) THEN s.context_tokens END AS context_tokens,
+          s.context_model,
+          CASE WHEN ${connector} IN (${withCompactions}) THEN s.compaction_count END AS compaction_count
         FROM agg a
         JOIN sessions s ON s.id = a.session_id
         WHERE a.responses >= ${minResponses}
@@ -131,9 +152,13 @@ export async function registerSessionEfficiencyRoute(app: FastifyInstance): Prom
        LIMIT ${limit}`,
     );
 
+    const pricing = loadPricing();
     const rows: SessionEfficiencyRow[] = rowsRaw.map((r) => {
       const rd = readRow(r, 'session-efficiency');
       const cwd = rd.str('project_cwd');
+      const contextTokens = rd.req('context_tokens') == null ? null : rd.num('context_tokens');
+      const contextWindow =
+        contextTokens === null ? null : (contextWindowFor(rd.str('context_model'), pricing) ?? null);
       return {
         sessionId: rd.str('session_id'),
         title: rd.str('title'),
@@ -152,6 +177,9 @@ export async function registerSessionEfficiencyRoute(app: FastifyInstance): Prom
         costPerResponse: rd.num('cost_per_response'),
         tokensPerResponse: rd.num('tokens_per_response'),
         toolCallsPerResponse: rd.num('tool_calls_per_response'),
+        contextTokens,
+        contextWindow,
+        compactionCount: rd.req('compaction_count') == null ? null : rd.num('compaction_count'),
       };
     });
 
@@ -166,6 +194,9 @@ export async function registerSessionEfficiencyRoute(app: FastifyInstance): Prom
       'tool_call_count',
       'tool_calls_per_response',
       'cache_hit_ratio',
+      // quantile_cont skips NULLs: these two cover only sessions with a value.
+      'context_tokens',
+      'compaction_count',
     ];
     const quantileExprs = statCols
       .map(
@@ -206,6 +237,8 @@ export async function registerSessionEfficiencyRoute(app: FastifyInstance): Prom
           toolCallCount: stat('tool_call_count'),
           toolCallsPerResponse: stat('tool_calls_per_response'),
           cacheHitRatio: stat('cache_hit_ratio'),
+          contextTokens: stat('context_tokens'),
+          compactionCount: stat('compaction_count'),
         },
       },
     };

--- a/packages/server/src/routes/sessions.ts
+++ b/packages/server/src/routes/sessions.ts
@@ -26,7 +26,8 @@ import { toIso } from './projects.js';
 import { assembleThread, buildSubagentRuns } from '../data/parser.js';
 import { loadSessionData } from '../data/session-loader.js';
 import { computeSessionFingerprint } from '../data/fingerprint.js';
-import { loadPricing } from '../data/pricing.js';
+import { contextWindowFor, loadPricing } from '../data/pricing.js';
+import { hasCompactionSignal, hasPromptSizedUsage } from '../data/agent-capabilities.js';
 import { connectorById } from '../connectors/registry.js';
 import { buildResumeInfo } from '../connectors/resume.js';
 import { resolveWindow, subagentsInWindow, truncateToolChars } from '../data/window.js';
@@ -44,6 +45,7 @@ const SORT_SQL: Record<SessionSort, string> = {
   tokens: 'total_tokens DESC',
   cost: 'total_cost_usd DESC',
   messages: 'message_count DESC',
+  context: 'context_tokens DESC NULLS LAST',
 };
 
 function rowToSessionMeta(r: Record<string, unknown>): SessionMeta {
@@ -57,6 +59,7 @@ function rowToSessionMeta(r: Record<string, unknown>): SessionMeta {
     const rates = pricing.providers?.[p.toLowerCase()];
     return rates !== undefined && isZeroRated(rates);
   });
+  const connectorId = rd.str('connector_id') || 'claude-code';
   const meta: SessionMeta = {
     id: rd.str('id'),
     projectId: cwd ? projectIdFromCwd(cwd) : '',
@@ -72,9 +75,17 @@ function rowToSessionMeta(r: Record<string, unknown>): SessionMeta {
     providers,
     sizeBytes: rd.num('size_bytes'),
     hasSidechain: rd.bool('has_sidechain'),
-    connectorId: rd.str('connector_id') || 'claude-code',
+    connectorId,
   };
   if (hasLocalProvider) meta.hasLocalProvider = true;
+  // Context/compactions read "unavailable" (absent) for agents whose format
+  // never records them — a property of the connector, not of this session.
+  if (hasPromptSizedUsage(connectorId) && rd.req('context_tokens') != null) {
+    meta.contextTokens = rd.num('context_tokens');
+    const window = contextWindowFor(rd.str('context_model'), pricing);
+    if (window !== undefined) meta.contextWindow = window;
+  }
+  if (hasCompactionSignal(connectorId)) meta.compactionCount = rd.num('compaction_count');
   if (rd.bool('title_derived')) meta.titleDerived = true;
   const gitBranch = rd.str('git_branch');
   if (gitBranch) meta.gitBranch = gitBranch;
@@ -186,8 +197,9 @@ export async function registerSessionsRoutes(app: FastifyInstance): Promise<void
       const meta = rowToSessionMeta(row);
 
       const { mainEvents, subagents: subagentSources } = await loadSessionData(id);
-      let thread = assembleThread(mainEvents);
-      let subagents = buildSubagentRuns(thread, subagentSources);
+      const assemble = { deriveContextSizes: hasPromptSizedUsage(meta.connectorId) };
+      let thread = assembleThread(mainEvents, assemble);
+      let subagents = buildSubagentRuns(thread, subagentSources, assemble);
 
       const cwd = readRow(row, 'sessions').str('project_cwd');
       const resume = buildResumeInfo(connectorById(meta.connectorId), id, cwd || null);

--- a/packages/server/test/codex.integration.test.ts
+++ b/packages/server/test/codex.integration.test.ts
@@ -283,6 +283,35 @@ function writeMalformedBootstrapRollout(): string {
   return file;
 }
 
+/**
+ * A rollout with ONE compaction, written the way Codex writes it: the top-level
+ * `compacted` record (the marker), plus the encrypted `compaction` response item
+ * and the `context_compacted` event, which must leave no trace in the thread.
+ */
+function writeCompactionRollout(): string {
+  const dir = join(codexDir, '2026', '01', '07');
+  mkdirSync(dir, { recursive: true });
+  const file = join(dir, 'rollout-2026-01-07T09-00-00-019f7777-aaaa-7bbb-8ccc-000000000007.jsonl');
+  writeFileSync(
+    file,
+    jsonl([
+      { type: 'session_meta', timestamp: ts(0), payload: { id: 'codex-compact-1', cwd: '/tmp/codexproj' } },
+      { type: 'turn_context', timestamp: ts(1), payload: { model: 'gpt-5.4' } },
+      { type: 'response_item', timestamp: ts(2), payload: { type: 'message', role: 'user', content: [{ type: 'input_text', text: 'grind through the long haul' }] } },
+      { type: 'response_item', timestamp: ts(3), payload: { type: 'message', role: 'assistant', content: [{ type: 'output_text', text: 'context is filling up' }] } },
+      // 120000 - 20000 cached = 100000 input + 20000 cache_read → a 120000 prompt.
+      { type: 'event_msg', timestamp: ts(4), payload: { type: 'token_count', info: { last_token_usage: { input_tokens: 120000, cached_input_tokens: 20000, output_tokens: 500 } }, rate_limits: {} } },
+      { type: 'compacted', timestamp: ts(5), payload: { message: 'squeezed the long haul into this', replacement_history: [{ type: 'message', role: 'user', content: [{ type: 'input_text', text: 'replacement history is not a transcript' }] }], window_number: 1 } },
+      { type: 'response_item', timestamp: ts(6), payload: { type: 'compaction', id: 'cmp_leak', encrypted_content: 'COMPACTION_ENCRYPTED_BLOB' } },
+      { type: 'event_msg', timestamp: ts(7), payload: { type: 'context_compacted' } },
+      { type: 'response_item', timestamp: ts(8), payload: { type: 'message', role: 'user', content: [{ type: 'input_text', text: 'carry on from the summary' }] } },
+      { type: 'response_item', timestamp: ts(9), payload: { type: 'message', role: 'assistant', content: [{ type: 'output_text', text: 'resumed with room to spare' }] } },
+      { type: 'event_msg', timestamp: ts(10), payload: { type: 'token_count', info: { last_token_usage: { input_tokens: 9000, cached_input_tokens: 0, output_tokens: 100 } }, rate_limits: {} } },
+    ]),
+  );
+  return file;
+}
+
 /** Guardian approval reviews are internal regardless of thread-source generation. */
 function writeGuardianRollouts(): void {
   const dir = join(codexDir, '2026', '01', '06');
@@ -316,6 +345,7 @@ beforeAll(async () => {
   writeBootstrapOnlyRollout();
   writeMalformedBootstrapRollout();
   writeGuardianRollouts();
+  writeCompactionRollout();
 
   const Fastify = (await import('fastify')).default;
   const { registerRoutes } = await import('../src/routes/index.js');
@@ -342,6 +372,7 @@ describe('Codex session indexing', () => {
     // The child rollout folds into its parent (never its own session); the orphan
     // child indexes under its absent root id `codex-gone`.
     expect(sessions.map((s: { id: string }) => s.id).sort()).toEqual([
+      'codex-compact-1',
       'codex-gone',
       'codex-local-1',
       'codex-sess-1',
@@ -680,5 +711,38 @@ describe('Codex session detail', () => {
     const allText = JSON.stringify(detail.thread);
     expect(allText).toContain('orphan probe text');
     expect(allText).toContain('orphan done');
+  });
+});
+
+describe('Codex compaction markers', () => {
+  it('counts the `compacted` record once and stamps the turn that follows it', async () => {
+    const detail = (await get('/api/sessions/codex-compact-1')).json();
+    expect(detail.meta.compactionCount).toBe(1);
+
+    // The stamp lands on the first turn the transcript shows after the boundary.
+    const stamped = detail.thread.filter((t: { compaction?: unknown }) => t.compaction);
+    expect(stamped).toHaveLength(1);
+    expect(JSON.stringify(stamped[0].blocks)).toContain('carry on from the summary');
+    expect(stamped[0].compaction).toMatchObject({
+      summary: 'squeezed the long haul into this',
+      // Codex records no sizes on the marker → derived from the adjacent turns.
+      preTokens: 120000,
+      postTokens: 9000,
+    });
+  });
+
+  it('leaves the encrypted `compaction` item and `context_compacted` out of the thread', async () => {
+    const detail = (await get('/api/sessions/codex-compact-1')).json();
+    const serialized = JSON.stringify(detail.thread);
+    expect(serialized).not.toContain('COMPACTION_ENCRYPTED_BLOB');
+    expect(serialized).not.toContain('replacement history is not a transcript');
+    // The marker is not an event: 2 user + 2 assistant turns, no `system` role.
+    expect(detail.meta.messageCount).toBe(4);
+    expect(detail.thread.map((t: { role: string }) => t.role)).toEqual([
+      'user',
+      'assistant',
+      'user',
+      'assistant',
+    ]);
   });
 });

--- a/packages/server/test/compactions.integration.test.ts
+++ b/packages/server/test/compactions.integration.test.ts
@@ -1,0 +1,372 @@
+/**
+ * Compactions + context-size indexing — the edges the derivation can get wrong.
+ *
+ * A synthetic ~/.claude/projects tree is indexed into a throwaway DuckDB and the
+ * `compactions` / `sessions` tables are read directly, because these are index
+ * facts (the API layer only maps them).
+ *
+ *  1. The boundary-or-summary rule: current Claude Code writes a
+ *     `compact_boundary` system row, the 2025 format flagged the summary user
+ *     turn with `isCompactSummary`, and a transition-period file carries BOTH
+ *     for ONE compaction — which must not count twice, while a file with only
+ *     the flag must still count.
+ *  2. Subagent compactions are recorded (their own thread shows them) but stay
+ *     out of the session's main-thread count.
+ *  3. Context = the prompt size of the LAST main-thread turn, not the peak: a
+ *     sawtooth session's earlier turn is larger, the final billed call is split
+ *     over two rows sharing one usage object, and a later sidechain turn is
+ *     irrelevant. No usage at all → NULL, not 0.
+ *  4. Compaction rows are keyed by FILE, not by session: reloading the parent
+ *     transcript must not drop the subagent file's row (they share a session
+ *     id), and removing a file must drop exactly its rows.
+ */
+
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { appendFileSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import type { DuckDBConnection } from '@duckdb/node-api';
+import type { FastifyInstance } from 'fastify';
+import type {
+  ReindexResponse,
+  SessionEfficiencyResponse,
+  SessionMeta,
+} from '@claudescope/shared';
+
+const work = mkdtempSync(join(tmpdir(), 'claudescope-compact-'));
+const projectsDir = join(work, 'projects');
+process.env.CLAUDE_PROJECTS_DIR = projectsDir;
+for (const v of [
+  'CODEX_SESSIONS_DIR',
+  'JUNIE_SESSIONS_DIR',
+  'PI_SESSIONS_DIR',
+  'OPENCODE_DATA_DIR',
+  'COPILOT_SESSIONS_DIR',
+  'ANTIGRAVITY_CLI_DIR',
+  'ANTIGRAVITY_DIR',
+  'GROK_SESSIONS_DIR',
+]) {
+  process.env[v] = join(work, `${v.toLowerCase()}-empty`);
+}
+process.env.DUCKDB_PATH = join(work, 'index.duckdb');
+process.env.CLAUDESCOPE_HOME = join(work, 'home');
+process.env.REINDEX_INTERVAL_MS = '0';
+// A base pricing whose `sonnet` family (and nothing else) knows its window.
+process.env.PRICING_PATH = join(work, 'pricing.json');
+
+const CWD = '/tmp/compactproj';
+const OPUS = 'claude-opus-4-8';
+const SONNET = 'claude-sonnet-4-9';
+
+const jsonl = (events: unknown[]): string => events.map((e) => JSON.stringify(e)).join('\n') + '\n';
+
+const user = (
+  uuid: string,
+  sessionId: string,
+  ts: string,
+  text: string,
+  extra: Record<string, unknown> = {},
+): Record<string, unknown> => ({
+  type: 'user', uuid, parentUuid: null, sessionId, timestamp: ts, cwd: CWD,
+  isSidechain: false, message: { role: 'user', content: text }, ...extra,
+});
+
+/** One assistant turn. `prompt` is split across input/cache-read (their sum is the context). */
+function asst(opts: {
+  uuid: string;
+  sessionId: string;
+  ts: string;
+  messageId: string;
+  prompt: number;
+  model?: string;
+  sidechain?: boolean;
+}): Record<string, unknown> {
+  return {
+    type: 'assistant',
+    uuid: opts.uuid,
+    parentUuid: null,
+    sessionId: opts.sessionId,
+    timestamp: opts.ts,
+    cwd: CWD,
+    isSidechain: opts.sidechain ?? false,
+    message: {
+      id: opts.messageId,
+      role: 'assistant',
+      model: opts.model ?? OPUS,
+      content: [{ type: 'text', text: `reply ${opts.uuid}` }],
+      usage: {
+        input_tokens: opts.prompt > 0 ? 100 : 0,
+        output_tokens: 20,
+        cache_read_input_tokens: opts.prompt > 0 ? opts.prompt - 100 : 0,
+        cache_creation_input_tokens: 0,
+      },
+    },
+  };
+}
+
+/** A current-format `compact_boundary` system record. */
+const boundary = (opts: {
+  uuid: string;
+  sessionId: string;
+  ts: string;
+  trigger: string;
+  pre: number;
+  post: number;
+  sidechain?: boolean;
+}): Record<string, unknown> => ({
+  type: 'system',
+  subtype: 'compact_boundary',
+  content: 'Conversation compacted',
+  level: 'info',
+  uuid: opts.uuid,
+  parentUuid: null,
+  sessionId: opts.sessionId,
+  timestamp: opts.ts,
+  cwd: CWD,
+  isSidechain: opts.sidechain ?? false,
+  compactMetadata: {
+    trigger: opts.trigger,
+    preTokens: opts.pre,
+    postTokens: opts.post,
+    cumulativeDroppedTokens: opts.pre - opts.post,
+  },
+});
+
+/** The 2025 format's marker: the summary turn itself, flagged. */
+const summaryTurn = (uuid: string, sessionId: string, ts: string, sidechain = false) =>
+  user(uuid, sessionId, ts, 'This session is being continued from a previous conversation…', {
+    isCompactSummary: true,
+    isSidechain: sidechain,
+  });
+
+const proj = join(projectsDir, 'enc-compactproj');
+const boundaryOnlyFile = join(proj, 'boundaryOnly.jsonl');
+const summaryOnlyFile = join(proj, 'summaryOnly.jsonl');
+const withSubFile = join(proj, 'withSub.jsonl');
+const subagentFile = join(proj, 'withSub', 'subagents', 'agent-x.jsonl');
+
+function writeFixtures(): void {
+  mkdirSync(join(proj, 'withSub', 'subagents'), { recursive: true });
+  const rate = { input: 3, output: 15, cacheWrite: 3.75, cacheRead: 0.3 };
+  writeFileSync(
+    process.env.PRICING_PATH!,
+    JSON.stringify({
+      models: {},
+      families: { sonnet: { ...rate, contextWindow: 200000 }, opus: rate },
+      default: rate,
+    }),
+  );
+
+  // Two boundaries, both with metadata.
+  writeFileSync(boundaryOnlyFile, jsonl([
+    user('b-u1', 'boundaryOnly', '2026-03-01T10:00:00.000Z', 'hi'),
+    asst({ uuid: 'b-a1', sessionId: 'boundaryOnly', ts: '2026-03-01T10:00:01.000Z', messageId: 'b1', prompt: 200000 }),
+    boundary({ uuid: 'b-c1', sessionId: 'boundaryOnly', ts: '2026-03-01T10:00:02.000Z', trigger: 'manual', pre: 331954, post: 17672 }),
+    asst({ uuid: 'b-a2', sessionId: 'boundaryOnly', ts: '2026-03-01T10:00:03.000Z', messageId: 'b2', prompt: 40000 }),
+    boundary({ uuid: 'b-c2', sessionId: 'boundaryOnly', ts: '2026-03-01T10:00:04.000Z', trigger: 'auto', pre: 300000, post: 15000 }),
+  ]));
+
+  // Transition-period file: ONE compaction written as both markers.
+  writeFileSync(join(proj, 'bothMarkers.jsonl'), jsonl([
+    user('m-u1', 'bothMarkers', '2026-03-02T10:00:00.000Z', 'hi'),
+    asst({ uuid: 'm-a1', sessionId: 'bothMarkers', ts: '2026-03-02T10:00:01.000Z', messageId: 'm1', prompt: 150000 }),
+    summaryTurn('m-s1', 'bothMarkers', '2026-03-02T10:00:02.000Z'),
+    boundary({ uuid: 'm-c1', sessionId: 'bothMarkers', ts: '2026-03-02T10:00:03.000Z', trigger: 'manual', pre: 150000, post: 9000 }),
+  ]));
+
+  // 2025 format: the flag is the only marker there is.
+  writeFileSync(summaryOnlyFile, jsonl([
+    user('s-u1', 'summaryOnly', '2026-03-03T10:00:00.000Z', 'hi'),
+    asst({ uuid: 's-a1', sessionId: 'summaryOnly', ts: '2026-03-03T10:00:01.000Z', messageId: 's1', prompt: 120000 }),
+    summaryTurn('s-s1', 'summaryOnly', '2026-03-03T10:00:02.000Z'),
+  ]));
+
+  // Main transcript + a subagent transcript that compacted too (same session id).
+  writeFileSync(withSubFile, jsonl([
+    user('w-u1', 'withSub', '2026-03-04T10:00:00.000Z', 'hi'),
+    asst({ uuid: 'w-a1', sessionId: 'withSub', ts: '2026-03-04T10:00:01.000Z', messageId: 'w1', prompt: 90000 }),
+    boundary({ uuid: 'w-c1', sessionId: 'withSub', ts: '2026-03-04T10:00:02.000Z', trigger: 'manual', pre: 90000, post: 8000 }),
+  ]));
+  writeFileSync(subagentFile, jsonl([
+    { ...user('w-su1', 'withSub', '2026-03-04T10:00:03.000Z', 'do the thing'), isSidechain: true },
+    asst({ uuid: 'w-sa1', sessionId: 'withSub', ts: '2026-03-04T10:00:04.000Z', messageId: 'ws1', prompt: 250000, sidechain: true }),
+    boundary({ uuid: 'w-sc1', sessionId: 'withSub', ts: '2026-03-04T10:00:05.000Z', trigger: 'auto', pre: 250000, post: 12000, sidechain: true }),
+  ]));
+
+  // Sawtooth: the peak (200k) is NOT the answer; the last billed call is written
+  // as two block rows sharing one usage; a later sidechain turn is ignored.
+  writeFileSync(join(proj, 'sawtooth.jsonl'), jsonl([
+    user('t-u1', 'sawtooth', '2026-03-05T10:00:00.000Z', 'hi'),
+    asst({ uuid: 't-a1', sessionId: 'sawtooth', ts: '2026-03-05T10:00:01.000Z', messageId: 't1', prompt: 5000 }),
+    asst({ uuid: 't-a2', sessionId: 'sawtooth', ts: '2026-03-05T10:00:02.000Z', messageId: 't2', prompt: 200000 }),
+    asst({ uuid: 't-a3', sessionId: 'sawtooth', ts: '2026-03-05T10:00:03.000Z', messageId: 't3', prompt: 30000, model: SONNET }),
+    asst({ uuid: 't-a4', sessionId: 'sawtooth', ts: '2026-03-05T10:00:03.000Z', messageId: 't3', prompt: 30000, model: SONNET }),
+    asst({ uuid: 't-s1', sessionId: 'sawtooth', ts: '2026-03-05T10:00:09.000Z', messageId: 't4', prompt: 999999, sidechain: true }),
+  ]));
+
+  // Output-only usage: no prompt was billed, so there is no known context.
+  writeFileSync(join(proj, 'noUsage.jsonl'), jsonl([
+    user('n-u1', 'noUsage', '2026-03-06T10:00:00.000Z', 'hi'),
+    asst({ uuid: 'n-a1', sessionId: 'noUsage', ts: '2026-03-06T10:00:01.000Z', messageId: 'n1', prompt: 0 }),
+  ]));
+}
+
+let reindex: () => Promise<ReindexResponse>;
+let conn: DuckDBConnection;
+let queryRows: typeof import('../src/db/duckdb.js').queryRows;
+let closeConnection: () => Promise<void>;
+let app: FastifyInstance;
+
+const compactionsOf = async (filePath: string): Promise<Record<string, unknown>[]> =>
+  queryRows(
+    conn,
+    `SELECT * FROM compactions WHERE file_path = '${filePath}' ORDER BY ts`,
+  );
+
+const sessionRow = async (id: string): Promise<Record<string, unknown> | undefined> =>
+  (
+    await queryRows(
+      conn,
+      `SELECT compaction_count, context_tokens, context_model FROM sessions WHERE id = '${id}'`,
+    )
+  )[0];
+
+beforeAll(async () => {
+  writeFixtures();
+  ({ reindex } = await import('../src/data/index.js'));
+  const duck = await import('../src/db/duckdb.js');
+  ({ queryRows, closeConnection } = duck);
+  conn = await duck.getConnection();
+  const Fastify = (await import('fastify')).default;
+  const { registerRoutes } = await import('../src/routes/index.js');
+  app = Fastify();
+  await registerRoutes(app);
+  await reindex();
+  await app.ready();
+});
+
+afterAll(async () => {
+  await app?.close();
+  await closeConnection?.();
+  rmSync(work, { recursive: true, force: true });
+});
+
+describe('compaction markers', () => {
+  it('records every compact_boundary with its metadata', async () => {
+    const rows = await compactionsOf(boundaryOnlyFile);
+    expect(rows.map((r) => r.uuid)).toEqual(['b-c1', 'b-c2']);
+    expect(rows.map((r) => r.trigger)).toEqual(['manual', 'auto']);
+    expect(rows[0]?.pre_tokens).toBe(331954);
+    expect(rows[0]?.post_tokens).toBe(17672);
+    expect(rows.every((r) => r.is_sidechain === false)).toBe(true);
+    expect((await sessionRow('boundaryOnly'))?.compaction_count).toBe(2);
+  });
+
+  it('counts a boundary and its flagged summary as ONE compaction', async () => {
+    const rows = await compactionsOf(join(proj, 'bothMarkers.jsonl'));
+    expect(rows.map((r) => r.uuid)).toEqual(['m-c1']); // the boundary wins
+    expect((await sessionRow('bothMarkers'))?.compaction_count).toBe(1);
+  });
+
+  it('falls back to the flagged summary in a file with no boundary', async () => {
+    const rows = await compactionsOf(summaryOnlyFile);
+    expect(rows.map((r) => r.uuid)).toEqual(['s-s1']);
+    // The 2025 format carries no metadata — unknown, not zero.
+    expect(rows[0]?.trigger).toBeNull();
+    expect(rows[0]?.pre_tokens).toBeNull();
+    expect((await sessionRow('summaryOnly'))?.compaction_count).toBe(1);
+  });
+
+  it('records a subagent compaction but keeps it out of the session count', async () => {
+    const sub = await compactionsOf(subagentFile);
+    expect(sub.map((r) => r.uuid)).toEqual(['w-sc1']);
+    expect(sub[0]?.is_sidechain).toBe(true);
+    expect(sub[0]?.session_id).toBe('withSub');
+    expect((await sessionRow('withSub'))?.compaction_count).toBe(1); // main thread only
+  });
+});
+
+describe('context at the last turn', () => {
+  it('takes the last main-thread prompt size, not the peak or a sidechain', async () => {
+    const s = await sessionRow('sawtooth');
+    expect(s?.context_tokens).toBe(30000); // not 200000 (peak) and not 999999 (sidechain)
+    expect(s?.context_model).toBe(SONNET);
+  });
+
+  it('leaves context unknown when no turn billed a prompt', async () => {
+    const s = await sessionRow('noUsage');
+    expect(s?.context_tokens).toBeNull();
+    expect(s?.context_model).toBeNull();
+  });
+});
+
+describe('incremental reload', () => {
+  it('replaces only the reloaded file’s rows (the subagent file survives)', async () => {
+    appendFileSync(
+      withSubFile,
+      jsonl([
+        asst({ uuid: 'w-a2', sessionId: 'withSub', ts: '2026-03-04T10:10:00.000Z', messageId: 'w2', prompt: 70000 }),
+        boundary({ uuid: 'w-c2', sessionId: 'withSub', ts: '2026-03-04T10:10:01.000Z', trigger: 'auto', pre: 70000, post: 7000 }),
+      ]),
+    );
+    await reindex();
+
+    expect((await compactionsOf(withSubFile)).map((r) => r.uuid)).toEqual(['w-c1', 'w-c2']);
+    // Same session id, different file — must not be swept by the parent's reload.
+    expect((await compactionsOf(subagentFile)).map((r) => r.uuid)).toEqual(['w-sc1']);
+    // Untouched files keep exactly their own rows.
+    expect((await compactionsOf(boundaryOnlyFile)).length).toBe(2);
+    expect((await sessionRow('withSub'))?.compaction_count).toBe(2);
+  });
+
+  it('drops a removed file’s compaction rows', async () => {
+    rmSync(summaryOnlyFile);
+    await reindex();
+    expect(await compactionsOf(summaryOnlyFile)).toEqual([]);
+    expect(await sessionRow('summaryOnly')).toBeUndefined();
+  });
+});
+
+// Runs last: it sees the state the reload tests left behind (withSub has two
+// compactions and 70k of context; summaryOnly is gone).
+describe('API surface', () => {
+  const sessions = async (query = ''): Promise<SessionMeta[]> =>
+    (await app.inject({ method: 'GET', url: `/api/sessions${query}` })).json();
+  const efficiency = async (query = ''): Promise<SessionEfficiencyResponse> =>
+    (await app.inject({ method: 'GET', url: `/api/analytics/sessions${query}` })).json();
+
+  it('maps context/compactions onto session meta, resolving the window through pricing', async () => {
+    const byId = new Map((await sessions()).map((s) => [s.id, s]));
+    const sawtooth = byId.get('sawtooth')!;
+    expect(sawtooth.contextTokens).toBe(30000);
+    expect(sawtooth.contextWindow).toBe(200000); // sonnet family knows its window
+    expect(sawtooth.compactionCount).toBe(0); // Claude Code records compactions: a real 0
+    const boundaryOnly = byId.get('boundaryOnly')!;
+    expect(boundaryOnly.contextTokens).toBe(40000);
+    expect('contextWindow' in boundaryOnly).toBe(false); // opus family has none
+    expect(boundaryOnly.compactionCount).toBe(2);
+    // No billed prompt → the key is absent, never 0.
+    expect('contextTokens' in byId.get('noUsage')!).toBe(false);
+  });
+
+  it('sort=context orders by context size with unknown last', async () => {
+    const ids = (await sessions('?sort=context')).map((s) => s.id);
+    expect(ids).toEqual(['bothMarkers', 'withSub', 'boundaryOnly', 'sawtooth', 'noUsage']);
+  });
+
+  it('exposes both columns in the efficiency table, sortable, with NULL-skipping quantiles', async () => {
+    const res = await efficiency('?sort=contextTokens');
+    expect(res.rows.map((r) => r.sessionId)).toEqual(['bothMarkers', 'withSub', 'boundaryOnly', 'sawtooth', 'noUsage']);
+    const rows = new Map(res.rows.map((r) => [r.sessionId, r]));
+    expect(rows.get('sawtooth')).toMatchObject({ contextTokens: 30000, contextWindow: 200000, compactionCount: 0 });
+    expect(rows.get('boundaryOnly')).toMatchObject({ contextTokens: 40000, contextWindow: null, compactionCount: 2 });
+    expect(rows.get('noUsage')).toMatchObject({ contextTokens: null, contextWindow: null, compactionCount: 0 });
+    // Median over the four sessions WITH a context (150k, 70k, 40k, 30k) — the
+    // unknown one is skipped, not counted as 0.
+    expect(res.summary.columns.contextTokens.median).toBe(55000);
+    expect(res.summary.columns.compactionCount.median).toBe(1); // [0, 0, 1, 2, 2]
+
+    const byCompactions = await efficiency('?sort=compactionCount');
+    expect(byCompactions.rows.slice(0, 2).map((r) => r.sessionId).sort()).toEqual(['boundaryOnly', 'withSub']);
+  });
+});

--- a/packages/server/test/copilot.integration.test.ts
+++ b/packages/server/test/copilot.integration.test.ts
@@ -109,8 +109,11 @@ function writeSession1(): void {
       }),
       ev('tool.execution_start', { toolCallId: 'call-edit', toolName: 'edit', arguments: { path: '/tmp/cproj/app.ts', old_str: 'bug', new_str: 'fixed' }, model: 'gpt-5-mini' }),
       ev('tool.execution_complete', { toolCallId: 'call-edit', success: true, result: { content: 'File app.ts updated with changes.' } }),
-      // Unknown event type — must be tolerated and skipped without breaking indexing.
+      // Only `reason: compaction` is a compaction marker; other reasons stay skipped.
+      ev('session.context_changed', { reason: 'model_change' }),
       ev('session.context_changed', { reason: 'compaction' }),
+      ev('user.message', { content: 'carry on from the summary' }),
+      ev('assistant.message', { messageId: 'm1b', model: 'gpt-5-mini', content: 'resumed with room to spare' }),
       ev('session.shutdown', {
         tokenDetails: { input: { tokenCount: 100 }, cache_read: { tokenCount: 20 }, output: { tokenCount: 50 } },
         codeChanges: { linesAdded: 1, linesRemoved: 1, filesModified: ['/tmp/cproj/app.ts'] },
@@ -180,6 +183,9 @@ function writeSession3(): void {
     }), 'call-task'),
     sub(ev('tool.execution_start', { toolCallId: 'call-sub-view', toolName: 'view' }), 'call-task'),
     sub(ev('tool.execution_complete', { toolCallId: 'call-sub-view', success: true, result: { content: '{"main":"src/index.ts"}' } }), 'call-task'),
+    // The subagent run compacts: the marker belongs to ITS stream, not the main one.
+    sub(ev('session.context_changed', { reason: 'compaction' }), 'call-task'),
+    sub(ev('assistant.message', { model: 'gpt-5-mini', content: 'resumed the zebrafinder scan' }), 'call-task'),
     sub(ev('subagent.completed', { toolCallId: 'call-task', agentName: 'explore' }), 'call-task'),
     ev('tool.execution_complete', { toolCallId: 'call-task', success: true, result: { content: 'Entry point is src/index.ts.' } }),
     // A tagged turn with no subagent.started — tolerated as a detached run.
@@ -379,5 +385,39 @@ describe('copilot subagent embedding', () => {
     expect(flat.some((b) => b.kind === 'attachment')).toBe(false);
     expect(JSON.stringify(detail.thread)).toContain('[📷 evil.png]');
     expect(JSON.stringify(detail)).not.toContain(SECRET_B64);
+  });
+});
+
+describe('copilot compaction markers', () => {
+  it('counts only the `compaction` reason and stamps the turn that follows it', async () => {
+    const detail = (await get('/api/sessions/copilot-sess-1')).json();
+    expect(detail.meta.compactionCount).toBe(1); // the model_change reason is not one
+
+    const stamped = detail.thread.filter((t: { compaction?: unknown }) => t.compaction);
+    expect(stamped).toHaveLength(1);
+    expect(JSON.stringify(stamped[0].blocks)).toContain('carry on from the summary');
+    // Copilot records neither a trigger nor a summary on the marker, and its
+    // usage is a session total pinned to the last turn — not a prompt size —
+    // so no before/after figure may be derived from it either.
+    expect(stamped[0].compaction).toEqual({});
+  });
+
+  it('reports the compaction count but no context size (session-level usage)', async () => {
+    const { meta } = (await get('/api/sessions/copilot-sess-1')).json();
+    expect(meta.compactionCount).toBe(1);
+    expect(meta.contextTokens).toBeUndefined();
+    expect(meta.contextWindow).toBeUndefined();
+  });
+
+  it('keeps a subagent compaction in its own run and out of the session count', async () => {
+    const detail = (await get('/api/sessions/copilot-sess-3')).json();
+    // Main thread only: the run compacted, the session did not.
+    expect(detail.meta.compactionCount).toBe(0);
+    expect(detail.thread.some((t: { compaction?: unknown }) => t.compaction)).toBe(false);
+
+    const run = detail.subagents.find((r: { agentType: string }) => r.agentType === 'explore');
+    const stamped = run.thread.filter((t: { compaction?: unknown }) => t.compaction);
+    expect(stamped).toHaveLength(1);
+    expect(JSON.stringify(stamped[0].blocks)).toContain('resumed the zebrafinder scan');
   });
 });

--- a/packages/server/test/grok.integration.test.ts
+++ b/packages/server/test/grok.integration.test.ts
@@ -350,6 +350,13 @@ describe('grok session indexing', () => {
 });
 
 describe('grok session detail', () => {
+  it('reports no context size: turn_completed usage is a per-turn total, not one prompt', async () => {
+    const detail = (await get('/api/sessions/grok-sess-1')).json();
+    expect(detail.meta.totalTokens).toBeGreaterThan(0);
+    expect('contextTokens' in detail.meta).toBe(false);
+    expect('compactionCount' in detail.meta).toBe(false);
+  });
+
   it('renders plaintext reasoning, strips the user_query wrapper, embeds the image, maps tools', async () => {
     const detail = (await get('/api/sessions/grok-sess-1')).json();
     const flat = detail.thread.flatMap((t: { blocks: Record<string, unknown>[] }) => t.blocks);

--- a/packages/server/test/junie.integration.test.ts
+++ b/packages/server/test/junie.integration.test.ts
@@ -237,6 +237,13 @@ describe('Junie session indexing', () => {
 });
 
 describe('Junie session detail', () => {
+  it('reports no context size: a Junie row sums every LLM call of the turn, not one prompt', async () => {
+    const detail = (await get(`/api/sessions/${SESSION_ID}`)).json();
+    expect(detail.meta.totalTokens).toBeGreaterThan(0);
+    expect('contextTokens' in detail.meta).toBe(false);
+    expect('compactionCount' in detail.meta).toBe(false); // no marker in the format either
+  });
+
   it('coalesces block events by stepId into paired tool interactions', async () => {
     const detail = (await get(`/api/sessions/${SESSION_ID}`)).json();
     expect(detail.subagents).toEqual([]);

--- a/packages/server/test/parser.test.ts
+++ b/packages/server/test/parser.test.ts
@@ -48,6 +48,27 @@ function assistant(
   } as unknown as RawEvent;
 }
 
+/** A `compact_boundary` system row (Claude Code native / synthesized). */
+function boundary(
+  opts: { compactMetadata?: Record<string, unknown>; summary?: string } = {},
+): RawEvent {
+  return {
+    type: 'system',
+    subtype: 'compact_boundary',
+    uuid: 'sys',
+    parentUuid: null,
+    sessionId: 's',
+    timestamp: ts(),
+    cwd: '/x',
+    ...opts,
+  } as unknown as RawEvent;
+}
+
+/** A user turn flagged as the post-compaction summary (2025 format). */
+function compactSummary(uuid: string, content: unknown): RawEvent {
+  return { ...(user(uuid, content) as object), isCompactSummary: true } as RawEvent;
+}
+
 describe('assembleThread', () => {
   it('renders plain user + assistant text turns (happy path)', () => {
     const thread = assembleThread([
@@ -132,6 +153,131 @@ describe('assembleThread', () => {
       user('u1', 'hi'),
     ]);
     expect(thread).toHaveLength(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Compaction stamping
+// ---------------------------------------------------------------------------
+
+describe('assembleThread compactions', () => {
+  it('stamps the boundary metadata on the next conversational turn', () => {
+    const thread = assembleThread([
+      assistant('a1', [{ type: 'text', text: 'before' }]),
+      boundary({ compactMetadata: { trigger: 'auto', preTokens: 152_000, postTokens: 21_000 } }),
+      user('u1', 'carry on'),
+    ]);
+    expect(thread[0]?.compaction).toBeUndefined();
+    expect(thread[1]?.compaction).toEqual({
+      trigger: 'auto',
+      preTokens: 152_000,
+      postTokens: 21_000,
+    });
+  });
+
+  it('carries the stamp past a tool_result-only turn onto the next rendered turn', () => {
+    const thread = assembleThread([
+      assistant('a1', [{ type: 'tool_use', id: 't1', name: 'Bash', input: {} }]),
+      boundary({ compactMetadata: { trigger: 'manual', preTokens: 90_000, postTokens: 8_000 } }),
+      user('u1', [{ type: 'tool_result', tool_use_id: 't1', content: 'done' }]),
+      assistant('a2', [{ type: 'text', text: 'after' }]),
+    ]);
+    expect(thread.map((t) => t.uuid)).toEqual(['a1', 'a2']);
+    expect(thread[1]?.compaction).toMatchObject({ trigger: 'manual', preTokens: 90_000 });
+  });
+
+  it('merges a boundary and its flagged summary turn into one stamp', () => {
+    const thread = assembleThread([
+      assistant('a1', [{ type: 'text', text: 'before' }]),
+      boundary({ compactMetadata: { trigger: 'auto', preTokens: 150_000, postTokens: 12_000 } }),
+      compactSummary('u1', 'This session is being continued from…'),
+      assistant('a2', [{ type: 'text', text: 'after' }]),
+    ]);
+    expect(thread[1]?.compaction).toEqual({
+      trigger: 'auto',
+      preTokens: 150_000,
+      postTokens: 12_000,
+      isSummaryTurn: true,
+    });
+    // One compaction -> one stamp; the following turn stays clean.
+    expect(thread[2]?.compaction).toBeUndefined();
+  });
+
+  it('merges them in either order (subagent files are timestamp-sorted, which can flip it)', () => {
+    // On disk the summary turn can carry an EARLIER timestamp than its boundary,
+    // so a sorted stream sees the summary first. Still one compaction.
+    const thread = assembleThread([
+      assistant('a1', [{ type: 'text', text: 'before' }]),
+      compactSummary('u1', 'This session is being continued from…'),
+      boundary({ compactMetadata: { trigger: 'manual', preTokens: 331_954, postTokens: 17_672 } }),
+      assistant('a2', [{ type: 'text', text: 'after' }]),
+    ]);
+    expect(thread[1]?.compaction).toEqual({
+      trigger: 'manual',
+      preTokens: 331_954,
+      postTokens: 17_672,
+      isSummaryTurn: true,
+    });
+    expect(thread[2]?.compaction).toBeUndefined();
+    // …but a boundary that follows a summary AND another turn is a second compaction.
+    const two = assembleThread([
+      compactSummary('u1', 'first summary'),
+      assistant('a1', [{ type: 'text', text: 'work' }]),
+      boundary({ compactMetadata: { trigger: 'auto' } }),
+      assistant('a2', [{ type: 'text', text: 'after' }]),
+    ]);
+    expect(two.filter((t) => t.compaction)).toHaveLength(2);
+  });
+
+  it('stamps a flagged summary turn that has no boundary row (2025 format)', () => {
+    const thread = assembleThread([
+      assistant('a1', [{ type: 'text', text: 'before' }]),
+      compactSummary('u1', 'Summary of the previous context'),
+    ]);
+    expect(thread[1]?.compaction).toEqual({ isSummaryTurn: true });
+  });
+
+  it('derives pre/post from the adjacent turns when the agent records neither', () => {
+    const thread = assembleThread([
+      assistant('a1', [{ type: 'text', text: 'before' }], {
+        usage: {
+          input_tokens: 100,
+          output_tokens: 40,
+          cache_read_input_tokens: 5_000,
+          cache_creation_input_tokens: 900,
+        },
+      }),
+      boundary({ summary: 'We refactored the parser.' }),
+      user('u1', 'continue'),
+      assistant('a2', [{ type: 'text', text: 'after' }], {
+        usage: { input_tokens: 50, output_tokens: 10, cache_read_input_tokens: 1_000 },
+      }),
+    ]);
+    expect(thread[1]?.compaction).toEqual({
+      summary: 'We refactored the parser.',
+      preTokens: 6_000,
+      postTokens: 1_050,
+    });
+  });
+
+  it('drops a boundary that nothing follows', () => {
+    const thread = assembleThread([
+      user('u1', 'hi'),
+      assistant('a1', [{ type: 'text', text: 'bye' }]),
+      boundary({ compactMetadata: { trigger: 'auto' } }),
+    ]);
+    expect(thread).toHaveLength(2);
+    expect(thread.some((t) => t.compaction !== undefined)).toBe(false);
+  });
+
+  it('leaves ordinary turns without a compaction key', () => {
+    const thread = assembleThread([
+      user('u1', 'hi'),
+      assistant('a1', [{ type: 'text', text: 'hello' }], {
+        usage: { input_tokens: 10, output_tokens: 5 },
+      }),
+    ]);
+    expect(thread.every((t) => !('compaction' in t))).toBe(true);
   });
 });
 

--- a/packages/server/test/pi.integration.test.ts
+++ b/packages/server/test/pi.integration.test.ts
@@ -42,6 +42,7 @@ const jsonl = (events: unknown[]): string => events.map((e) => JSON.stringify(e)
 const ts = (s: number) => `2026-06-15T10:00:${String(s).padStart(2, '0')}.000Z`;
 const ts2 = (s: number) => `2026-06-15T11:00:${String(s).padStart(2, '0')}.000Z`;
 const ts3 = (s: number) => `2026-06-15T13:00:${String(s).padStart(2, '0')}.000Z`;
+const ts4 = (s: number) => `2026-06-15T14:00:${String(s).padStart(2, '0')}.000Z`;
 
 // Composite tool ids as pi writes them (`call_…|fc_…`) — must survive verbatim
 // on both the tool_use and its tool_result, or the pairing breaks.
@@ -228,6 +229,36 @@ function writeMixedProviderSession(): void {
   );
 }
 
+/**
+ * A session with ONE `compaction` entry: pi records the summary AND the
+ * pre-compaction size, so `tokensBefore` must win over the derived figure. The
+ * `branch_summary` entry looks similar but marks no compaction.
+ */
+function writeCompactionSession(): void {
+  const dir = join(piDir, '--tmp-piproj--');
+  writeFileSync(
+    join(dir, '2026-06-15T14-00-00-000Z_05dddddd-1111-7222-8333-444455556666.jsonl'),
+    jsonl([
+      { type: 'session', version: 3, id: 'pi-compact-1', timestamp: ts4(0), cwd: '/tmp/piproj' },
+      { type: 'message', id: 'u1', parentId: null, timestamp: ts4(1), message: { role: 'user', content: [{ type: 'text', text: 'grind through the long haul' }] } },
+      { type: 'message', id: 'a1', parentId: 'u1', timestamp: ts4(2), message: {
+        role: 'assistant', model: 'gpt-5.4-mini', provider: 'openai-codex',
+        content: [{ type: 'text', text: 'context is filling up' }],
+        usage: { input: 90000, output: 400, cacheRead: 30000, cacheWrite: 0, totalTokens: 120400 },
+      } },
+      { type: 'compaction', id: 'cmp1', parentId: 'a1', timestamp: ts4(3), summary: 'squeezed the long haul into this', firstKeptEntryId: 'u2', tokensBefore: 123456 },
+      // Not a compaction — a branch digest. Must not count as a second marker.
+      { type: 'branch_summary', id: 'bs1', parentId: 'cmp1', timestamp: ts4(4), summary: 'a branch digest, not a compaction' },
+      { type: 'message', id: 'u2', parentId: 'cmp1', timestamp: ts4(5), message: { role: 'user', content: [{ type: 'text', text: 'carry on from the summary' }] } },
+      { type: 'message', id: 'a2', parentId: 'u2', timestamp: ts4(6), message: {
+        role: 'assistant', model: 'gpt-5.4-mini', provider: 'openai-codex',
+        content: [{ type: 'text', text: 'resumed with room to spare' }],
+        usage: { input: 9000, output: 100, cacheRead: 0, cacheWrite: 0, totalTokens: 9100 },
+      } },
+    ]),
+  );
+}
+
 let app: FastifyInstance;
 let closeConnection: () => Promise<void>;
 
@@ -237,6 +268,7 @@ beforeAll(async () => {
   writeSubagentSession();
   writeEmptyParentSession();
   writeMixedProviderSession();
+  writeCompactionSession();
 
   const Fastify = (await import('fastify')).default;
   const { registerRoutes } = await import('../src/routes/index.js');
@@ -264,6 +296,7 @@ describe('pi session indexing', () => {
     // top-level sessions; the orphan (parent file missing) stays standalone, and
     // the empty parent is listed via its child's re-keyed rows.
     expect(sessions.map((s: { id: string }) => s.id).sort()).toEqual([
+      'pi-compact-1',
       'pi-empty-parent',
       'pi-orphan-1',
       'pi-sess-1',
@@ -445,5 +478,34 @@ describe('pi provider-aware cost', () => {
     expect(s.totalCostUsd).toBeCloseTo(0.0006, 6);
     // A zero-rated provider on the session sets the local marker.
     expect(s.hasLocalProvider).toBe(true);
+  });
+});
+
+describe('pi compaction markers', () => {
+  it('counts the compaction entry and stamps the turn after it with pi’s own sizes', async () => {
+    const detail = (await get('/api/sessions/pi-compact-1')).json();
+    expect(detail.meta.compactionCount).toBe(1); // branch_summary is not one
+
+    const stamped = detail.thread.filter((t: { compaction?: unknown }) => t.compaction);
+    expect(stamped).toHaveLength(1);
+    expect(JSON.stringify(stamped[0].blocks)).toContain('carry on from the summary');
+    expect(stamped[0].compaction).toMatchObject({
+      summary: 'squeezed the long haul into this',
+      // `tokensBefore` verbatim — NOT the 120000 the previous turn would derive.
+      preTokens: 123456,
+      postTokens: 9000,
+    });
+  });
+
+  it('keeps the marker out of the events (no system turn, message count unchanged)', async () => {
+    const detail = (await get('/api/sessions/pi-compact-1')).json();
+    expect(detail.meta.messageCount).toBe(4);
+    expect(detail.thread.map((t: { role: string }) => t.role)).toEqual([
+      'user',
+      'assistant',
+      'user',
+      'assistant',
+    ]);
+    expect(JSON.stringify(detail.thread)).not.toContain('a branch digest');
   });
 });

--- a/packages/server/test/pricing-refresh.test.ts
+++ b/packages/server/test/pricing-refresh.test.ts
@@ -29,7 +29,7 @@ const LITELLM = {
     litellm_provider: 'one of https://docs.litellm.ai/docs/providers',
     mode: 'chat',
   },
-  // anthropic chat model with all four rates present.
+  // anthropic chat model with all four rates present (+ a context window).
   'claude-sonnet-4-5': {
     litellm_provider: 'anthropic',
     mode: 'chat',
@@ -37,6 +37,15 @@ const LITELLM = {
     output_cost_per_token: 15e-6,
     cache_creation_input_token_cost: 3.75e-6,
     cache_read_input_token_cost: 0.3e-6,
+    max_input_tokens: 200000,
+  },
+  // a non-integer window must not cost the entry its rates.
+  'claude-haiku-4-5': {
+    litellm_provider: 'anthropic',
+    mode: 'chat',
+    input_cost_per_token: 1e-6,
+    output_cost_per_token: 5e-6,
+    max_input_tokens: '200k',
   },
   // openai chat model missing cache fields (one null, one absent) → 0.
   'gpt-5': {
@@ -99,7 +108,14 @@ describe('mapLiteLLM', () => {
       output: 15,
       cacheWrite: 3.75,
       cacheRead: 0.3,
+      contextWindow: 200000,
     });
+  });
+
+  it('leaves the window out (not the entry) when max_input_tokens is unusable', () => {
+    expect(rates['claude-haiku-4-5']).toEqual({ input: 1, output: 5, cacheWrite: 0, cacheRead: 0 });
+    // gpt-5 has no max_input_tokens at all → no key, not `contextWindow: undefined`.
+    expect('contextWindow' in rates['gpt-5']!).toBe(false);
   });
 
   it('defaults missing/null cache fields to 0', () => {
@@ -170,8 +186,8 @@ describe('refreshPricing', () => {
 
     const result = await refreshPricing();
     expect(result.path).toBe(fetchedPath);
-    expect(result.modelCount).toBe(3); // claude-sonnet-4-5, gpt-5, gpt-5-codex
-    expect(result.changed).toBe(3); // no previous snapshot → all changed
+    expect(result.modelCount).toBe(4); // claude-sonnet-4-5, claude-haiku-4-5, gpt-5, gpt-5-codex
+    expect(result.changed).toBe(4); // no previous snapshot → all changed
 
     const snapshot = JSON.parse(readFileSync(fetchedPath, 'utf8'));
     expect(typeof snapshot.fetchedAt).toBe('string');
@@ -181,6 +197,7 @@ describe('refreshPricing', () => {
       output: 15,
       cacheWrite: 3.75,
       cacheRead: 0.3,
+      contextWindow: 200000,
     });
   });
 
@@ -197,7 +214,7 @@ describe('refreshPricing', () => {
 
     const result = await refreshPricing();
     expect(result.changed).toBe(1);
-    expect(result.modelCount).toBe(3);
+    expect(result.modelCount).toBe(4);
   });
 
   it('leaves an existing snapshot untouched when the fetch is invalid', async () => {

--- a/packages/server/test/pricing.test.ts
+++ b/packages/server/test/pricing.test.ts
@@ -56,9 +56,12 @@ const BASE: PricingConfig = {
   models: {
     'claude-opus-4-8': { input: 15, output: 75, cacheWrite: 18.75, cacheRead: 1.5 },
     'only-in-base': { input: 9, output: 9, cacheWrite: 9, cacheRead: 9 },
+    // A user-set window on an exact id: LiteLLM's rates for it still win.
+    'claude-opus-4-1[1m]': { input: 15, output: 75, cacheWrite: 18.75, cacheRead: 1.5, contextWindow: 1000000 },
   },
   families: {
     sonnet: { input: 3, output: 15, cacheWrite: 3.75, cacheRead: 0.3 },
+    opus: { input: 15, output: 75, cacheWrite: 18.75, cacheRead: 1.5, contextWindow: 200000 },
   },
   default: { input: 1, output: 2, cacheWrite: 0, cacheRead: 0 },
 };
@@ -76,7 +79,7 @@ const bumpMtime = (path: string): void => {
   utimesSync(path, mtimeTick, mtimeTick);
 };
 
-const { loadPricing } = await import('../src/data/pricing.js');
+const { loadPricing, contextWindowFor } = await import('../src/data/pricing.js');
 const { reconcilePricingConfig, PRICING_SCHEMA_VERSION } = await import('../src/config.js');
 
 describe('loadPricing — layered merge', () => {
@@ -121,6 +124,37 @@ describe('loadPricing — layered merge', () => {
     const cfg = loadPricing();
     expect(cfg.models['claude-opus-4-8']).toEqual(BASE.models['claude-opus-4-8']);
     expect(cfg.models['gpt-5-codex']).toBeUndefined();
+  });
+
+  it('carries a fetched context window through sanitize and drops an unusable one silently', () => {
+    writeJson(fetchedPath, {
+      fetchedAt: new Date().toISOString(),
+      models: {
+        'gpt-5-codex': { input: 1.25, output: 10, cacheWrite: 0, cacheRead: 0, contextWindow: 400000 },
+        // a hand-edited bad window keeps its rates and just loses the window
+        'gpt-5': { input: 1.25, output: 10, cacheWrite: 0, cacheRead: 0, contextWindow: -1 },
+        // the feed's rates win, the user's window on the same id survives
+        'claude-opus-4-1[1m]': { input: 20, output: 100, cacheWrite: 25, cacheRead: 2, contextWindow: 200000 },
+      },
+    });
+    bumpMtime(fetchedPath);
+    const cfg = loadPricing();
+    expect(cfg.models['gpt-5-codex']?.contextWindow).toBe(400000);
+    expect(cfg.models['gpt-5']).toEqual({ input: 1.25, output: 10, cacheWrite: 0, cacheRead: 0 });
+    expect(cfg.models['claude-opus-4-1[1m]']).toEqual({
+      input: 20, output: 100, cacheWrite: 25, cacheRead: 2, contextWindow: 1000000,
+    });
+  });
+
+  it('resolves a context window by exact id, then family, else unknown', () => {
+    const cfg = loadPricing();
+    expect(contextWindowFor('gpt-5-codex', cfg)).toBe(400000);
+    // no exact id: the date-suffixed opus id resolves through the family
+    expect(contextWindowFor('claude-opus-4-1-20250805', cfg)).toBe(200000);
+    // a family without a window is not a match; the default has no window
+    expect(contextWindowFor('claude-sonnet-4-5', cfg)).toBeUndefined();
+    expect(contextWindowFor('some-local-model', cfg)).toBeUndefined();
+    expect(contextWindowFor(null, cfg)).toBeUndefined();
   });
 
   it('re-reads when the fetched file mtime changes (cache invalidation)', () => {

--- a/packages/shared/src/api.ts
+++ b/packages/shared/src/api.ts
@@ -68,6 +68,19 @@ export interface SessionMeta {
   hasSidechain: boolean;
   /** Agent that produced this session, e.g. `claude-code` or `codex`. */
   connectorId: string;
+  /**
+   * Prompt size (input + cache read + cache write) of the last main-thread
+   * assistant turn — the session's context as of that turn. Absent when the
+   * agent's format has no per-response usage (Copilot, Antigravity, Junie).
+   */
+  contextTokens?: number;
+  /** Context window of the model at that turn, when pricing knows it. */
+  contextWindow?: number;
+  /**
+   * Main-thread context compactions. Absent when the agent's format carries no
+   * compaction marker (opencode, Grok, Antigravity, Junie) — distinct from 0.
+   */
+  compactionCount?: number;
 }
 
 /** A single full-text search hit. */
@@ -113,7 +126,7 @@ export interface AnalyticsTotals {
 // Request query parameter shapes
 // ---------------------------------------------------------------------------
 
-export type SessionSort = 'recent' | 'oldest' | 'tokens' | 'cost' | 'messages';
+export type SessionSort = 'recent' | 'oldest' | 'tokens' | 'cost' | 'messages' | 'context';
 
 export interface SessionsQuery {
   project?: string;
@@ -220,7 +233,9 @@ export type SessionEfficiencySort =
   | 'costPerResponse'
   | 'tokensPerResponse'
   | 'toolCallCount'
-  | 'toolCallsPerResponse';
+  | 'toolCallsPerResponse'
+  | 'contextTokens'
+  | 'compactionCount';
 
 /** Sort direction. */
 export type SortDir = 'asc' | 'desc';
@@ -258,6 +273,12 @@ export interface SessionEfficiencyRow {
   costPerResponse: number;
   tokensPerResponse: number;
   toolCallsPerResponse: number;
+  /** Context at the last main-thread turn; null when the agent has no per-response usage. */
+  contextTokens: number | null;
+  /** Window of the model at that turn, when pricing knows it. */
+  contextWindow: number | null;
+  /** Main-thread compactions; null when the agent's format has no compaction marker. */
+  compactionCount: number | null;
 }
 
 /**
@@ -293,6 +314,10 @@ export interface SessionEfficiencyResponse {
       toolCallCount: SessionEfficiencyStat;
       toolCallsPerResponse: SessionEfficiencyStat;
       cacheHitRatio: SessionEfficiencyStat;
+      /** Over sessions with a known context only. */
+      contextTokens: SessionEfficiencyStat;
+      /** Over sessions whose agent records compactions only. */
+      compactionCount: SessionEfficiencyStat;
     };
   };
 }

--- a/packages/shared/src/events.ts
+++ b/packages/shared/src/events.ts
@@ -144,6 +144,12 @@ export interface UserEvent extends EventEnvelope {
   message: RawMessage;
   permissionMode?: string;
   promptId?: string;
+  /**
+   * Claude Code (2025 format): this user turn IS the post-compaction summary.
+   * Current Claude Code writes a `system` `compact_boundary` row instead (see
+   * {@link SystemEvent}); mid-period files carry both for one compaction.
+   */
+  isCompactSummary?: boolean;
 }
 
 export interface AssistantEvent extends EventEnvelope {
@@ -152,12 +158,32 @@ export interface AssistantEvent extends EventEnvelope {
   requestId?: string;
 }
 
+/** Claude Code's `compactMetadata` on a `compact_boundary` system row. */
+export interface CompactMetadata {
+  /** `auto` or `manual`. */
+  trigger?: string;
+  /** Context size (tokens) just before / after the compaction. */
+  preTokens?: number;
+  postTokens?: number;
+  [key: string]: unknown;
+}
+
+/**
+ * A `subtype: 'compact_boundary'` system event marks a context compaction that
+ * happened right before the next conversational event. Claude Code writes these
+ * natively; the Codex/pi/Copilot normalizers synthesize the same shape so one
+ * parser path and one index projection serve every agent.
+ */
 export interface SystemEvent extends EventEnvelope {
   type: 'system';
   subtype?: string;
   isMeta?: boolean;
   messageCount?: number;
   durationMs?: number;
+  content?: string;
+  compactMetadata?: CompactMetadata;
+  /** Synthetic only (Codex/pi): the plaintext compaction summary, when stored. */
+  summary?: string;
 }
 
 export interface AttachmentEvent extends EventEnvelope {

--- a/packages/shared/src/pricing.ts
+++ b/packages/shared/src/pricing.ts
@@ -12,6 +12,11 @@ export interface ModelRates {
   cacheWrite: number;
   /** USD per 1M cache-read tokens. */
   cacheRead: number;
+  /**
+   * Model context window in tokens (LiteLLM `max_input_tokens`), when known.
+   * Not a rate: it only feeds the "context used" percentage in the UI.
+   */
+  contextWindow?: number;
 }
 
 /** Snapshot of rates fetched at runtime (e.g. from LiteLLM). */

--- a/packages/shared/src/thread.ts
+++ b/packages/shared/src/thread.ts
@@ -55,6 +55,23 @@ export type ThreadBlock =
   | ParsedAttachmentBlock;
 
 /**
+ * A context compaction that happened immediately before the thread item it is
+ * attached to. `preTokens`/`postTokens` come from Claude Code's boundary
+ * metadata when present, else are derived from the adjacent assistant turns'
+ * usage (prompt size = input + cache read + cache write); either may be absent.
+ */
+export interface CompactionInfo {
+  /** `auto` or `manual`, when the agent records it. */
+  trigger?: string;
+  preTokens?: number;
+  postTokens?: number;
+  /** Plaintext summary the agent stored for the compaction (Codex/pi). */
+  summary?: string;
+  /** True when the item itself is the summary turn (Claude Code 2025 format). */
+  isSummaryTurn?: boolean;
+}
+
+/**
  * One ordered message in an assembled session thread. Aggregates the parsed
  * blocks for a single user/assistant turn together with its metadata.
  */
@@ -67,6 +84,8 @@ export interface ThreadItem {
   usage?: MessageUsage;
   isSidechain: boolean;
   blocks: ThreadBlock[];
+  /** Present when a compaction happened right before this turn. */
+  compaction?: CompactionInfo;
 }
 
 /**

--- a/packages/web/src/pages/analytics/SessionEfficiencyTable.tsx
+++ b/packages/web/src/pages/analytics/SessionEfficiencyTable.tsx
@@ -18,7 +18,7 @@ import type {
   SortDir,
 } from '@claudescope/shared';
 import { AgentBadge } from '../../components/index.js';
-import { formatCost, formatPct, formatPerCost } from './format.js';
+import { formatCost, formatCount, formatPct, formatPerCost } from './format.js';
 
 /** Numeric columns share a key across the row and the summary's per-column stats. */
 type ColKey = keyof SessionEfficiencyResponse['summary']['columns'];
@@ -42,6 +42,8 @@ const COLS: Col[] = [
   { key: 'costPerResponse', label: '$/resp', sortKey: 'costPerResponse', flag: true, fmt: formatPerCost },
   { key: 'toolCallCount', label: 'Tools', sortKey: 'toolCallCount', fmt: intFmt },
   { key: 'toolCallsPerResponse', label: 'Tools/resp', sortKey: 'toolCallsPerResponse', flag: true, fmt: (n) => n.toFixed(2) },
+  { key: 'contextTokens', label: 'Context', sortKey: 'contextTokens', fmt: formatCount },
+  { key: 'compactionCount', label: 'Compactions', sortKey: 'compactionCount', fmt: intFmt },
   { key: 'cacheHitRatio', label: 'Cache', sortKey: 'cacheHitRatio', flag: true, cacheOnly: true, fmt: formatPct },
 ];
 
@@ -98,6 +100,8 @@ function NumCell({
   stat: SessionEfficiencyStat;
 }) {
   const value = row[col.key];
+  // null = the agent never records this metric (not 0) — see SessionEfficiencyRow.
+  if (value === null) return <td className="tv-eff__num tv-muted">—</td>;
   const text = col.fmt(value);
   const dir = col.flag ? outlierDir(value, stat) : null;
   if (!dir) return <td className="tv-eff__num">{text}</td>;

--- a/packages/web/src/pages/browse/SessionList.tsx
+++ b/packages/web/src/pages/browse/SessionList.tsx
@@ -1,9 +1,10 @@
 import { useEffect, useMemo, useState } from 'react';
 import { Link } from 'react-router';
+import { RotateCcw } from 'lucide-react';
 import type { SessionMeta, SessionSort } from '@claudescope/shared';
 import { api, ApiError } from '../../api/client.js';
 import { AgentBadge, agentLabel, ErrorBox, formatCost, formatCount, LocalBadge, ModelChips, SearchField, Spinner } from '../../components';
-import { formatBytes, formatDateTime, timeAgo } from './format.js';
+import { contextLevel, contextLabel, formatBytes, formatDateTime, timeAgo } from './format.js';
 import { useProjectContext } from './ProjectLayout.js';
 import { useDataVersionRefetch } from '../../status/useDataVersionRefetch.js';
 
@@ -13,6 +14,7 @@ const SORT_OPTIONS: { value: SessionSort; label: string }[] = [
   { value: 'tokens', label: 'Most tokens' },
   { value: 'cost', label: 'Highest cost' },
   { value: 'messages', label: 'Most messages' },
+  { value: 'context', label: 'Context' },
 ];
 
 /** Ignore aborted/offline fetch errors that are not user-actionable. */
@@ -169,6 +171,15 @@ function SessionRow({ session }: { session: SessionMeta }) {
               sidechain
             </span>
           ) : null}
+          {session.compactionCount ? (
+            <span
+              className="tv-chip tv-chip--compaction"
+              title={`Context was compacted ${session.compactionCount} time${session.compactionCount === 1 ? '' : 's'}`}
+            >
+              <RotateCcw size={11} aria-hidden="true" /> {session.compactionCount} compaction
+              {session.compactionCount === 1 ? '' : 's'}
+            </span>
+          ) : null}
         </div>
         <div className="tv-session-row__meta tv-muted">
           <span title={formatDateTime(session.startedAt)}>{timeAgo(session.endedAt || session.startedAt)}</span>
@@ -176,6 +187,12 @@ function SessionRow({ session }: { session: SessionMeta }) {
           <span>{session.messageCount} msgs</span>
           <span>·</span>
           <span>{session.toolCallCount} tools</span>
+          {session.contextTokens !== undefined ? (
+            <>
+              <span>·</span>
+              <ContextMeta tokens={session.contextTokens} contextWindow={session.contextWindow} />
+            </>
+          ) : null}
           {session.gitBranch ? (
             <>
               <span>·</span>
@@ -215,5 +232,18 @@ function SessionRow({ session }: { session: SessionMeta }) {
         ) : null}
       </div>
     </li>
+  );
+}
+
+/** `ctx 142K (71%)` — the percent only when pricing knows the model's window. */
+function ContextMeta({ tokens, contextWindow }: { tokens: number; contextWindow?: number }) {
+  const level = contextLevel(tokens, contextWindow);
+  return (
+    <span
+      className={level ? `tv-ctx tv-ctx--${level}` : 'tv-ctx'}
+      title="Context at the last turn (input + cache read + cache write of the last assistant response)"
+    >
+      context {contextLabel(tokens, contextWindow)}
+    </span>
   );
 }

--- a/packages/web/src/pages/browse/browse.css
+++ b/packages/web/src/pages/browse/browse.css
@@ -272,6 +272,12 @@
   border-color: var(--tv-warning);
   color: var(--tv-warning);
 }
+/* Compaction count — informational, not a warning: quiet next to the title. */
+.tv-chip--compaction {
+  align-items: center;
+  border-color: var(--tv-border-strong);
+  color: var(--tv-fg-muted);
+}
 .tv-chip--pr {
   border-color: var(--tv-accent);
   color: var(--tv-accent);

--- a/packages/web/src/pages/browse/format.ts
+++ b/packages/web/src/pages/browse/format.ts
@@ -1,3 +1,5 @@
+import { formatCount } from '../../components/TokenChips.js';
+
 /**
  * Small presentational helpers shared by the browse + session views.
  * Kept local to these pages (no shell files touched).
@@ -72,6 +74,53 @@ export function formatDuration(startIso: string | undefined, endIso: string | un
   const week = Math.floor(day / 7);
   const d = day % 7;
   return d ? `${week}w ${d}d` : `${week}w`;
+}
+
+/**
+ * Share of the model's context window used at a turn, or undefined when the
+ * window (or the figure itself) is unknown — no window, no ratio.
+ */
+function contextRatio(
+  tokens: number | null | undefined,
+  window: number | null | undefined,
+): number | undefined {
+  if (tokens == null || window == null) return undefined;
+  if (!Number.isFinite(tokens) || !Number.isFinite(window) || window <= 0) return undefined;
+  return tokens / window;
+}
+
+/**
+ * How hot the context is at a turn: `warm` from 80 % of the window, `hot` from
+ * 95 %. The single source of the thresholds for every view that flags them.
+ */
+export function contextLevel(
+  tokens: number | null | undefined,
+  window: number | null | undefined,
+): 'warm' | 'hot' | undefined {
+  const ratio = contextRatio(tokens, window);
+  if (ratio === undefined) return undefined;
+  if (ratio >= 0.95) return 'hot';
+  if (ratio >= 0.8) return 'warm';
+  return undefined;
+}
+
+/**
+ * "395K of 1M (39%)" — the last prompt's size against the model's window, so it
+ * cannot be mistaken for the session's cumulative token total shown beside it;
+ * just "395K" when the window is unknown.
+ */
+export function contextLabel(tokens: number, window: number | null | undefined): string {
+  const pct = contextPct(tokens, window);
+  return pct ? `${formatCount(tokens)} of ${formatCount(window as number)} (${pct})` : formatCount(tokens);
+}
+
+/** Context fill as a whole-percent label ("71%"), or "" when the window is unknown. */
+export function contextPct(
+  tokens: number | null | undefined,
+  window: number | null | undefined,
+): string {
+  const ratio = contextRatio(tokens, window);
+  return ratio === undefined ? '' : `${Math.round(ratio * 100)}%`;
 }
 
 /** Human-readable byte size (e.g. "1.3 MB"). */

--- a/packages/web/src/pages/session/SessionPage.tsx
+++ b/packages/web/src/pages/session/SessionPage.tsx
@@ -1,10 +1,17 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { Link, useParams, useSearchParams } from 'react-router';
-import { ArrowUpRight, GitBranch, GitPullRequest, MessageSquare, RefreshCw, Wrench } from 'lucide-react';
-import type { SessionDetailResponse, SubagentRun } from '@claudescope/shared';
+import { ArrowUpRight, GitBranch, GitPullRequest, MessageSquare, RefreshCw, RotateCcw, Wrench } from 'lucide-react';
+import type { SessionDetailResponse, SessionMeta, SubagentRun } from '@claudescope/shared';
 import { api, ApiError } from '../../api/client.js';
 import { AgentBadge, ErrorBox, formatCost, formatCount, LocalBadge, ModelChips, Spinner } from '../../components';
-import { formatBytes, formatDateTime, formatDuration } from '../browse/format.js';
+import {
+  contextLabel,
+  contextLevel,
+  formatBytes,
+  formatDateTime,
+  formatDuration,
+  shortModel,
+} from '../browse/format.js';
 import { hasRenderableContent } from './blocks.js';
 import { SubagentBlock, SubagentJumpMenu, ThreadList, useHashTarget } from './ThreadView.js';
 import { useProgressiveMount } from './useProgressiveMount.js';
@@ -493,7 +500,10 @@ function SessionView({
             │
           </span>
           <span className="tv-session__cost">{formatCost(meta.totalCostUsd)}</span>
-          <span className="tv-session__tokens">{formatCount(meta.totalTokens)} tokens</span>
+          <span className="tv-session__tokens" title="Tokens billed across every turn of the session">
+            {formatCount(meta.totalTokens)} total tokens
+          </span>
+          <ContextFigure meta={meta} />
           {duration ? <span className="tv-muted">{duration}</span> : null}
         </div>
 
@@ -505,6 +515,12 @@ function SessionView({
           <span className="tv-session__meta-item">
             <Wrench size={13} aria-hidden="true" /> {meta.toolCallCount} tools
           </span>
+          {meta.compactionCount !== undefined ? (
+            <span className="tv-session__meta-item" title="Context compactions on the main thread">
+              <RotateCcw size={13} aria-hidden="true" /> {meta.compactionCount} compaction
+              {meta.compactionCount === 1 ? '' : 's'}
+            </span>
+          ) : null}
           {meta.gitBranch ? (
             <span className="tv-session__meta-item tv-mono" title="git branch">
               <GitBranch size={13} aria-hidden="true" /> {meta.gitBranch}
@@ -554,4 +570,36 @@ function SessionView({
       ) : null}
     </div>
   );
+}
+
+/**
+ * Context at the last main-thread turn, with the share of the model's window
+ * when pricing knows it. Absent for agents that record no per-response usage.
+ */
+function ContextFigure({ meta }: { meta: SessionMeta }) {
+  if (meta.contextTokens === undefined) return null;
+  const level = contextLevel(meta.contextTokens, meta.contextWindow);
+  // Own group after the spend figures: context is a snapshot, not a total.
+  return (
+    <>
+      <span className="tv-session__sep" aria-hidden="true">
+        │
+      </span>
+      <span className={level ? `tv-ctx tv-ctx--${level}` : 'tv-ctx'} title={contextTitle(meta)}>
+        context {contextLabel(meta.contextTokens, meta.contextWindow)}
+      </span>
+    </>
+  );
+}
+
+/** Spells out what the figure measures and which window it is measured against. */
+function contextTitle(meta: SessionMeta): string {
+  const what =
+    'Context at the last turn: input + cache read + cache write of the last assistant response.';
+  if (meta.contextWindow === undefined) return `${what} The window size is unknown for this model.`;
+  // The window belongs to the model of that turn; name it only for a
+  // single-model session, where there is no ambiguity about which one that is.
+  const only = meta.models.length === 1 ? meta.models[0] : undefined;
+  const model = only ? ` (${shortModel(only)})` : '';
+  return `${what} Window: ${formatCount(meta.contextWindow)}${model}`;
 }

--- a/packages/web/src/pages/session/ThreadView.tsx
+++ b/packages/web/src/pages/session/ThreadView.tsx
@@ -1,7 +1,14 @@
-import { Fragment, memo, useContext, useEffect, useRef, useState } from 'react';
-import { Puzzle } from 'lucide-react';
-import type { SubagentRun, ThreadBlock, ThreadItem } from '@claudescope/shared';
-import { ClampedText, Collapsible, ErrorBoundary, ErrorBox, TokenChips } from '../../components';
+import { Fragment, memo, useContext, useEffect, useRef, useState, type ReactNode } from 'react';
+import { Puzzle, RotateCcw } from 'lucide-react';
+import type { CompactionInfo, SubagentRun, ThreadBlock, ThreadItem } from '@claudescope/shared';
+import {
+  ClampedText,
+  Collapsible,
+  ErrorBoundary,
+  ErrorBox,
+  formatCount,
+  TokenChips,
+} from '../../components';
 import { formatDateTime, shortModel } from '../browse/format.js';
 import { ThreadBlockView, hasRenderableContent } from './blocks.js';
 import {
@@ -40,11 +47,16 @@ export function ThreadList({
   /** tool_use id → the subagent run(s) it spawned (Workflow fans out to many). */
   subagentsByToolUseId?: Map<string, SubagentRun[]>;
 }) {
+  // A compaction divider is a sibling of the turn it precedes (never nested in
+  // it, and never carrying its `id`), so anchors and deep links are untouched.
   return (
     <>
-      {items.map((item) => (
-        <Turn key={item.uuid} item={item} subagentsByToolUseId={subagentsByToolUseId} />
-      ))}
+      {items.flatMap((item) => [
+        item.compaction ? (
+          <CompactionDivider key={`${item.uuid}-compaction`} compaction={item.compaction} />
+        ) : null,
+        <Turn key={item.uuid} item={item} subagentsByToolUseId={subagentsByToolUseId} />,
+      ])}
     </>
   );
 }
@@ -61,6 +73,14 @@ const Turn = memo(function Turn({
   item: ThreadItem;
   subagentsByToolUseId?: Map<string, SubagentRun[]>;
 }) {
+  // Claude Code's 2025 compaction format replaces the context with a summary
+  // carried by this very turn — it reads as harness output, not as a person.
+  if (item.compaction?.isSummaryTurn && item.blocks.every((b) => b.kind === 'text')) {
+    return (
+      <SystemTurn item={item} label="Compaction summary" subtitle="replaced the compacted context" />
+    );
+  }
+
   // Harness-injected user turns (task notifications, bash I/O, slash-command
   // output) are noise in the conversation — collapse them behind a label.
   const systemLabel = item.role === 'user' ? classifySystemTurn(item) : null;
@@ -165,7 +185,16 @@ function classifySystemTurn(item: ThreadItem): string | null {
 }
 
 /** Compact, collapsed-by-default rendering for a harness/system user turn. */
-function SystemTurn({ item, label }: { item: ThreadItem; label: string }) {
+function SystemTurn({
+  item,
+  label,
+  subtitle,
+}: {
+  item: ThreadItem;
+  label: string;
+  /** Overrides the default "system / harness message" line. */
+  subtitle?: ReactNode;
+}) {
   const text = turnText(item);
   // Claude Code wraps slash/bash turns in XML-style tags; parse them into clean
   // command/terminal UI. Non-command system turns (task notifications, system
@@ -181,7 +210,7 @@ function SystemTurn({ item, label }: { item: ThreadItem; label: string }) {
           className="tv-collapsible--system"
           icon="⚙︎"
           title={label}
-          subtitle={cmd ? commandSubtitle(cmd) : 'system / harness message'}
+          subtitle={cmd ? commandSubtitle(cmd) : (subtitle ?? 'system / harness message')}
           headerExtra={
             item.timestamp ? (
               <a className="tv-turn__time tv-muted" href={`#${item.uuid}`}>
@@ -199,6 +228,51 @@ function SystemTurn({ item, label }: { item: ThreadItem; label: string }) {
       </div>
     </article>
   );
+}
+
+/**
+ * A rule marking where the agent compacted its context, rendered before the
+ * first turn that followed. `preTokens`/`postTokens` are best effort — either
+ * may be missing, in which case only the known side is shown.
+ */
+function CompactionDivider({ compaction }: { compaction: CompactionInfo }) {
+  const [open, setOpen] = useState(false);
+  const span = compactionSpan(compaction);
+  const summary = compaction.summary?.trim();
+  return (
+    <div className="tv-compaction">
+      <div className="tv-compaction__line">
+        <span className="tv-compaction__label">
+          <RotateCcw size={12} aria-hidden="true" /> Context compacted
+          {compaction.trigger ? <> · {compaction.trigger}</> : null}
+          {span ? <> · <span className="tv-compaction__span">{span}</span></> : null}
+          {summary ? (
+            <button
+              type="button"
+              className="tv-compaction__toggle"
+              aria-expanded={open}
+              onClick={() => setOpen((o) => !o)}
+            >
+              summary <span aria-hidden="true">{open ? '▾' : '▸'}</span>
+            </button>
+          ) : null}
+        </span>
+      </div>
+      {open && summary ? (
+        <ClampedText className="tv-system-turn__pre tv-compaction__summary" text={summary} />
+      ) : null}
+    </div>
+  );
+}
+
+/** "332K → 18K", or whichever side the agent recorded, or "" for neither. */
+function compactionSpan({ preTokens, postTokens }: CompactionInfo): string {
+  if (preTokens !== undefined && postTokens !== undefined) {
+    return `${formatCount(preTokens)} → ${formatCount(postTokens)}`;
+  }
+  if (preTokens !== undefined) return `before ${formatCount(preTokens)}`;
+  if (postTokens !== undefined) return `after ${formatCount(postTokens)}`;
+  return '';
 }
 
 /** The actual command, surfaced in the collapsed header so it's legible unexpanded. */

--- a/packages/web/src/pages/session/session.css
+++ b/packages/web/src/pages/session/session.css
@@ -845,6 +845,55 @@
   color: var(--tv-finder-active-fg);
 }
 
+/* ── Compaction divider ────────────────────────────────────────────────── */
+
+/* Where the agent compacted its context: a rule across the thread with a
+   centered label, so the sawtooth is visible while reading. */
+.tv-compaction {
+  display: flex;
+  flex-direction: column;
+  gap: var(--tv-space-2);
+}
+.tv-compaction__line {
+  display: flex;
+  align-items: center;
+  gap: var(--tv-space-3);
+}
+.tv-compaction__line::before,
+.tv-compaction__line::after {
+  content: '';
+  flex: 1 1 0;
+  border-top: 1px dashed var(--tv-border-strong);
+}
+.tv-compaction__label {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--tv-space-1);
+  font-size: var(--tv-fs-sm);
+  color: var(--tv-fg-muted);
+  white-space: nowrap;
+}
+.tv-compaction__span {
+  font-variant-numeric: tabular-nums;
+}
+.tv-compaction__toggle {
+  margin-left: var(--tv-space-1);
+  padding: 0;
+  background: transparent;
+  border: 0;
+  cursor: pointer;
+  font-size: var(--tv-fs-sm);
+  color: var(--tv-accent);
+}
+.tv-compaction__toggle:hover {
+  text-decoration: underline;
+}
+.tv-compaction__summary {
+  border: 1px dashed var(--tv-border);
+  border-radius: var(--tv-radius);
+  background: var(--tv-bg-elevated);
+}
+
 /* ── System / harness turns (collapsed by default) ────────────────────── */
 
 .tv-turn--system .tv-turn__role-dot {

--- a/packages/web/src/styles/global.css
+++ b/packages/web/src/styles/global.css
@@ -1062,6 +1062,20 @@ mark {
   font-family: var(--tv-font-mono);
 }
 
+/* Context at the last turn (session header + list rows). Quiet by default, amber
+   from 80 % of the model's window and red from 95 % — see `contextLevel`. */
+.tv-ctx {
+  color: var(--tv-fg-muted);
+  font-variant-numeric: tabular-nums;
+}
+.tv-ctx--warm {
+  color: var(--tv-warning);
+}
+.tv-ctx--hot {
+  color: var(--tv-danger);
+  font-weight: 600;
+}
+
 /* Summary strip — compact stat tiles anchoring a list view (portfolio / project). */
 .tv-summary {
   display: flex;


### PR DESCRIPTION
## What

Every session shows its **context at the last main-thread turn** (the last prompt's size, with a percent of the model's window when pricing knows it) and its **compaction count**. The transcript gets a divider where each compaction happened, with before/after sizes and the stored summary where the agent keeps one. Sessions sort by context; the efficiency table gains `Context` and `Compactions` columns.

Plan: [docs/plans/0083](docs/plans/0083-context-window-and-compactions.md).

## How

- **Index (schema v20)**: a file-keyed `compactions` aux table (staged and swapped per file like titles/pr_links) plus `sessions.context_tokens / context_model / compaction_count` derived at rebuild. Claude Code reads its `compact_boundary` system rows and falls back to the 2025 `isCompactSummary` turn only in files with no boundary, so the mid-period both-markers format counts once.
- **Connectors**: Codex (`compacted`), pi (`compaction`), Copilot (`session.context_changed`) synthesize the Claude Code boundary event and write a `compaction` row into their existing NDJSON cache; the events projection filters those rows by type, so the canonical events contract is untouched.
- **Parser**: stamps `ThreadItem.compaction` on the turn after a boundary, merges a flagged summary turn in either order (subagent files are timestamp-sorted), and derives missing sizes from adjacent turns — only for agents whose rows are one prompt.
- **Capabilities**: `data/agent-capabilities.ts` decides *unavailable* vs 0. Context needs prompt-sized rows (Claude Code, Codex, pi, opencode): Copilot is session-level, Junie sums a whole turn into one row, Grok records one total per user turn. Compaction markers exist for Claude Code, Codex, pi, Copilot.
- **Pricing**: LiteLLM `max_input_tokens` rides along as `contextWindow`; a user window on an exact id survives the fetched overlay; a snapshot without windows is treated as stale on boot so the percent appears right after upgrading.
- **Web**: `context 395K of 1.0M (39%)` in the header (amber ≥ 80 %, red ≥ 95 %), `N compactions` in tier two, list row meta + chip, `Context` sort, transcript divider, efficiency columns. CLI/MCP session header carries `ctx … · N compactions`.

## Tests

`npm test` (707) and `npm run typecheck` green. New coverage: the three Claude Code marker formats, sidechain exclusion, last-turn context with block-split rows, file-keyed reload/prune, one compaction each for Codex/pi/Copilot, parser stamping/merge/derivation, pricing window mapping/sanitize/override, API gating and sorts, Junie/Grok report no context.
