### PR TITLE
feat: nest subagents spawned by subagents

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -172,6 +172,17 @@ The CLI `update` command (`cli.ts`) detects the install method and defers to
   is absent or drifted, the shared parser may fall back to an exact full match
   between the spawning `Agent`/`Task.prompt` and the child's first user prompt.
   Empty or ambiguous matches stay detached; there is no fuzzy prompt matching.
+- **Nested subagents (a subagent spawning a subagent)** — the grandchild is a
+  SIBLING file in the same `subagents/` dir, not nested a level deeper; its
+  meta carries `toolUseId` (the `Agent` call inside its parent's transcript)
+  and `parentAgentId`. `SubagentRun`s stay a flat list with a `parentAgentId`
+  pointer, not a tree; spawn points are collected from every run's thread
+  (plus the main thread), so a call living inside a run can still be matched.
+  Description/prompt matching is scoped to the named parent's own spawns, or —
+  without a parent — to the main thread only, never another run, so a
+  same-named call elsewhere can't steal the match. A window carries a run's
+  descendants along with it. pi and Grok still only re-key one hop, so their
+  grandchildren surface as their own top-level sessions (follow-up).
 - **pi connector** (`connectors/pi/`) — JSONL like Claude/Codex but `cwd` is on
   the `session` line and tool results are separate `toolResult` records, so a
   `prepare()` pass normalizes to canonical NDJSON (Codex pattern). `model` comes
@@ -258,6 +269,14 @@ The CLI `update` command (`cli.ts`) detects the install method and defers to
   with zero ID linkage to the spawner (only the coincidental prompt text).
   Matching command text to session prompts would be heuristic and fragile, so
   they intentionally list as separate top-level sessions.
+- **Never `scrollIntoView({ behavior: 'smooth' })` across the transcript.**
+  Turns are lazily sized (`content-visibility: auto` with a 280px intrinsic
+  size in `session.css`), so their real heights replace the estimates as the
+  viewport passes them and the document shrinks by tens of thousands of pixels
+  mid-animation — the scroll lands far past its target (the jump-menu bug on
+  nested subagents). Navigate with an instant jump plus `holdAnchor` from
+  `useScrollRestore.ts`, which re-pins the element each frame until layout
+  settles and yields to the reader's own scroll.
 - **Cost is a local estimate** from token usage × rates; not real billing.
   Computed once at index time and stored. Rates auto-refresh daily from LiteLLM
   at runtime (`pricing.fetched.json`); `pricing.json` is the fallback/override

--- a/docs/plans/0084-nested-subagents.md
+++ b/docs/plans/0084-nested-subagents.md
@@ -1,0 +1,118 @@
+# 0084 — Nested subagents (a subagent spawning a subagent)
+
+- **Status:** done
+- **Date:** 2026-09-04
+- **PR:** [#108](https://github.com/vladar107/claudescope/pull/108)
+
+## Context
+
+Claude Code lets a subagent call the `Agent` tool. Verified with a real
+depth-2 spawn: the grandchild is a **sibling** file in the same
+`<session>/subagents/` directory (no nested folder); its
+`agent-<id>.meta.json` carries `toolUseId` (the `Agent` call inside the
+depth-1 child's transcript), `parentAgentId`, and `spawnDepth: 2`; the rows
+themselves only carry their own `agentId`.
+
+What Claudescope did with it:
+
+- the loader read only `agentType`/`description` from the metadata, so even
+  the exact spawning id was ignored (Codex was the only connector ever setting
+  `SubagentSource.toolUseId`);
+- `buildSubagentRuns` collected spawn points from the **main thread only**,
+  so a call living in a run's thread could never match — the grandchild landed
+  in the "Other subagents" section, and with a description equal to an unused
+  main-thread call it would have nested under the **wrong** call;
+- `subagentsInWindow` dropped unlinked runs, so windowed reads (MCP
+  `get_session`, the CLI, the web's paged loading) lost the grandchild;
+- `SubagentBlock` rendered its thread without the run map, so nothing could
+  recurse even when linked.
+
+Survey of the other connectors (plan text of 0075 explicitly scoped recursion
+out): root re-keying already walks the full ancestor chain for Codex, opencode,
+and Antigravity; pi and Grok hop **one** level (a grandchild becomes its own
+top-level session); Copilot keeps everything in one file with flat per-agent
+streams; Junie has no linkage by design. No connector supplied an exact id or
+a parent for a grandchild: Codex looked only in the root rollout's spawn map,
+Copilot discarded the id it already had (`sub.agentId` IS the spawning
+`task` call id), opencode built descriptions from the root session only,
+Antigravity has synthesized ids only. No pi/opencode/Copilot/Grok/Antigravity
+data exists on this machine.
+
+## Goal
+
+A subagent spawned by a subagent nests under the call that spawned it, in the
+web, in windowed reads, and in Markdown/CLI/MCP output — for Claude Code with
+exact ids, and for the connectors where that is a small, code-certain change.
+
+## Decisions
+
+- **Flat list plus a parent pointer, not a tree.** `SubagentRun.parentAgentId`
+  names the run whose thread holds the spawning call. The API shape stays
+  backward compatible; the web's map by tool-use id already covers nested
+  runs; depth is derived where needed. Chains are acyclic (the parser breaks a
+  cycle by unlinking the closing run).
+- **Spawn points come from every thread.** All runs are assembled first, then
+  spawn points are collected from the main thread and each run's thread,
+  tagged with their owner — a parent may be listed after its child.
+- **Matching order.** The exact id anywhere (except a run's own thread). Else,
+  when the source names its parent, description/prompt matching is restricted
+  to that parent's spawns. Else the previous main-thread-only behaviour, so
+  legacy metadata can never pull a nested run under a same-named call in some
+  other run. An unknown or self-referential parent is ignored.
+- **Windows carry descendants.** A run is included when its spawn turn is in
+  the slice or its parent is included, iterated to a fixpoint.
+- **Scope.** Shared machinery + Claude Code (reads `toolUseId` and
+  `parentAgentId`; `spawnDepth` is left unread since depth follows from the
+  parent chain) + Codex (merge the spawn maps of every parsed
+  child; parent from `thread_spawn`) + Copilot (pass the id it has plus the
+  owning stream) + opencode and Antigravity (parent id; descriptions from every
+  session). **pi and Grok are a follow-up**: their one-hop root re-key changes
+  session identity and cannot be verified locally.
+
+## Approach
+
+1. Shared contract: `SubagentRun.parentAgentId`, `SubagentSource.parentAgentId`;
+   parser `collectSpawns` over all threads, owner-scoped matching,
+   `breakParentCycles`; `subagentsInWindow` fixpoint. Unit tests.
+2. Connectors: Claude Code metadata fields; Codex spawn-map merge + parent;
+   Copilot `toolUseId`/`parentAgentId`; opencode/Antigravity parent +
+   descriptions from all sessions. Integration tests per connector, the Claude
+   Code fixture taken from the real depth-2 files.
+3. Web: `SubagentBlock` passes the run map into its own `ThreadList`;
+   mount-before-navigate, hash targets, and search auto-open resolve through
+   the ancestor chain; jump menu indents by depth.
+4. Export and agent surfaces: Markdown export and `shapeSessionMarkdown` order
+   runs depth-first and label nested ones with their parent.
+5. Docs: CLAUDE.md gotcha.
+
+## Files affected
+
+- `packages/shared/src/thread.ts`, `packages/server/src/data/session-loader.ts` — contract.
+- `packages/server/src/data/{parser,window}.ts` — spawn collection, matching, windows.
+- `packages/server/src/connectors/claude-code/claude-code.ts`, `codex/{codex,normalize}.ts`,
+  `copilot/{copilot,normalize}.ts`, `opencode/{opencode,normalize}.ts`,
+  `antigravity/{antigravity,normalize}.ts`.
+- `packages/web/src/pages/session/{SessionPage,ThreadView}.tsx`, `search.ts`.
+- `packages/shared/src/markdown.ts`, `packages/server/src/agent/shape.ts`.
+- Tests: `parser.test.ts`, `window.test.ts`, a Claude Code nested fixture, and
+  one nested case per connector above.
+
+## Testing
+
+- `npm test`, `npm run typecheck`.
+- Parser: exact id into another run (child listed first); the same-description
+  trap with a named parent; legacy (no parent) stays main-thread only; unknown
+  / self parent ignored; a cycle is broken.
+- Window: nested runs ride with their ancestor and drop with it.
+- API: the depth-2 Claude Code run carries `toolUseId` + `parentAgentId`; a
+  window around the depth-1 spawn turn includes both runs; export nests.
+- Web: Playwright on a real session with a depth-2 run.
+
+## Risks / open questions
+
+- Copilot: whether inner-inner events are tagged with the inner or the outer
+  `agentId` is unverified (plan 0032 had no real sample either).
+- pi/Grok grandchildren still surface as their own top-level sessions until
+  their re-key walks the chain (follow-up).
+- Antigravity and opencode nesting rests on description matching scoped to
+  the named parent; synthetic fixtures only.

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -108,3 +108,4 @@ decision, or a change worth explaining before doing. Skip it for one-line fixes.
 | 0081 | [Skill usage and exact-match search in the web](./0081-web-skill-usage-and-exact-search.md) | done |
 | 0082 | [Brew release waits for the npm tarball](./0082-brew-release-waits-for-npm-tarball.md) | done |
 | 0083 | [Context size and compaction count per session](./0083-context-window-and-compactions.md) | done |
+| 0084 | [Nested subagents (a subagent spawning a subagent)](./0084-nested-subagents.md) | done |

--- a/packages/server/src/agent/shape.ts
+++ b/packages/server/src/agent/shape.ts
@@ -14,7 +14,7 @@ import type {
   ToolUsageKind,
   ToolUsageResponse,
 } from '@claudescope/shared';
-import { redactText, threadItemsToMarkdown } from '@claudescope/shared';
+import { orderSubagentRunsDepthFirst, redactText, threadItemsToMarkdown } from '@claudescope/shared';
 import { projectIdFromCwd } from '../data/project-id.js';
 
 /** Default hits/rows returned by the list-shaped tools/commands. */
@@ -172,9 +172,12 @@ export function shapeSessionMarkdown(data: SessionDetailResponse, redact: boolea
 
   const opts = { redact };
   const parts = [head.join('\n'), '---', threadItemsToMarkdown(data.thread, opts)];
-  for (const run of data.subagents) {
+  const byId = new Map(data.subagents.map((run) => [run.agentId, run]));
+  for (const run of orderSubagentRunsDepthFirst(data.subagents)) {
+    const parent = run.parentAgentId ? byId.get(run.parentAgentId) : undefined;
+    const nested = parent ? ` · nested in ${r(parent.description || parent.agentId)}` : '';
     parts.push(
-      `--- subagent · ${run.agentType} — ${r(run.description || run.agentId)} ---`,
+      `--- subagent · ${run.agentType} — ${r(run.description || run.agentId)}${nested} ---`,
       threadItemsToMarkdown(run.thread, opts),
     );
   }

--- a/packages/server/src/connectors/antigravity/antigravity.ts
+++ b/packages/server/src/connectors/antigravity/antigravity.ts
@@ -93,10 +93,15 @@ async function loadSession(sessionId: string, paths: string[]): Promise<SessionD
       mainEvents.push(...parsed.events);
     } else {
       const meta = subagentMetaFor(p);
+      // A spawning conversation that is itself a subagent scopes the description
+      // match to that run's own `invoke_subagent` calls; the root is implied.
+      const parentAgentId =
+        meta && meta.parentConvId !== sessionId ? meta.parentConvId : undefined;
       subagents.push({
         agentId: parsed.convId,
         agentType: meta?.agentType ?? '',
         description: meta?.description ?? '',
+        ...(parentAgentId ? { parentAgentId } : {}),
         events: parsed.events,
       });
     }

--- a/packages/server/src/connectors/antigravity/normalize.ts
+++ b/packages/server/src/connectors/antigravity/normalize.ts
@@ -276,11 +276,22 @@ export function getContext(appDataDir: string): AntigravityContext {
   return ctx;
 }
 
-/** Subagent metadata (agentType, matched description) for a transcript, if it's a child. */
-export function subagentMetaFor(path: string): { agentType: string; description: string } | null {
+/**
+ * Subagent metadata for a transcript, if it's a child: its type, the description
+ * derived from the spawning prompt (identically to the `Task` block the spawning
+ * conversation emits), and the conversation that spawned it — which is the root
+ * at depth 1 and another subagent deeper.
+ */
+export function subagentMetaFor(
+  path: string,
+): { agentType: string; description: string; parentConvId: string } | null {
   const link = getContext(appDataDirFromPath(path)).subagents.get(convIdFromPath(path));
   if (!link) return null;
-  return { agentType: link.typeName, description: subagentLabel(link.prompt) };
+  return {
+    agentType: link.typeName,
+    description: subagentLabel(link.prompt),
+    parentConvId: link.parentConvId,
+  };
 }
 
 // --- content cleaning -------------------------------------------------------

--- a/packages/server/src/connectors/claude-code/claude-code.ts
+++ b/packages/server/src/connectors/claude-code/claude-code.ts
@@ -324,17 +324,36 @@ function agentIdFromPath(path: string): string {
   return basename(path).replace(/^agent-/, '').replace(/\.jsonl$/, '');
 }
 
-/** Read the sibling `agent-<id>.meta.json` ({ agentType, description }). */
-function readSubagentMeta(jsonlPath: string): { agentType: string; description: string } {
+/**
+ * Read the sibling `agent-<id>.meta.json`. Current Claude Code writes
+ * `{agentType, description, toolUseId, spawnDepth}`, plus `parentAgentId` when
+ * a SUBAGENT made the call — a depth-2 run is a sibling file in the same
+ * `subagents/` dir, and its `toolUseId` names an `Agent` call inside the
+ * depth-1 transcript. Older metadata has only `agentType`, so every field is
+ * optional and the description/prompt fallback stays. `spawnDepth` is not read:
+ * depth follows from the parent chain.
+ */
+function readSubagentMeta(jsonlPath: string): {
+  agentType: string;
+  description: string;
+  toolUseId?: string;
+  parentAgentId?: string;
+} {
   const metaPath = jsonlPath.replace(/\.jsonl$/, '.meta.json');
   try {
     const parsed = JSON.parse(readFileSync(metaPath, 'utf8')) as {
       agentType?: unknown;
       description?: unknown;
+      toolUseId?: unknown;
+      parentAgentId?: unknown;
     };
+    const toolUseId = typeof parsed.toolUseId === 'string' ? parsed.toolUseId : '';
+    const parentAgentId = typeof parsed.parentAgentId === 'string' ? parsed.parentAgentId : '';
     return {
       agentType: typeof parsed.agentType === 'string' ? parsed.agentType : '',
       description: typeof parsed.description === 'string' ? parsed.description : '',
+      ...(toolUseId ? { toolUseId } : {}),
+      ...(parentAgentId ? { parentAgentId } : {}),
     };
   } catch {
     return { agentType: '', description: '' };
@@ -411,6 +430,8 @@ async function loadSession(sessionId: string, paths: string[]): Promise<SessionD
       agentId: agentIdFromPath(p),
       agentType: meta.agentType,
       description,
+      ...(meta.toolUseId ? { toolUseId: meta.toolUseId } : {}),
+      ...(meta.parentAgentId ? { parentAgentId: meta.parentAgentId } : {}),
       ...(slug ? { slug } : {}),
       ...(prompt ? { prompt } : {}),
       ...(workflowId ? { workflowId } : {}),

--- a/packages/server/src/connectors/codex/codex.ts
+++ b/packages/server/src/connectors/codex/codex.ts
@@ -55,26 +55,39 @@ function auxProjections(filePath: string): AuxProjections {
 /**
  * Load a session's events, splitting the resolved rollouts into the main thread
  * (its own thread id equals the session id) and one subagent per re-keyed child
- * rollout. A child's metadata comes from the parent's matching `spawn_agent`
- * call, correlated by the legacy child `agent_id` or current canonical
+ * rollout. A child's metadata comes from the matching `spawn_agent` call,
+ * correlated by the legacy child `agent_id` or current canonical
  * `task_name`/`agent_path`, so the run anchors to the exact canonical `Task`.
+ *
+ * A spawn record lives in the rollout that made the call, so a subagent spawned
+ * by a subagent is described by the DEPTH-1 child's rollout, not the root's —
+ * hence the merged spawn map plus the `parent_thread_id` pointer.
  */
 async function loadSession(sessionId: string, paths: string[]): Promise<SessionData> {
   const sessions = paths
     .map((p) => parseRollout(p))
     .filter((s): s is CodexSession => s !== null);
   const main = sessions.find((s) => s.sessionId === sessionId);
+  // Root first, so it wins a key collision with a child's own spawn record.
+  const ordered = main ? [main, ...sessions.filter((s) => s !== main)] : sessions;
+  const spawned = new Map<string, { description: string; agentType: string; toolUseId: string }>();
+  for (const s of ordered) {
+    for (const [key, meta] of s.spawnedAgents) if (!spawned.has(key)) spawned.set(key, meta);
+  }
+  const childIds = new Set(sessions.filter((s) => s !== main).map((s) => s.sessionId));
   const subagents: SubagentSource[] = [];
   for (const s of sessions) {
     if (s === main) continue;
-    const meta =
-      (s.agentPath ? main?.spawnedAgents.get(s.agentPath) : undefined) ??
-      main?.spawnedAgents.get(s.sessionId);
+    const meta = (s.agentPath ? spawned.get(s.agentPath) : undefined) ?? spawned.get(s.sessionId);
+    // Only a parent that is itself a child is passed on — the root is implied.
+    const parentAgentId =
+      s.parentThreadId && childIds.has(s.parentThreadId) ? s.parentThreadId : undefined;
     subagents.push({
       agentId: s.sessionId,
       agentType: meta?.agentType ?? s.agentRole ?? '',
       description: meta?.description ?? s.agentPath ?? '',
       toolUseId: meta?.toolUseId,
+      ...(parentAgentId ? { parentAgentId } : {}),
       events: s.events,
     });
   }

--- a/packages/server/src/connectors/codex/normalize.ts
+++ b/packages/server/src/connectors/codex/normalize.ts
@@ -63,6 +63,9 @@ export interface CodexSession {
   agentRole?: string;
   /** Current Codex's canonical task path from `thread_spawn.agent_path`. */
   agentPath?: string;
+  /** `thread_spawn.parent_thread_id` — the thread that made the spawning call.
+   *  Equals the root only at depth 1; deeper, it names another subagent. */
+  parentThreadId?: string;
   cwd: string;
   gitBranch?: string;
   /** `model_provider` from session_meta — session-level, applied to every
@@ -721,11 +724,13 @@ export function parseRollout(path: string): CodexSession | null {
   let isSidechain = false;
   let agentRole: string | undefined;
   let agentPath: string | undefined;
+  let parentThreadId: string | undefined;
   if (str(meta.thread_source) === 'subagent') {
     const spawn = rec(subagentSource.thread_spawn);
     const parentId = str(spawn.parent_thread_id);
     agentRole = str(spawn.agent_role) || undefined;
     agentPath = str(spawn.agent_path) || undefined;
+    parentThreadId = parentId || undefined;
     if (parentId) {
       isSidechain = true;
       indexSessionId = rootThreadId(parentId, getCodexContext().parents);
@@ -1013,6 +1018,7 @@ export function parseRollout(path: string): CodexSession | null {
     isSidechain,
     agentRole,
     agentPath,
+    parentThreadId,
     cwd,
     gitBranch,
     modelProvider,

--- a/packages/server/src/connectors/copilot/copilot.ts
+++ b/packages/server/src/connectors/copilot/copilot.ts
@@ -77,13 +77,17 @@ async function loadSession(_sessionId: string, paths: string[]): Promise<Session
     .map((p) => parseCopilotSession(p, { resolveImages: true }))
     .filter((s): s is CopilotSession => s !== null);
   const mainEvents = sessions.flatMap((s) => s.events);
-  // Inline subagent runs, segmented out by the normalizer — each anchors to its
-  // canonical `Task` block via the shared description string.
+  // Inline subagent runs, segmented out by the normalizer. `agentId` IS the
+  // spawning `task` toolCallId — the exact id of its canonical `Task` block —
+  // and `parentAgentId` names the run that made the call when a subagent
+  // spawned this one.
   const subagents: SubagentSource[] = sessions.flatMap((s) =>
     s.subagents.map((sub) => ({
       agentId: sub.agentId,
       agentType: sub.agentType,
       description: sub.description,
+      toolUseId: sub.agentId,
+      ...(sub.parentAgentId ? { parentAgentId: sub.parentAgentId } : {}),
       events: sub.events,
     })),
   );

--- a/packages/server/src/connectors/copilot/normalize.ts
+++ b/packages/server/src/connectors/copilot/normalize.ts
@@ -35,7 +35,13 @@
  *    event-level `agentId` (= the spawning `task` toolCallId). Tagged events are
  *    routed into per-agent buffers (never the main thread), the `task` call is
  *    canonicalized to a `Task` block, and each buffer becomes a `SubagentSource`
- *    nested at its spawn point (matched by description, see `buildSubagentRuns`).
+ *    nested at its spawn point — by that exact id, see `buildSubagentRuns`.
+ *    A subagent that spawns a subagent makes the call from its own stream, so
+ *    the inner run is segmented like any other and carries the outer agent as
+ *    its `parentAgentId`. Whether Copilot tags the inner run's events with the
+ *    inner or the outer `agentId` is UNVERIFIED — no real nested sample exists;
+ *    the flat per-agent map assumes the inner one (anything else collapses the
+ *    inner run into its parent's stream rather than mislabelling it).
  *
  * STRICTLY READ-ONLY with respect to ~/.copilot — files are only ever read.
  */
@@ -73,6 +79,9 @@ export interface CopilotSubagent {
   /** The `task` call's `arguments.description` — same string the canonical
    *  `Task` block carries, so the run anchors to its spawn point. */
   description: string;
+  /** agentId of the run whose stream carried the spawning `task` call, when a
+   *  subagent spawned this one; absent when the main thread did. */
+  parentAgentId?: string;
   events: CopilotThreadEvent[];
 }
 
@@ -283,8 +292,12 @@ export function parseCopilotSession(
   const knownAgentIds = new Set<string>();
   // `task` toolRequest descriptions by toolCallId — the Task block and its
   // SubagentSource must carry the SAME string (the anchor buildSubagentRuns
-  // matches on), so both sides read from this one map.
+  // matches on), so both sides read from this one map. The owner is the stream
+  // the spawning message ran in ('' = main thread): a subagent that spawns a
+  // subagent makes the call from inside its OWN stream, and the nested run
+  // needs that pointer to resolve against the right spawn point.
   const taskDescById = new Map<string, string>();
+  const taskOwnerById = new Map<string, string>();
   for (const ev of lines) {
     const d = rec(ev.data);
     if (str(ev.agentId)) knownAgentIds.add(str(ev.agentId));
@@ -294,6 +307,7 @@ export function parseCopilotSession(
         const tr = rec(r);
         if (str(tr.name) === 'task' && str(tr.toolCallId)) {
           taskDescById.set(str(tr.toolCallId), str(rec(tr.arguments).description));
+          taskOwnerById.set(str(tr.toolCallId), str(ev.agentId));
         }
       }
     } else if (ev.type === 'session.start') {
@@ -478,11 +492,13 @@ export function parseCopilotSession(
   const subagents: CopilotSubagent[] = [];
   for (const [agentId, s] of subStreams) {
     if (s.events.length === 0) continue; // spawned but produced nothing — no run to show
+    const owner = taskOwnerById.get(agentId) ?? '';
     subagents.push({
       agentId,
       agentType: agentMetaById.get(agentId)?.agentType ?? '',
       // '' when the spawning call is lost — renders detached, never mismatched.
       description: taskDescById.get(agentId) ?? '',
+      ...(owner && owner !== agentId ? { parentAgentId: owner } : {}),
       events: s.events,
     });
   }

--- a/packages/server/src/connectors/opencode/opencode.ts
+++ b/packages/server/src/connectors/opencode/opencode.ts
@@ -70,8 +70,10 @@ function auxProjections(filePath: string): AuxProjections {
 /**
  * Load a session's events, splitting the resolved synthetic files into the main
  * transcript (its id equals the session id) and one subagent per re-parented
- * task-spawned child. Children are labeled from the parent's `task` parts
- * (matched via `state.metadata.sessionId`) so each run anchors to its Task block.
+ * task-spawned child. Children are labeled from the spawning session's `task`
+ * parts (matched via `state.metadata.sessionId`) so each run anchors to its Task
+ * block — scanned across every resolved session, since a subagent that spawns a
+ * subagent holds the grandchild's `task` part in its OWN transcript.
  */
 async function loadSession(sessionId: string, paths: string[]): Promise<SessionData> {
   const sessions = [...paths]
@@ -84,7 +86,7 @@ async function loadSession(sessionId: string, paths: string[]): Promise<SessionD
 
   const main = sessions.filter((s) => s.id === sessionId);
   const mainEvents = main.flatMap(buildEvents);
-  const spawns = new Map(main.flatMap((s) => [...taskSpawns(s)]));
+  const spawns = new Map(sessions.flatMap((s) => [...taskSpawns(s)]));
   const subagents: SubagentSource[] = sessions
     .filter((s) => s.id !== sessionId)
     .map((s) => ({
@@ -94,6 +96,9 @@ async function loadSession(sessionId: string, paths: string[]): Promise<SessionD
       // own title; it renders detached rather than anchored, which is the
       // honest state, but at least carries a human-readable label.
       description: spawns.get(s.id)?.description || s.title,
+      // Only a spawning session that is itself a child is passed on — the root
+      // is implied, and it scopes matching to that run's own `task` calls.
+      ...(s.parentId && s.parentId !== sessionId ? { parentAgentId: s.parentId } : {}),
       events: buildEvents(s),
     }));
 

--- a/packages/server/src/data/parser.ts
+++ b/packages/server/src/data/parser.ts
@@ -259,6 +259,8 @@ function usageTokens(usage?: MessageUsage): number {
 interface SpawnPoint {
   toolUseId: string;
   spawnUuid: string;
+  /** agentId of the run whose thread holds the call; undefined = main thread. */
+  owner?: string;
   description?: string;
   subagentType?: string;
   prompt?: string;
@@ -268,8 +270,73 @@ interface SpawnPoint {
 interface WorkflowSpawn {
   toolUseId: string;
   spawnUuid: string;
+  owner?: string;
   /** Concatenated tool-result text — searched for the workflow run id. */
   resultText: string;
+}
+
+/** Collect the spawn points of one thread (the main thread or a run's). */
+function collectSpawns(
+  thread: ThreadItem[],
+  owner: string | undefined,
+  spawns: SpawnPoint[],
+  workflowSpawns: WorkflowSpawn[],
+): void {
+  for (const item of thread) {
+    for (const block of item.blocks) {
+      if (block.kind !== 'tool') continue;
+      if (SUBAGENT_TOOL_NAMES.has(block.name)) {
+        const input = (block.input ?? {}) as Record<string, unknown>;
+        spawns.push({
+          toolUseId: block.id,
+          spawnUuid: item.uuid,
+          owner,
+          description: typeof input.description === 'string' ? input.description : undefined,
+          subagentType: typeof input.subagent_type === 'string' ? input.subagent_type : undefined,
+          prompt: typeof input.prompt === 'string' ? input.prompt : undefined,
+          used: false,
+        });
+      } else if (block.name === 'Workflow') {
+        workflowSpawns.push({
+          toolUseId: block.id,
+          spawnUuid: item.uuid,
+          owner,
+          resultText: resultText(block),
+        });
+      }
+    }
+  }
+}
+
+/**
+ * Break parent cycles (A spawned in B's thread, B in A's) by unlinking the run
+ * whose pointer closes the cycle. Not producible by a real harness, but a
+ * corrupt or hand-edited id must never make a consumer walking
+ * `parentAgentId` chains loop forever — and a run whose chain merely passes
+ * through a cycle keeps its own link.
+ */
+function breakParentCycles(runs: SubagentRun[]): void {
+  const byId = new Map(runs.map((r) => [r.agentId, r]));
+  const settled = new Set<string>();
+  for (const start of runs) {
+    if (settled.has(start.agentId)) continue;
+    const path: SubagentRun[] = [];
+    const onPath = new Set<string>();
+    let cur: SubagentRun | undefined = start;
+    while (cur !== undefined && !settled.has(cur.agentId)) {
+      if (onPath.has(cur.agentId)) {
+        const closer = path[path.length - 1]!;
+        delete closer.parentAgentId;
+        delete closer.toolUseId;
+        delete closer.spawnUuid;
+        break;
+      }
+      onPath.add(cur.agentId);
+      path.push(cur);
+      cur = cur.parentAgentId !== undefined ? byId.get(cur.parentAgentId) : undefined;
+    }
+    for (const r of path) settled.add(r.agentId);
+  }
 }
 
 /** Plain text of a tool result's content blocks (for run-id matching). */
@@ -282,12 +349,18 @@ function resultText(tool: ToolInteraction): string {
 
 /**
  * Build {@link SubagentRun}s from the loaded subagent sources, correlating each
- * to the `Agent`/`Task` tool call in the main thread that spawned it.
+ * to the `Agent`/`Task` tool call that spawned it — in the main thread, or in
+ * another run's thread when a subagent spawned a subagent.
  *
- * Correlation key is the task description (+ subagent type as a tiebreaker),
- * which is unique per call in practice. Matching is intentionally strict: a
- * subagent that can't be confidently matched is returned WITHOUT a spawn link
- * (the UI lists it separately) rather than risk attaching it to the wrong call.
+ * Every run is assembled first so spawn points can be collected from all
+ * threads (a parent may be listed after its child). Matching order: the exact
+ * spawning id anywhere; else the task description (+ subagent type), which is
+ * unique per call in practice — searched only in the parent the source names,
+ * or, when it names none, only in the main thread, so a legacy nested run can
+ * never be pulled under a same-named call in some other run. Matching is
+ * intentionally strict: a subagent that can't be confidently matched is
+ * returned WITHOUT a spawn link (the UI lists it separately) rather than risk
+ * attaching it to the wrong call.
  */
 export function buildSubagentRuns(
   mainThread: ThreadItem[],
@@ -296,41 +369,43 @@ export function buildSubagentRuns(
 ): SubagentRun[] {
   const spawns: SpawnPoint[] = [];
   const workflowSpawns: WorkflowSpawn[] = [];
-  for (const item of mainThread) {
-    for (const block of item.blocks) {
-      if (block.kind !== 'tool') continue;
-      if (SUBAGENT_TOOL_NAMES.has(block.name)) {
-        const input = (block.input ?? {}) as Record<string, unknown>;
-        spawns.push({
-          toolUseId: block.id,
-          spawnUuid: item.uuid,
-          description: typeof input.description === 'string' ? input.description : undefined,
-          subagentType: typeof input.subagent_type === 'string' ? input.subagent_type : undefined,
-          prompt: typeof input.prompt === 'string' ? input.prompt : undefined,
-          used: false,
-        });
-      } else if (block.name === 'Workflow') {
-        workflowSpawns.push({
-          toolUseId: block.id,
-          spawnUuid: item.uuid,
-          resultText: resultText(block),
-        });
-      }
-    }
-  }
+  collectSpawns(mainThread, undefined, spawns, workflowSpawns);
 
-  const runs: SubagentRun[] = [];
-  for (const src of sources) {
+  const assembled = sources.map((src) => {
     const thread = assembleThread(src.events, opts);
     const toolCallCount = thread.reduce(
       (n, t) => n + t.blocks.filter((b) => b.kind === 'tool').length,
       0,
     );
     const totalTokens = thread.reduce((n, t) => n + usageTokens(t.usage), 0);
+    return { src, thread, toolCallCount, totalTokens };
+  });
+  const runIds = new Set(sources.map((s) => s.agentId));
+  for (const a of assembled) collectSpawns(a.thread, a.src.agentId, spawns, workflowSpawns);
 
-    let match: { toolUseId: string; spawnUuid: string } | undefined;
+  const runs: SubagentRun[] = [];
+  for (const { src, thread, toolCallCount, totalTokens } of assembled) {
+    // A named parent narrows description matching to that run's own calls. An
+    // unknown or self-referential parent is ignored, not trusted.
+    const parent =
+      src.parentAgentId && src.parentAgentId !== src.agentId && runIds.has(src.parentAgentId)
+        ? src.parentAgentId
+        : undefined;
+    const inScope = (s: { owner?: string }): boolean =>
+      parent !== undefined ? s.owner === parent : s.owner === undefined;
+
+    let match: { toolUseId: string; spawnUuid: string; owner?: string } | undefined;
+    // The exact id wins — except in the run's own thread, and, when the source
+    // names its parent, never inside some unrelated run (a colliding id would
+    // otherwise re-parent the run to wherever that id happens to live).
     const directSpawn = src.toolUseId
-      ? spawns.find((s) => !s.used && s.toolUseId === src.toolUseId)
+      ? spawns.find(
+          (s) =>
+            !s.used &&
+            s.toolUseId === src.toolUseId &&
+            s.owner !== src.agentId &&
+            (parent === undefined || s.owner === parent || s.owner === undefined),
+        )
       : undefined;
     if (directSpawn) {
       directSpawn.used = true;
@@ -338,7 +413,9 @@ export function buildSubagentRuns(
     } else if (src.workflowId) {
       // Workflow agents: link all of a run's agents to the Workflow tool call
       // whose result references the run id (a one-to-many spawn; not consumed).
-      match = workflowSpawns.find((w) => w.resultText.includes(src.workflowId as string));
+      match = workflowSpawns.find(
+        (w) => inScope(w) && w.resultText.includes(src.workflowId as string),
+      );
     } else {
       // Agent/Task: match description (+ type), earliest unused. Require a
       // non-empty description so missing-meta agents never match by emptiness.
@@ -348,9 +425,10 @@ export function buildSubagentRuns(
           spawns.find(
             (s) =>
               !s.used &&
+              inScope(s) &&
               s.description === src.description &&
               (!s.subagentType || !src.agentType || s.subagentType === src.agentType),
-          ) ?? spawns.find((s) => !s.used && s.description === src.description);
+          ) ?? spawns.find((s) => !s.used && inScope(s) && s.description === src.description);
         if (sp) {
           sp.used = true;
           match = sp;
@@ -364,6 +442,7 @@ export function buildSubagentRuns(
         const promptMatches = spawns.filter(
           (s) =>
             !s.used &&
+            inScope(s) &&
             s.prompt === src.prompt &&
             (!s.subagentType || !src.agentType || s.subagentType === src.agentType),
         );
@@ -390,10 +469,12 @@ export function buildSubagentRuns(
     if (match) {
       run.toolUseId = match.toolUseId;
       run.spawnUuid = match.spawnUuid;
+      if (match.owner !== undefined) run.parentAgentId = match.owner;
     }
     runs.push(run);
   }
 
+  breakParentCycles(runs);
   return runs;
 }
 

--- a/packages/server/src/data/session-loader.ts
+++ b/packages/server/src/data/session-loader.ts
@@ -21,6 +21,12 @@ export interface SubagentSource {
   slug?: string;
   /** Exact id of the Agent/Task call that spawned this run, when known. */
   toolUseId?: string;
+  /**
+   * agentId of the subagent that spawned this run, when the source records it
+   * (a subagent spawned by a subagent). Narrows description matching to that
+   * run's own calls; without it, description matching stays main-thread only.
+   */
+  parentAgentId?: string;
   /** Full first user prompt, retained for guarded exact-match correlation. */
   prompt?: string;
   /**

--- a/packages/server/src/data/window.ts
+++ b/packages/server/src/data/window.ts
@@ -37,6 +37,9 @@ export const DEFAULT_RADIUS = 10;
  *
  * `tail` returns the last N items, clamped to the thread.
  */
+/** Bound on parent-chain walks; real chains are a few hops deep. */
+const MAX_PARENT_HOPS = 32;
+
 export function resolveWindow(
   thread: ThreadItem[],
   subagents: SubagentRun[],
@@ -49,11 +52,20 @@ export function resolveWindow(
     let idx = thread.findIndex((t) => t.uuid === params.around);
     let anchorFound = idx >= 0;
     if (!anchorFound) {
-      // The uuid may belong to a subagent turn — anchor on its spawn point.
-      const run = subagents.find((r) => r.thread.some((t) => t.uuid === params.around));
-      if (run?.spawnUuid) {
-        idx = thread.findIndex((t) => t.uuid === run.spawnUuid);
-        anchorFound = idx >= 0;
+      // The uuid may belong to a subagent turn — anchor on its spawn point. A
+      // nested run's spawn turn is inside its PARENT's thread, so walk the
+      // parent chain until a spawn turn lands in the main thread (chains are
+      // acyclic, see parser.ts:breakParentCycles; the cap is belt and braces).
+      let run = subagents.find((r) => r.thread.some((t) => t.uuid === params.around));
+      for (let hop = 0; run?.spawnUuid !== undefined && hop < MAX_PARENT_HOPS; hop++) {
+        const spawnUuid = run.spawnUuid;
+        idx = thread.findIndex((t) => t.uuid === spawnUuid);
+        if (idx >= 0) {
+          anchorFound = true;
+          break;
+        }
+        const parentId = run.parentAgentId;
+        run = parentId !== undefined ? subagents.find((r) => r.agentId === parentId) : undefined;
       }
     }
     const start = anchorFound ? Math.max(0, idx - radius) : 0;
@@ -73,12 +85,30 @@ export function resolveWindow(
 
 /**
  * Subagent runs visible from a thread slice: those whose spawn turn
- * (`spawnUuid`) is inside it. Runs that never correlated to a spawn point have
- * no anchor to window against and are dropped from windowed responses.
+ * (`spawnUuid`) is inside it, plus — transitively — the runs they spawned, whose
+ * spawn turn sits in a run's thread rather than in the slice. Runs that never
+ * correlated to a spawn point have no anchor to window against and are
+ * dropped from windowed responses.
  */
 export function subagentsInWindow(slice: ThreadItem[], subagents: SubagentRun[]): SubagentRun[] {
   const uuids = new Set(slice.map((t) => t.uuid));
-  return subagents.filter((r) => r.spawnUuid !== undefined && uuids.has(r.spawnUuid));
+  const included = new Set<string>();
+  for (const r of subagents) {
+    if (r.spawnUuid !== undefined && uuids.has(r.spawnUuid)) included.add(r.agentId);
+  }
+  // Parent chains are acyclic (see parser.ts:breakParentCycles), so this
+  // terminates within `subagents.length` passes.
+  let grew = true;
+  while (grew) {
+    grew = false;
+    for (const r of subagents) {
+      if (!included.has(r.agentId) && r.parentAgentId !== undefined && included.has(r.parentAgentId)) {
+        included.add(r.agentId);
+        grew = true;
+      }
+    }
+  }
+  return subagents.filter((r) => included.has(r.agentId));
 }
 
 function truncateBlock(block: ThreadBlock, max: number): ThreadBlock {

--- a/packages/server/test/antigravity.integration.test.ts
+++ b/packages/server/test/antigravity.integration.test.ts
@@ -49,6 +49,8 @@ process.env.REINDEX_INTERVAL_MS = '0';
 const PARENT = '11111111-1111-1111-1111-111111111111';
 const CHILD = '22222222-2222-2222-2222-222222222222';
 const ORPHAN = '33333333-3333-3333-3333-333333333333';
+/** A subagent of the subagent: linked from the CHILD's transcript, not the root's. */
+const GRANDCHILD = '44444444-4444-4444-4444-444444444444';
 const IMG_NAME = 'uploaded_media_0_1782909688549.png';
 const IMG_ABS = join(cliDir, 'brain', PARENT, IMG_NAME);
 // A poisoned upload: textually inside the conversation dir, but a symlink whose
@@ -176,13 +178,41 @@ function writeFixtures(): void {
       tool_calls: [{ name: 'view_file', args: { AbsolutePath: '', Path: '/tmp/proj/a/README.md' } }],
     }),
     step(2, 'MODEL', 'VIEW_FILE', { content: 'File Path: `file:///tmp/proj/a/README.md`\n# A' }),
+    // The subagent spawns one of its own: the prompt (and so the description the
+    // grandchild is matched by) exists ONLY in this transcript.
     step(3, 'MODEL', 'PLANNER_RESPONSE', {
+      content: 'Delegating the manifest read.',
+      tool_calls: [
+        {
+          name: 'invoke_subagent',
+          args: {
+            Subagents: [
+              { Prompt: 'Read the manifest in /tmp/proj.', Role: 'Reader', TypeName: 'read', Workspace: 'inherit' },
+            ],
+            toolAction: 'Invoke',
+            toolSummary: 'Invoke',
+          },
+        },
+      ],
+    }),
+    step(4, 'MODEL', 'PLANNER_RESPONSE', {
+      content: `I have started the \`read\` subagent (Conversation ID: \`${GRANDCHILD}\`) to read the manifest.`,
+    }),
+    step(5, 'MODEL', 'PLANNER_RESPONSE', {
       content: 'Reporting back.',
       tool_calls: [
         { name: 'send_message', args: { ConversationId: PARENT, Message: '### Workspace Summary\nProjects found: 3.' } },
       ],
     }),
-    step(4, 'MODEL', 'GENERIC', { content: `Message sent to "${PARENT}".` }),
+    step(6, 'MODEL', 'GENERIC', { content: `Message sent to "${PARENT}".` }),
+  ]);
+
+  // Grandchild: its own conversation, linked only from the CHILD's transcript.
+  writeTranscript(GRANDCHILD, [
+    step(0, 'USER_EXPLICIT', 'USER_INPUT', {
+      content: '<USER_REQUEST>\nRead the manifest in /tmp/proj.\n</USER_REQUEST>',
+    }),
+    step(1, 'MODEL', 'PLANNER_RESPONSE', { content: 'The platypusmanifest lists 3 packages.' }),
   ]);
 
   // Orphan: a top-level conversation with NO history entry → unknown-cwd bucket.
@@ -306,8 +336,8 @@ describe('antigravity session indexing', () => {
 describe('antigravity session detail', () => {
   it('nests the subagent under its invoke_subagent (Task) call', async () => {
     const detail = (await get(`/api/sessions/${PARENT}`)).json();
-    expect(detail.subagents).toHaveLength(1);
-    const run = detail.subagents[0];
+    expect(detail.subagents).toHaveLength(2);
+    const run = detail.subagents.find((r: { agentId: string }) => r.agentId === CHILD);
     expect(run.agentType).toBe('research');
     expect(run.description).toBe('Inspect all subdirectories inside /tmp/proj.');
     expect(run.thread.length).toBeGreaterThan(0);
@@ -323,6 +353,32 @@ describe('antigravity session detail', () => {
     const task = flat.find((b: Record<string, unknown>) => b.kind === 'tool' && b.name === 'Task');
     expect(task).toBeTruthy();
     expect(run.toolUseId).toBe(task.id);
+    expect(run.parentAgentId).toBeUndefined(); // spawned by the root conversation
+  });
+
+  it('nests a subagent of the subagent under the call in its parent run', async () => {
+    const detail = (await get(`/api/sessions/${PARENT}`)).json();
+    const child = detail.subagents.find((r: { agentId: string }) => r.agentId === CHILD);
+    // The spawning `invoke_subagent` → Task lives in the CHILD's thread, and its
+    // description exists nowhere else — only the parent pointer scopes the match
+    // there instead of the root's (differently described) Task call.
+    const innerTask = child.thread
+      .flatMap((t: { blocks: Record<string, unknown>[] }) => t.blocks)
+      .find((b: Record<string, unknown>) => b.kind === 'tool' && b.name === 'Task');
+    expect(innerTask.input).toMatchObject({
+      description: 'Read the manifest in /tmp/proj.',
+      subagent_type: 'read',
+    });
+
+    const grandchild = detail.subagents.find((r: { agentId: string }) => r.agentId === GRANDCHILD);
+    expect(grandchild).toMatchObject({
+      agentType: 'read',
+      description: 'Read the manifest in /tmp/proj.',
+      toolUseId: innerTask.id,
+      parentAgentId: CHILD,
+    });
+    expect(JSON.stringify(grandchild.thread)).toContain('platypusmanifest');
+    expect(JSON.stringify(detail.thread)).not.toContain('platypusmanifest');
   });
 
   it('renders plaintext thinking, a canonical Write, a synthesized Read, and the image', async () => {

--- a/packages/server/test/cli-query.test.ts
+++ b/packages/server/test/cli-query.test.ts
@@ -62,6 +62,44 @@ function writeFixtures(): void {
       { ...base2, type: 'assistant', uuid: 'q2a1', parentUuid: 'q2u1', timestamp: '2026-01-03T09:00:04.000Z', isSidechain: false, message: { role: 'assistant', model: 'claude-opus-4-8', content: [{ type: 'text', text: 'ok' }, { type: 'tool_use', id: 't1', name: 'Bash', input: {} }], usage } },
     ]),
   );
+
+  // Session 3: a subagent spawning a subagent — `session --redact`/plain
+  // Markdown must nest the grandchild under its parent, not the main thread.
+  // Kept in its own project so it doesn't shift the `/tmp/projQ`-scoped
+  // assertions above.
+  const projN = join(projectsDir, 'enc-projN');
+  const subN = join(projN, 'sessN', 'subagents');
+  mkdirSync(subN, { recursive: true });
+  const baseN = { sessionId: 'sessN', cwd: '/tmp/projN', gitBranch: 'main', version: '2.1.0' };
+  writeFileSync(
+    join(projN, 'sessN.jsonl'),
+    jsonl([
+      { type: 'ai-title', sessionId: 'sessN', aiTitle: 'Nested subagent session' },
+      { ...baseN, type: 'user', uuid: 'n-u1', parentUuid: null, timestamp: '2026-01-04T10:00:00.000Z', isSidechain: false, message: { role: 'user', content: 'go explore' } },
+      { ...baseN, type: 'assistant', uuid: 'n-a1', parentUuid: 'n-u1', timestamp: '2026-01-04T10:00:05.000Z', isSidechain: false, message: { role: 'assistant', model: 'claude-opus-4-8', content: [{ type: 'tool_use', id: 'tu_outer', name: 'Agent', input: { description: 'Outer explore', subagent_type: 'Explore', prompt: 'explore outer' } }], usage } },
+      { ...baseN, type: 'user', uuid: 'n-u2', parentUuid: 'n-a1', timestamp: '2026-01-04T10:01:00.000Z', isSidechain: false, message: { role: 'user', content: [{ type: 'tool_result', tool_use_id: 'tu_outer', content: 'outer done' }] } },
+    ]),
+  );
+  const subBaseN = { sessionId: 'sessN', cwd: '/tmp/projN', isSidechain: true };
+  writeFileSync(
+    join(subN, 'agent-outer.jsonl'),
+    jsonl([
+      { ...subBaseN, type: 'user', uuid: 'so-u1', parentUuid: null, agentId: 'outer', timestamp: '2026-01-04T10:00:10.000Z', message: { role: 'user', content: 'explore outer' } },
+      { ...subBaseN, type: 'assistant', uuid: 'so-a1', parentUuid: 'so-u1', agentId: 'outer', timestamp: '2026-01-04T10:00:20.000Z', message: { role: 'assistant', model: 'claude-opus-4-8', content: [{ type: 'tool_use', id: 'tu_inner', name: 'Agent', input: { description: 'Inner probe', subagent_type: 'general-purpose', prompt: 'probe inner' } }], usage } },
+    ]),
+  );
+  writeFileSync(join(subN, 'agent-outer.meta.json'), JSON.stringify({ agentType: 'Explore', description: 'Outer explore', toolUseId: 'tu_outer' }));
+  writeFileSync(
+    join(subN, 'agent-inner.jsonl'),
+    jsonl([
+      { ...subBaseN, type: 'user', uuid: 'si-u1', parentUuid: null, agentId: 'inner', timestamp: '2026-01-04T10:00:25.000Z', message: { role: 'user', content: 'probe inner' } },
+      { ...subBaseN, type: 'assistant', uuid: 'si-a1', parentUuid: 'si-u1', agentId: 'inner', timestamp: '2026-01-04T10:00:30.000Z', message: { role: 'assistant', model: 'claude-opus-4-8', content: [{ type: 'text', text: 'probed' }], usage } },
+    ]),
+  );
+  writeFileSync(
+    join(subN, 'agent-inner.meta.json'),
+    JSON.stringify({ agentType: 'general-purpose', description: 'Inner probe', toolUseId: 'tu_inner', parentAgentId: 'outer' }),
+  );
 }
 
 let app: FastifyInstance;
@@ -119,7 +157,7 @@ describe('cli query subcommands', () => {
   it('sessions --json returns the raw rows', async () => {
     const out = await query.querySessions(client, { json: true });
     const rows = JSON.parse(out) as SessionMeta[];
-    expect(rows.map((r) => r.id).sort()).toEqual(['sessQ1', 'sessQ2']);
+    expect(rows.map((r) => r.id).sort()).toEqual(['sessN', 'sessQ1', 'sessQ2']);
     expect(rows[0]).toHaveProperty('totalCostUsd');
   });
 
@@ -151,6 +189,13 @@ describe('cli query subcommands', () => {
     const raw = JSON.parse(await query.querySession(client, 'sessQ1', { redact: true, json: true })) as SessionDetailResponse;
     expect(raw.window).toMatchObject({ offset: 0 });
     expect(JSON.stringify(raw)).toContain('/Users/testuser/secret/needle.txt');
+  });
+
+  it('session nests a subagent-spawned subagent under its parent, depth-first', async () => {
+    const out = await query.querySession(client, 'sessN', {});
+    expect(out).toContain('--- subagent · Explore — Outer explore ---');
+    expect(out).toContain('--- subagent · general-purpose — Inner probe · nested in Outer explore ---');
+    expect(out.indexOf('Outer explore')).toBeLessThan(out.indexOf('Inner probe'));
   });
 
   it('analytics renders rows plus a totals line', async () => {

--- a/packages/server/test/codex.integration.test.ts
+++ b/packages/server/test/codex.integration.test.ts
@@ -178,9 +178,14 @@ function writeChildRollout(): string {
       { type: 'session_meta', timestamp: ts(30), payload: { id: '019f2222-aaaa-7bbb-8ccc-000000000001', cwd: '/tmp/codexproj', thread_source: 'subagent', source: { subagent: { thread_spawn: { parent_thread_id: 'codex-sess-1', depth: 1, agent_nickname: 'Linnaeus', agent_role: 'explorer' } } }, git: { branch: 'main' } } },
       { type: 'turn_context', timestamp: ts(31), payload: { model: 'gpt-5.4' } },
       { type: 'response_item', timestamp: ts(32), payload: { type: 'message', role: 'user', content: [{ type: 'input_text', text: 'Scan the repo for issues.' }] } },
-      { type: 'response_item', timestamp: ts(33), payload: { type: 'message', role: 'assistant', content: [{ type: 'output_text', text: 'zebranugget report from the child' }] } },
+      // This child spawns a child of its own in the LEGACY form: the output names
+      // the grandchild thread id, and the readable label exists ONLY here — the
+      // root's spawn map knows nothing about it.
+      { type: 'response_item', timestamp: ts(33), payload: { type: 'function_call', name: 'spawn_agent', arguments: '{"agent_type":"summarizer","message":"Tally the findings.\\nBe brief."}', call_id: 'call_spawn3' } },
+      { type: 'response_item', timestamp: ts(34), payload: { type: 'function_call_output', call_id: 'call_spawn3', output: '{"agent_id":"019f2222-aaaa-7bbb-8ccc-000000000004","nickname":"Tallier"}' } },
+      { type: 'response_item', timestamp: ts(35), payload: { type: 'message', role: 'assistant', content: [{ type: 'output_text', text: 'zebranugget report from the child' }] } },
       // Child usage folds into the parent session's totals (claude-code precedent).
-      { type: 'event_msg', timestamp: ts(34), payload: { type: 'token_count', info: { last_token_usage: { input_tokens: 100, cached_input_tokens: 0, output_tokens: 50 } }, rate_limits: {} } },
+      { type: 'event_msg', timestamp: ts(36), payload: { type: 'token_count', info: { last_token_usage: { input_tokens: 100, cached_input_tokens: 0, output_tokens: 50 } }, rate_limits: {} } },
     ]),
   );
   return file;
@@ -197,7 +202,48 @@ function writeCurrentChildRollout(): string {
       { type: 'session_meta', timestamp: ts(35), payload: { id: '019f2222-aaaa-7bbb-8ccc-000000000002', cwd: '/tmp/codexproj', thread_source: 'subagent', source: { subagent: { thread_spawn: { parent_thread_id: 'codex-sess-1', depth: 1, agent_path: '/root/locate_analytics_range', agent_nickname: 'Cartographer', agent_role: 'context_explorer' } } }, git: { branch: 'main' } } },
       { type: 'turn_context', timestamp: ts(36), payload: { model: 'gpt-5.4' } },
       { type: 'response_item', timestamp: ts(37), payload: { type: 'message', role: 'user', content: [{ type: 'input_text', text: 'copied parent context, not the task label' }] } },
-      { type: 'response_item', timestamp: ts(38), payload: { type: 'message', role: 'assistant', content: [{ type: 'output_text', text: 'current-format child report' }] } },
+      // This child spawns a child of its own: the spawn record lives HERE, not in
+      // the root rollout, so only a merged spawn map can resolve the grandchild.
+      { type: 'response_item', timestamp: ts(38), payload: { type: 'function_call', name: 'spawn_agent', namespace: 'collaboration', arguments: '{"agent_type":"summarizer","message":"Summarize what you found.","task_name":"summarize_findings"}', call_id: 'call_spawn4' } },
+      { type: 'response_item', timestamp: ts(39), payload: { type: 'function_call_output', call_id: 'call_spawn4', output: '{"task_name":"/root/locate_analytics_range/summarize_findings"}' } },
+      { type: 'response_item', timestamp: ts(40), payload: { type: 'message', role: 'assistant', content: [{ type: 'output_text', text: 'current-format child report' }] } },
+    ]),
+  );
+  return file;
+}
+
+/** A DEPTH-2 rollout: `parent_thread_id` names the depth-1 child above, and its
+ *  `agent_path` extends that child's canonical path. */
+function writeGrandchildRollout(): string {
+  const dir = join(codexDir, '2026', '01', '01');
+  mkdirSync(dir, { recursive: true });
+  const file = join(dir, 'rollout-2026-01-01T10-03-00-019f2222-aaaa-7bbb-8ccc-000000000003.jsonl');
+  writeFileSync(
+    file,
+    jsonl([
+      { type: 'session_meta', timestamp: ts(41), payload: { id: '019f2222-aaaa-7bbb-8ccc-000000000003', cwd: '/tmp/codexproj', thread_source: 'subagent', source: { subagent: { thread_spawn: { parent_thread_id: '019f2222-aaaa-7bbb-8ccc-000000000002', depth: 2, agent_path: '/root/locate_analytics_range/summarize_findings', agent_nickname: 'Chronicler', agent_role: 'summarizer' } } }, git: { branch: 'main' } } },
+      { type: 'turn_context', timestamp: ts(42), payload: { model: 'gpt-5.4' } },
+      { type: 'response_item', timestamp: ts(43), payload: { type: 'message', role: 'user', content: [{ type: 'input_text', text: 'Summarize what you found.' }] } },
+      { type: 'response_item', timestamp: ts(44), payload: { type: 'message', role: 'assistant', content: [{ type: 'output_text', text: 'quokkaline grandchild summary' }] } },
+    ]),
+  );
+  return file;
+}
+
+/** A DEPTH-2 rollout under the LEGACY child: it has no `agent_path`, so its
+ *  whole identity (label, type, spawning id) comes from a spawn record that
+ *  exists only in the depth-1 child's rollout. */
+function writeLegacyGrandchildRollout(): string {
+  const dir = join(codexDir, '2026', '01', '01');
+  mkdirSync(dir, { recursive: true });
+  const file = join(dir, 'rollout-2026-01-01T10-04-00-019f2222-aaaa-7bbb-8ccc-000000000004.jsonl');
+  writeFileSync(
+    file,
+    jsonl([
+      { type: 'session_meta', timestamp: ts(45), payload: { id: '019f2222-aaaa-7bbb-8ccc-000000000004', cwd: '/tmp/codexproj', thread_source: 'subagent', source: { subagent: { thread_spawn: { parent_thread_id: '019f2222-aaaa-7bbb-8ccc-000000000001', depth: 2, agent_nickname: 'Tallier', agent_role: 'summarizer' } } }, git: { branch: 'main' } } },
+      { type: 'turn_context', timestamp: ts(46), payload: { model: 'gpt-5.4' } },
+      { type: 'response_item', timestamp: ts(47), payload: { type: 'message', role: 'user', content: [{ type: 'input_text', text: 'Tally the findings.' }] } },
+      { type: 'response_item', timestamp: ts(48), payload: { type: 'message', role: 'assistant', content: [{ type: 'output_text', text: 'wombatcount tally from the grandchild' }] } },
     ]),
   );
   return file;
@@ -340,6 +386,8 @@ beforeAll(async () => {
   writeRollout();
   writeChildRollout();
   writeCurrentChildRollout();
+  writeGrandchildRollout();
+  writeLegacyGrandchildRollout();
   writeOrphanRollout();
   writeLocalRollout();
   writeBootstrapOnlyRollout();
@@ -535,7 +583,7 @@ describe('Codex session detail', () => {
       subagent_type: 'explorer',
     });
 
-    expect(detail.subagents).toHaveLength(2);
+    expect(detail.subagents).toHaveLength(4);
     const run = detail.subagents.find(
       (candidate: { agentId: string }) => candidate.agentId === '019f2222-aaaa-7bbb-8ccc-000000000001',
     );
@@ -570,6 +618,46 @@ describe('Codex session detail', () => {
       toolUseId: 'call_spawn2',
     });
     expect(JSON.stringify(currentRun.thread)).toContain('current-format child report');
+  });
+
+  it('nests depth-2 rollouts at the spawn call inside their depth-1 child', async () => {
+    const detail = (await get('/api/sessions/codex-sess-1')).json();
+    const runOf = (id: string) =>
+      detail.subagents.find((candidate: { agentId: string }) => candidate.agentId === id);
+    /** uuid of the turn in `run`'s thread carrying the tool call `callId`. */
+    const spawnUuidIn = (run: { thread: { uuid: string; blocks: { id?: string }[] }[] }, callId: string) =>
+      run.thread.find((t) => t.blocks.some((b) => b.id === callId))?.uuid;
+
+    // Both spawn records live in a CHILD's rollout — invisible to the root's own
+    // spawn map — and `parent_thread_id` names that child, not the root.
+    const current = runOf('019f2222-aaaa-7bbb-8ccc-000000000003');
+    expect(current).toMatchObject({
+      agentType: 'summarizer',
+      description: '/root/locate_analytics_range/summarize_findings',
+      toolUseId: 'call_spawn4',
+      parentAgentId: '019f2222-aaaa-7bbb-8ccc-000000000002',
+    });
+    expect(current.spawnUuid).toBe(
+      spawnUuidIn(runOf('019f2222-aaaa-7bbb-8ccc-000000000002'), 'call_spawn4'),
+    );
+
+    // The legacy form has no `agent_path`: label, type and id come only from the
+    // depth-1 child's `agent_id` spawn record.
+    const legacy = runOf('019f2222-aaaa-7bbb-8ccc-000000000004');
+    expect(legacy).toMatchObject({
+      agentType: 'summarizer',
+      description: 'Tally the findings.',
+      toolUseId: 'call_spawn3',
+      parentAgentId: '019f2222-aaaa-7bbb-8ccc-000000000001',
+    });
+    expect(legacy.spawnUuid).toBe(
+      spawnUuidIn(runOf('019f2222-aaaa-7bbb-8ccc-000000000001'), 'call_spawn3'),
+    );
+
+    // Neither grandchild's turns leak into the main transcript.
+    const main = JSON.stringify(detail.thread);
+    expect(main).not.toContain('quokkaline grandchild summary');
+    expect(main).not.toContain('wombatcount tally from the grandchild');
   });
 
   it('fans apply_patch out to canonical Write/Edit blocks the changeset keys off', async () => {

--- a/packages/server/test/copilot.integration.test.ts
+++ b/packages/server/test/copilot.integration.test.ts
@@ -186,6 +186,20 @@ function writeSession3(): void {
     // The subagent run compacts: the marker belongs to ITS stream, not the main one.
     sub(ev('session.context_changed', { reason: 'compaction' }), 'call-task'),
     sub(ev('assistant.message', { model: 'gpt-5-mini', content: 'resumed the zebrafinder scan' }), 'call-task'),
+    // The subagent spawns a subagent: the `task` call is made from ITS stream, so
+    // the inner Task block belongs to the outer run and the inner events open a
+    // stream of their own.
+    sub(ev('assistant.message', {
+      model: 'gpt-5-mini',
+      content: 'Delegating the manifest read.',
+      toolRequests: [
+        { toolCallId: 'call-inner', name: 'task', arguments: { description: 'Read the manifest', prompt: 'Read package.json and report.' } },
+      ],
+    }), 'call-task'),
+    sub(ev('subagent.started', { toolCallId: 'call-inner', agentName: 'read', agentDisplayName: 'Read Agent', model: 'gpt-5-mini' }), 'call-task'),
+    sub(ev('assistant.message', { model: 'gpt-5-mini', content: 'the narwhalmanifest names src/index.ts' }), 'call-inner'),
+    sub(ev('subagent.completed', { toolCallId: 'call-inner', agentName: 'read' }), 'call-task'),
+    sub(ev('tool.execution_complete', { toolCallId: 'call-inner', success: true, result: { content: 'The manifest names src/index.ts.' } }), 'call-task'),
     sub(ev('subagent.completed', { toolCallId: 'call-task', agentName: 'explore' }), 'call-task'),
     ev('tool.execution_complete', { toolCallId: 'call-task', success: true, result: { content: 'Entry point is src/index.ts.' } }),
     // A tagged turn with no subagent.started — tolerated as a detached run.
@@ -352,15 +366,44 @@ describe('copilot subagent embedding', () => {
 
     // The run is anchored to that Task block and carries the subagent's turns.
     const runs: Run[] = detail.subagents;
-    expect(runs).toHaveLength(2);
+    expect(runs).toHaveLength(3);
     const run = runs.find((r) => r.agentType === 'explore');
     expect(run).toMatchObject({ description: 'Inspect entry point', toolUseId: task.id });
+    expect(run.parentAgentId).toBeUndefined(); // spawned from the main thread
     expect(run.spawnUuid).toBeTruthy();
     expect(JSON.stringify(run.thread)).toContain('zebrafinder');
     const runBlocks: Block[] = run.thread.flatMap((t: { blocks: Block[] }) => t.blocks);
     const view = runBlocks.find((b) => b.kind === 'tool' && b.name === 'Read');
     expect(view.input.file_path).toBe('/tmp/cproj/package.json');
     expect(JSON.stringify(view.result.content)).toContain('src/index.ts');
+  });
+
+  it('nests a subagent spawned by a subagent under the inner Task call', async () => {
+    const detail = (await get('/api/sessions/copilot-sess-3')).json();
+    const outer = detail.subagents.find((r: Run) => r.agentId === 'call-task');
+    const outerBlocks: Block[] = outer.thread.flatMap((t: { blocks: Block[] }) => t.blocks);
+
+    // The inner `task` call is canonicalized inside the OUTER run's thread, and
+    // the main thread never sees it.
+    const innerTask = outerBlocks.find((b) => b.kind === 'tool' && b.name === 'Task');
+    expect(innerTask).toMatchObject({ id: 'call-inner' });
+    expect(innerTask.input).toMatchObject({ description: 'Read the manifest', subagent_type: 'read' });
+    expect(JSON.stringify(detail.thread)).not.toContain('narwhalmanifest');
+
+    // `agentId` IS the spawning toolCallId, so the run anchors by exact id and
+    // reports the outer run as its parent.
+    const inner = detail.subagents.find((r: Run) => r.agentId === 'call-inner');
+    expect(inner).toMatchObject({
+      agentType: 'read',
+      description: 'Read the manifest',
+      toolUseId: 'call-inner',
+      parentAgentId: 'call-task',
+    });
+    const spawnTurn = outer.thread.find((t: { blocks: Block[] }) =>
+      t.blocks.some((b: Block) => b.id === 'call-inner'),
+    );
+    expect(inner.spawnUuid).toBe(spawnTurn.uuid);
+    expect(JSON.stringify(inner.thread)).toContain('narwhalmanifest');
   });
 
   it('tolerates a tagged turn with no subagent.started as a detached run', async () => {

--- a/packages/server/test/nested-subagents.integration.test.ts
+++ b/packages/server/test/nested-subagents.integration.test.ts
@@ -1,0 +1,282 @@
+/**
+ * Nested subagents (a subagent that spawns a subagent) — Claude Code.
+ *
+ * Depth-2 runs are SIBLING files in the same `<session>/subagents/` dir; only
+ * the metadata says otherwise (`toolUseId` names an `Agent` call inside the
+ * depth-1 transcript, `parentAgentId` names the depth-1 run). A synthetic
+ * projects tree is indexed into a throwaway DuckDB and read back through the
+ * real session route, because the edges here span the connector, the matcher
+ * and the windowing:
+ *
+ *  1. the exact spawning id resolves against a call in ANOTHER run's thread,
+ *     even though the child file sorts (and is therefore matched) BEFORE it;
+ *  2. the same-description trap: a depth-2 run whose description equals an
+ *     unused MAIN-thread call must follow its named parent, not the main call;
+ *  3. legacy metadata (no ids) stays main-thread-scoped, so it goes unlinked
+ *     rather than stealing a call from another run;
+ *  4. a window around the main spawn turn carries the whole descendant chain,
+ *     and a window elsewhere carries none of it.
+ */
+
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import type { FastifyInstance } from 'fastify';
+
+const work = mkdtempSync(join(tmpdir(), 'claudescope-nested-'));
+const projectsDir = join(work, 'projects');
+
+process.env.CLAUDE_PROJECTS_DIR = projectsDir;
+for (const v of [
+  'CODEX_SESSIONS_DIR',
+  'JUNIE_SESSIONS_DIR',
+  'PI_SESSIONS_DIR',
+  'OPENCODE_DATA_DIR',
+  'COPILOT_SESSIONS_DIR',
+  'ANTIGRAVITY_CLI_DIR',
+  'ANTIGRAVITY_DIR',
+  'GROK_SESSIONS_DIR',
+]) {
+  process.env[v] = join(work, `${v.toLowerCase()}-empty`);
+}
+process.env.DUCKDB_PATH = join(work, 'index.duckdb');
+process.env.CLAUDESCOPE_HOME = join(work, 'home');
+process.env.REINDEX_INTERVAL_MS = '0';
+
+const SESSION = 'nested';
+const CWD = '/tmp/nestedproj';
+const MODEL = 'claude-sonnet-4-9';
+/** The description of the MAIN thread's call — reused by the trap run. */
+const MAIN_DESC = 'Probe: nested subagent spawn';
+
+const jsonl = (events: unknown[]): string => events.map((e) => JSON.stringify(e)).join('\n') + '\n';
+
+const base = { sessionId: SESSION, cwd: CWD, gitBranch: 'main', version: '2.1.0' };
+
+const user = (
+  uuid: string,
+  parentUuid: string | null,
+  ts: string,
+  content: unknown,
+  extra: Record<string, unknown> = {},
+): Record<string, unknown> => ({
+  ...base, type: 'user', uuid, parentUuid, timestamp: ts, isSidechain: false,
+  message: { role: 'user', content }, ...extra,
+});
+
+const asst = (
+  uuid: string,
+  parentUuid: string | null,
+  ts: string,
+  content: unknown[],
+  extra: Record<string, unknown> = {},
+): Record<string, unknown> => ({
+  ...base, type: 'assistant', uuid, parentUuid, timestamp: ts, isSidechain: false,
+  message: {
+    role: 'assistant', model: MODEL, content,
+    usage: { input_tokens: 20, output_tokens: 10, cache_read_input_tokens: 0, cache_creation_input_tokens: 0 },
+  },
+  ...extra,
+});
+
+/** An `Agent` tool_use block — the spawn point a run anchors to. */
+const agentCall = (id: string, description: string, prompt: string) => ({
+  type: 'tool_use', id, name: 'Agent',
+  input: { description, subagent_type: 'general-purpose', prompt },
+});
+
+const proj = join(projectsDir, 'enc-nestedproj');
+const subDir = join(proj, SESSION, 'subagents');
+
+/** One subagent transcript + its `agent-<id>.meta.json` sibling. */
+function writeSubagent(
+  agentId: string,
+  meta: Record<string, unknown>,
+  events: Record<string, unknown>[],
+): void {
+  writeFileSync(join(subDir, `agent-${agentId}.jsonl`), jsonl(events));
+  writeFileSync(join(subDir, `agent-${agentId}.meta.json`), JSON.stringify(meta));
+}
+
+/** Mark a subagent row: sidechain, carrying its own agent id (never a parent). */
+const inRun = (agentId: string) => ({ isSidechain: true, agentId });
+
+function writeFixtures(): void {
+  mkdirSync(subDir, { recursive: true });
+
+  writeFileSync(
+    join(proj, `${SESSION}.jsonl`),
+    jsonl([
+      user('m-u1', null, '2026-04-01T10:00:00.000Z', 'kick off the nesting probe'),
+      asst('m-a1', 'm-u1', '2026-04-01T10:00:05.000Z', [
+        agentCall('toolu_main', MAIN_DESC, 'probe the nesting'),
+      ]),
+      user('m-u2', 'm-a1', '2026-04-01T10:01:00.000Z', [
+        { type: 'tool_result', tool_use_id: 'toolu_main', content: 'probe finished' },
+      ]),
+      asst('m-a2', 'm-u2', '2026-04-01T10:01:05.000Z', [{ type: 'text', text: 'all done' }]),
+    ]),
+  );
+
+  // Depth 1: spawned by the main thread's `toolu_main`, and itself the spawner
+  // of every depth-2 run below.
+  writeSubagent(
+    'p1',
+    { agentType: 'general-purpose', description: MAIN_DESC, toolUseId: 'toolu_main', spawnDepth: 1, model: 'sonnet' },
+    [
+      { ...user('p1-u1', null, '2026-04-01T10:00:06.000Z', 'probe the nesting'), ...inRun('p1') },
+      { ...asst('p1-a1', 'p1-u1', '2026-04-01T10:00:10.000Z', [
+        agentCall('toolu_nested', 'nested probe', 'do the nested work'),
+      ]), ...inRun('p1') },
+      { ...asst('p1-a2', 'p1-a1', '2026-04-01T10:00:20.000Z', [
+        // Same description as the MAIN thread's call — the trap.
+        agentCall('toolu_trap', MAIN_DESC, 'trap probe'),
+        agentCall('toolu_legacy', 'nested probe', 'legacy nested work'),
+      ]), ...inRun('p1') },
+      { ...asst('p1-a3', 'p1-a2', '2026-04-01T10:00:50.000Z', [
+        { type: 'text', text: 'depth-1 summary' },
+      ]), ...inRun('p1') },
+    ],
+  );
+
+  // Depth 2, exact id: `toolu_nested` lives in p1's thread, not the main one.
+  // Sorts before `agent-p1.jsonl`, so it is matched before its parent exists
+  // as a run — the matcher must assemble every run before correlating any.
+  writeSubagent(
+    'c1',
+    { agentType: 'general-purpose', description: 'nested probe', toolUseId: 'toolu_nested', parentAgentId: 'p1', spawnDepth: 2, model: 'sonnet' },
+    [
+      { ...user('c1-u1', null, '2026-04-01T10:00:11.000Z', 'do the nested work'), ...inRun('c1') },
+      { ...asst('c1-a1', 'c1-u1', '2026-04-01T10:00:15.000Z', [
+        { type: 'text', text: 'grandchild kaleidoscope report' },
+      ]), ...inRun('c1') },
+    ],
+  );
+
+  // Depth 2, description only (no `toolUseId`): its description equals the main
+  // thread's still-unmatched call, so only the named parent keeps it honest.
+  writeSubagent(
+    'c2',
+    { agentType: 'general-purpose', description: MAIN_DESC, parentAgentId: 'p1', spawnDepth: 2, model: 'sonnet' },
+    [
+      { ...user('c2-u1', null, '2026-04-01T10:00:21.000Z', 'trap probe'), ...inRun('c2') },
+      { ...asst('c2-a1', 'c2-u1', '2026-04-01T10:00:25.000Z', [
+        { type: 'text', text: 'trap run report' },
+      ]), ...inRun('c2') },
+    ],
+  );
+
+  // Depth 2 written by an older Claude Code: no ids at all. Its spawning call
+  // (`toolu_legacy`) is in p1's thread, which legacy metadata can never reach.
+  writeSubagent(
+    'legacy',
+    { agentType: 'general-purpose', description: 'nested probe' },
+    [
+      { ...user('lg-u1', null, '2026-04-01T10:00:22.000Z', 'legacy nested work'), ...inRun('legacy') },
+      { ...asst('lg-a1', 'lg-u1', '2026-04-01T10:00:26.000Z', [
+        { type: 'text', text: 'legacy run report' },
+      ]), ...inRun('legacy') },
+    ],
+  );
+}
+
+interface Run {
+  agentId: string;
+  toolUseId?: string;
+  spawnUuid?: string;
+  parentAgentId?: string;
+  thread: unknown[];
+}
+
+let app: FastifyInstance;
+let closeConnection: () => Promise<void>;
+
+beforeAll(async () => {
+  writeFixtures();
+  const Fastify = (await import('fastify')).default;
+  const { registerRoutes } = await import('../src/routes/index.js');
+  const { reindex } = await import('../src/data/index.js');
+  ({ closeConnection } = await import('../src/db/duckdb.js'));
+
+  app = Fastify();
+  await registerRoutes(app);
+  await reindex();
+  await app.ready();
+});
+
+afterAll(async () => {
+  await app?.close();
+  await closeConnection?.();
+  rmSync(work, { recursive: true, force: true });
+});
+
+const get = (url: string) => app.inject({ method: 'GET', url });
+const runsOf = async (url: string): Promise<Run[]> => (await get(url)).json().subagents;
+const byId = (runs: Run[], id: string): Run =>
+  runs.find((r) => r.agentId === id) as Run;
+
+describe('nested Claude Code subagents', () => {
+  it('links a depth-2 run to the Agent call inside its parent run', async () => {
+    const runs = await runsOf(`/api/sessions/${SESSION}`);
+    expect(runs.map((r) => r.agentId).sort()).toEqual(['c1', 'c2', 'legacy', 'p1']);
+
+    // Depth 1 anchors in the main thread and names no parent.
+    expect(byId(runs, 'p1')).toMatchObject({ toolUseId: 'toolu_main', spawnUuid: 'm-a1' });
+    expect(byId(runs, 'p1').parentAgentId).toBeUndefined();
+
+    // Depth 2 anchors at the call inside p1's thread.
+    expect(byId(runs, 'c1')).toMatchObject({
+      toolUseId: 'toolu_nested',
+      parentAgentId: 'p1',
+      spawnUuid: 'p1-a1',
+    });
+    expect(JSON.stringify(byId(runs, 'c1').thread)).toContain('grandchild kaleidoscope report');
+  });
+
+  it('keeps a same-description nested run under its named parent', async () => {
+    const runs = await runsOf(`/api/sessions/${SESSION}`);
+    // Without parent scoping this would have matched the main thread's
+    // `toolu_main` (still unmatched when c2 is correlated) and displaced p1.
+    expect(byId(runs, 'c2')).toMatchObject({
+      toolUseId: 'toolu_trap',
+      parentAgentId: 'p1',
+      spawnUuid: 'p1-a2',
+    });
+  });
+
+  it('leaves legacy metadata unlinked instead of guessing a parent', async () => {
+    const legacy = byId(await runsOf(`/api/sessions/${SESSION}`), 'legacy');
+    expect(legacy.toolUseId).toBeUndefined();
+    expect(legacy.spawnUuid).toBeUndefined();
+    expect(legacy.parentAgentId).toBeUndefined();
+  });
+
+  it('keeps every nested run out of the main thread', async () => {
+    const thread = JSON.stringify((await get(`/api/sessions/${SESSION}`)).json().thread);
+    expect(thread).not.toContain('grandchild kaleidoscope report');
+    expect(thread).not.toContain('depth-1 summary');
+  });
+
+  it('carries the whole descendant chain into a window around the spawn turn', async () => {
+    const detail = (await get(`/api/sessions/${SESSION}?around=m-a1&radius=0`)).json();
+    expect(detail.thread.map((t: { uuid: string }) => t.uuid)).toEqual(['m-a1']);
+    // p1 anchors in the slice; c1/c2 anchor inside p1's thread and ride along.
+    // The unlinked legacy run has no anchor at all and is dropped.
+    expect(detail.subagents.map((r: Run) => r.agentId).sort()).toEqual(['c1', 'c2', 'p1']);
+  });
+
+  it('anchors a window on a depth-2 turn at the main-thread spawn of its chain', async () => {
+    // MCP `get_session` anchors on search hits, which can be sidechain rows.
+    const detail = (await get(`/api/sessions/${SESSION}?around=c1-a1&radius=0`)).json();
+    expect(detail.window.anchorFound).toBe(true);
+    expect(detail.thread.map((t: { uuid: string }) => t.uuid)).toEqual(['m-a1']);
+    expect(detail.subagents.map((r: Run) => r.agentId).sort()).toEqual(['c1', 'c2', 'p1']);
+  });
+
+  it('drops nested runs from a window that excludes their ancestor', async () => {
+    const detail = (await get(`/api/sessions/${SESSION}?around=m-u1&radius=0`)).json();
+    expect(detail.thread.map((t: { uuid: string }) => t.uuid)).toEqual(['m-u1']);
+    expect(detail.subagents).toEqual([]);
+  });
+});

--- a/packages/server/test/opencode.integration.test.ts
+++ b/packages/server/test/opencode.integration.test.ts
@@ -75,6 +75,9 @@ function writeDb(): void {
   ses.run('ses_test1', '/tmp/ocproj', 'Test session', null, 1000, 3000);
   // task-spawned child — must fold into ses_test1, its title must NOT clobber the parent's.
   ses.run('ses_child1', '/tmp/ocproj', 'Inspect entry point (@explore subagent)', 'ses_test1', 2500, 2900);
+  // grandchild — spawned by ses_child1, so its `task` part lives in the CHILD's
+  // transcript and its parent is not the root.
+  ses.run('ses_gchild1', '/tmp/ocproj', 'Read the manifest (@read subagent)', 'ses_child1', 2750, 2900);
   // degraded parent links: a dangling parent_id and a two-session cycle. All three
   // must index as standalone sessions — no re-keying, no hang, no crash.
   ses.run('ses_dangling', '/tmp/ocproj', 'Dangling child', 'ses_ghost', 4000, 4100);
@@ -153,6 +156,31 @@ function writeDb(): void {
   }));
   part.run('cp2', 'ca1', 'ses_child1', 2701, 2701, JSON.stringify({
     type: 'text', text: 'The xylophone entry point is packages/server/src/index.ts',
+  }));
+
+  // The child spawns a child of its own: the only description for the grandchild
+  // lives in THIS transcript, never in the root's.
+  msg.run('ca2', 'ses_child1', 2750, 2750, JSON.stringify({
+    role: 'assistant', modelID: 'gpt-5.4-mini-fast', providerID: 'openai', time: { created: 2750 },
+    tokens: { total: 0, input: 0, output: 0, reasoning: 0, cache: { write: 0, read: 0 } },
+  }));
+  part.run('cp3', 'ca2', 'ses_child1', 2751, 2751, JSON.stringify({
+    type: 'tool', tool: 'task', callID: 'call_t2',
+    state: {
+      status: 'completed',
+      input: { description: 'Read the manifest', prompt: 'Read package.json and report.', subagent_type: 'read' },
+      output: 'The manifest names src/index.ts',
+      metadata: { sessionId: 'ses_gchild1', parentSessionId: 'ses_child1' },
+    },
+  }));
+  msg.run('gu1', 'ses_gchild1', 2800, 2800, JSON.stringify({ role: 'user', time: { created: 2800 } }));
+  part.run('gp1', 'gu1', 'ses_gchild1', 2801, 2801, JSON.stringify({ type: 'text', text: 'Read package.json and report.' }));
+  msg.run('ga1', 'ses_gchild1', 2810, 2810, JSON.stringify({
+    role: 'assistant', modelID: 'gpt-5.4-mini-fast', providerID: 'openai', time: { created: 2810 },
+    tokens: { total: 0, input: 0, output: 0, reasoning: 0, cache: { write: 0, read: 0 } },
+  }));
+  part.run('gp2', 'ga1', 'ses_gchild1', 2811, 2811, JSON.stringify({
+    type: 'text', text: 'The platypusmanifest names packages/server/src/index.ts',
   }));
 
   // Degraded sessions need at least one event row to materialize in the index.
@@ -296,7 +324,7 @@ describe('opencode session detail', () => {
     expect(task.input).toMatchObject({ description: 'Inspect entry point', subagent_type: 'explore' });
 
     // the child session rides in as a SubagentRun anchored to that block.
-    expect(detail.subagents).toHaveLength(1);
+    expect(detail.subagents).toHaveLength(2);
     const run = detail.subagents[0];
     expect(run).toMatchObject({
       agentId: 'ses_child1',
@@ -304,9 +332,32 @@ describe('opencode session detail', () => {
       description: 'Inspect entry point',
     });
     expect(run.toolUseId).toBe(task.id);
+    expect(run.parentAgentId).toBeUndefined(); // spawned by the root
     // the child's own turns render inside the run, not in the main thread.
     expect(JSON.stringify(run.thread)).toContain('xylophone');
     expect(JSON.stringify(detail.thread)).not.toContain('xylophone');
+  });
+
+  it('nests a task-spawned grandchild under the Task call in its parent run', async () => {
+    const detail = (await get('/api/sessions/ses_test1')).json();
+    const child = detail.subagents.find((r: { agentId: string }) => r.agentId === 'ses_child1');
+    // The grandchild's `task` part lives in the CHILD's transcript; opencode
+    // carries no tool id on a subagent, so `parent_id` is what scopes the
+    // description match to that run instead of the (unrelated) main thread.
+    const innerTask = child.thread
+      .flatMap((t: { blocks: Record<string, unknown>[] }) => t.blocks)
+      .find((b: Record<string, unknown>) => b.kind === 'tool' && b.name === 'Task');
+    expect(innerTask.input).toMatchObject({ description: 'Read the manifest', subagent_type: 'read' });
+
+    const grandchild = detail.subagents.find((r: { agentId: string }) => r.agentId === 'ses_gchild1');
+    expect(grandchild).toMatchObject({
+      agentType: 'read',
+      description: 'Read the manifest',
+      toolUseId: innerTask.id,
+      parentAgentId: 'ses_child1',
+    });
+    expect(JSON.stringify(grandchild.thread)).toContain('platypusmanifest');
+    expect(JSON.stringify(detail.thread)).not.toContain('platypusmanifest');
   });
 
   it('serves a degraded (dangling-parent) child as its own session', async () => {

--- a/packages/server/test/parser.test.ts
+++ b/packages/server/test/parser.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import type { RawEvent, ThreadItem } from '@claudescope/shared';
+import type { RawEvent, SubagentRun, ThreadItem } from '@claudescope/shared';
 import { assembleThread, buildSubagentRuns } from '../src/data/parser.js';
 import type { SubagentSource } from '../src/data/session-loader.js';
 
@@ -482,6 +482,106 @@ describe('buildSubagentRuns', () => {
       source({ agentId: 'r2', description: 'dup' }),
     ]);
     expect(new Set(runs.map((r) => r.toolUseId))).toEqual(new Set(['tu1', 'tu2']));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Nested subagents (a subagent spawning a subagent)
+// ---------------------------------------------------------------------------
+
+/** A depth-1 run whose thread itself carries an Agent call (`tu_nested`). */
+function spawningSource(agentId: string, description: string, nestedDescription: string): SubagentSource {
+  return source({
+    agentId,
+    agentType: 'general-purpose',
+    description,
+    events: [
+      user('su', 'do it', true),
+      assistant(
+        `${agentId}-spawn`,
+        [
+          {
+            kind: 'tool',
+            type: 'tool_use',
+            id: 'tu_nested',
+            name: 'Agent',
+            input: { description: nestedDescription, subagent_type: 'general-purpose', prompt: 'nested prompt' },
+          },
+        ],
+        { isSidechain: true },
+      ),
+    ],
+  });
+}
+
+describe('buildSubagentRuns — nested subagents', () => {
+  it('links a run by exact id to a call inside another run, whichever is listed first', () => {
+    const runs = buildSubagentRuns(mainThreadWithSpawns(), [
+      // Child listed BEFORE its parent: spawn points must come from every run.
+      source({ agentId: 'child', description: 'nested probe', toolUseId: 'tu_nested', parentAgentId: 'parent' }),
+      spawningSource('parent', 'Explore X', 'nested probe'),
+    ]);
+    const byId = new Map(runs.map((r) => [r.agentId, r]));
+    expect(byId.get('parent')).toMatchObject({ toolUseId: 'tu_agent', spawnUuid: 'm1' });
+    expect(byId.get('parent')?.parentAgentId).toBeUndefined();
+    expect(byId.get('child')).toMatchObject({ toolUseId: 'tu_nested', spawnUuid: 'parent-spawn', parentAgentId: 'parent' });
+  });
+
+  it('a named parent narrows description matching to that run — the same-description trap', () => {
+    // The nested call reuses the main thread's description. Without the parent
+    // restriction the child would be attached to the main-thread call.
+    const runs = buildSubagentRuns(mainThreadWithSpawns(), [
+      spawningSource('parent', 'Explore X', 'Explore X'),
+      source({ agentId: 'child', description: 'Explore X', parentAgentId: 'parent' }),
+    ]);
+    const byId = new Map(runs.map((r) => [r.agentId, r]));
+    expect(byId.get('child')).toMatchObject({ toolUseId: 'tu_nested', parentAgentId: 'parent' });
+    expect(byId.get('parent')).toMatchObject({ toolUseId: 'tu_agent' });
+  });
+
+  it('without parent metadata, description matching never leaves the main thread', () => {
+    // Legacy child: no id, no parent. Its description only exists inside a
+    // run's thread — it must stay unlinked rather than nest by guesswork.
+    const runs = buildSubagentRuns(mainThreadWithSpawns(), [
+      spawningSource('parent', 'Explore X', 'nested probe'),
+      source({ agentId: 'legacy', description: 'nested probe' }),
+    ]);
+    const legacy = runs.find((r) => r.agentId === 'legacy');
+    expect(legacy?.toolUseId).toBeUndefined();
+    expect(legacy?.parentAgentId).toBeUndefined();
+  });
+
+  it('ignores an unknown or self-referential parent, and unlinks a parent cycle', () => {
+    const unknown = buildSubagentRuns(mainThreadWithSpawns(), [
+      source({ agentId: 'a', description: 'Explore X', parentAgentId: 'ghost' }),
+    ]);
+    // Falls back to main-thread matching, so the depth-1 link still lands.
+    expect(unknown[0]).toMatchObject({ toolUseId: 'tu_agent' });
+    expect(unknown[0]?.parentAgentId).toBeUndefined();
+
+    const self = buildSubagentRuns(mainThreadWithSpawns(), [
+      source({ agentId: 'a', description: 'Explore X', parentAgentId: 'a', toolUseId: 'tu_agent' }),
+    ]);
+    expect(self[0]).toMatchObject({ toolUseId: 'tu_agent' });
+    expect(self[0]?.parentAgentId).toBeUndefined();
+
+    // a's call is in b's thread and b's call is in a's thread. The cycle must
+    // be broken (one link may legitimately survive) so a chain walker ends.
+    const cycle = buildSubagentRuns([], [
+      { ...spawningSource('a', 'A', 'B'), toolUseId: 'tu_nested', parentAgentId: 'b' },
+      { ...spawningSource('b', 'B', 'A'), toolUseId: 'tu_nested', parentAgentId: 'a' },
+    ]);
+    const byId = new Map(cycle.map((r) => [r.agentId, r]));
+    for (const r of cycle) {
+      let cur: SubagentRun | undefined = r;
+      let hops = 0;
+      while (cur?.parentAgentId !== undefined && hops < 5) {
+        cur = byId.get(cur.parentAgentId);
+        hops++;
+      }
+      expect(hops).toBeLessThan(2);
+    }
+    expect(cycle.filter((r) => r.parentAgentId !== undefined).length).toBeLessThan(2);
   });
 });
 

--- a/packages/server/test/window.test.ts
+++ b/packages/server/test/window.test.ts
@@ -64,6 +64,20 @@ describe('resolveWindow', () => {
     });
   });
 
+  it('anchors around a turn inside a nested run on the top-level ancestor’s spawn turn', () => {
+    const subs = [
+      run('in', 'm2', ['x']),
+      { ...run('child', 'x', ['y']), parentAgentId: 'in' },
+      { ...run('grandchild', 'y', ['z']), parentAgentId: 'child' },
+    ];
+    expect(resolveWindow(thread, subs, { around: 'z', radius: 0 })).toEqual({
+      offset: 2, limit: 1, total: 6, anchorFound: true,
+    });
+    // A chain that never reaches the main thread (unlinked ancestor) is not an anchor.
+    const loose = [{ ...run('child', 'x', ['y']), parentAgentId: 'ghost' }];
+    expect(resolveWindow(thread, loose, { around: 'y', radius: 0 }).anchorFound).toBe(false);
+  });
+
   it('around wins over offset/limit, and offset clamps past the end', () => {
     expect(resolveWindow(thread, [], { around: 'm4', radius: 0, offset: 0, limit: 99 })).toEqual({
       offset: 4, limit: 1, total: 6, anchorFound: true,
@@ -79,6 +93,22 @@ describe('subagentsInWindow', () => {
     const subs = [run('in', 'm2', ['x']), run('out', 'm5', ['y']), run('orphan', undefined, ['z'])];
     const slice = thread.slice(1, 4); // m1..m3
     expect(subagentsInWindow(slice, subs).map((r) => r.agentId)).toEqual(['in']);
+  });
+
+  it('carries nested runs with their ancestor, however deep, and drops them with it', () => {
+    // grandchild → child → in (spawned at m2); their spawn turns are run
+    // turns, never in the main slice.
+    const subs = [
+      run('in', 'm2', ['x']),
+      { ...run('child', 'x', ['y']), parentAgentId: 'in' },
+      { ...run('grandchild', 'y', ['z']), parentAgentId: 'child' },
+      { ...run('elsewhere', 'q', ['w']), parentAgentId: 'out' },
+      run('out', 'm5', ['q']),
+    ];
+    expect(subagentsInWindow(thread.slice(1, 4), subs).map((r) => r.agentId)).toEqual([
+      'in', 'child', 'grandchild',
+    ]);
+    expect(subagentsInWindow(thread.slice(0, 1), subs)).toEqual([]);
   });
 });
 

--- a/packages/shared/src/markdown.ts
+++ b/packages/shared/src/markdown.ts
@@ -108,12 +108,58 @@ function turnToMd(item: ThreadItem, rr: Renderers): string {
   return `### ${who}\n\n${body}`;
 }
 
-function subagentToMd(run: SubagentRun, rr: Renderers): string {
+/**
+ * Order subagent runs depth-first — each run immediately followed by its
+ * children (in list order) — so a nested run (one spawned from another run's
+ * thread) renders right after its parent instead of scattered by discovery
+ * order. Shared by {@link sessionToMarkdown} and the server's
+ * `shapeSessionMarkdown` so both export paths nest the same way.
+ *
+ * A run whose `parentAgentId` doesn't name another run in the list (absent,
+ * or dangling — e.g. the parent fell outside a window) renders as top-level.
+ * Defensive against a corrupt parent cycle: a run is emitted at most once, so
+ * two runs pointing at each other terminate instead of recursing forever.
+ */
+export function orderSubagentRunsDepthFirst(runs: SubagentRun[]): SubagentRun[] {
+  const byId = new Map(runs.map((r) => [r.agentId, r]));
+  const children = new Map<string, SubagentRun[]>();
+  const roots: SubagentRun[] = [];
+  for (const run of runs) {
+    const parent =
+      run.parentAgentId !== undefined && run.parentAgentId !== run.agentId
+        ? byId.get(run.parentAgentId)
+        : undefined;
+    if (!parent) {
+      roots.push(run);
+      continue;
+    }
+    const siblings = children.get(parent.agentId);
+    if (siblings) siblings.push(run);
+    else children.set(parent.agentId, [run]);
+  }
+
+  const ordered: SubagentRun[] = [];
+  const visited = new Set<string>();
+  const visit = (run: SubagentRun): void => {
+    if (visited.has(run.agentId)) return;
+    visited.add(run.agentId);
+    ordered.push(run);
+    for (const child of children.get(run.agentId) ?? []) visit(child);
+  };
+  for (const root of roots) visit(root);
+  for (const run of runs) if (!visited.has(run.agentId)) visit(run); // cycle leftovers
+
+  return ordered;
+}
+
+function subagentToMd(run: SubagentRun, rr: Renderers, parent?: SubagentRun): string {
   const turns = run.thread
     .map((t) => turnToMd(t, rr))
     .join('\n\n')
     .replace(/^### /gm, '#### '); // demote one level inside a subagent
-  return `### 🧩 Subagent · ${run.agentType} — ${rr.r(run.description || run.agentId)}\n\n${turns}`;
+  const head = `### 🧩 Subagent · ${run.agentType} — ${rr.r(run.description || run.agentId)}`;
+  const nested = parent ? ` (nested in ${rr.r(parent.description || parent.agentId)})` : '';
+  return `${head}${nested}\n\n${turns}`;
 }
 
 function renderers(opts: ExportOptions): Renderers {
@@ -150,7 +196,13 @@ export function sessionToMarkdown(data: SessionDetailResponse, opts: ExportOptio
 
   const parts = [head.join('\n\n'), '---', ...thread.map((t) => turnToMd(t, rr))];
   if (subagents.length > 0) {
-    parts.push('---', '## Subagents', ...subagents.map((s) => subagentToMd(s, rr)));
+    const byId = new Map(subagents.map((s) => [s.agentId, s]));
+    const ordered = orderSubagentRunsDepthFirst(subagents);
+    parts.push(
+      '---',
+      '## Subagents',
+      ...ordered.map((s) => subagentToMd(s, rr, s.parentAgentId ? byId.get(s.parentAgentId) : undefined)),
+    );
   }
   return parts.join('\n\n') + '\n';
 }

--- a/packages/shared/src/thread.ts
+++ b/packages/shared/src/thread.ts
@@ -104,12 +104,19 @@ export interface SubagentRun {
   /** Optional slug carried on the subagent's events. */
   slug?: string;
   /**
-   * The main-thread `Agent`/`Task` tool_use id that spawned this run, when it
-   * could be correlated (by description + type). Absent if unmatched.
+   * The `Agent`/`Task` tool_use id that spawned this run, when it could be
+   * correlated (exact id, else description + type). The call lives in the main
+   * thread, or — for a subagent spawned by a subagent — in the thread of the
+   * run named by {@link parentAgentId}. Absent if unmatched.
    */
   toolUseId?: string;
-  /** uuid of the main-thread turn carrying that tool_use (jump/anchor target). */
+  /** uuid of the turn carrying that tool_use (jump/anchor target). */
   spawnUuid?: string;
+  /**
+   * agentId of the run whose thread holds the spawning call. Absent for runs
+   * spawned from the main thread and for unmatched runs. Chains are acyclic.
+   */
+  parentAgentId?: string;
   /** Number of assembled turns in the subagent thread. */
   messageCount: number;
   /** Number of tool calls the subagent made. */

--- a/packages/shared/test/markdown.test.ts
+++ b/packages/shared/test/markdown.test.ts
@@ -1,6 +1,12 @@
 import { describe, expect, it } from 'vitest';
-import type { SessionDetailResponse, ThreadItem } from '../src/index.js';
-import { redactText, sessionToMarkdown, threadItemsToMarkdown, truncateText } from '../src/index.js';
+import type { SessionDetailResponse, SubagentRun, ThreadItem } from '../src/index.js';
+import {
+  orderSubagentRunsDepthFirst,
+  redactText,
+  sessionToMarkdown,
+  threadItemsToMarkdown,
+  truncateText,
+} from '../src/index.js';
 
 describe('redactText', () => {
   it('masks home-dir paths to ~', () => {
@@ -73,6 +79,70 @@ describe('sessionToMarkdown', () => {
     expect(red).not.toContain('/Users/me/');
     expect(red).toContain('~/app/settings.ts');
     expect(red).toContain('redaction');
+  });
+});
+
+function subagentRun(agentId: string, description: string, parentAgentId?: string): SubagentRun {
+  return {
+    agentId,
+    agentType: 'general-purpose',
+    description,
+    ...(parentAgentId ? { parentAgentId } : {}),
+    messageCount: 0,
+    toolCallCount: 0,
+    totalTokens: 0,
+    thread: [],
+  };
+}
+
+describe('orderSubagentRunsDepthFirst', () => {
+  it('places each run immediately after its parent, children in list order', () => {
+    const parent = subagentRun('parent', 'Explore X');
+    const unlinked = subagentRun('unlinked', 'separate task');
+    const child = subagentRun('child', 'nested probe', 'parent');
+    // The child is listed AFTER the unrelated root run — it must still be
+    // promoted to sit right after its own parent, not stay where it was.
+    expect(orderSubagentRunsDepthFirst([parent, unlinked, child]).map((r) => r.agentId)).toEqual([
+      'parent',
+      'child',
+      'unlinked',
+    ]);
+  });
+
+  it('renders a run with a dangling parentAgentId as top-level', () => {
+    const orphan = subagentRun('orphan', 'ghost parent', 'missing');
+    const other = subagentRun('other', 'unrelated');
+    expect(orderSubagentRunsDepthFirst([orphan, other]).map((r) => r.agentId)).toEqual(['orphan', 'other']);
+  });
+
+  it('terminates on a parent cycle instead of hanging', () => {
+    const a = subagentRun('a', 'A', 'b');
+    const b = subagentRun('b', 'B', 'a');
+    const ordered = orderSubagentRunsDepthFirst([a, b]);
+    expect(ordered.map((r) => r.agentId).sort()).toEqual(['a', 'b']);
+  });
+});
+
+describe('sessionToMarkdown — nested subagents', () => {
+  const parentRun: SubagentRun = {
+    ...subagentRun('parent', 'Explore X'),
+    thread: [turn('assistant', [{ kind: 'text', type: 'text', text: 'parent work' }])],
+  };
+  const childRun: SubagentRun = {
+    ...subagentRun('child', 'nested probe', 'parent'),
+    thread: [turn('assistant', [{ kind: 'text', type: 'text', text: 'child work' }])],
+  };
+  const data: SessionDetailResponse = {
+    meta: baseMeta,
+    thread: [],
+    subagents: [childRun, parentRun], // list order is not depth-first
+  };
+
+  it('orders runs depth-first and labels the nested one with its parent', () => {
+    const md = sessionToMarkdown(data, { redact: false });
+    expect(md).toContain('### 🧩 Subagent · general-purpose — Explore X');
+    expect(md).toContain('### 🧩 Subagent · general-purpose — nested probe (nested in Explore X)');
+    expect(md.indexOf('Explore X')).toBeLessThan(md.indexOf('nested probe'));
   });
 });
 

--- a/packages/web/src/pages/session/SessionPage.tsx
+++ b/packages/web/src/pages/session/SessionPage.tsx
@@ -13,7 +13,13 @@ import {
   shortModel,
 } from '../browse/format.js';
 import { hasRenderableContent } from './blocks.js';
-import { SubagentBlock, SubagentJumpMenu, ThreadList, useHashTarget } from './ThreadView.js';
+import {
+  ancestorRunIds,
+  SubagentBlock,
+  SubagentJumpMenu,
+  ThreadList,
+  useHashTarget,
+} from './ThreadView.js';
 import { useProgressiveMount } from './useProgressiveMount.js';
 import { useScrollRestore } from './useScrollRestore.js';
 import { holdBottom, isNearBottom, useLiveSession } from './useLiveSession.js';
@@ -183,6 +189,7 @@ function SessionView({
     return map;
   }, [subagents]);
   const orphanSubagents = useMemo(() => subagents.filter((s) => !s.toolUseId), [subagents]);
+  const runById = useMemo(() => new Map(subagents.map((s) => [s.agentId, s])), [subagents]);
 
   // Mount turns progressively: the first chunk renders immediately, the rest
   // stream in during idle time, so a huge session never blocks the first paint
@@ -192,7 +199,9 @@ function SessionView({
 
   // subagentId → uuid of the top-level turn its run renders under. Used to
   // mount the right turn before navigating to a match/anchor inside a nested
-  // subagent (orphan runs render after the list and are always mounted).
+  // subagent (orphan runs render after the list and are always mounted). A run
+  // spawned by another run renders inside its parent's panel, so it resolves
+  // through the ancestor chain to the turn its top-level ancestor renders under.
   const spawnTurnBySubagentId = useMemo(() => {
     const map = new Map<string, string>();
     for (const item of items) {
@@ -201,8 +210,18 @@ function SessionView({
         for (const run of subagentsByToolUseId.get(block.id) ?? []) map.set(run.agentId, item.uuid);
       }
     }
+    for (const run of subagents) {
+      if (map.has(run.agentId)) continue;
+      for (const id of ancestorRunIds(run, runById)) {
+        const uuid = map.get(id);
+        if (uuid !== undefined) {
+          map.set(run.agentId, uuid);
+          break;
+        }
+      }
+    }
     return map;
-  }, [items, subagentsByToolUseId]);
+  }, [items, subagents, subagentsByToolUseId, runById]);
 
   // Post-load hash navigation (subagent jump menu, time anchors): the target's
   // turn may not be mounted yet, in which case the native hash scroll (and a
@@ -299,9 +318,26 @@ function SessionView({
   // Reset to the first match whenever the result set changes.
   useEffect(() => setActiveIndex(0), [matches]);
 
-  // Reveal ONLY the active match's block/subagent — never all of them.
+  // Reveal ONLY the active match's block/subagent — never all of them — plus
+  // the runs above it: a nested run is rendered by its parent's panel, so it
+  // exists in the DOM only while every ancestor is open. The hash target's
+  // ancestors join the set for the same reason; the target itself is left to
+  // SubagentBlock's own hash effect, which opens AND scrolls to it (and leaves
+  // it collapsible).
   const activeMatch = count > 0 ? matches[Math.min(activeIndex, count - 1)] : undefined;
-  const reveal = useMemo(() => revealForMatch(activeMatch), [activeMatch]);
+  const hashRunId = hashTarget.startsWith('subagent-')
+    ? hashTarget.slice('subagent-'.length)
+    : undefined;
+  const reveal = useMemo(() => {
+    const base = revealForMatch(activeMatch);
+    const subagentIds = new Set(base.subagentIds);
+    const targets = [...base.subagentIds, ...(hashRunId ? [hashRunId] : [])];
+    for (const id of targets) {
+      const run = runById.get(id);
+      if (run) for (const ancestor of ancestorRunIds(run, runById)) subagentIds.add(ancestor);
+    }
+    return { blockIds: base.blockIds, subagentIds };
+  }, [activeMatch, hashRunId, runById]);
 
   // Highlight the active match within its (now-revealed) block. Scoped to one
   // block, so it stays cheap. Re-run on a short delay to catch async code
@@ -391,7 +427,11 @@ function SessionView({
                 <span className="tv-muted"> (not linked to a tool call)</span>
               </h2>
               {orphanSubagents.map((run) => (
-                <SubagentBlock key={run.agentId} run={run} />
+                <SubagentBlock
+                  key={run.agentId}
+                  run={run}
+                  subagentsByToolUseId={subagentsByToolUseId}
+                />
               ))}
             </section>
           ) : null}

--- a/packages/web/src/pages/session/ThreadView.tsx
+++ b/packages/web/src/pages/session/ThreadView.tsx
@@ -1,4 +1,15 @@
-import { Fragment, memo, useContext, useEffect, useRef, useState, type ReactNode } from 'react';
+import {
+  createContext,
+  Fragment,
+  memo,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type CSSProperties,
+  type ReactNode,
+} from 'react';
 import { Puzzle, RotateCcw } from 'lucide-react';
 import type { CompactionInfo, SubagentRun, ThreadBlock, ThreadItem } from '@claudescope/shared';
 import {
@@ -10,6 +21,7 @@ import {
   TokenChips,
 } from '../../components';
 import { formatDateTime, shortModel } from '../browse/format.js';
+import { holdAnchor } from './useScrollRestore.js';
 import { ThreadBlockView, hasRenderableContent } from './blocks.js';
 import {
   classifySystemText,
@@ -23,6 +35,73 @@ import { blockRevealId } from './search.js';
 /** DOM id for a subagent block, used as the jump-menu / deep-link anchor. */
 export function subagentAnchor(agentId: string): string {
   return `subagent-${agentId}`;
+}
+
+/**
+ * Hop limit for walks over `parentAgentId` chains. The server serves acyclic
+ * chains (it unlinks a run that closes a cycle), so this only bounds a corrupt
+ * or hand-edited payload.
+ */
+const MAX_PARENT_HOPS = 32;
+
+/**
+ * How many subagent panels the current one is nested inside. The server
+ * breaks parent cycles, so this only caps a corrupt payload — a stack
+ * overflow would take the whole tab down instead of one panel.
+ */
+const NestDepthContext = createContext(0);
+
+/**
+ * Ancestor run ids of `run`, nearest first — the runs whose threads it renders
+ * inside. Empty for a run spawned from the main thread or left unlinked.
+ */
+export function ancestorRunIds(run: SubagentRun, runById: Map<string, SubagentRun>): string[] {
+  const out: string[] = [];
+  let cur = run;
+  for (let hop = 0; hop < MAX_PARENT_HOPS; hop++) {
+    const parent = cur.parentAgentId ? runById.get(cur.parentAgentId) : undefined;
+    if (!parent || parent.agentId === run.agentId || out.includes(parent.agentId)) break;
+    out.push(parent.agentId);
+    cur = parent;
+  }
+  return out;
+}
+
+/**
+ * Runs in depth-first order — each run followed by the ones it spawned — with
+ * the nesting depth of each. A run whose parent isn't in the list (windowed
+ * reads keep ancestors, but be defensive) is treated as a root, and any run a
+ * broken chain would otherwise hide is appended flat rather than dropped.
+ */
+function nestedRunOrder(runs: SubagentRun[]): { run: SubagentRun; depth: number }[] {
+  const known = new Set(runs.map((r) => r.agentId));
+  const childrenOf = new Map<string, SubagentRun[]>();
+  const roots: SubagentRun[] = [];
+  for (const run of runs) {
+    const parent = run.parentAgentId;
+    if (parent && parent !== run.agentId && known.has(parent)) {
+      const list = childrenOf.get(parent);
+      if (list) list.push(run);
+      else childrenOf.set(parent, [run]);
+    } else {
+      roots.push(run);
+    }
+  }
+  const out: { run: SubagentRun; depth: number }[] = [];
+  const seen = new Set<string>();
+  const walk = (run: SubagentRun, depth: number) => {
+    if (seen.has(run.agentId) || depth > MAX_PARENT_HOPS) return;
+    seen.add(run.agentId);
+    out.push({ run, depth });
+    for (const child of childrenOf.get(run.agentId) ?? []) walk(child, depth + 1);
+  };
+  for (const run of roots) walk(run, 0);
+  for (const run of runs) {
+    if (seen.has(run.agentId)) continue;
+    seen.add(run.agentId);
+    out.push({ run, depth: 0 });
+  }
+  return out;
 }
 
 /** Track the current location hash (decoded), updating on hashchange. */
@@ -123,7 +202,11 @@ const Turn = memo(function Turn({
                   role={item.role}
                 />
                 {runs?.map((run) => (
-                  <SubagentBlock key={run.agentId} run={run} />
+                  <SubagentBlock
+                    key={run.agentId}
+                    run={run}
+                    subagentsByToolUseId={subagentsByToolUseId}
+                  />
                 ))}
               </Fragment>
             );
@@ -332,21 +415,46 @@ function CommandOutput({ stdout, stderr }: { stdout: string; stderr: string }) {
 /**
  * A collapsible, indented panel rendering a subagent's full thread. Collapsed by
  * default; opens (and scrolls into view) when the location hash targets it, so
- * the "Subagents" jump menu and deep-links land on an expanded run.
+ * the "Subagents" jump menu and deep-links land on an expanded run. It also
+ * opens when a run it (transitively) spawned is the target — SessionPage puts
+ * the ancestors of a targeted run in the reveal set, since a nested run only
+ * mounts once every panel above it is open.
  */
-export function SubagentBlock({ run }: { run: SubagentRun }) {
+export function SubagentBlock({
+  run,
+  subagentsByToolUseId,
+}: {
+  run: SubagentRun;
+  /** Passed on so a subagent that spawned a subagent nests it in turn. */
+  subagentsByToolUseId?: Map<string, SubagentRun[]>;
+}) {
   const anchor = subagentAnchor(run.agentId);
   const hashTarget = useHashTarget();
   const { subagentIds } = useContext(SessionSearchContext);
+  const depth = useContext(NestDepthContext);
   const forceOpen = subagentIds.has(run.agentId);
   const [open, setOpen] = useState(false);
   const ref = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
-    if (hashTarget === anchor) {
-      setOpen(true);
-      ref.current?.scrollIntoView({ block: 'start', behavior: 'smooth' });
+    if (hashTarget !== anchor) return;
+    setOpen(true);
+    const el = ref.current;
+    if (!el) return;
+    const scroller = el.closest('main.tv-main');
+    if (!(scroller instanceof HTMLElement)) {
+      el.scrollIntoView({ block: 'start' });
+      return;
     }
+    // Not a smooth scrollIntoView: lazily sized turns above and below shrink
+    // as the viewport passes them, so an animation aimed at this block's
+    // current position lands far past it. Jump, then hold the block at the
+    // top while layout settles (the reader's own scroll cancels the hold).
+    let cancelled = false;
+    holdAnchor(scroller, el, () => 0, () => cancelled);
+    return () => {
+      cancelled = true;
+    };
   }, [hashTarget, anchor]);
 
   const items = run.thread.filter((t) => hasRenderableContent(t.blocks));
@@ -377,7 +485,12 @@ export function SubagentBlock({ run }: { run: SubagentRun }) {
           {items.length === 0 ? (
             <p className="tv-muted">No renderable messages in this subagent run.</p>
           ) : (
-            <ThreadList items={items} />
+            <NestDepthContext.Provider value={depth + 1}>
+              <ThreadList
+                items={items}
+                subagentsByToolUseId={depth < MAX_PARENT_HOPS ? subagentsByToolUseId : undefined}
+              />
+            </NestDepthContext.Provider>
           )}
         </div>
       </Collapsible>
@@ -386,7 +499,9 @@ export function SubagentBlock({ run }: { run: SubagentRun }) {
 }
 
 /**
- * A compact dropdown listing all subagents, each linking to its anchor.
+ * A compact dropdown listing all subagents, each linking to its anchor. Runs
+ * are listed depth-first and indented by nesting depth, so a subagent spawned
+ * by a subagent reads as belonging to it.
  *
  * The native `<details>` is controlled so it closes the way users expect: on
  * selecting an item AND on clicking anywhere outside (native `<details>` does
@@ -395,6 +510,7 @@ export function SubagentBlock({ run }: { run: SubagentRun }) {
 export function SubagentJumpMenu({ subagents }: { subagents: SubagentRun[] }) {
   const [open, setOpen] = useState(false);
   const ref = useRef<HTMLDetailsElement>(null);
+  const ordered = useMemo(() => nestedRunOrder(subagents), [subagents]);
 
   useEffect(() => {
     if (!open) return;
@@ -425,13 +541,18 @@ export function SubagentJumpMenu({ subagents }: { subagents: SubagentRun[] }) {
         <span className="tv-subagent-menu__count">{subagents.length}</span>
       </summary>
       <ul className="tv-subagent-menu__list">
-        {subagents.map((s) => (
-          <li key={s.agentId}>
+        {ordered.map(({ run: s, depth }) => (
+          <li key={s.agentId} style={{ '--tv-menu-depth': depth } as CSSProperties}>
             <a
               href={`#${subagentAnchor(s.agentId)}`}
               className="tv-subagent-menu__item"
               onClick={() => setOpen(false)}
             >
+              {depth > 0 ? (
+                <span className="tv-subagent-menu__nest" aria-hidden="true">
+                  ↳
+                </span>
+              ) : null}
               <span className="tv-subagent-menu__type">{s.agentType || 'agent'}</span>
               <span className="tv-subagent-menu__desc">
                 {s.description || s.slug || s.agentId}

--- a/packages/web/src/pages/session/search.ts
+++ b/packages/web/src/pages/session/search.ts
@@ -99,10 +99,37 @@ function pushTurnEntries(
 }
 
 /**
- * Flatten the transcript into searchable entries, walking in render order: each
- * main-thread turn, and — right after a tool call that spawned subagents — that
- * tool's subagent runs (which render nested there). Orphan subagents come last.
- * Role filtering is NOT applied here so the corpus survives filter changes.
+ * Push one thread's entries in render order: each turn, and — right after a
+ * tool call that spawned subagents — those runs' own threads, recursively, so
+ * a subagent spawned by a subagent is searchable too. `nested` records every
+ * run already walked, which both keeps the trailing orphan pass from repeating
+ * one and bounds the recursion against a cyclic map.
+ */
+function pushThreadEntries(
+  thread: ThreadItem[],
+  subagentId: string | undefined,
+  subagentsByToolUseId: Map<string, SubagentRun[]>,
+  nested: Set<string>,
+  out: CorpusEntry[],
+): void {
+  for (const turn of thread) {
+    pushTurnEntries(turn, subagentId, out);
+    for (const block of turn.blocks) {
+      if (block.kind !== 'tool') continue;
+      for (const run of subagentsByToolUseId.get(block.id) ?? []) {
+        if (nested.has(run.agentId)) continue;
+        nested.add(run.agentId);
+        pushThreadEntries(run.thread, run.agentId, subagentsByToolUseId, nested, out);
+      }
+    }
+  }
+}
+
+/**
+ * Flatten the transcript into searchable entries, walking in render order: the
+ * main thread with each spawned run nested at its tool call. Subagents that
+ * never rendered nested (orphans) come last. Role filtering is NOT applied here
+ * so the corpus survives filter changes.
  */
 export function buildSearchCorpus(
   thread: ThreadItem[],
@@ -111,23 +138,33 @@ export function buildSearchCorpus(
 ): CorpusEntry[] {
   const out: CorpusEntry[] = [];
   const nested = new Set<string>();
-  for (const turn of thread) {
-    pushTurnEntries(turn, undefined, out);
-    for (const block of turn.blocks) {
-      if (block.kind !== 'tool') continue;
-      const runs = subagentsByToolUseId.get(block.id);
-      if (!runs) continue;
-      for (const run of runs) {
-        nested.add(run.agentId);
-        for (const t of run.thread) pushTurnEntries(t, run.agentId, out);
-      }
-    }
-  }
-  for (const run of subagents) {
+  pushThreadEntries(thread, undefined, subagentsByToolUseId, nested, out);
+  // Runs not reached from the main thread (unlinked, or nested under an
+  // unlinked parent): walk parents before children so a nested run is
+  // indexed inside its parent's panel, matching render order.
+  for (const run of parentsFirst(subagents)) {
     if (nested.has(run.agentId)) continue;
-    for (const t of run.thread) pushTurnEntries(t, run.agentId, out);
+    nested.add(run.agentId);
+    pushThreadEntries(run.thread, run.agentId, subagentsByToolUseId, nested, out);
   }
   return out;
+}
+
+/** Stable sort by nesting depth (parent hops, capped) — payload order within a depth. */
+function parentsFirst(runs: SubagentRun[]): SubagentRun[] {
+  const byId = new Map(runs.map((r) => [r.agentId, r]));
+  const depthOf = (run: SubagentRun): number => {
+    let depth = 0;
+    let cur: SubagentRun | undefined = run;
+    while (cur?.parentAgentId !== undefined && cur.parentAgentId !== cur.agentId && depth < 32) {
+      cur = byId.get(cur.parentAgentId);
+      depth++;
+    }
+    return depth;
+  };
+  return runs.map((run, i) => ({ run, i, depth: depthOf(run) }))
+    .sort((a, b) => a.depth - b.depth || a.i - b.i)
+    .map((x) => x.run);
 }
 
 /** Scan a prebuilt corpus for a query — the only work that runs per keystroke. */

--- a/packages/web/src/pages/session/session.css
+++ b/packages/web/src/pages/session/session.css
@@ -415,9 +415,17 @@
   align-items: baseline;
   gap: var(--tv-space-2);
   padding: var(--tv-space-2);
+  /* Runs are listed depth-first; `--tv-menu-depth` (set per item) indents a
+     run spawned by another run under it. */
+  padding-left: calc(var(--tv-space-2) + var(--tv-menu-depth, 0) * var(--tv-space-4));
   border-radius: var(--tv-radius-sm);
   text-decoration: none;
   color: inherit;
+}
+.tv-subagent-menu__nest {
+  flex: 0 0 auto;
+  margin-left: calc(-1 * var(--tv-space-1));
+  color: var(--tv-fg-muted);
 }
 .tv-subagent-menu__item:hover {
   background: var(--tv-bg-inset);

--- a/packages/web/src/pages/session/useScrollRestore.ts
+++ b/packages/web/src/pages/session/useScrollRestore.ts
@@ -98,9 +98,12 @@ const HOLD_MS = 1200;
  * Keep `el` at `targetDelta()` px below the scroller top until layout settles.
  * Any scroll the hold didn't make itself — user wheel/touch, a hash
  * navigation, finder jumps, Chrome's own scroll anchoring — cancels it
- * immediately, so it only ever counteracts silent layout shift.
+ * immediately, so it only ever counteracts silent layout shift. Also the way
+ * to *navigate* to an element in this transcript: turns are sized lazily
+ * (`content-visibility`), so a one-shot smooth scroll aims at a position that
+ * moves by tens of thousands of pixels while the animation runs.
  */
-function holdAnchor(
+export function holdAnchor(
   scroller: HTMLElement,
   el: HTMLElement,
   targetDelta: () => number,


### PR DESCRIPTION
## What

A subagent can spawn a subagent. Such a grandchild now nests under the call that spawned it — in the web, in windowed reads (MCP `get_session`, CLI, paged loading), and in Markdown export — instead of landing in "Other subagents" or, with a same-named main-thread call, under the wrong one.

Plan: [docs/plans/0084](docs/plans/0084-nested-subagents.md).

## How

- **Contract**: `SubagentRun.parentAgentId` — runs stay a flat list with a parent pointer (backward compatible; chains are acyclic). `SubagentSource.parentAgentId` for connectors that know the parent.
- **Parser**: every run is assembled first, spawn points are collected from the main thread *and* each run's thread, then matched: exact id anywhere (never inside the run's own thread, never in an unrelated run when a parent is named) → description/prompt matching scoped to the named parent → main-thread only when no parent is named, so legacy metadata can never nest a run by guesswork. Parent cycles are broken.
- **Window**: nested runs ride along with their ancestor; `around=<turn inside a nested run>` anchors on the chain's main-thread spawn turn.
- **Connectors**: Claude Code reads `toolUseId`/`parentAgentId` from `agent-*.meta.json` (verified against a real depth-2 spawn on this machine); Codex merges every parsed rollout's spawn map and takes the parent from `thread_spawn`; Copilot passes `toolUseId` (= `sub.agentId`) plus the owning stream; opencode and Antigravity name the parent and read task descriptions from every session. pi and Grok are a follow-up (their root re-key is one hop, so a grandchild is still its own session).
- **Web**: subagent panels pass the run map into their own thread, so nesting recurses (depth-capped); deep links, search hits and mount-before-navigate resolve through the ancestor chain and open the parents; the jump menu lists runs depth-first, indented.
- **Export / CLI / MCP**: depth-first order with a `nested in <parent>` label.

## Tests

`npm test` (729) and `npm run typecheck` green. New: parser (exact id into another run with the child listed first, the same-description trap, legacy stays main-thread only, unknown/self parent, cycle), window (chain carry, chain anchor), a Claude Code end-to-end fixture from the real depth-2 files (linkage, trap, legacy, windows), nested cases for Codex/Copilot/opencode/Antigravity, Markdown/CLI ordering. Verified in the browser on the real depth-2 session.
