### PR TITLE
fix: audit hardening — counting rules, DuckDB lifecycle, connector seam, fitness functions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,6 +63,17 @@ npm-workspaces monorepo (`packages/*`):
   `config.ts`, never a bare `mkdirSync`. Every file writer passes
   `STATE_FILE_MODE`, and the server sets `umask 0077` at boot for the files
   DuckDB creates itself.
+- DuckDB downloads the `json`/`fts` extensions itself (~31 MB, first run and
+  after every DuckDB bump), so `openAndPrepare` points `extension_directory` at
+  `DUCKDB_EXTENSION_DIR` (`~/.claudescope/duckdb-extensions`) — never the default
+  `~/.duckdb`, which would write outside the state dir. Tests pin it to the
+  machine's shared cache via `vitest.config.ts`. Only the default dir gets the
+  owner-only mode; an override is created but never chmod'ed (a shared cache's
+  mode is not ours to change).
+- **A lock conflict or an extension-install failure must never discard the
+  index** — only evidence of corruption may (`isNonCorruptionOpenError` in
+  `db/duckdb.ts`). A second process opening the same DB is normal, and deleting
+  it there wipes the live daemon's index.
 - The normalize cache (`cache/<agent>/*.ndjson`, written by `prepare()`) holds
   transcript text **verbatim**, so it is pruned every pass once its source file is
   gone — `ndjsonCache` owns the layout and `pruneNdjsonCaches` the sweep. A

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -139,6 +139,14 @@ The CLI `update` command (`cli.ts`) detects the install method and defers to
   dedup-by-`message.id`, stale-cache / index-corruption recovery, pricing refresh
   and fallback, connector normalization quirks. Don't pad coverage with trivial
   cases that can't realistically fail.
+- **Fitness functions:** some tests encode a *rule* rather than an instance —
+  `architecture-rules.test.ts` (no agent ids under `data/`/`routes/`),
+  `connector-error-signal.test.ts` (declared vs emitted error signal per
+  connector), `analytics-tool-counts.integration.test.ts` (every route counts
+  tool calls the same way), `duckdb-open.test.ts` (open-failure
+  classification), the finalize-recovery and shutdown tests. When a review
+  finds a *class* of bug, land the rule test with the fix and extend these
+  when adding a connector or route.
 - **Commits:** [Conventional Commits](https://www.conventionalcommits.org)
   (`feat:`, `fix:`, `chore:`, `docs:`, `refactor:`, `test:`). **Do not add AI
   co-author / "Generated with" trailers** — keep history clean and human-authored.
@@ -350,6 +358,37 @@ The CLI `update` command (`cli.ts`) detects the install method and defers to
   `process.kill` the pid from `daemon.json` directly. The record is written by
   the server after a successful bind (`CLAUDESCOPE_DAEMON=1`), not by the
   spawner, so a losing concurrent spawn can never clobber it.
+- **Two counting rules for `events` aggregates** (`data/analytics-metrics.ts`):
+  token/cost SUMs filter on `usage_canonical`; per-row COUNTS
+  (`tool_use_count`, the `tool_names`/`skill_names` unnest,
+  `tool_error_count`) exclude fork copies only (`toolCallRowsSql`) and never
+  go through the usage election — Claude Code splits one message across rows
+  and the elected row rarely carries the tool blocks. The parser applies the
+  same per-`message.id` election to subagent run totals.
+- **Tool-error signal is a declared capability** (`TOOL_ERROR_SIGNAL` in
+  `data/agent-capabilities.ts`): a connector either sets `is_error` from its
+  format's failure shape or emits `tool_error_count: null` — a real-looking 0
+  is never fabricated. A new connector must be declared there; the conformance
+  test walks the registry.
+- **Agent knowledge stays behind the connector seam.** Per-agent facts live in
+  `data/agent-capabilities.ts`; format-specific SQL or encodings (Codex's
+  fallback-title stripping, Claude Code's memory dir slug) go through
+  `AgentConnector` hooks (`fallbackTitleCandidateSql`, `projectMemorySlug`).
+  `architecture-rules.test.ts` fails on any connector-id literal or
+  `connectors/<id>/` import under `src/data/` or `src/routes/`.
+- **A failed finalize is remembered.** `files` bookkeeping advances per loaded
+  file, so `doReindex` latches `derivedDirty` (plus the touched session ids)
+  until the FTS rebuild completes, and the idle early-return requires it
+  clear. Never add an early exit that bypasses that flag.
+- **Shutdown drains, then closes DuckDB** (`shutdown.ts`): SIGTERM/SIGINT wait
+  up to `DRAIN_MS` (3.5 s) for an in-flight pass, close Fastify, then
+  `closeConnection()` so the WAL is checkpointed; a pass still running skips
+  the DB close. `DRAIN_MS` must stay under `daemon.ts` `EXIT_WAIT_MS` (5 s) or
+  every `claudescope stop` reports a hung daemon.
+- **FTS is keyed by `events.doc_id`** (`hash(file_path, uuid)`, unique per
+  row). `uuid` repeats across fork copies, and the old fix — relaxing
+  `scalar_subquery_error_on_multiple_rows` connection-wide — masked genuine
+  multi-row scalar-subquery bugs everywhere; never reintroduce it.
 - **Release is maintainer-only** and tag-triggered (npm Trusted Publishing /
   OIDC). See `CONTRIBUTING.md`.
 

--- a/README.md
+++ b/README.md
@@ -298,6 +298,7 @@ All optional — set via environment variables.
 | `ANTIGRAVITY_DIR`     | `~/.gemini/antigravity` | Where to read Google Antigravity desktop-app transcripts from. A leading `~` is expanded. |
 | `GROK_SESSIONS_DIR`   | `~/.grok/sessions`     | Where to read xAI Grok CLI transcripts from. A leading `~` is expanded. |
 | `CLAUDESCOPE_HOME`    | `~/.claudescope`       | Where the app keeps its own state (index, pricing copy, logs, PID).    |
+| `DUCKDB_EXTENSION_DIR`| `~/.claudescope/duckdb-extensions` | Where DuckDB keeps its `json`/`fts` extensions. Point it at `~/.duckdb/extensions` to reuse a machine-wide cache. |
 | `REINDEX_INTERVAL_MS` | `15000`                | How often to auto-pick-up new/updated sessions. Set `0` to disable.    |
 
 Each agent source is optional — if a directory doesn't exist it's simply skipped,
@@ -494,7 +495,9 @@ Claudescope runs entirely on your machine. It treats every agent source
 **read-only**, **binds to `127.0.0.1` only**, and sends **no telemetry**. Its only
 outbound requests are a cached npm-registry version check for the update notice
 and a daily fetch of public model pricing rates from LiteLLM (disable with
-`PRICING_REFRESH_INTERVAL_MS=0`). See
+`PRICING_REFRESH_INTERVAL_MS=0`). On first run — and again after a DuckDB
+upgrade — DuckDB itself also downloads its `json`/`fts` extensions (~31 MB) from
+DuckDB's own extension repository into `$DUCKDB_EXTENSION_DIR`. See
 [`SECURITY.md`](./SECURITY.md) for the full breakdown of filesystem, network,
 shell, and self-update behavior — and how to report a vulnerability.
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -47,7 +47,11 @@ None of these are misused; they're listed here so you can verify that.
   within each agent's own directory, never from your project folders.
 - **Writes** only inside its own state dir `~/.claudescope/` (override:
   `$CLAUDESCOPE_HOME`): the DuckDB index (a rebuildable cache), a user-editable
-  `pricing.json`, the daemon PID/port file, and logs.
+  `pricing.json`, the daemon PID/port file, and logs. DuckDB's own `json`/`fts`
+  extensions land there too, under `~/.claudescope/duckdb-extensions/` (override:
+  `$DUCKDB_EXTENSION_DIR`) — the node client doesn't bundle them, so DuckDB
+  downloads them itself, and pointing its `extension_directory` here keeps that
+  write inside the state dir instead of the default `~/.duckdb/extensions`.
 - **Creates that state dir owner-only** (`0700`, files `0600`) — the index, and
   the normalized per-session copies under `cache/`, hold transcript text verbatim.
   Those copies are removed automatically once the source session is gone. The
@@ -83,6 +87,15 @@ None of these are misused; they're listed here so you can verify that.
     disable it entirely.
 
   Both are GET requests that **send no data** beyond the request itself.
+- **DuckDB fetches its own extensions.** The index needs the `json` and `fts`
+  extensions, which the node client doesn't bundle, so on first run — and again
+  after a DuckDB version bump — DuckDB downloads them (~31 MB) into
+  `~/.claudescope/duckdb-extensions/` (override: `$DUCKDB_EXTENSION_DIR`). This
+  is a GET that sends nothing about you, but note it goes over **plain HTTP** to
+  `http://extensions.duckdb.org/<duckdb-version>/<platform>/…` — DuckDB's own
+  default endpoint, unencrypted because the extension binaries are
+  signature-verified rather than transport-protected. Pre-seed that directory (or
+  copy it from another machine) to skip the download and run fully offline.
 - **No telemetry, analytics, or data exfiltration.** Your transcript content
   never leaves your machine.
 - The only other URLs in the repository (`example.com`, `platform.claude.com`)

--- a/docs/plans/0086-audit-fixes-and-fitness-functions.md
+++ b/docs/plans/0086-audit-fixes-and-fitness-functions.md
@@ -1,0 +1,151 @@
+# 0086 — Audit fixes and fitness functions
+
+- **Status:** done
+- **Date:** 2026-09-05
+- **PR:** <https://github.com/vladar107/claudescope/pull/110>
+
+## Context
+
+A full audit of the codebase (architecture, code quality, workarounds, bugs,
+gaps) found that the code is mature and well documented, with two clusters of
+real defects:
+
+- **Analytics derivation.** Claude Code writes one JSONL row per content block,
+  all sharing one `message.id` and repeating the full `usage` object. The
+  `usage_canonical` election dedups *tokens* correctly, but several routes also
+  applied it to `tool_use_count`, which lives on specific block rows. Measured
+  on a real index: the tools route counted 4974 Claude Code calls, the errors
+  and agents routes 2728; the shown error rate was 4.8% against a true 2.7%.
+  The parser summed subagent usage per row (3.84× inflation on a real run).
+  Codex shell failures never carried `is_error`; pi reported a fabricated 0.
+- **DuckDB lifecycle.** `getConnection` treated *every* open failure as
+  corruption and deleted the index — including a lock held by another process
+  (a second `npm run dev` beside the daemon, or two `claudescope mcp` spawns)
+  and a failed extension download. The server had no shutdown handler, so
+  DuckDB was never closed cleanly. Extensions were silently downloaded into
+  `~/.duckdb`, contradicting the documented "writes only inside the state
+  dir" guarantee.
+
+Smaller items: a finalize failure left derived tables stale until the next
+file change; agent-specific literals leaked into `data/` and `routes/`; the
+FTS index relied on a connection-wide relaxation of a DuckDB safety setting;
+interval env vars were unvalidated; two CLI error paths printed stack traces;
+plus a handful of web and wording nits.
+
+The shared indexer/route DuckDB connection was reviewed and deliberately kept
+as is — it is the documented design, not a defect.
+
+## Goal
+
+Fix every audit finding except the shared-connection design, and land each
+fix with a *fitness function*: a test that encodes the rule the bug broke, so
+the same class of defect cannot return silently.
+
+## Decisions
+
+- **Counting rules are named SQL fragments, not inline filters.** Token and
+  cost sums filter on `usage_canonical`; tool-call counts exclude fork copies
+  (`forked_from_session_id IS NULL`) and never use the usage election. One
+  cross-route test asserts all consumers agree on a per-block-split fixture.
+  `sessions.tool_call_count` switches to the fork-excluded sum for consistency.
+- **Error signal is a declared capability.** `agent-capabilities.ts` lists the
+  connectors whose format carries a tool-error flag; a conformance test
+  asserts declared-vs-emitted nullness for every registered connector, so a
+  connector can neither fabricate a zero nor silently drop a real flag.
+- **Discard only on evidence of corruption.** `getConnection` classifies the
+  open error: the stale-schema sentinel and DuckDB storage/WAL corruption
+  rebuild; a lock conflict or an extension-install failure rethrows with a
+  clear message and leaves the file alone.
+- **DuckDB extensions live under the state dir** (`<state>/duckdb-extensions`,
+  override `DUCKDB_EXTENSION_DIR`). Existing users re-download ~30 MB once;
+  in exchange the SECURITY.md containment claim becomes true. Tests pin the
+  shared `~/.duckdb/extensions` cache via the vitest config so CI does not
+  download per test file. Verified while implementing: DuckDB fetches the
+  extensions over plain HTTP (signature-verified, not TLS), which README and
+  SECURITY.md now state. Rejected: documenting `~/.duckdb` and leaving it.
+- **FTS gets a unique document key** (`events.doc_id = hash(file_path, uuid)`,
+  schema v22) so `scalar_subquery_error_on_multiple_rows` can stay at its
+  default. Costs one index rebuild on upgrade; the connection-wide relaxation
+  masked genuine multi-row scalar-subquery bugs everywhere. Rejected: keeping
+  the setting.
+- **Agent knowledge stays behind the seam.** Availability notes and the
+  interrupt / PR-link / subagent-share capabilities move into
+  `agent-capabilities.ts`; Codex's fallback-title stripping becomes a
+  connector hook. An architecture test scans `src/data/` and `src/routes/`
+  for connector-id literals.
+- **Graceful shutdown drains for at most 4 s**, staying under the CLI's 5 s
+  exit wait, then closes Fastify and DuckDB so a clean stop leaves no WAL.
+
+## Approach
+
+Waves keep parallel work on disjoint files.
+
+1. **Wave 1** — counting rules (analytics routes + `rebuildSessions`),
+   parser dedup of subagent totals, connector error signals (Codex exec exit
+   codes, pi error flag, capability set), interval/CLI validation, web and
+   wording nits with `nosniff` / `Referrer-Policy` headers.
+2. **Wave 2** — open-failure classification + extension dir, finalize dirty
+   flag, graceful shutdown.
+3. **Wave 3** — agent knowledge behind the seam + architecture test.
+4. **Wave 4** — FTS unique document key (schema v22), remove the setting.
+5. **Wave 5** — this plan, CLAUDE.md anti-regression rules, `/review`,
+   `npm test`, `npm run typecheck`, markdownlint.
+
+## Fitness functions
+
+1. Per-block split fixture; tools, errors, agents, efficiency, digest, and
+   session meta report the same tool count; tokens count once.
+2. Parser: subagent run totals equal one message's usage on split rows.
+3. Error-signal conformance across every registered connector.
+4. Open-failure classifier on real messages; a child process holding the
+   index makes `getConnection` reject without deleting the file.
+5. Injected finalize failure is repaired by the next idle pass.
+6. Shutdown sequence with injected deps; a clean close leaves no `.wal`.
+7. No connector-id literal under `src/data/` or `src/routes/` outside the
+   capability map.
+8. Scalar-subquery setting at default; FTS key unique on the forked fixture.
+9. Extension directory resolves under the state dir by default.
+10. Interval env parsing; offline `update`; unknown flags are usage errors.
+
+## Files affected
+
+- `packages/server/src/data/analytics-metrics.ts`, `routes/analytics-*.ts`,
+  `data/index.ts` — counting rules and their consumers.
+- `packages/server/src/data/parser.ts` — subagent usage dedup.
+- `packages/server/src/connectors/codex/normalize.ts`, `pi/normalize.ts`,
+  `data/agent-capabilities.ts` — error signals and the capability set.
+- `packages/server/src/db/duckdb.ts`, `config.ts`, `vitest.config.ts` —
+  open-failure classification, extension directory.
+- `packages/server/src/data/index.ts` — finalize dirty flag.
+- `packages/server/src/shutdown.ts` (new), `index.ts`, `daemon.ts` — clean
+  shutdown.
+- `packages/server/src/connectors/types.ts`, `codex/codex.ts`,
+  `claude-code/claude-code.ts`, `data/memory.ts`, `routes/sessions.ts`,
+  `routes/analytics-agents.ts`, `routes/analytics-errors.ts`,
+  `routes/analytics-sessions.ts`, `routes/analytics-digest.ts` — seam.
+- `packages/server/src/db/schema.ts`, `routes/search.ts` — FTS doc key.
+- `packages/server/src/cli.ts`, `config.ts` — validation and error paths.
+- `packages/web/src/pages/search/SearchPage.tsx`,
+  `status/StatusProvider.tsx`, `packages/server/src/security.ts`,
+  `scripts/bundle.mjs` — web and hygiene nits.
+- `packages/server/test/*` — the fitness functions above.
+- `README.md`, `SECURITY.md`, `CLAUDE.md` — extension dir, rules.
+
+## Testing
+
+`npm test` and `npm run typecheck` green (final: 78 files / 807 tests, up from
+72 / 759); each new test was run against the pre-fix code and failed there
+before the fix landed. Measured checks against the live
+daemon after rebuild: errors/agents tool counts equal the tools route;
+subagent headers show deduped totals; `SELECT current_setting(
+'extension_directory')` points under `~/.claudescope`.
+
+## Risks / open questions
+
+- Schema v22 forces a one-time rebuild for every user (seconds to minutes).
+- Existing users re-download DuckDB extensions once into the state dir.
+- pi's tool-result error field must be confirmed against its message type;
+  if absent, pi is declared as having no signal and emits NULL.
+- Deferred to a follow-up plan: sessions-list pagination, Codex incremental
+  prepare and per-file context re-walk, FTS rebuild debouncing (part of the
+  shared-connection topic).

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -110,3 +110,4 @@ decision, or a change worth explaining before doing. Skip it for one-line fixes.
 | 0083 | [Context size and compaction count per session](./0083-context-window-and-compactions.md) | done |
 | 0084 | [Nested subagents (a subagent spawning a subagent)](./0084-nested-subagents.md) | done |
 | 0085 | [Security review hardening](./0085-security-review-hardening.md) | done |
+| 0086 | [Audit fixes and fitness functions](./0086-audit-fixes-and-fitness-functions.md) | done |

--- a/packages/server/src/cli.ts
+++ b/packages/server/src/cli.ts
@@ -30,6 +30,8 @@ import {
   ensureStateDir,
 } from './config.js';
 import { claudeProjectsDir, openBrowserOnStart } from './settings.js';
+import { detectedConnectors } from './connectors/registry.js';
+import { contractHome } from './util/paths.js';
 import {
   DAEMON_FILE,
   LOG_FILE,
@@ -162,7 +164,7 @@ async function start(port: number, open: boolean): Promise<void> {
     return;
   }
   console.log(`\n✓ claudescope running → ${url}`);
-  console.log(`  Sessions: ${claudeProjectsDir()} (read-only)`);
+  console.log(`  ${sourcesLine()}`);
   if (open) openBrowser(url);
   await maybeNotifyUpdate(false);
 }
@@ -251,6 +253,15 @@ function loopbackUrl(port: number): string | null {
   return `http://127.0.0.1:${port}`;
 }
 
+/** One-line summary of the agent transcript sources found on this machine, for
+ *  the post-start banner. Falls back to the (always-configured) Claude Code
+ *  dir when nothing is detected yet, so the line is never empty. */
+function sourcesLine(): string {
+  const dirs = detectedConnectors().map((c) => contractHome(c.sourceDir));
+  const shown = dirs.length > 0 ? dirs : [contractHome(claudeProjectsDir())];
+  return `Sources: ${shown.join(', ')} (read-only)`;
+}
+
 /** Last `n` lines of the daemon log, or '' when there is nothing to show.
  *  Used to explain a startup failure instead of just reporting the timeout. */
 function logTail(n: number): string {
@@ -294,8 +305,11 @@ async function confirm(question: string, defaultYes: boolean): Promise<boolean> 
  *  Resolves the target version and confirms before installing; `--yes` (or a
  *  non-interactive stdin) skips the prompt. Installs the hardcoded package only.
  *  For package-manager-managed installs (brew/nix), defers to that manager. */
-async function update(skipConfirm: boolean): Promise<void> {
-  const latest = await getLatestVersion(true);
+export async function update(skipConfirm: boolean): Promise<void> {
+  // getLatestVersion only returns null for a non-OK registry response — a
+  // network failure (offline) rejects instead, which must fall into the same
+  // "could not reach the registry" branch below rather than crash with a stack.
+  const latest = await getLatestVersion(true).catch(() => null);
   if (latest && !isNewer(latest, APP_VERSION)) {
     console.log(`✓ Already on the latest version (v${APP_VERSION}).`);
     return;
@@ -370,7 +384,7 @@ async function pricingUpdate(): Promise<void> {
 }
 
 /** A bad flag value or missing argument on a query subcommand. */
-class UsageError extends Error {}
+export class UsageError extends Error {}
 
 /**
  * Parse `--port`. Rejects everything the server cannot listen on, because an
@@ -431,7 +445,7 @@ Subcommands:
 }
 
 function help(): void {
-  console.log(`claudescope v${APP_VERSION} — local viewer for Claude Code transcripts
+  console.log(`claudescope v${APP_VERSION} — local viewer for AI coding-agent transcripts
 
 Usage: claudescope [command] [options]
 
@@ -476,49 +490,63 @@ Options:
   -y, --yes        Skip the confirmation prompt (for \`update\`)
 
 State (index, pricing, logs, PID) lives in ${CLAUDESCOPE_HOME}
-(override with $CLAUDESCOPE_HOME). Sessions are read from
-${claudeProjectsDir()} (override with $CLAUDE_PROJECTS_DIR).
+(override with $CLAUDESCOPE_HOME). Source directories are per agent and
+configurable in the web UI's Settings page, or via env vars (see README).
 Settings edited in the web UI persist to settings.json in the state dir
 (env vars always win over saved settings).
 CLAUDESCOPE_AUTO_RESTART=0 disables automatic daemon restarts on version skew.`);
 }
 
-async function main(): Promise<void> {
-  const { values, positionals } = parseArgs({
-    allowPositionals: true,
-    options: {
-      port: { type: 'string' },
-      follow: { type: 'boolean', short: 'f' },
-      help: { type: 'boolean', short: 'h' },
-      version: { type: 'boolean', short: 'v' },
-      yes: { type: 'boolean', short: 'y' },
-      // parseArgs has no built-in negation, so the flag is literally `no-open`.
-      'no-open': { type: 'boolean' },
-      // Query subcommand flags (search/sessions/session/projects/analytics).
-      project: { type: 'string' },
-      cwd: { type: 'string' },
-      agent: { type: 'string' },
-      branch: { type: 'string' },
-      role: { type: 'string' },
-      scope: { type: 'string' },
-      literal: { type: 'boolean' },
-      sort: { type: 'string' },
-      q: { type: 'string' },
-      limit: { type: 'string' },
-      offset: { type: 'string' },
-      session: { type: 'string' },
-      around: { type: 'string' },
-      radius: { type: 'string' },
-      tail: { type: 'string' },
-      'max-tool-chars': { type: 'string' },
-      redact: { type: 'boolean' },
-      json: { type: 'boolean' },
-      'group-by': { type: 'string' },
-      from: { type: 'string' },
-      to: { type: 'string' },
-      timezone: { type: 'string' },
-    },
-  });
+/** Parse process.argv into flags/positionals. A thin wrapper so the inline
+ *  `options` literal keeps parseArgs' precise per-flag type inference (a bare
+ *  try/catch around the call would widen `values` to the generic fallback
+ *  type) while still converting parseArgs' strict-mode throw on an
+ *  unknown/malformed flag (ERR_PARSE_ARGS_UNKNOWN_OPTION, a stack) into a
+ *  UsageError like every other usage mistake. */
+function parseCliArgs() {
+  try {
+    return parseArgs({
+      allowPositionals: true,
+      options: {
+        port: { type: 'string' },
+        follow: { type: 'boolean', short: 'f' },
+        help: { type: 'boolean', short: 'h' },
+        version: { type: 'boolean', short: 'v' },
+        yes: { type: 'boolean', short: 'y' },
+        // parseArgs has no built-in negation, so the flag is literally `no-open`.
+        'no-open': { type: 'boolean' },
+        // Query subcommand flags (search/sessions/session/projects/analytics).
+        project: { type: 'string' },
+        cwd: { type: 'string' },
+        agent: { type: 'string' },
+        branch: { type: 'string' },
+        role: { type: 'string' },
+        scope: { type: 'string' },
+        literal: { type: 'boolean' },
+        sort: { type: 'string' },
+        q: { type: 'string' },
+        limit: { type: 'string' },
+        offset: { type: 'string' },
+        session: { type: 'string' },
+        around: { type: 'string' },
+        radius: { type: 'string' },
+        tail: { type: 'string' },
+        'max-tool-chars': { type: 'string' },
+        redact: { type: 'boolean' },
+        json: { type: 'boolean' },
+        'group-by': { type: 'string' },
+        from: { type: 'string' },
+        to: { type: 'string' },
+        timezone: { type: 'string' },
+      },
+    });
+  } catch (err) {
+    throw new UsageError(err instanceof Error ? err.message : String(err));
+  }
+}
+
+export async function main(): Promise<void> {
+  const { values, positionals } = parseCliArgs();
 
   const port = parsePort(values.port, DEFAULT_PORT);
   // Flag wins, then the persisted setting (which itself folds settings.json >

--- a/packages/server/src/config.ts
+++ b/packages/server/src/config.ts
@@ -49,6 +49,29 @@ function resolvePort(raw: string | undefined): number {
 
 export const PORT = resolvePort(process.env.PORT);
 
+/**
+ * Validate an interval-in-milliseconds env var shared by the pricing-refresh
+ * and self-restart timers: undefined uses `dflt`, `0` disables the timer, and
+ * anything else must be an integer ≥ 1000 — a typo silently disabling a
+ * feature (NaN) or a tiny value hammering the network/spawning processes on
+ * every tick are both worse than falling back to the default.
+ */
+export function resolveIntervalMs(name: string, raw: string | undefined, dflt: number): number {
+  if (raw === undefined) return dflt;
+  // Number('') is 0, not NaN — an empty value must fall through to the warning,
+  // not be mistaken for an explicit "0" (disabled).
+  const n = raw.trim() === '' ? NaN : Number(raw);
+  if (n === 0) return 0;
+  if (!Number.isInteger(n) || n < 1000) {
+    console.warn(
+      `[config] ignoring ${name}='${raw}' — expected 0 (disabled) or an integer ≥ 1000 ms; ` +
+        `using ${dflt}`,
+    );
+    return dflt;
+  }
+  return n;
+}
+
 /** Root directory of the server package (resolved from dist or src at runtime). */
 export const PACKAGE_ROOT = join(__dirname, '..');
 
@@ -120,11 +143,13 @@ export const LITELLM_PRICING_URL =
 
 /**
  * How often (ms) the daemon re-fetches pricing from LiteLLM. Set
- * PRICING_REFRESH_INTERVAL_MS=0 to disable. Default 24h. (The timer itself is
- * wired up in a later wave; this constant only declares the interval.)
+ * PRICING_REFRESH_INTERVAL_MS=0 to disable. Default 24h. The timer itself is
+ * wired up in index.ts, next to the boot-time staleness check.
  */
-export const PRICING_REFRESH_INTERVAL_MS = Number(
-  process.env.PRICING_REFRESH_INTERVAL_MS ?? 24 * 60 * 60 * 1000,
+export const PRICING_REFRESH_INTERVAL_MS = resolveIntervalMs(
+  'PRICING_REFRESH_INTERVAL_MS',
+  process.env.PRICING_REFRESH_INTERVAL_MS,
+  24 * 60 * 60 * 1000,
 );
 
 /**
@@ -133,8 +158,10 @@ export const PRICING_REFRESH_INTERVAL_MS = Number(
  * into the new code (post-update self-heal — see self-restart.ts). Set
  * SELF_RESTART_INTERVAL_MS=0 to disable. Default 5 min.
  */
-export const SELF_RESTART_INTERVAL_MS = Number(
-  process.env.SELF_RESTART_INTERVAL_MS ?? 5 * 60 * 1000,
+export const SELF_RESTART_INTERVAL_MS = resolveIntervalMs(
+  'SELF_RESTART_INTERVAL_MS',
+  process.env.SELF_RESTART_INTERVAL_MS,
+  5 * 60 * 1000,
 );
 
 /**

--- a/packages/server/src/config.ts
+++ b/packages/server/src/config.ts
@@ -110,6 +110,19 @@ export const CLAUDESCOPE_HOME = expandHome(
 export const DUCKDB_PATH = process.env.DUCKDB_PATH ?? join(CLAUDESCOPE_HOME, 'index.duckdb');
 
 /**
+ * Where DuckDB stores the `json`/`fts` extensions. The node client doesn't
+ * bundle them, so DuckDB downloads them itself on first run (and after every
+ * DuckDB version bump) — by default into `~/.duckdb/extensions`, a write
+ * OUTSIDE the state dir, which breaks the "we only write inside
+ * CLAUDESCOPE_HOME" guarantee. Pointing it here keeps that promise (and makes
+ * the download reproducible/removable with the rest of our state). Override
+ * with DUCKDB_EXTENSION_DIR to share a machine-wide cache — which is what the
+ * test suite does, so throwaway state dirs don't re-download per test file.
+ */
+export const DEFAULT_DUCKDB_EXTENSION_DIR = join(CLAUDESCOPE_HOME, 'duckdb-extensions');
+export const DUCKDB_EXTENSION_DIR = process.env.DUCKDB_EXTENSION_DIR ?? DEFAULT_DUCKDB_EXTENSION_DIR;
+
+/**
  * Read-only pricing template shipped inside the package. Seeds the user copy on
  * first run and is the fallback when no user copy exists. Resolved for both the
  * bundled layout (`<pkg>/pricing.default.json` next to the bundle) and the dev

--- a/packages/server/src/connectors/claude-code/claude-code.ts
+++ b/packages/server/src/connectors/claude-code/claude-code.ts
@@ -18,7 +18,7 @@ import { sqlPath, sqlString } from '../../db/duckdb.js';
 import type { SessionData, SubagentSource } from '../../data/session-loader.js';
 import type { AgentConnector, AuxProjections, DiscoveredFile } from '../types.js';
 import { MAX_TOOL_ERROR_TEXT } from '../tool-errors.js';
-import { globalMemory, projectMemory } from './memory.js';
+import { globalMemory, memorySlugForCwd, projectMemory } from './memory.js';
 
 /**
  * Shared `read_ndjson` options for the line-delimited Claude transcripts.
@@ -459,6 +459,7 @@ export const claudeCodeConnector: AgentConnector = {
   loadSession,
   globalMemory,
   projectMemory,
+  projectMemorySlug: memorySlugForCwd,
   resumeSpec: (id) => ({
     resumeArgv: ['claude', '--resume', id],
     forkArgv: ['claude', '--resume', id, '--fork-session'],

--- a/packages/server/src/connectors/codex/codex.ts
+++ b/packages/server/src/connectors/codex/codex.ts
@@ -53,6 +53,48 @@ function auxProjections(filePath: string): AuxProjections {
 }
 
 /**
+ * Codex records its injected AGENTS/environment bootstrap with a USER role, so
+ * a session's first user message is frequently the preamble rather than the
+ * prompt. This strips only the complete, leading wrapper — the `# AGENTS.md
+ * instructions` header through `</INSTRUCTIONS>`, then an `<environment_context>`
+ * block if one follows, or a bare `<environment_context>` prefix — so a
+ * bootstrap-only message falls away (empty candidate → the indexer moves to the
+ * next message) while a prompt coalesced into the same event survives.
+ * Unfamiliar or malformed shapes fall back to the raw text, untouched.
+ */
+function fallbackTitleCandidateSql(sourceExpr: string, textExpr: string): string {
+  const remainder = `substring(${sourceExpr}, strpos(${sourceExpr}, '</INSTRUCTIONS>') + length('</INSTRUCTIONS>'))`;
+  // The remainder keeps the wrapper's trailing newlines; trim them before
+  // testing for the environment block that may follow.
+  const trimmed = `ltrim(${remainder}, chr(9) || chr(10) || chr(13) || ' ')`;
+  const afterEnvironment = (expr: string) =>
+    `substring(${expr}, strpos(${expr}, '</environment_context>') + length('</environment_context>'))`;
+  return `
+    CASE
+      WHEN regexp_matches(
+             ${sourceExpr},
+             '^# AGENTS\\.md instructions(?: for [^\\r\\n]+)?\\r?\\n[\\t\\r\\n ]*<INSTRUCTIONS>'
+           )
+        AND strpos(${sourceExpr}, '<INSTRUCTIONS>') > 0
+        AND strpos(${sourceExpr}, '</INSTRUCTIONS>') > strpos(${sourceExpr}, '<INSTRUCTIONS>')
+      THEN
+        CASE
+          WHEN starts_with(${trimmed}, '<environment_context>') THEN
+            CASE
+              WHEN strpos(${trimmed}, '</environment_context>') > length('<environment_context>')
+              THEN ${afterEnvironment(trimmed)}
+              ELSE ${textExpr}
+            END
+          ELSE ${remainder}
+        END
+      WHEN starts_with(${sourceExpr}, '<environment_context>')
+        AND strpos(${sourceExpr}, '</environment_context>') > length('<environment_context>')
+      THEN ${afterEnvironment(sourceExpr)}
+      ELSE ${textExpr}
+    END`;
+}
+
+/**
  * Load a session's events, splitting the resolved rollouts into the main thread
  * (its own thread id equals the session id) and one subagent per re-keyed child
  * rollout. A child's metadata comes from the matching `spawn_agent` call,
@@ -111,6 +153,7 @@ export const codexConnector: AgentConnector = {
   prepare,
   eventsProjectionSql,
   auxProjections,
+  fallbackTitleCandidateSql,
   loadSession,
   globalMemory: codexGlobalMemory,
   resumeSpec: (id) => ({

--- a/packages/server/src/connectors/codex/normalize.ts
+++ b/packages/server/src/connectors/codex/normalize.ts
@@ -344,17 +344,27 @@ function toolOutputText(output: unknown): string {
   }
 }
 
+/** The shell tool's exec-output envelope (`Chunk ID: … / Wall time: … / Process
+ *  exited with code N / … / Output:`) — group 1 is the exit code, group 2 the
+ *  captured stdout. */
+const EXEC_ENVELOPE_RE =
+  /^Chunk ID: [^\n]*\nWall time: [^\n]*\nProcess exited with code (-?\d+)\n(?:[^\n]*\n)*?Output:\n?([\s\S]*)$/;
+
+/** The exec envelope's exit code, or null when the output carries no envelope
+ *  (nothing to conclude — a failure there is unknowable, not absent). */
+function execExitCode(output: string): number | null {
+  const m = output.match(EXEC_ENVELOPE_RE);
+  return m ? Number(m[1]) : null;
+}
+
 /**
- * Strip Codex's exec-output envelope (`Chunk ID: … / Wall time: … / Process exited
- * with code N / … / Output:`) down to the captured stdout, so a command's output
- * renders clean — and, for a file read (`cat`/`sed`/…), highlights like a file. A
- * non-zero exit keeps the full envelope (the exit code is then the failure signal),
- * and non-envelope output passes through untouched.
+ * Strip Codex's exec-output envelope down to the captured stdout, so a command's
+ * output renders clean — and, for a file read (`cat`/`sed`/…), highlights like a
+ * file. A non-zero exit keeps the full envelope (the exit code is then the failure
+ * signal), and non-envelope output passes through untouched.
  */
 function stripExecEnvelope(output: string): string {
-  const m = output.match(
-    /^Chunk ID: [^\n]*\nWall time: [^\n]*\nProcess exited with code (-?\d+)\n(?:[^\n]*\n)*?Output:\n?([\s\S]*)$/,
-  );
+  const m = output.match(EXEC_ENVELOPE_RE);
   if (!m) return output;
   return Number(m[1]) === 0 ? m[2]! : output;
 }
@@ -912,10 +922,16 @@ export function parseRollout(path: string): CodexSession | null {
           /* unparseable spawn output — the child will render detached */
         }
       }
+      // A failed shell command is the commonest Codex tool failure, and it is
+      // reported ONLY by the envelope's exit code — without this the connector
+      // would report a fabricated zero errors for every session.
+      const exitCode = execExitCode(output);
+      const isError = pl.is_error === true || (exitCode !== null && exitCode !== 0);
       blocks.push({
         type: 'tool_result',
         tool_use_id: callId,
         content: stripExecEnvelope(output),
+        ...(isError ? { is_error: true } : {}),
       });
     } else if (kind === 'custom_tool_call') {
       // Direct apply_patch and the current statically recoverable exec wrapper

--- a/packages/server/src/connectors/pi/normalize.ts
+++ b/packages/server/src/connectors/pi/normalize.ts
@@ -232,6 +232,8 @@ interface PiLine {
     toolCallId?: string;
     /** Set on `toolResult` records — the tool the result belongs to. */
     toolName?: string;
+    /** `toolResult` records only: pi-ai's `ToolResultMessage.isError`. */
+    isError?: unknown;
     /** `subagent` toolResult metadata: `{mode, runId, results:[{agent, task}]}`. */
     details?: unknown;
   };
@@ -378,6 +380,9 @@ export function parsePiSession(path: string): PiSession | null {
         type: 'tool_result',
         tool_use_id: str(msg.toolCallId),
         content: contentBlocks(msg.content),
+        // Without this the row's `tool_error_count` would be a fabricated 0 —
+        // pi is a signal-carrying format, so the flag must be read.
+        ...(msg.isError === true ? { is_error: true } : {}),
       });
       if (!toolResultTs) toolResultTs = ts;
       continue;

--- a/packages/server/src/connectors/types.ts
+++ b/packages/server/src/connectors/types.ts
@@ -81,6 +81,18 @@ export interface AgentConnector {
   auxProjections(filePath: string): AuxProjections;
 
   /**
+   * Optional: this agent's cleaned first-user-message candidate for the fallback
+   * session title, as a SQL expression over the two given column expressions —
+   * `sourceExpr` yields the left-trimmed message text, `textExpr` the raw one.
+   * Agents that inject a bootstrap preamble (instructions, environment context)
+   * into the first user turn strip it here, so the derived title is the user's
+   * actual prompt; a candidate that comes back empty is skipped and the next
+   * message is considered. Connectors whose first user message is already the
+   * prompt omit this and get the raw text.
+   */
+  fallbackTitleCandidateSql?(sourceExpr: string, textExpr: string): string;
+
+  /**
    * Read a single session's files (already resolved from the `files` table) and
    * normalize them into the domain `SessionData` consumed by the thread
    * assembler. `paths` are all files recorded for the session.
@@ -124,6 +136,16 @@ export interface AgentConnector {
    * of scope: surfacing it would require reading arbitrary project dirs.)
    */
   projectMemory?(): AgentMemoryDir[];
+
+  /**
+   * Optional: the encoded-cwd directory name this connector uses to name a
+   * per-project memory dir (the `slug` of {@link AgentMemoryDir}). Implemented
+   * alongside {@link projectMemory} so the route can map a project cwd back to
+   * its memory dir — the attribution fallback for facts whose origin session is
+   * unknown. Each agent encodes a cwd its own way, so a slug only means
+   * something to the connector that produced it.
+   */
+  projectMemorySlug?(cwd: string): string;
 
   /**
    * Optional: how to reopen this session in the agent's own CLI. Returns the

--- a/packages/server/src/daemon.ts
+++ b/packages/server/src/daemon.ts
@@ -38,7 +38,10 @@ export const LOG_FILE = join(CLAUDESCOPE_HOME, 'daemon.log');
 /** Roll the append-only daemon log once it grows past this, so a long-lived or
  *  crash-looping daemon doesn't grow the log without bound. */
 const LOG_MAX_BYTES = 5 * 1024 * 1024;
-/** How long to wait for a signalled process to actually exit before giving up. */
+/** How long to wait for a signalled process to actually exit before giving up.
+ *  The server's own SIGTERM handler drains an in-flight index pass before it
+ *  exits, so its drain budget (`DRAIN_MS` in shutdown.ts) is deliberately sized
+ *  to fit inside this window — a graceful stop must never look like a hang. */
 export const EXIT_WAIT_MS = 5000;
 
 export interface DaemonRecord {

--- a/packages/server/src/data/agent-capabilities.ts
+++ b/packages/server/src/data/agent-capabilities.ts
@@ -8,6 +8,13 @@
 import type { AgentUsageGranularity } from '@claudescope/shared';
 
 /**
+ * The agent a row with no recorded `connector_id` belongs to. Claude Code was
+ * the only source before the column existed, so a legacy/NULL id is its row —
+ * a fallback for stored data, never a guess about an unknown agent.
+ */
+export const DEFAULT_CONNECTOR_ID = 'claude-code';
+
+/**
  * How each agent records token usage:
  * - copilot: tokens live only in `session.shutdown`, attached to the last
  *   assistant row — session totals are real, per-response ratios are not, and
@@ -95,4 +102,58 @@ export function connectorsWithToolErrorSignal(): string[] {
 
 export function connectorsWithoutToolErrorSignal(): string[] {
   return [...NO_TOOL_ERROR_SIGNAL];
+}
+
+/**
+ * Agents whose format records a user interrupt: Claude Code writes the
+ * `[Request interrupted by user…]` marker as the user message's text. No other
+ * source persists the event at all, so their interrupt count is `null`
+ * ("unavailable"), never the 0 a marker search would produce.
+ */
+const INTERRUPT_SIGNAL = new Set(['claude-code']);
+
+export function hasInterruptSignal(connectorId: string): boolean {
+  return INTERRUPT_SIGNAL.has(connectorId);
+}
+
+/**
+ * Agents whose transcripts link a subagent run back to the session that spawned
+ * it. Junie delegates by running `junie …` as a plain terminal command, so its
+ * children are independent sessions with zero ID linkage (see CLAUDE.md) — a
+ * subagent share derived for it would report 0 delegation, not "unknown".
+ * Unknown connectors are assumed to have linkage: that is the canonical shape.
+ */
+const NO_SUBAGENT_LINKAGE = new Set(['junie']);
+
+export function hasSubagentLinkage(connectorId: string): boolean {
+  return !NO_SUBAGENT_LINKAGE.has(connectorId);
+}
+
+/**
+ * Why an agent's usage figures read n/a (or skewed) on the agent comparison —
+ * the human sentence behind {@link usageGranularity} and the nulls around it.
+ * A property of the source format, so it lives here rather than in the route.
+ */
+const USAGE_AVAILABILITY_NOTES: Record<string, string> = {
+  copilot:
+    'Copilot records usage once per session (at shutdown), so per-response ratios are unavailable; crashed or still-running sessions carry no usage.',
+  antigravity:
+    'Antigravity transcripts carry no token counts — tokens and cost are unavailable by design.',
+  junie: 'Junie delegates via plain terminal commands, so subagent usage is invisible.',
+  grok: 'Grok records usage once per user turn (in updates.jsonl); a session whose updates file is missing or truncated reports zero tokens.',
+};
+
+export function usageAvailabilityNote(connectorId: string): string | undefined {
+  return USAGE_AVAILABILITY_NOTES[connectorId];
+}
+
+/** The same, for the error/interrupt signals (see {@link hasToolErrorSignal}). */
+const ERROR_AVAILABILITY_NOTES: Record<string, string> = {
+  junie: 'Junie tool results are plain strings — the format has no error signal.',
+  antigravity: 'Antigravity result records carry no error signal.',
+  copilot: 'Copilot counts permission-denied calls as errors.',
+};
+
+export function errorAvailabilityNote(connectorId: string): string | undefined {
+  return ERROR_AVAILABILITY_NOTES[connectorId];
 }

--- a/packages/server/src/data/agent-capabilities.ts
+++ b/packages/server/src/data/agent-capabilities.ts
@@ -67,3 +67,32 @@ export function hasCompactionSignal(connectorId: string): boolean {
 export function connectorsWithCompactionSignal(): string[] {
   return [...COMPACTION_SIGNAL];
 }
+
+/**
+ * Agents whose format marks a tool call as FAILED, so `events.tool_error_count`
+ * carries a real number: Claude Code (`tool_result.is_error`, derived in SQL),
+ * Codex (`is_error` plus the exec/custom envelope's exit code), pi
+ * (`toolResult.isError`), opencode (`state.status === 'error'`), Copilot
+ * (`tool.execution_complete.success === false`). Junie's "modified: path" result
+ * strings, Antigravity's typed result records and Grok's bare `tool_result`
+ * bodies carry no such flag — their normalizers emit NULL so analytics reads
+ * "unavailable" rather than a fabricated 0.
+ */
+const TOOL_ERROR_SIGNAL = new Set(['claude-code', 'codex', 'pi', 'opencode', 'copilot']);
+
+/** The other side of {@link TOOL_ERROR_SIGNAL} — every remaining connector must
+ *  be listed here, so adding an agent forces a deliberate classification
+ *  (enforced by `connector-error-signal.test.ts`). */
+const NO_TOOL_ERROR_SIGNAL = new Set(['junie', 'antigravity', 'grok']);
+
+export function hasToolErrorSignal(connectorId: string): boolean {
+  return TOOL_ERROR_SIGNAL.has(connectorId);
+}
+
+export function connectorsWithToolErrorSignal(): string[] {
+  return [...TOOL_ERROR_SIGNAL];
+}
+
+export function connectorsWithoutToolErrorSignal(): string[] {
+  return [...NO_TOOL_ERROR_SIGNAL];
+}

--- a/packages/server/src/data/analytics-metrics.ts
+++ b/packages/server/src/data/analytics-metrics.ts
@@ -42,3 +42,43 @@ export function cacheHitRatioSql(cacheRead: string, cacheWrite: string, input: s
   const denominator = `(${read} + COALESCE(${cacheWrite}, 0) + COALESCE(${input}, 0))`;
   return `CASE WHEN ${denominator} > 0 THEN ${read}::DOUBLE / ${denominator} ELSE 0 END`;
 }
+
+/**
+ * THE RULE — an aggregate over `events` deduplicates one of two ways, and which
+ * one depends on what the column measures:
+ *
+ *  - **Token/cost SUMs dedup by billed API call** ({@link usageRowsSql}). Claude
+ *    Code writes one row per content block of an assistant message; every row
+ *    shares the `message.id` and repeats the FULL `usage`, and a fork copies the
+ *    lot into a second file. `electCanonicalUsage` (see `data/index.ts`) elects
+ *    exactly one row per `message_id`, so summing only elected rows counts each
+ *    billed call once.
+ *  - **Per-row COUNTS dedup fork copies only** ({@link toolCallRowsSql}):
+ *    `tool_use_count`, the `tool_names`/`skill_names` unnest, and
+ *    `tool_error_count` live on the SPECIFIC rows carrying those blocks — and
+ *    since only one row per message can win the usage election, most of them
+ *    LOSE it. Filtering these on `usage_canonical` hides the majority of real
+ *    tool calls (measured on a real index: 4974 Claude Code calls counted the
+ *    right way vs 2728 through the election). The only duplicates a per-row
+ *    count has to fear are fork copies, which carry `forked_from_session_id`.
+ *
+ * `tool_error_count` sits on the USER rows carrying the tool_results, whose
+ * `message_id` is NULL and which are therefore always canonical — so there the
+ * usage filter was a no-op and the fork exclusion is the whole dedup.
+ *
+ * The two rules are not interchangeable, and a route that mixes them reports a
+ * tool-call number that contradicts /api/analytics/tools.
+ */
+
+/** Rows to SUM tokens/cost over: one elected row per billed API call. */
+export function usageRowsSql(alias = 'e'): string {
+  return `${alias ? `${alias}.` : ''}usage_canonical`;
+}
+
+/**
+ * Rows to COUNT tool calls / tool errors over: everything except fork copies.
+ * Pass `''` for an unaliased query (the indexer's `FROM events`).
+ */
+export function toolCallRowsSql(alias = 'e'): string {
+  return `${alias ? `${alias}.` : ''}forked_from_session_id IS NULL`;
+}

--- a/packages/server/src/data/index.ts
+++ b/packages/server/src/data/index.ts
@@ -476,26 +476,43 @@ async function rebuildSessions(conn: DuckDBConnection): Promise<void> {
 }
 
 /**
+ * The title-candidate expression over the `user_text` CTE: each connector that
+ * cleans its own first message gets a branch keyed by its registry id, everyone
+ * else the raw text. Built from the registry, so no agent is named here.
+ */
+function candidateExpression(): string {
+  const branches = connectors
+    .filter((c) => c.fallbackTitleCandidateSql)
+    .map(
+      (c) =>
+        `WHEN connector_id = ${sqlString(c.id)} THEN ${c.fallbackTitleCandidateSql!('source', 'text_content')}`,
+    );
+  if (branches.length === 0) return 'text_content';
+  return `CASE ${branches.join(' ')} ELSE text_content END`;
+}
+
+/**
  * Fill in fallback titles for sessions with no real stored title, by cleaning
  * the first genuine user message (see {@link cleanFallbackTitleCandidate}).
  * Runs after the derived `sessions` rebuild, so it only touches rows whose
  * `title` came back empty.
  *
- * Codex records its injected AGENTS/environment bootstrap with a user role. The
- * candidate CTE removes only that complete, leading wrapper: an empty
- * bootstrap-only row falls away, while a prompt coalesced into the same event
- * remains. Other connectors and unfamiliar/malformed Codex shapes pass through
- * untouched.
+ * Some agents record an injected bootstrap (instructions, environment context)
+ * with a user role, so their first user message is not the prompt. Stripping it
+ * is the connector's business, not the indexer's: each contributes its own
+ * candidate expression via {@link AgentConnector.fallbackTitleCandidateSql}, and
+ * connectors without one use the raw text (see {@link candidateExpression}).
  *
  * Candidates are considered in small per-session batches. The shared TS
- * eligibility rule can therefore reject a complete harness turn (such as
- * Claude Code's `/clear`) and continue to the next user message without loading
- * every turn into memory. Candidate text is capped to a few KB only AFTER
- * Codex wrapper removal, then cleaned and written with `title_derived = TRUE`.
+ * eligibility rule can therefore reject a complete harness turn (such as a
+ * `/clear`) and continue to the next user message without loading every turn
+ * into memory. Candidate text is capped to a few KB only AFTER the connector's
+ * cleanup, then cleaned and written with `title_derived = TRUE`.
  */
 async function applyFallbackTitles(conn: DuckDBConnection): Promise<void> {
   const updates: string[] = [];
   const CANDIDATE_BATCH_SIZE = 8;
+  const candidateSql = candidateExpression();
   let firstRank = 1;
   let pendingSessionIds: string[] | null = null;
 
@@ -521,67 +538,13 @@ async function applyFallbackTitles(conn: DuckDBConnection): Promise<void> {
           AND e.text_content IS NOT NULL
           AND length(trim(e.text_content)) > 0
           ${sessionFilter}
-      ), instruction_bounds AS (
-        SELECT
-          *,
-          strpos(source, '<INSTRUCTIONS>') AS instructions_start,
-          strpos(source, '</INSTRUCTIONS>') AS instructions_end
-        FROM user_text
-      ), instruction_remainders AS (
-        SELECT
-          *,
-          CASE
-            WHEN connector_id = 'codex'
-              AND regexp_matches(
-                source,
-                '^# AGENTS\\.md instructions(?: for [^\\r\\n]+)?\\r?\\n[\\t\\r\\n ]*<INSTRUCTIONS>'
-              )
-              AND instructions_start > 0
-              AND instructions_end > instructions_start
-            THEN substring(source, instructions_end + length('</INSTRUCTIONS>'))
-            ELSE NULL
-          END AS instructions_remainder
-        FROM instruction_bounds
       ), candidates AS (
         SELECT
           session_id,
           ts,
           uuid,
-          CASE
-            WHEN instructions_remainder IS NOT NULL THEN
-              CASE
-                WHEN starts_with(
-                  ltrim(instructions_remainder, chr(9) || chr(10) || chr(13) || ' '),
-                  '<environment_context>'
-                ) THEN
-                  CASE
-                    WHEN strpos(
-                      ltrim(instructions_remainder, chr(9) || chr(10) || chr(13) || ' '),
-                      '</environment_context>'
-                    )
-                      > length('<environment_context>')
-                    THEN substring(
-                      ltrim(instructions_remainder, chr(9) || chr(10) || chr(13) || ' '),
-                      strpos(
-                        ltrim(instructions_remainder, chr(9) || chr(10) || chr(13) || ' '),
-                        '</environment_context>'
-                      )
-                        + length('</environment_context>')
-                    )
-                    ELSE text_content
-                  END
-                ELSE instructions_remainder
-              END
-            WHEN connector_id = 'codex'
-              AND starts_with(source, '<environment_context>')
-              AND strpos(source, '</environment_context>') > length('<environment_context>')
-            THEN substring(
-              source,
-              strpos(source, '</environment_context>') + length('</environment_context>')
-            )
-            ELSE text_content
-          END AS raw
-        FROM instruction_remainders
+          ${candidateSql} AS raw
+        FROM user_text
       ), ranked AS (
         SELECT
           session_id,

--- a/packages/server/src/data/index.ts
+++ b/packages/server/src/data/index.ts
@@ -251,7 +251,8 @@ async function loadFile(
       ${costExpr} AS cost_usd,
       ev.text_content,
       ev.message_id, ev.forked_from_session_id, TRUE AS usage_canonical,
-      ev.tool_error_count, ev.tool_error_text, ev.skill_names
+      ev.tool_error_count, ev.tool_error_text, ev.skill_names,
+      hash(ev.file_path, ev.uuid) AS doc_id
     FROM (
       ${connector.eventsProjectionSql(file.path)}
     ) AS ev
@@ -601,12 +602,16 @@ async function applyFallbackTitles(conn: DuckDBConnection): Promise<void> {
 
 /** (Re)build the BM25 full-text index over event text. */
 async function rebuildFtsIndex(conn: DuckDBConnection): Promise<void> {
+  // Keyed by `doc_id`, not `uuid`: the generated match_bm25 macro looks a
+  // document up with a scalar subquery on that column, so it must be unique per
+  // row — a fork/resume copy repeats every uuid (see schema.ts).
+  //
   // DuckDB's default ignore expression drops every non-letter, which makes
   // versions, issue numbers, and other identifiers impossible to find. Keep
   // digits as terms while punctuation remains a token boundary.
   await conn.run(`
     PRAGMA create_fts_index(
-      'events', 'uuid', 'text_content', ignore='[^a-z0-9]+', overwrite=1
+      'events', 'doc_id', 'text_content', ignore='[^a-z0-9]+', overwrite=1
     )
   `);
   // Force a CHECKPOINT so the FTS index DDL is merged into the main DB file

--- a/packages/server/src/data/index.ts
+++ b/packages/server/src/data/index.ts
@@ -391,7 +391,10 @@ async function rebuildSessions(conn: DuckDBConnection): Promise<void> {
         min(ts) AS started_at,
         max(ts) AS ended_at,
         count(*) AS message_count,
-        sum(tool_use_count) AS tool_call_count,
+        -- Per-row count: fork copies excluded, the usage election NOT applied
+        -- (it would drop the tool_use rows of every split message). See THE RULE
+        -- in data/analytics-metrics.ts.
+        COALESCE(sum(tool_use_count) FILTER (WHERE forked_from_session_id IS NULL), 0) AS tool_call_count,
         -- Usage/cost SUMs filter on usage_canonical so a single billed API call
         -- (written as many content-block rows, or copied by a fork) is counted
         -- once; COALESCE guards a session whose every usage row is non-canonical.

--- a/packages/server/src/data/index.ts
+++ b/packages/server/src/data/index.ts
@@ -38,6 +38,24 @@ let progress: IndexingProgress | null = null;
  *  moves. Resets on daemon restart, so clients compare by inequality. */
 let dataVersion = 0;
 
+/** True from the moment a pass finds file changes until its finalize step
+ *  (electCanonicalUsage → refreshFileEdits → electCanonicalEdits →
+ *  rebuildSessions → rebuildFtsIndex) actually completes. Files bookkeeping
+ *  (the `files`/`events` tables) advances per file *before* finalize runs, so
+ *  a failed finalize must be remembered — otherwise the next pass would see
+ *  no changed files, take the idle early-return, and leave `sessions`,
+ *  `file_edits`, and the FTS index permanently stale versus `events`. */
+let derivedDirty = false;
+/** Sessions whose `file_edits` are owed a refresh, carried across a failed
+ *  finalize so a later pass with no file changes still repairs them. */
+let pendingEditSessions = new Set<string>();
+/** Test seam: makes the NEXT finalize step throw once, so the recovery path
+ *  above can be exercised without fabricating a broken table state. */
+let failNextFinalize = false;
+export function failNextFinalizeForTests(): void {
+  failNextFinalize = true;
+}
+
 /** Min interval between mid-first-build partial `sessions` rebuilds (ms).
  *  Env-overridable so tests can force a rebuild after every file. */
 const PARTIAL_REBUILD_MS = Number(process.env.PARTIAL_REBUILD_MS ?? 3000);
@@ -796,6 +814,10 @@ async function doReindex(): Promise<ReindexResponse> {
     return !(prev && prev.mtime === file.mtimeMs && prev.size === file.size);
   });
 
+  // Latch as soon as we know this pass has work: `files`/`events` start
+  // advancing per file below, ahead of finalize (see {@link derivedDirty}).
+  if (changed.length > 0 || removed > 0) derivedDirty = true;
+
   let reindexed = 0;
   // Files this pass could not load. Reported on ReindexResponse so a pass that
   // failed on everything is distinguishable from an idle one — otherwise both
@@ -865,20 +887,40 @@ async function doReindex(): Promise<ReindexResponse> {
     // tables untouched and skipping the rebuild is correct today. The guard is
     // belt-and-braces — if a future non-atomic path ever half-applies a load,
     // this must not report a clean idle pass over an inconsistent index.
-    if (reindexed === 0 && removed === 0 && failed === 0) {
+    // `!derivedDirty`: a prior pass's finalize may have thrown after `files`
+    // already advanced — this pass must still run finalize even though it
+    // sees no changes of its own.
+    if (reindexed === 0 && removed === 0 && failed === 0 && !derivedDirty) {
       ready = true;
       return { reindexed, failed, durationMs: Date.now() - start };
     }
 
-    // Something changed: re-elect the usage-canonical rows globally, then rebuild
-    // derived tables + FTS so additions, edits, and removals are all reflected.
+    // Carry this pass's touched sessions forward before finalize can throw,
+    // so a failed finalize doesn't lose track of what it still owes.
+    for (const s of editSessions) pendingEditSessions.add(s);
+
+    // Test seam (see {@link failNextFinalizeForTests}): throw before finalize
+    // does anything, to exercise the recovery path above.
+    if (failNextFinalize) {
+      failNextFinalize = false;
+      throw new Error('injected finalize failure');
+    }
+
+    // Something changed (or a prior finalize never completed): re-elect the
+    // usage-canonical rows globally, then rebuild derived tables + FTS so
+    // additions, edits, and removals are all reflected.
     await electCanonicalUsage(conn);
-    // Refresh code-impact rows for the touched sessions, then re-elect the
-    // canonical edit per (uuid, tool_use_id) globally (fork copies dedup).
-    await refreshFileEdits(conn, editSessions);
+    // Refresh code-impact rows for every session still owed one (this pass's,
+    // plus any left over from a failed finalize), then re-elect the canonical
+    // edit per (uuid, tool_use_id) globally (fork copies dedup).
+    await refreshFileEdits(conn, pendingEditSessions);
     await electCanonicalEdits(conn);
     await rebuildSessions(conn);
     await rebuildFtsIndex(conn);
+
+    // Only clear once finalize has fully succeeded.
+    derivedDirty = false;
+    pendingEditSessions.clear();
 
     ready = true;
     dataVersion += 1;

--- a/packages/server/src/data/memory.ts
+++ b/packages/server/src/data/memory.ts
@@ -14,7 +14,6 @@ import { getConnection, queryRows } from '../db/duckdb.js';
 import { connectors } from '../connectors/registry.js';
 import type { AgentConnector } from '../connectors/types.js';
 import { displayNameFromCwd, projectIdFromCwd } from './project-id.js';
-import { memorySlugForCwd } from '../connectors/claude-code/memory.js';
 
 /** One memory source, attributed to a connector and (for project facts) a project. */
 export interface AttributedMemory {
@@ -69,20 +68,33 @@ export async function collectMemory(): Promise<AttributedMemory[]> {
   );
 
   const sessionToProject = new Map<string, string>();
-  const slugToProject = new Map<string, string>();
+  const projectByCwd = new Map<string, string>();
   const displayNames = new Map<string, string>();
   for (const r of rows) {
     const cwd = String(r.project_cwd);
     const projectId = projectIdFromCwd(cwd);
     if (r.id != null) sessionToProject.set(String(r.id), projectId);
-    const slug = memorySlugForCwd(cwd);
-    if (!slugToProject.has(slug)) slugToProject.set(slug, projectId);
+    if (!projectByCwd.has(cwd)) projectByCwd.set(cwd, projectId);
     if (!displayNames.has(projectId)) displayNames.set(projectId, displayNameFromCwd(cwd));
+  }
+
+  // A dir slug is the connector's OWN encoding of a cwd, so the fallback map is
+  // built per connector — only those that expose their encoding get one.
+  const slugToProject = new Map<string, Map<string, string>>();
+  for (const c of connectors) {
+    const slugForCwd = c.projectMemorySlug;
+    if (!slugForCwd) continue;
+    const bySlug = new Map<string, string>();
+    for (const [cwd, projectId] of projectByCwd) {
+      const slug = slugForCwd(cwd);
+      if (!bySlug.has(slug)) bySlug.set(slug, projectId);
+    }
+    slugToProject.set(c.id, bySlug);
   }
 
   for (const c of connectors) {
     for (const dir of safeProject(c)) {
-      const fallback = slugToProject.get(dir.slug);
+      const fallback = slugToProject.get(c.id)?.get(dir.slug);
       for (const source of dir.facts) {
         const byOrigin = source.originSessionId
           ? sessionToProject.get(source.originSessionId)

--- a/packages/server/src/data/parser.ts
+++ b/packages/server/src/data/parser.ts
@@ -256,6 +256,39 @@ function usageTokens(usage?: MessageUsage): number {
   );
 }
 
+/**
+ * Sum usage across a subagent's raw events, one addend per billed API call.
+ *
+ * Claude Code writes one row per content block of an assistant message, and
+ * every row of that message shares the same `message.id` and repeats the
+ * FULL `usage` object — summing per-row (as the assembled thread does per
+ * {@link ThreadItem}) multiplies a single API call's usage by its block
+ * count. Mirrors the SQL election in `electCanonicalUsage` (index.ts): within
+ * a `message.id` group, the row with the largest `output_tokens` wins, since
+ * only output grows across a streamed group (ties keep the first seen).
+ * Events without a `message.id` count individually.
+ */
+function subagentUsageTokens(events: RawEvent[]): number {
+  const byMessageId = new Map<string, MessageUsage>();
+  let total = 0;
+  for (const e of events) {
+    // Like messageContent(), tolerate a row with no `message` at all.
+    if (e.type !== 'assistant' || !e.message?.usage) continue;
+    const usage = e.message.usage;
+    const id = e.message.id;
+    if (id === undefined) {
+      total += usageTokens(usage);
+      continue;
+    }
+    const current = byMessageId.get(id);
+    if (!current || (usage.output_tokens ?? 0) > (current.output_tokens ?? 0)) {
+      byMessageId.set(id, usage);
+    }
+  }
+  for (const usage of byMessageId.values()) total += usageTokens(usage);
+  return total;
+}
+
 interface SpawnPoint {
   toolUseId: string;
   spawnUuid: string;
@@ -377,7 +410,7 @@ export function buildSubagentRuns(
       (n, t) => n + t.blocks.filter((b) => b.kind === 'tool').length,
       0,
     );
-    const totalTokens = thread.reduce((n, t) => n + usageTokens(t.usage), 0);
+    const totalTokens = subagentUsageTokens(src.events);
     return { src, thread, toolCallCount, totalTokens };
   });
   const runIds = new Set(sources.map((s) => s.agentId));

--- a/packages/server/src/db/duckdb.ts
+++ b/packages/server/src/db/duckdb.ts
@@ -99,20 +99,6 @@ async function prepare(inst: DuckDBInstance): Promise<{
   await conn.run('INSTALL json; LOAD json;');
   await conn.run('INSTALL fts; LOAD fts;');
 
-  // `events.uuid` is NOT unique: fork/resume copies re-list the same lines under
-  // a new session id. `fts_main_events.match_bm25(uuid, …)` looks the document up
-  // with a scalar subquery keyed by uuid, so it legitimately hits multiple rows,
-  // and newer DuckDB raises on that. The duplicates are identical copies, so
-  // picking a representative is correct (see routes/search.ts).
-  //
-  // Applied here, at open time, rather than inside the search handler: this is a
-  // CONNECTION-level setting on a connection shared with the indexer and every
-  // other route, so setting it per request meant an unrelated HTTP call silently
-  // changed query semantics process-wide — and left them changed. Doing it once
-  // makes the connection's behaviour deterministic instead of depending on
-  // whether a search has run yet.
-  await conn.run('SET scalar_subquery_error_on_multiple_rows = false');
-
   // A schema-version mismatch means the persisted shape is outdated. The index
   // is a derived cache, so signal a discard+rebuild rather than migrate in place.
   if (await isStaleSchema(conn)) {

--- a/packages/server/src/db/duckdb.ts
+++ b/packages/server/src/db/duckdb.ts
@@ -5,11 +5,16 @@
  */
 
 import { createHash } from 'node:crypto';
-import { rmSync } from 'node:fs';
+import { mkdirSync, rmSync } from 'node:fs';
 import { dirname } from 'node:path';
 import { DuckDBInstance } from '@duckdb/node-api';
 import type { DuckDBConnection } from '@duckdb/node-api';
-import { DUCKDB_PATH, ensureStateDir } from '../config.js';
+import {
+  DEFAULT_DUCKDB_EXTENSION_DIR,
+  DUCKDB_EXTENSION_DIR,
+  DUCKDB_PATH,
+  ensureStateDir,
+} from '../config.js';
 import { SCHEMA_DDL, SCHEMA_VERSION } from './schema.js';
 
 /**
@@ -59,8 +64,38 @@ async function openAndPrepare(): Promise<{ conn: DuckDBConnection; inst: DuckDBI
   // Owner-only: DuckDB creates index.duckdb itself (we can't pass a mode), so
   // the 0700 directory is what keeps the indexed transcript corpus private.
   ensureStateDir(dirname(DUCKDB_PATH));
+  // The default extension dir is app-owned state and gets the owner-only mode;
+  // an override may be a shared cache (the tests point at ~/.duckdb/extensions)
+  // whose mode is not ours to change — create it, never chmod it.
+  if (DUCKDB_EXTENSION_DIR === DEFAULT_DUCKDB_EXTENSION_DIR) ensureStateDir(DUCKDB_EXTENSION_DIR);
+  else mkdirSync(DUCKDB_EXTENSION_DIR, { recursive: true });
   const inst = await DuckDBInstance.create(DUCKDB_PATH);
+  try {
+    return await prepare(inst);
+  } catch (err) {
+    // Anything that throws past the open must release the file lock: the caller
+    // either discards the file (which needs it closed) or rethrows to a process
+    // that may retry later.
+    try {
+      inst.closeSync();
+    } catch {
+      /* already closed */
+    }
+    throw err;
+  }
+}
+
+/** Configure the open instance and apply the schema. Split out of
+ *  {@link openAndPrepare} so every failure below shares one lock-release path. */
+async function prepare(inst: DuckDBInstance): Promise<{
+  conn: DuckDBConnection;
+  inst: DuckDBInstance;
+}> {
   const conn = await inst.connect();
+  // The node client bundles neither extension, so DuckDB downloads them the
+  // first time (and after each DuckDB version bump). Redirect that write into
+  // our own state dir — see DUCKDB_EXTENSION_DIR.
+  await conn.run(`SET extension_directory = ${sqlString(DUCKDB_EXTENSION_DIR)}`);
   await conn.run('INSTALL json; LOAD json;');
   await conn.run('INSTALL fts; LOAD fts;');
 
@@ -81,7 +116,6 @@ async function openAndPrepare(): Promise<{ conn: DuckDBConnection; inst: DuckDBI
   // A schema-version mismatch means the persisted shape is outdated. The index
   // is a derived cache, so signal a discard+rebuild rather than migrate in place.
   if (await isStaleSchema(conn)) {
-    inst.closeSync();
     throw new Error(`index schema is stale (expected v${SCHEMA_VERSION}); rebuilding`);
   }
 
@@ -93,6 +127,75 @@ async function openAndPrepare(): Promise<{ conn: DuckDBConnection; inst: DuckDBI
     `INSERT OR REPLACE INTO meta (key, value) VALUES ('schema_signature', '${SCHEMA_SIGNATURE}')`,
   );
   return { conn, inst };
+}
+
+/** DuckDB's single-writer guard, e.g. `IO Error: Could not set lock on file
+ *  "…/index.duckdb": Conflicting lock is held in …/bin/node (PID 66590) by user
+ *  …`. Another live process owns the index; the file itself is fine. */
+const LOCK_CONFLICT = /Could not set lock on file/i;
+
+/** OS-level failures to open/write the file: no permission, or no space. */
+const OS_FAILURE = /\b(EACCES|EPERM|ENOSPC)\b/;
+
+/**
+ * Whether an open failure came from installing/loading the `json`/`fts`
+ * extensions rather than from the database file. DuckDB downloads them from its
+ * extension repository, so an offline or proxy-blocked machine fails here with a
+ * perfectly healthy index. The generic network markers only count when the
+ * message also mentions an extension — a corrupt-file message quoting a path
+ * must never be mistaken for a download failure.
+ */
+function isExtensionFailure(message: string): boolean {
+  if (/Failed to download extension/i.test(message)) return true;
+  if (/IO Error: Extension/i.test(message)) return true;
+  if (/Could not establish connection/i.test(message)) return true;
+  if (!/extension/i.test(message)) return false;
+  return /could not be loaded|not found|\bHTTP\b/i.test(message);
+}
+
+/**
+ * Whether an open failure is something OTHER than a corrupt index — a lock held
+ * by another process, an extension that couldn't be installed, or an OS-level
+ * permission/disk error. None of those are fixed by deleting the index, and
+ * deleting it on a lock conflict destroys the *live* daemon's database (a second
+ * server — a stray `npm run dev` beside the global daemon, or a racing
+ * `claudescope mcp` — shares the same state dir). Everything else, including the
+ * stale-schema sentinel and an unreplayable WAL, stays rebuildable.
+ */
+export function isNonCorruptionOpenError(err: unknown): boolean {
+  const code = (err as { code?: unknown } | null | undefined)?.code;
+  if (typeof code === 'string' && OS_FAILURE.test(code)) return true;
+
+  const message = err instanceof Error ? err.message : String(err ?? '');
+  if (LOCK_CONFLICT.test(message) || OS_FAILURE.test(message)) return true;
+  return isExtensionFailure(message);
+}
+
+/** Wrap a non-corruption open failure in an actionable error (original kept as
+ *  `cause`), naming what to do about it instead of silently rebuilding. */
+function describeOpenFailure(err: unknown): Error {
+  const message = err instanceof Error ? err.message : String(err ?? '');
+  let hint: string;
+  if (LOCK_CONFLICT.test(message)) {
+    const holder = message.match(/Conflicting lock is held in (.+?) by user/)?.[1];
+    hint =
+      `another Claudescope (or other DuckDB) process already holds the index lock — ` +
+      `${holder ?? 'holder unknown'}. Stop it (\`claudescope stop\`) or run this one ` +
+      `against a different DUCKDB_PATH; the index was left untouched.`;
+  } else if (isExtensionFailure(message)) {
+    hint =
+      `the DuckDB \`json\`/\`fts\` extensions could not be installed. They are ` +
+      `downloaded once from DuckDB's extension repository into ${DUCKDB_EXTENSION_DIR} ` +
+      `(override: DUCKDB_EXTENSION_DIR), so this needs network access — or a copy of ` +
+      `that directory. The index was left untouched.`;
+  } else {
+    hint =
+      `the index file is not usable (check permissions and free disk space). ` +
+      `It was left untouched.`;
+  }
+  return new Error(`[duckdb] cannot open index at ${DUCKDB_PATH}: ${hint} Cause: ${message}`, {
+    cause: err,
+  });
 }
 
 /** Delete the persistent DB file and its WAL/temp siblings. Used by the
@@ -114,6 +217,12 @@ export function discardDbFiles(): void {
  * killed mid-write, a known hazard with FTS index DDL), we discard the file and
  * rebuild from scratch rather than wedging startup. The subsequent reindex
  * repopulates it.
+ *
+ * That discard applies ONLY to evidence of corruption. A failure the index isn't
+ * to blame for — another process holding the lock, an extension that couldn't be
+ * downloaded, a permission/disk error ({@link isNonCorruptionOpenError}) — is
+ * rethrown with an actionable message and leaves every file on disk alone.
+ * Rebuilding there would delete a healthy (possibly live) index.
  */
 export async function getConnection(): Promise<DuckDBConnection> {
   if (connection) return connection;
@@ -124,6 +233,7 @@ export async function getConnection(): Promise<DuckDBConnection> {
     try {
       opened = await openAndPrepare();
     } catch (err) {
+      if (isNonCorruptionOpenError(err)) throw describeOpenFailure(err);
       console.warn(
         `[duckdb] failed to open index at ${DUCKDB_PATH}; discarding and rebuilding. Cause:`,
         err instanceof Error ? err.message : err,

--- a/packages/server/src/db/schema.ts
+++ b/packages/server/src/db/schema.ts
@@ -46,7 +46,9 @@
 //      compaction, per file) + sessions.context_tokens / context_model /
 //      compaction_count derived at rebuild.
 // v21: pr_links admits only http(s) URLs (pr_url is rendered as a link).
-export const SCHEMA_VERSION = 21;
+// v22: FTS keyed by a unique per-row doc_id = hash(file_path, uuid) so the
+//      connection-wide scalar-subquery relaxation can go.
+export const SCHEMA_VERSION = 22;
 
 /** All DDL statements, executed in order at startup. Idempotent. */
 export const SCHEMA_DDL: readonly string[] = [
@@ -100,7 +102,11 @@ export const SCHEMA_DDL: readonly string[] = [
      tool_error_text VARCHAR,
      -- Comma-joined skill argument of canonical Skill tool calls, shaped like
      -- tool_names, which on its own only ever says "Skill".
-     skill_names     VARCHAR DEFAULT ''
+     skill_names     VARCHAR DEFAULT '',
+     -- FTS document key: hash(file_path, uuid), unique per row because
+     -- (file_path, uuid) is — a fork/resume copy repeats the uuid, but in
+     -- ANOTHER file. Keep it LAST: loadFile stages by column order.
+     doc_id          UBIGINT
    )`,
 
   `CREATE TABLE IF NOT EXISTS sessions (

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -23,6 +23,7 @@ import { registerHostGuard, registerMutationGuard, registerSecurityHeaders } fro
 import { startIndexer, stopIndexerTimer } from './indexer-lifecycle.js';
 import { refreshPricing } from './data/pricing-refresh.js';
 import { maybeSelfRestart } from './self-restart.js';
+import { installShutdownHandlers } from './shutdown.js';
 import { refreshLatestVersion } from './update-check.js';
 import { openBrowser } from './util/open-browser.js';
 import { connectorById, connectors, detectedConnectors } from './connectors/registry.js';
@@ -159,6 +160,9 @@ async function main(): Promise<void> {
   // Only a CLI-spawned daemon owns daemon.json; a foreground `npm start` or a
   // dev run must not register itself as the daemon the CLI signals.
   if (process.env.CLAUDESCOPE_DAEMON === '1') writeDaemonRecord(PORT);
+  // `claudescope stop`/`restart` SIGTERM this process: drain, close the server
+  // and the index cleanly instead of dying mid-write. See shutdown.ts.
+  installShutdownHandlers(app);
 
   const url = `http://localhost:${PORT}`;
   // A human-friendly banner so the app reads like a real local tool, not a

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -17,7 +17,6 @@ import {
   WEB_DIST_DIR,
   initStateDir,
 } from './config.js';
-import { claudeProjectsDir } from './settings.js';
 import { writeDaemonRecord } from './daemon.js';
 import { registerRoutes } from './routes/index.js';
 import { registerHostGuard, registerMutationGuard, registerSecurityHeaders } from './security.js';
@@ -26,6 +25,8 @@ import { refreshPricing } from './data/pricing-refresh.js';
 import { maybeSelfRestart } from './self-restart.js';
 import { refreshLatestVersion } from './update-check.js';
 import { openBrowser } from './util/open-browser.js';
+import { connectorById, connectors, detectedConnectors } from './connectors/registry.js';
+import { contractHome } from './util/paths.js';
 
 /** How old a fetched-pricing snapshot may be before a boot refresh fires. */
 const PRICING_STALE_MS = 24 * 60 * 60 * 1000;
@@ -146,10 +147,12 @@ async function main(): Promise<void> {
     });
   }
 
-  if (!existsSync(claudeProjectsDir())) {
+  const detected = detectedConnectors();
+  if (detected.length === 0) {
     app.log.warn(
-      `sessions directory not found: ${claudeProjectsDir()} — the app will be empty. ` +
-        'Set CLAUDE_PROJECTS_DIR to point at your Claude Code transcripts.',
+      'no agent source directories found — the app will be empty. Checked: ' +
+        connectors.map((c) => `${c.label} (${contractHome(c.sourceDir)})`).join(', ') +
+        '. Configure a source on the Settings page or via its env var.',
     );
   }
   await app.listen({ port: PORT, host: '127.0.0.1' });
@@ -159,12 +162,17 @@ async function main(): Promise<void> {
 
   const url = `http://localhost:${PORT}`;
   // A human-friendly banner so the app reads like a real local tool, not a
-  // bare server log. Shows the resolved (configurable) sessions directory.
+  // bare server log. Shows the detected (configurable) source directories,
+  // falling back to the Claude Code dir when nothing was detected yet.
+  const sourcesLabel =
+    detected.length > 0
+      ? detected.map((c) => contractHome(c.sourceDir)).join(', ')
+      : contractHome(connectorById(undefined).sourceDir);
   app.log.info(
     '\n' +
       `  Claudescope v${APP_VERSION}\n` +
       `  ▸ URL:      ${url}\n` +
-      `  ▸ Sessions: ${claudeProjectsDir()} (read-only)\n` +
+      `  ▸ Sources:  ${sourcesLabel} (read-only)\n` +
       (servesWeb ? '' : '  ▸ Note:     web build not found — run `npm run build` to serve the UI\n'),
   );
 

--- a/packages/server/src/routes/analytics-agents.ts
+++ b/packages/server/src/routes/analytics-agents.ts
@@ -30,18 +30,13 @@ import { getConnection, queryRows } from '../db/duckdb.js';
 import { readRow } from '../db/row.js';
 import { cacheHitRatio, toolCallRowsSql } from '../data/analytics-metrics.js';
 import { scopeFilters } from '../data/analytics-scope.js';
-import { usageGranularity } from '../data/agent-capabilities.js';
+import {
+  hasInterruptSignal,
+  hasSubagentLinkage,
+  usageAvailabilityNote,
+  usageGranularity,
+} from '../data/agent-capabilities.js';
 import { errorSignalsByAgent } from './analytics-errors.js';
-
-/** Human notes behind the n/a markers, keyed by connector id. */
-const AVAILABILITY_NOTES: Record<string, string> = {
-  copilot:
-    'Copilot records usage once per session (at shutdown), so per-response ratios are unavailable; crashed or still-running sessions carry no usage.',
-  antigravity:
-    'Antigravity transcripts carry no token counts — tokens and cost are unavailable by design.',
-  junie: 'Junie delegates via plain terminal commands, so subagent usage is invisible.',
-  grok: 'Grok records usage once per user turn (in updates.jsonl); a session whose updates file is missing or truncated reports zero tokens.',
-};
 
 export async function registerAgentComparisonRoute(app: FastifyInstance): Promise<void> {
   app.get<{
@@ -125,10 +120,11 @@ export async function registerAgentComparisonRoute(app: FastifyInstance): Promis
 
       const hasTokens = granularity !== 'none';
       const perResponse = granularity === 'per-response';
+      const availabilityNote = usageAvailabilityNote(connectorId);
       return {
         connectorId,
         usageGranularity: granularity,
-        ...(AVAILABILITY_NOTES[connectorId] ? { availabilityNote: AVAILABILITY_NOTES[connectorId] } : {}),
+        ...(availabilityNote ? { availabilityNote } : {}),
         sessions,
         responses,
         toolCalls,
@@ -145,13 +141,13 @@ export async function registerAgentComparisonRoute(app: FastifyInstance): Promis
         cacheHitRatio: hasTokens ? cacheHitRatio(cacheRead, cacheWrite, input) : null,
         subagentSessions,
         subagentShare:
-          connectorId === 'junie' ? null : sessions > 0 ? subagentSessions / sessions : null,
+          hasSubagentLinkage(connectorId) && sessions > 0 ? subagentSessions / sessions : null,
         toolErrors,
         errorRate:
           toolErrors !== null && sig !== undefined && sig.toolCalls > 0
             ? toolErrors / sig.toolCalls
             : null,
-        interrupts: connectorId === 'claude-code' ? (sig?.interrupts ?? 0) : null,
+        interrupts: hasInterruptSignal(connectorId) ? (sig?.interrupts ?? 0) : null,
       };
     });
 

--- a/packages/server/src/routes/analytics-agents.ts
+++ b/packages/server/src/routes/analytics-agents.ts
@@ -4,8 +4,10 @@
  *
  * Same aggregation semantics as /api/analytics (assistant events,
  * usage_canonical dedup, the shared cache-hit denominator), grouped by the
- * session's connector. Date bounds filter on the session START — a session is
- * atomic here, like /api/analytics/sessions.
+ * session's connector — except the tool-call count, which is a per-row count and
+ * dedups fork copies only (THE RULE in `data/analytics-metrics.ts`). Date bounds
+ * filter on the session START — a session is atomic here, like
+ * /api/analytics/sessions.
  *
  * Data-gap semantics are the point of this endpoint: agents record usage at
  * different granularities (see AgentUsageGranularity), so metrics an agent
@@ -26,7 +28,7 @@ import type {
 } from '@claudescope/shared';
 import { getConnection, queryRows } from '../db/duckdb.js';
 import { readRow } from '../db/row.js';
-import { cacheHitRatio } from '../data/analytics-metrics.js';
+import { cacheHitRatio, toolCallRowsSql } from '../data/analytics-metrics.js';
 import { scopeFilters } from '../data/analytics-scope.js';
 import { usageGranularity } from '../data/agent-capabilities.js';
 import { errorSignalsByAgent } from './analytics-errors.js';
@@ -71,7 +73,8 @@ export async function registerAgentComparisonRoute(app: FastifyInstance): Promis
            sum(e.cache_read_tokens)  FILTER (WHERE e.usage_canonical) AS cache_read_tokens,
            sum(e.cache_write_tokens) FILTER (WHERE e.usage_canonical) AS cache_write_tokens,
            sum(e.cost_usd)           FILTER (WHERE e.usage_canonical) AS cost_usd,
-           sum(e.tool_use_count)     FILTER (WHERE e.usage_canonical) AS tool_calls,
+           -- Per-row count: fork copies only (THE RULE in data/analytics-metrics.ts).
+           sum(e.tool_use_count)     FILTER (WHERE ${toolCallRowsSql()}) AS tool_calls,
            count(*)                  FILTER (WHERE e.usage_canonical) AS responses
          FROM events e
          JOIN scoped sc ON e.session_id = sc.id

--- a/packages/server/src/routes/analytics-digest.ts
+++ b/packages/server/src/routes/analytics-digest.ts
@@ -31,6 +31,7 @@ import {
 } from '../data/analytics-scope.js';
 import { readRow } from '../db/row.js';
 import { projectIdFromCwd } from '../data/project-id.js';
+import { toolCallRowsSql } from '../data/analytics-metrics.js';
 import { errorSignalsByAgent } from './analytics-errors.js';
 import { computeStreaks } from './analytics-activity.js';
 import { timestampParam } from '../params.js';
@@ -140,7 +141,7 @@ export async function registerDigestRoute(app: FastifyInstance): Promise<void> {
        FROM (
          SELECT unnest(string_split(e.tool_names, ',')) AS tool
          FROM events e JOIN scoped s ON e.session_id = s.id
-         WHERE e.type = 'assistant' AND e.usage_canonical AND e.tool_names <> ''
+         WHERE e.type = 'assistant' AND ${toolCallRowsSql()} AND e.tool_names <> ''
        ) t
        WHERE tool <> ''
        GROUP BY tool ORDER BY count DESC, tool LIMIT ${TOP_LIMIT}`,

--- a/packages/server/src/routes/analytics-digest.ts
+++ b/packages/server/src/routes/analytics-digest.ts
@@ -33,6 +33,7 @@ import { readRow } from '../db/row.js';
 import { projectIdFromCwd } from '../data/project-id.js';
 import { toolCallRowsSql } from '../data/analytics-metrics.js';
 import { errorSignalsByAgent } from './analytics-errors.js';
+import { hasInterruptSignal } from '../data/agent-capabilities.js';
 import { computeStreaks } from './analytics-activity.js';
 import { timestampParam } from '../params.js';
 
@@ -243,8 +244,8 @@ export async function registerDigestRoute(app: FastifyInstance): Promise<void> {
             .map((s) => s.connectorId),
         }
       : null;
-    const claude = signals.find((s) => s.connectorId === 'claude-code');
-    const interrupts = claude ? claude.interrupts : null;
+    const interrupting = signals.find((s) => hasInterruptSignal(s.connectorId));
+    const interrupts = interrupting ? interrupting.interrupts : null;
 
     return {
       from,

--- a/packages/server/src/routes/analytics-errors.ts
+++ b/packages/server/src/routes/analytics-errors.ts
@@ -31,17 +31,11 @@ import { getConnection, queryRows, sqlString } from '../db/duckdb.js';
 import { readRow } from '../db/row.js';
 import { scopeFilters } from '../data/analytics-scope.js';
 import { toolCallRowsSql } from '../data/analytics-metrics.js';
+import { errorAvailabilityNote, hasInterruptSignal } from '../data/agent-capabilities.js';
 
 /** Prefix of the user-message text Claude Code stores on an interrupt (both
  *  variants: `…by user]` and `…by user for tool use]`). */
 const INTERRUPT_PREFIX = '[Request interrupted by user';
-
-/** Why a metric is n/a (or skewed), keyed by connector id. */
-const AVAILABILITY_NOTES: Record<string, string> = {
-  junie: 'Junie tool results are plain strings — the format has no error signal.',
-  antigravity: 'Antigravity result records carry no error signal.',
-  copilot: 'Copilot counts permission-denied calls as errors.',
-};
 
 export interface ErrorScope {
   project?: string;
@@ -115,16 +109,16 @@ export async function registerErrorsRoute(app: FastifyInstance): Promise<void> {
     const signals = await errorSignalsByAgent(conn, req.query);
 
     const rows: ErrorAnalyticsRow[] = signals.map((s) => {
-      const isClaude = s.connectorId === 'claude-code';
-      const note = AVAILABILITY_NOTES[s.connectorId];
+      const interrupted = hasInterruptSignal(s.connectorId);
+      const note = errorAvailabilityNote(s.connectorId);
       return {
         connectorId: s.connectorId,
         sessions: s.sessions,
         toolCalls: s.toolCalls,
         toolErrors: s.toolErrors,
         errorRate: s.toolErrors === null || s.toolCalls === 0 ? null : s.toolErrors / s.toolCalls,
-        interrupts: isClaude ? s.interrupts : null,
-        interruptsPerSession: isClaude && s.sessions > 0 ? s.interrupts / s.sessions : null,
+        interrupts: interrupted ? s.interrupts : null,
+        interruptsPerSession: interrupted && s.sessions > 0 ? s.interrupts / s.sessions : null,
         ...(note ? { availabilityNote: note } : {}),
       };
     });

--- a/packages/server/src/routes/analytics-errors.ts
+++ b/packages/server/src/routes/analytics-errors.ts
@@ -3,6 +3,11 @@
  * sessions in scope (optional project + date bounds on the session START —
  * sessions are atomic here, like /api/analytics/sessions).
  *
+ * Tool calls and tool errors are both per-row counts, so they dedup fork copies
+ * only — never through `usage_canonical`, which would drop the tool_use blocks
+ * of every split message. See THE RULE in `data/analytics-metrics.ts`; this is
+ * what keeps the numbers here equal to /api/analytics/tools.
+ *
  * Two signals with very different availability, both exposed n/a-aware:
  *  - Tool errors: sums of `events.tool_error_count` (whichever rows carry the
  *    tool_result — user rows for Claude Code/Codex, see the SQL comment).
@@ -25,6 +30,7 @@ import type { ErrorAnalyticsResponse, ErrorAnalyticsRow } from '@claudescope/sha
 import { getConnection, queryRows, sqlString } from '../db/duckdb.js';
 import { readRow } from '../db/row.js';
 import { scopeFilters } from '../data/analytics-scope.js';
+import { toolCallRowsSql } from '../data/analytics-metrics.js';
 
 /** Prefix of the user-message text Claude Code stores on an interrupt (both
  *  variants: `…by user]` and `…by user for tool use]`). */
@@ -72,13 +78,12 @@ export async function errorSignalsByAgent(
      SELECT
        COALESCE(sc.connector_id, 'unknown') AS connector_id,
        count(DISTINCT sc.id) AS sessions,
-       COALESCE(sum(e.tool_use_count) FILTER (WHERE e.type = 'assistant' AND e.usage_canonical), 0) AS tool_calls,
+       COALESCE(sum(e.tool_use_count) FILTER (WHERE e.type = 'assistant' AND ${toolCallRowsSql()}), 0) AS tool_calls,
        -- Errors live wherever the connector recorded the tool_result (user rows
-       -- for Claude Code/Codex), so no type filter. Fork copies of result rows
-       -- have NULL message ids (all elected canonical), so they are excluded by
-       -- origin instead; if the original file is later deleted the surviving
-       -- copy goes uncounted — an accepted edge, same as the interrupt count.
-       sum(e.tool_error_count) FILTER (WHERE e.usage_canonical AND e.forked_from_session_id IS NULL) AS tool_errors,
+       -- for Claude Code/Codex), so no type filter — only the fork exclusion. If
+       -- the original file is later deleted the surviving copy goes uncounted —
+       -- an accepted edge, same as the interrupt count.
+       sum(e.tool_error_count) FILTER (WHERE ${toolCallRowsSql()}) AS tool_errors,
        count(*) FILTER (
          WHERE e.type = 'user' AND NOT e.is_sidechain AND e.forked_from_session_id IS NULL
            AND e.text_content LIKE ${sqlString(`${INTERRUPT_PREFIX}%`)}

--- a/packages/server/src/routes/analytics-sessions.ts
+++ b/packages/server/src/routes/analytics-sessions.ts
@@ -19,7 +19,7 @@ import type {
 } from '@claudescope/shared';
 import { getConnection, queryRows, sqlString } from '../db/duckdb.js';
 import { scopeFilters } from '../data/analytics-scope.js';
-import { cacheHitRatioSql } from '../data/analytics-metrics.js';
+import { cacheHitRatioSql, toolCallRowsSql } from '../data/analytics-metrics.js';
 import {
   connectorsWithCompactionSignal,
   connectorsWithPromptSizedUsage,
@@ -100,10 +100,10 @@ export async function registerSessionEfficiencyRoute(app: FastifyInstance): Prom
           sum(e.cache_write_tokens) FILTER (WHERE e.usage_canonical) AS cache_write_tokens,
           sum(e.cache_read_tokens)  FILTER (WHERE e.usage_canonical) AS cache_read_tokens,
           sum(e.cost_usd)           FILTER (WHERE e.usage_canonical) AS cost_usd,
-          -- tool_use_count is deduped via usage_canonical here (deliberately unlike
-          -- sessions.tool_call_count, which sums it un-deduped) so fork/resume copies
-          -- don't double-count tools — keeping it consistent with the token/cost sums.
-          sum(e.tool_use_count)     FILTER (WHERE e.usage_canonical) AS tool_call_count,
+          -- tool_use_count is a per-row count: it dedups fork copies only, never
+          -- through the usage election, which would drop the tool_use blocks of
+          -- every split message (THE RULE in data/analytics-metrics.ts).
+          sum(e.tool_use_count)     FILTER (WHERE ${toolCallRowsSql()}) AS tool_call_count,
           count(*)                  FILTER (WHERE e.usage_canonical) AS responses
         FROM events e
         WHERE e.type = 'assistant'

--- a/packages/server/src/routes/analytics-sessions.ts
+++ b/packages/server/src/routes/analytics-sessions.ts
@@ -23,6 +23,7 @@ import { cacheHitRatioSql, toolCallRowsSql } from '../data/analytics-metrics.js'
 import {
   connectorsWithCompactionSignal,
   connectorsWithPromptSizedUsage,
+  DEFAULT_CONNECTOR_ID,
 } from '../data/agent-capabilities.js';
 import { contextWindowFor, loadPricing } from '../data/pricing.js';
 import { readRow } from '../db/row.js';
@@ -86,7 +87,7 @@ export async function registerSessionEfficiencyRoute(app: FastifyInstance): Prom
     // them, so they sort last and stay out of the quantiles.
     // COALESCE mirrors rowToSessionMeta's default so both routes agree on a
     // (theoretical) NULL connector_id.
-    const connector = "COALESCE(s.connector_id, 'claude-code')";
+    const connector = `COALESCE(s.connector_id, ${sqlString(DEFAULT_CONNECTOR_ID)})`;
     const withContext = sqlList(connectorsWithPromptSizedUsage());
     const withCompactions = sqlList(connectorsWithCompactionSignal());
 

--- a/packages/server/src/routes/analytics-tools.ts
+++ b/packages/server/src/routes/analytics-tools.ts
@@ -2,12 +2,9 @@
  * GET /api/analytics/tools — count of tool calls by raw (canonical) tool name
  * AND the agent that emitted it (joined from `sessions.connector_id`), descending.
  * Unnests the `events.tool_names` CSV. Duplicates are dropped by excluding fork
- * copies (`forked_from_session_id`, set on every copied row), NOT by
- * `usage_canonical`: that elects one row per billed message for token sums, while
- * a split message keeps its tool_use blocks on specific rows — most of which lose
- * the election, so filtering on it hides the majority of real calls. The web maps
- * raw names → categories via `toolCategory()` and surfaces the per-agent
- * attribution in the tooltip.
+ * copies (`toolCallRowsSql`), NOT by `usage_canonical` — see THE RULE in
+ * `data/analytics-metrics.ts`. The web maps raw names → categories via
+ * `toolCategory()` and surfaces the per-agent attribution in the tooltip.
  *
  * `kind=skill` swaps the source column to `events.skill_names` — the `skill`
  * argument of each canonical `Skill` tool_use call — so the same `tool` field
@@ -18,6 +15,7 @@ import type { ToolUsageKind, ToolUsageResponse, ToolUsageRow } from '@claudescop
 import { getConnection, queryRows } from '../db/duckdb.js';
 import { readRow } from '../db/row.js';
 import { scopeFilters } from '../data/analytics-scope.js';
+import { toolCallRowsSql } from '../data/analytics-metrics.js';
 import { enumParam } from '../params.js';
 
 const TOOL_USAGE_KINDS = ['tool', 'skill'] as const;
@@ -31,7 +29,7 @@ export async function registerToolsRoute(app: FastifyInstance): Promise<void> {
     const column = kind === 'skill' ? 'skill_names' : 'tool_names';
     const filters: string[] = [
       "e.type = 'assistant'",
-      'e.forked_from_session_id IS NULL',
+      toolCallRowsSql(),
       `e.${column} <> ''`,
     ];
     // Project scope resolves like every other analytics route; date bounds stay

--- a/packages/server/src/routes/search.ts
+++ b/packages/server/src/routes/search.ts
@@ -2,7 +2,7 @@
  * GET /api/search — full-text search over transcripts and/or agent memory.
  *
  * Transcripts use the BM25 `fts` index on `events.text_content` (keyed by
- * `uuid`); memory is searched live (it isn't indexed). The `scope` param picks
+ * `doc_id`); memory is searched live (it isn't indexed). The `scope` param picks
  * which: `sessions` (default), `all` (both), or `memory` (memory only). Both
  * kinds carry a snippet with matched terms highlighted via `<mark>`. Optional
  * filters: `project` (slug) and `type` (user|assistant|all; sessions only).
@@ -41,13 +41,11 @@ async function searchSessions(
   project: string | undefined,
   format: SnippetFormat,
 ): Promise<SearchResult[]> {
-  // NOTE: this query depends on `scalar_subquery_error_on_multiple_rows = false`,
-  // which is applied once when the connection opens (see db/duckdb.ts) rather than
-  // here — it is a connection-level setting, and the connection is shared.
+  // The FTS index is keyed by `events.doc_id`, unique per row (see schema.ts).
   const conn = await getConnection();
   const identifierQuery = /\d/.test(q);
   const matchExpression = `fts_main_events.match_bm25(
-    e.uuid,
+    e.doc_id,
     ${sqlString(q)}${identifierQuery ? ', conjunctive := true' : ''}
   )`;
 

--- a/packages/server/src/routes/sessions.ts
+++ b/packages/server/src/routes/sessions.ts
@@ -1,6 +1,6 @@
 /**
  * GET /api/sessions — list sessions with optional project filter, sort, and a
- * lightweight title/text query (`q`).
+ * lightweight title query (`q`).
  *
  * GET /api/sessions/:id — full session detail: derived meta + the assembled
  * thread (parsed directly from the session's JSONL on disk).

--- a/packages/server/src/routes/sessions.ts
+++ b/packages/server/src/routes/sessions.ts
@@ -27,7 +27,11 @@ import { assembleThread, buildSubagentRuns } from '../data/parser.js';
 import { loadSessionData } from '../data/session-loader.js';
 import { computeSessionFingerprint } from '../data/fingerprint.js';
 import { contextWindowFor, loadPricing } from '../data/pricing.js';
-import { hasCompactionSignal, hasPromptSizedUsage } from '../data/agent-capabilities.js';
+import {
+  DEFAULT_CONNECTOR_ID,
+  hasCompactionSignal,
+  hasPromptSizedUsage,
+} from '../data/agent-capabilities.js';
 import { connectorById } from '../connectors/registry.js';
 import { buildResumeInfo } from '../connectors/resume.js';
 import { resolveWindow, subagentsInWindow, truncateToolChars } from '../data/window.js';
@@ -59,7 +63,7 @@ function rowToSessionMeta(r: Record<string, unknown>): SessionMeta {
     const rates = pricing.providers?.[p.toLowerCase()];
     return rates !== undefined && isZeroRated(rates);
   });
-  const connectorId = rd.str('connector_id') || 'claude-code';
+  const connectorId = rd.str('connector_id') || DEFAULT_CONNECTOR_ID;
   const meta: SessionMeta = {
     id: rd.str('id'),
     projectId: cwd ? projectIdFromCwd(cwd) : '',

--- a/packages/server/src/security.ts
+++ b/packages/server/src/security.ts
@@ -48,6 +48,12 @@ export const CONTENT_SECURITY_POLICY = [
 export function registerSecurityHeaders(app: FastifyInstance): void {
   app.addHook('onSend', async (_req, reply, payload) => {
     reply.header('Content-Security-Policy', CONTENT_SECURITY_POLICY);
+    // Stops a browser from MIME-sniffing a response into an executable type
+    // (e.g. treating a transcript-derived download as HTML/JS).
+    reply.header('X-Content-Type-Options', 'nosniff');
+    // Never leak this app's URLs (session ids, search queries) to an external
+    // site a rendered link points at.
+    reply.header('Referrer-Policy', 'no-referrer');
     return payload;
   });
 }

--- a/packages/server/src/shutdown.ts
+++ b/packages/server/src/shutdown.ts
@@ -1,0 +1,169 @@
+/**
+ * Graceful shutdown — what a SIGTERM from `claudescope stop`/`restart` (or a
+ * Ctrl-C in the foreground) must do before this process dies.
+ *
+ * Without a handler Node kills the process on the spot, which leaves DuckDB's
+ * WAL behind for replay on the next open — and a kill landing between the
+ * `PRAGMA create_fts_index` and the CHECKPOINT that follows it (see
+ * `rebuildFtsIndex` in data/index.ts) leaves a WAL DuckDB *cannot* replay, so
+ * the index is discarded and rebuilt from scratch. Draining the in-flight pass
+ * and closing the connection cleanly turns that into a no-op, and lines the
+ * signal path up with self-restart.ts, which already refuses to hand off
+ * mid-pass.
+ */
+
+import type { FastifyInstance } from 'fastify';
+import { isReindexInFlight, reindex } from './data/index.js';
+import { closeConnection } from './db/duckdb.js';
+import { stopIndexerTimer } from './indexer-lifecycle.js';
+
+/**
+ * How long shutdown waits for an in-flight index pass to drain.
+ *
+ * Must stay comfortably under daemon.ts's `EXIT_WAIT_MS` (5000) *including* the
+ * Fastify close that follows it: once that budget is spent `terminateDaemon`
+ * gives up and reports a hung daemon with a `kill -9` hint, so a drain that
+ * outlives it would turn every stop into a scary error message.
+ */
+export const DRAIN_MS = 3500;
+
+/** Everything the shutdown sequence touches, injected so it can be exercised
+ *  without signals, a real server, or a real database. */
+export interface ShutdownDeps {
+  log(msg: string): void;
+  stopTimers(): void;
+  /** The running index pass, or null when none is in flight. */
+  inFlightPass(): Promise<unknown> | null;
+  closeApp(): Promise<void>;
+  closeDb(): Promise<void>;
+  exit(code: number): void;
+}
+
+function describe(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}
+
+/** Run one shutdown step, reporting a failure instead of propagating it: none
+ *  of them may keep the process from exiting. */
+async function step(deps: ShutdownDeps, what: string, fn: () => unknown): Promise<void> {
+  try {
+    await fn();
+  } catch (err) {
+    deps.log(`shutdown: ${what} failed — ${describe(err)}`);
+  }
+}
+
+/** Wait for the pass to finish, up to `drainMs`; the result says whether it
+ *  did. A pass that REJECTED counts as finished — what matters is only that
+ *  nothing is still running against the connection. */
+async function drain(pass: Promise<unknown>, drainMs: number): Promise<boolean> {
+  let timer: NodeJS.Timeout | undefined;
+  try {
+    return await Promise.race([
+      pass.then(
+        () => true,
+        () => true,
+      ),
+      new Promise<boolean>((resolve) => {
+        timer = setTimeout(() => resolve(false), drainMs);
+        timer.unref();
+      }),
+    ]);
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+/**
+ * Stop accepting work, let an index pass finish, close the HTTP server, and
+ * close the index — then exit. Every step is best-effort: one failure logs and
+ * moves on, because the process must exit either way (the CLI is waiting).
+ */
+export async function shutdown(deps: ShutdownDeps, drainMs = DRAIN_MS): Promise<void> {
+  deps.log('shutting down — draining');
+  await step(deps, 'stopping the indexer', () => deps.stopTimers());
+
+  let pass: Promise<unknown> | null = null;
+  try {
+    pass = deps.inFlightPass();
+  } catch (err) {
+    deps.log(`shutdown: could not check for an in-flight index pass — ${describe(err)}`);
+  }
+  const drained = pass ? await drain(pass, drainMs) : true;
+
+  await step(deps, 'closing the HTTP server', () => deps.closeApp());
+
+  if (drained) {
+    // Nothing is running against the connection any more, so DuckDB can
+    // checkpoint and drop the WAL — the next open needs no replay.
+    await step(deps, 'closing the index', () => deps.closeDb());
+  } else {
+    deps.log(
+      `shutdown: index pass still running after ${drainMs}ms — leaving the index open ` +
+        'rather than closing it under a live statement; WAL replay covers it on reopen',
+    );
+  }
+
+  deps.exit(0);
+}
+
+/** Installed handlers: `handler` so tests can drive a signal without raising
+ *  one, `uninstall` so they don't leak listeners between suites. */
+export interface ShutdownHandle {
+  handler: (signal: NodeJS.Signals) => void;
+  uninstall: () => void;
+}
+
+let installed: ShutdownHandle | null = null;
+
+/**
+ * Register the SIGTERM/SIGINT handlers (once per process). The first signal
+ * starts {@link shutdown}; a second one during it stops waiting and exits
+ * non-zero, so an impatient Ctrl-C still works.
+ */
+export function installShutdownHandlers(
+  app: FastifyInstance,
+  overrides: Partial<ShutdownDeps> = {},
+): ShutdownHandle {
+  if (installed) return installed;
+
+  const deps: ShutdownDeps = {
+    log: (msg) => app.log.info(msg),
+    // Only the reindex poller is stopped here; the boot-time pricing,
+    // update-check and self-restart intervals are cleared by index.ts's
+    // `onClose` hooks when app.close() runs below.
+    stopTimers: stopIndexerTimer,
+    // reindex() hands back the in-flight promise when a pass is running, so
+    // this joins that pass instead of starting another one.
+    inFlightPass: () => (isReindexInFlight() ? reindex() : null),
+    closeApp: () => app.close(),
+    closeDb: closeConnection,
+    exit: (code) => process.exit(code),
+    ...overrides,
+  };
+
+  let shuttingDown = false;
+  const handler = (signal: NodeJS.Signals): void => {
+    if (shuttingDown) {
+      deps.log(`${signal} during shutdown — exiting now`);
+      deps.exit(1);
+      return;
+    }
+    shuttingDown = true;
+    deps.log(`${signal} received`);
+    void shutdown(deps);
+  };
+
+  process.on('SIGTERM', handler);
+  process.on('SIGINT', handler);
+  const handle: ShutdownHandle = {
+    handler,
+    uninstall: () => {
+      process.off('SIGTERM', handler);
+      process.off('SIGINT', handler);
+      if (installed === handle) installed = null;
+    },
+  };
+  installed = handle;
+  return handle;
+}

--- a/packages/server/test/analytics-tool-counts.integration.test.ts
+++ b/packages/server/test/analytics-tool-counts.integration.test.ts
@@ -1,0 +1,250 @@
+/**
+ * Tool-count semantics integration tests.
+ *
+ * THE RULE under test: token/cost SUMs dedup by billed API call
+ * (`usage_canonical`), but per-row COUNTS — `tool_use_count`, the
+ * `tool_names`/`skill_names` unnest, `tool_error_count` — dedup fork copies ONLY
+ * (`forked_from_session_id IS NULL`). Claude Code writes one JSONL row per
+ * content block of an assistant message, all sharing `message.id` and repeating
+ * the FULL usage; exactly one of those rows wins the usage election, and it is
+ * usually NOT one of the rows carrying the tool_use blocks. Filtering tool
+ * counts on `usage_canonical` therefore hides most real tool calls.
+ *
+ * The fixture is one Claude Code session written the REAL way (a text row plus
+ * two tool_use rows under one `message.id`), a user row carrying the two
+ * tool_results (one failed), and a second single-row response — then a full FORK
+ * copy of that file under a second sessionId, every line carrying `forkedFrom`.
+ * The copy must contribute nothing, exactly as it contributes no tokens.
+ *
+ * Built like `dedup.integration.test.ts`: a synthetic ~/.claude/projects tree is
+ * indexed into a throwaway DuckDB, then exercised through Fastify `.inject()`.
+ */
+
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import type { FastifyInstance } from 'fastify';
+
+// --- temp locations (decided before any server module is imported) ----------
+const work = mkdtempSync(join(tmpdir(), 'claudescope-toolcounts-'));
+const projectsDir = join(work, 'projects');
+
+process.env.CLAUDE_PROJECTS_DIR = projectsDir;
+// Isolate from every real agent home so this Claude-only suite stays deterministic.
+process.env.CODEX_SESSIONS_DIR = join(work, 'codex-empty');
+process.env.JUNIE_SESSIONS_DIR = join(work, 'junie-empty');
+process.env.PI_SESSIONS_DIR = join(work, 'pi-empty');
+process.env.OPENCODE_DATA_DIR = join(work, 'opencode-empty');
+process.env.COPILOT_SESSIONS_DIR = join(work, 'copilot-empty');
+process.env.ANTIGRAVITY_CLI_DIR = join(work, 'antigravity-empty');
+process.env.ANTIGRAVITY_DIR = join(work, 'antigravity-empty-desktop');
+process.env.GROK_SESSIONS_DIR = join(work, 'grok-empty');
+process.env.DUCKDB_PATH = join(work, 'index.duckdb');
+process.env.CLAUDESCOPE_HOME = join(work, 'home');
+process.env.REINDEX_INTERVAL_MS = '0';
+
+const jsonl = (events: unknown[]): string => events.map((e) => JSON.stringify(e)).join('\n') + '\n';
+
+const MODEL = 'claude-opus-4-8';
+const CWD = '/tmp/toolcounts';
+const MAIN = 'toolMain';
+const FORK = 'toolFork';
+
+/** The two billed calls, each written once per fixture session. */
+const USAGE_1 = { input: 100, output: 10, cacheRead: 50, cacheWrite: 0 };
+const USAGE_2 = { input: 200, output: 20, cacheRead: 0, cacheWrite: 0 };
+
+type Usage = { input: number; output: number; cacheRead: number; cacheWrite: number };
+
+/** One assistant line: a single content block, the message-level usage repeated. */
+function asst(opts: {
+  uuid: string;
+  parentUuid: string | null;
+  sessionId: string;
+  timestamp: string;
+  messageId: string;
+  content: Record<string, unknown>;
+  usage: Usage;
+  forkedFrom?: { sessionId: string; messageUuid: string };
+}): Record<string, unknown> {
+  const line: Record<string, unknown> = {
+    type: 'assistant',
+    uuid: opts.uuid,
+    parentUuid: opts.parentUuid,
+    sessionId: opts.sessionId,
+    timestamp: opts.timestamp,
+    cwd: CWD,
+    isSidechain: false,
+    requestId: `req_${opts.uuid}`,
+    message: {
+      id: opts.messageId,
+      role: 'assistant',
+      model: MODEL,
+      content: [opts.content],
+      usage: {
+        input_tokens: opts.usage.input,
+        output_tokens: opts.usage.output,
+        cache_read_input_tokens: opts.usage.cacheRead,
+        cache_creation_input_tokens: opts.usage.cacheWrite,
+      },
+    },
+  };
+  if (opts.forkedFrom) line.forkedFrom = opts.forkedFrom;
+  return line;
+}
+
+const userText = (uuid: string, parentUuid: string | null, sessionId: string, ts: string, text: string) => ({
+  type: 'user',
+  uuid,
+  parentUuid,
+  sessionId,
+  timestamp: ts,
+  cwd: CWD,
+  isSidechain: false,
+  message: { role: 'user', content: text },
+});
+
+/** The user turn carrying both tool_results — one of them failed. */
+const userResults = (sessionId: string) => ({
+  type: 'user',
+  uuid: 'm-u2',
+  parentUuid: 'm-a3',
+  sessionId,
+  timestamp: '2026-01-01T10:00:03.000Z',
+  cwd: CWD,
+  isSidechain: false,
+  message: {
+    role: 'user',
+    content: [
+      { type: 'tool_result', tool_use_id: 'tu_bash', content: 'command not found', is_error: true },
+      { type: 'tool_result', tool_use_id: 'tu_read', content: 'file contents' },
+    ],
+  },
+});
+
+/**
+ * One session's lines. `forkedFrom` (when given) is stamped on EVERY line, the
+ * way Claude Code marks a forked copy of the whole history.
+ */
+function lines(sessionId: string, forkedFrom?: { sessionId: string; messageUuid: string }): unknown[] {
+  const ff = forkedFrom ? { forkedFrom } : {};
+  return [
+    { type: 'ai-title', sessionId, aiTitle: `Session ${sessionId}` },
+    { ...userText('m-u1', null, sessionId, '2026-01-01T10:00:00.000Z', 'run something'), ...ff },
+    // ONE billed response (msg_1) written as THREE rows sharing message.id and
+    // repeating the full usage: a text block, then the two tool_use blocks. The
+    // uuid tiebreak makes the TEXT row canonical, so both tool calls sit on rows
+    // that lose the usage election.
+    asst({ uuid: 'm-a1', parentUuid: 'm-u1', sessionId, timestamp: '2026-01-01T10:00:01.000Z', messageId: 'msg_1', usage: USAGE_1, content: { type: 'text', text: 'on it' }, ...ff }),
+    asst({ uuid: 'm-a2', parentUuid: 'm-u1', sessionId, timestamp: '2026-01-01T10:00:01.100Z', messageId: 'msg_1', usage: USAGE_1, content: { type: 'tool_use', id: 'tu_bash', name: 'Bash', input: { command: 'ls' } }, ...ff }),
+    asst({ uuid: 'm-a3', parentUuid: 'm-u1', sessionId, timestamp: '2026-01-01T10:00:01.200Z', messageId: 'msg_1', usage: USAGE_1, content: { type: 'tool_use', id: 'tu_read', name: 'Read', input: { file_path: '/tmp/x' } }, ...ff }),
+    { ...userResults(sessionId), ...ff },
+    asst({ uuid: 'm-a4', parentUuid: 'm-u2', sessionId, timestamp: '2026-01-01T10:00:05.000Z', messageId: 'msg_2', usage: USAGE_2, content: { type: 'text', text: 'done' }, ...ff }),
+  ];
+}
+
+function writeFixtures(): void {
+  const proj = join(projectsDir, 'enc-toolcounts');
+  mkdirSync(proj, { recursive: true });
+  writeFileSync(join(proj, `${MAIN}.jsonl`), jsonl(lines(MAIN)));
+  // Fork: the same history copied under a new sessionId, every line marked.
+  writeFileSync(
+    join(proj, `${FORK}.jsonl`),
+    jsonl(lines(FORK, { sessionId: MAIN, messageUuid: 'm-a4' })),
+  );
+}
+
+const RANGE = '?from=2026-01-01T00:00:00.000Z&to=2026-01-01T23:59:59.999Z';
+
+let app: FastifyInstance;
+let closeConnection: () => Promise<void>;
+
+beforeAll(async () => {
+  writeFixtures();
+
+  const Fastify = (await import('fastify')).default;
+  const { registerRoutes } = await import('../src/routes/index.js');
+  const { reindex } = await import('../src/data/index.js');
+  ({ closeConnection } = await import('../src/db/duckdb.js'));
+
+  app = Fastify();
+  await registerRoutes(app);
+  await reindex();
+  await app.ready();
+});
+
+afterAll(async () => {
+  await app?.close();
+  await closeConnection?.();
+  rmSync(work, { recursive: true, force: true });
+});
+
+const get = async (url: string) => (await app.inject({ method: 'GET', url })).json();
+
+describe('tool calls are counted per row excluding fork copies, never through the usage election', () => {
+  it('/api/analytics/tools: each tool_use block counted once (Bash 1, Read 1)', async () => {
+    const { rows } = await get('/api/analytics/tools');
+    const claude = rows.filter((r: { agent: string }) => r.agent === 'claude-code');
+    const byTool = new Map(claude.map((r: { tool: string; count: number }) => [r.tool, r.count]));
+    expect(byTool.get('Bash')).toBe(1);
+    expect(byTool.get('Read')).toBe(1);
+    expect(claude.reduce((acc: number, r: { count: number }) => acc + r.count, 0)).toBe(2);
+  });
+
+  it('/api/analytics/errors: toolCalls 2, toolErrors 1, errorRate 0.5', async () => {
+    const { rows } = await get('/api/analytics/errors');
+    const claude = rows.find((r: { connectorId: string }) => r.connectorId === 'claude-code');
+    expect(claude.toolCalls).toBe(2);
+    expect(claude.toolErrors).toBe(1);
+    expect(claude.errorRate).toBeCloseTo(0.5, 12);
+  });
+
+  it('/api/analytics/agents: toolCalls 2 against 2 deduped responses', async () => {
+    const { rows } = await get('/api/analytics/agents');
+    const claude = rows.find((r: { connectorId: string }) => r.connectorId === 'claude-code');
+    expect(claude.toolCalls).toBe(2);
+    // Responses stay on the usage election: two billed calls, not five rows.
+    expect(claude.responses).toBe(2);
+    expect(claude.toolCallsPerResponse).toBeCloseTo(1, 12);
+  });
+
+  it('/api/analytics/sessions: the original session reports both tool calls', async () => {
+    const { rows } = await get(`/api/analytics/sessions${RANGE}`);
+    const main = rows.find((r: { sessionId: string }) => r.sessionId === MAIN);
+    expect(main.toolCallCount).toBe(2);
+    expect(main.responses).toBe(2);
+    expect(main.toolCallsPerResponse).toBeCloseTo(1, 12);
+    // The fork's copied rows are excluded everywhere, so it has no canonical
+    // response left and falls below the route's minResponses floor — the same
+    // reason its token totals are zero. Its zero tool calls are asserted through
+    // /api/sessions below, which has no such floor.
+    expect(rows.some((r: { sessionId: string }) => r.sessionId === FORK)).toBe(false);
+  });
+
+  it('/api/sessions: tool calls attribute to the original, none to the fork copy', async () => {
+    const sessions = await get('/api/sessions');
+    const byId = new Map(sessions.map((s: { id: string }) => [s.id, s]));
+    expect((byId.get(MAIN) as { toolCallCount: number }).toolCallCount).toBe(2);
+    expect((byId.get(FORK) as { toolCallCount: number }).toolCallCount).toBe(0);
+  });
+
+  it('/api/analytics/digest: reliability and tool mix see the same 2 calls', async () => {
+    const digest = await get(`/api/analytics/digest${RANGE}`);
+    expect(digest.errors.toolCalls).toBe(2);
+    expect(digest.errors.toolErrors).toBe(1);
+    const byTool = new Map(
+      digest.topTools.map((t: { key: string; count: number }) => [t.key, t.count]),
+    );
+    expect(byTool.get('Bash')).toBe(1);
+    expect(byTool.get('Read')).toBe(1);
+  });
+
+  it('tokens still count once per billed message, unaffected by the row-level rule', async () => {
+    const { totals } = await get('/api/analytics');
+    expect(totals.inputTokens).toBe(USAGE_1.input + USAGE_2.input); // 300
+    expect(totals.outputTokens).toBe(USAGE_1.output + USAGE_2.output); // 30
+    expect(totals.cacheReadTokens).toBe(USAGE_1.cacheRead + USAGE_2.cacheRead); // 50
+    expect(totals.messageCount).toBe(2);
+  });
+});

--- a/packages/server/test/architecture-rules.test.ts
+++ b/packages/server/test/architecture-rules.test.ts
@@ -1,0 +1,82 @@
+/**
+ * Fitness function for the connector boundary.
+ *
+ * CLAUDE.md's promise is that everything below the connector boundary is
+ * agent-agnostic: `data/` and `routes/` operate on the canonical event contract,
+ * and the ONE place allowed to record a per-agent fact is
+ * `data/agent-capabilities.ts` (properties of the CONNECTOR, not of the data).
+ *
+ * The way that erodes is invisible in any feature test: a `connector_id =
+ * 'codex'` branch in indexer SQL, a `=== 'claude-code'` ternary in a route, a
+ * note map keyed by agent id, an import reaching into one connector's internals.
+ * Each is small and correct on its own, and together they mean adding an agent
+ * touches the shared layer again. So this test scans the two agent-agnostic
+ * directories for any registered connector id spelled as a string literal, and
+ * for imports from a specific connector's directory.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { mkdtempSync, readdirSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join, relative } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+// The registry import resolves each connector's source dir; keep any state it
+// might touch inside a temp home, never the real one.
+const work = mkdtempSync(join(tmpdir(), 'claudescope-archrules-'));
+process.env.CLAUDESCOPE_HOME = join(work, 'home');
+process.on('exit', () => rmSync(work, { recursive: true, force: true }));
+
+const { connectors } = await import('../src/connectors/registry.js');
+
+const serverRoot = join(dirname(fileURLToPath(import.meta.url)), '..');
+/** The layers that must not know any agent by name. */
+const AGENT_AGNOSTIC_DIRS = [join(serverRoot, 'src', 'data'), join(serverRoot, 'src', 'routes')];
+/** The single sanctioned home for per-agent facts. */
+const CAPABILITIES_FILE = join(serverRoot, 'src', 'data', 'agent-capabilities.ts');
+
+function tsFilesUnder(dir: string): string[] {
+  const out: string[] = [];
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const path = join(dir, entry.name);
+    if (entry.isDirectory()) out.push(...tsFilesUnder(path));
+    else if (entry.name.endsWith('.ts')) out.push(path);
+  }
+  return out;
+}
+
+const ids = connectors.map((c) => c.id);
+const idAlternation = ids.map((id) => id.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')).join('|');
+/** A connector id spelled as a string literal: `'codex'`, `"claude-code"`, backticks. */
+const ID_LITERAL = new RegExp(`(['"\`])(?:${idAlternation})\\1`);
+/** An import (or any path) reaching into one connector's directory. */
+const CONNECTOR_IMPORT = new RegExp(`connectors/(?:${idAlternation})/`);
+
+function violations(): string[] {
+  const found: string[] = [];
+  for (const dir of AGENT_AGNOSTIC_DIRS) {
+    for (const file of tsFilesUnder(dir)) {
+      if (file === CAPABILITIES_FILE) continue;
+      const lines = readFileSync(file, 'utf8').split('\n');
+      lines.forEach((line, i) => {
+        if (ID_LITERAL.test(line) || CONNECTOR_IMPORT.test(line)) {
+          found.push(`${relative(serverRoot, file)}:${i + 1}: ${line.trim()}`);
+        }
+      });
+    }
+  }
+  return found;
+}
+
+describe('connector boundary', () => {
+  it('has connectors to check', () => {
+    expect(ids.length).toBeGreaterThan(1);
+  });
+
+  it('names no agent in data/ or routes/', () => {
+    // Reported as `file:line: text` so a failure points straight at the leak;
+    // the fix is an accessor in data/agent-capabilities.ts (a fact about the
+    // connector) or a hook on the `AgentConnector` port (behaviour it owns).
+    expect(violations()).toEqual([]);
+  });
+});

--- a/packages/server/test/cli.test.ts
+++ b/packages/server/test/cli.test.ts
@@ -16,11 +16,21 @@ import { existsSync, mkdirSync, mkdtempSync, rmSync, statSync, writeFileSync } f
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
-// Only `spawn` is faked (spawnDaemon must not launch a real server); the rest of
+// `spawn` and `spawnSync` are faked (spawnDaemon must not launch a real server,
+// and `update` must never shell out to a real `npm install -g`); the rest of
 // the module stays real — daemonOwnsPid's execFileSync probe is under test too.
 vi.mock('node:child_process', async (importOriginal) => ({
   ...(await importOriginal<typeof import('node:child_process')>()),
   spawn: vi.fn(),
+  spawnSync: vi.fn(() => ({ status: 0 }) as unknown as ReturnType<typeof import('node:child_process').spawnSync>),
+}));
+
+// getLatestVersion rejects on a network error (it only returns null for a
+// non-OK registry response) — faked here so the `update` offline test never
+// touches the real npm registry.
+vi.mock('../src/update-check.js', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../src/update-check.js')>()),
+  getLatestVersion: vi.fn(() => Promise.reject(new Error('offline'))),
 }));
 
 // --- temp state dir (decided before importing the module under test) ---------
@@ -455,5 +465,32 @@ describe('parsePort', () => {
   // the OS picks the port and the recorded one can never answer.
   it.each(['abc', '0', '-1', '99999', '80.5', '', ' '])('rejects %s', (v) => {
     expect(() => cli.parsePort(v, 4317)).toThrow(/between 1 and 65535/);
+  });
+});
+
+describe('update — offline registry lookup', () => {
+  // getLatestVersion (mocked above) rejects instead of resolving null, the way
+  // a real network failure does; `update` must fall into the same "could not
+  // reach the registry" branch a non-OK response takes, not crash with a stack.
+  it('prints the friendly notice instead of throwing', async () => {
+    const logs: string[] = [];
+    vi.spyOn(console, 'log').mockImplementation((msg: string) => void logs.push(msg));
+    await expect(cli.update(true)).resolves.toBeUndefined();
+    expect(logs).toContain('⚠ Could not reach the npm registry to confirm the latest version.');
+  });
+});
+
+describe('main — unknown flag', () => {
+  // parseArgs is strict, so an unrecognized flag throws ERR_PARSE_ARGS_UNKNOWN_OPTION;
+  // that must surface as a UsageError (message only, no stack) like every other
+  // usage mistake, not escape as a raw exception.
+  it('surfaces as a UsageError rather than a raw parseArgs exception', async () => {
+    const originalArgv = process.argv;
+    process.argv = [process.execPath, 'cli.js', '--bogus'];
+    try {
+      await expect(cli.main()).rejects.toBeInstanceOf(cli.UsageError);
+    } finally {
+      process.argv = originalArgv;
+    }
   });
 });

--- a/packages/server/test/codex.integration.test.ts
+++ b/packages/server/test/codex.integration.test.ts
@@ -162,6 +162,10 @@ function writeRollout(): string {
       { type: 'response_item', timestamp: ts(46), payload: { type: 'custom_tool_call_output', call_id: 'call_exec_concat', is_error: false, output: 'Script completed\nWall time 0.1 seconds\nOutput:\n{}' } },
       { type: 'response_item', timestamp: ts(47), payload: { type: 'custom_tool_call', name: 'exec', call_id: 'call_exec_unconfirmed', input: execApplyPatch(directNestedPatch, true) } },
       { type: 'response_item', timestamp: ts(48), payload: { type: 'message', role: 'assistant', content: [{ type: 'output_text', text: 'waiting for the patch result' }] } },
+      // A FAILED shell command: `function_call_output` carries no `is_error`, so
+      // the envelope's non-zero exit code is the only failure signal there is.
+      { type: 'response_item', timestamp: ts(49), payload: { type: 'function_call', name: 'exec_command', arguments: '{"cmd":"grepper needle"}', call_id: 'call_fail1' } },
+      { type: 'response_item', timestamp: ts(50), payload: { type: 'function_call_output', call_id: 'call_fail1', output: 'Chunk ID: b12f9c\nWall time: 0.0100 seconds\nProcess exited with code 127\nOriginal token count: 12\nOutput:\nsh: grepper: command not found' } },
     ]),
   );
   return file;
@@ -380,6 +384,8 @@ function writeGuardianRollouts(): void {
 
 let app: FastifyInstance;
 let closeConnection: () => Promise<void>;
+let getConnection: typeof import('../src/db/duckdb.js').getConnection;
+let queryRows: typeof import('../src/db/duckdb.js').queryRows;
 
 beforeAll(async () => {
   mkdirSync(claudeDir, { recursive: true });
@@ -398,7 +404,7 @@ beforeAll(async () => {
   const Fastify = (await import('fastify')).default;
   const { registerRoutes } = await import('../src/routes/index.js');
   const { reindex } = await import('../src/data/index.js');
-  ({ closeConnection } = await import('../src/db/duckdb.js'));
+  ({ getConnection, queryRows, closeConnection } = await import('../src/db/duckdb.js'));
 
   app = Fastify();
   await registerRoutes(app);
@@ -510,6 +516,23 @@ describe('Codex session indexing', () => {
     const ids = results.map((r: { sessionId: string }) => r.sessionId);
     expect(ids).toContain('codex-sess-1');
     expect(ids).not.toContain('019f2222-aaaa-7bbb-8ccc-000000000001');
+  });
+
+  it("counts a shell command's non-zero exit as a failed tool call", async () => {
+    const conn = await getConnection();
+    const [row] = await queryRows(
+      conn,
+      `SELECT count(*) FILTER (WHERE tool_error_text LIKE '%grepper: command not found%') AS failed,
+              COALESCE(sum(tool_error_count) FILTER (WHERE tool_error_text LIKE '%grepper%'), 0) AS errors,
+              count(*) FILTER (WHERE tool_error_text LIKE '%exited with code 0%') AS false_positives
+         FROM events WHERE session_id = 'codex-sess-1'`,
+    );
+    // `function_call_output` carries no `is_error`, so before the exit code was
+    // read every failed shell command indexed as a success.
+    expect(Number(row!.failed)).toBe(1);
+    expect(Number(row!.errors)).toBe(1);
+    // …and a SUCCEEDING envelope must not be dragged in with it.
+    expect(Number(row!.false_positives)).toBe(0);
   });
 });
 

--- a/packages/server/test/config.test.ts
+++ b/packages/server/test/config.test.ts
@@ -1,0 +1,38 @@
+/**
+ * Unit tests for resolveIntervalMs (config.ts): the shared validator behind
+ * PRICING_REFRESH_INTERVAL_MS and SELF_RESTART_INTERVAL_MS. A typo used to
+ * silently disable the feature (NaN) or, for a tiny value, fire the timer on
+ * every millisecond — both fall back to the default with a warning instead.
+ */
+
+import { describe, expect, it, vi } from 'vitest';
+import { resolveIntervalMs } from '../src/config.js';
+
+describe('resolveIntervalMs', () => {
+  it('uses the default when the env var is unset', () => {
+    expect(resolveIntervalMs('X_INTERVAL_MS', undefined, 5000)).toBe(5000);
+  });
+
+  it("treats '0' as an explicit disable, not an invalid value", () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    expect(resolveIntervalMs('X_INTERVAL_MS', '0', 5000)).toBe(0);
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  it('accepts an integer at or above the 1000ms floor', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    expect(resolveIntervalMs('X_INTERVAL_MS', '1000', 5000)).toBe(1000);
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  it.each(['1', '-5', 'abc', '1.5', ''])(
+    "falls back to the default and warns for '%s'",
+    (raw) => {
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      expect(resolveIntervalMs('X_INTERVAL_MS', raw, 5000)).toBe(5000);
+      expect(warn).toHaveBeenCalledTimes(1);
+      expect(warn.mock.calls[0]?.[0]).toContain('X_INTERVAL_MS');
+      warn.mockRestore();
+    },
+  );
+});

--- a/packages/server/test/connector-error-signal.test.ts
+++ b/packages/server/test/connector-error-signal.test.ts
@@ -1,0 +1,291 @@
+/**
+ * Fitness function for the tool-error signal contract.
+ *
+ * `events.tool_error_count` is a three-valued column: a number when the source
+ * format can tell a failed tool call from a successful one, NULL when it cannot
+ * (so analytics reports "unavailable" instead of a fabricated 0). Two ways to
+ * break that are invisible in a connector's own test: a connector that HAS a
+ * signal but never sets `is_error` (reporting 0 errors forever), and a new
+ * connector nobody classified at all.
+ *
+ * So this test walks the real registry: every connector id must be declared
+ * either with or without a signal, and each TypeScript normalizer is run over a
+ * minimal fixture holding ONE failing tool call — the declared ones must count
+ * it, the undeclared ones must keep every row NULL. Claude Code derives the
+ * column in SQL (`analytics-errors.integration.test.ts` covers it end to end),
+ * so only its declaration is checked here.
+ */
+
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import type { CanonicalRow } from '../src/connectors/canonical.js';
+
+const work = mkdtempSync(join(tmpdir(), 'claudescope-errsignal-'));
+const codexDir = join(work, 'codex');
+const piDir = join(work, 'pi');
+const copilotDir = join(work, 'copilot');
+const junieDir = join(work, 'junie');
+const antigravityDir = join(work, 'antigravity');
+const grokDir = join(work, 'grok');
+
+process.env.CLAUDE_PROJECTS_DIR = join(work, 'claude-empty');
+process.env.CODEX_SESSIONS_DIR = codexDir;
+process.env.JUNIE_SESSIONS_DIR = junieDir;
+process.env.PI_SESSIONS_DIR = piDir;
+process.env.OPENCODE_DATA_DIR = join(work, 'opencode-empty');
+process.env.COPILOT_SESSIONS_DIR = copilotDir;
+process.env.ANTIGRAVITY_CLI_DIR = antigravityDir;
+process.env.ANTIGRAVITY_DIR = join(work, 'antigravity-desktop-empty');
+process.env.GROK_SESSIONS_DIR = grokDir;
+process.env.CLAUDESCOPE_HOME = join(work, 'home');
+
+const jsonl = (rows: unknown[]): string => rows.map((r) => JSON.stringify(r)).join('\n') + '\n';
+const at = (s: number) => `2026-08-01T09:00:${String(s).padStart(2, '0')}.000Z`;
+
+/**
+ * The canonical rows of one connector's minimal fixture. Populated in
+ * `beforeAll` because the connector modules read their source dirs through the
+ * env vars set above.
+ */
+const rowsByConnector = new Map<string, CanonicalRow[]>();
+
+/** Codex: a shell call whose exec envelope reports a non-zero exit. */
+async function codexRows(): Promise<CanonicalRow[]> {
+  const dir = join(codexDir, '2026', '08', '01');
+  mkdirSync(dir, { recursive: true });
+  const file = join(dir, 'rollout-2026-08-01T09-00-00-019f8888-aaaa-7bbb-8ccc-000000000001.jsonl');
+  writeFileSync(
+    file,
+    jsonl([
+      { type: 'session_meta', timestamp: at(0), payload: { id: 'codex-fail-1', cwd: '/tmp/errproj' } },
+      { type: 'turn_context', timestamp: at(1), payload: { model: 'gpt-5.4' } },
+      { type: 'response_item', timestamp: at(2), payload: { type: 'message', role: 'user', content: [{ type: 'input_text', text: 'build it' }] } },
+      { type: 'response_item', timestamp: at(3), payload: { type: 'function_call', name: 'exec_command', arguments: '{"cmd":"npm run build"}', call_id: 'c1' } },
+      { type: 'response_item', timestamp: at(4), payload: { type: 'function_call_output', call_id: 'c1', output: 'Chunk ID: a1\nWall time: 0.2 seconds\nProcess exited with code 1\nOutput:\nsh: vitest: command not found' } },
+    ]),
+  );
+  const { parseRollout, toCanonicalRows } = await import('../src/connectors/codex/normalize.js');
+  return toCanonicalRows(parseRollout(file)!, file);
+}
+
+/** pi: a `toolResult` record flagged `isError`. */
+async function piRows(): Promise<CanonicalRow[]> {
+  const dir = join(piDir, '--tmp-errproj--');
+  mkdirSync(dir, { recursive: true });
+  const file = join(dir, '2026-08-01T09-00-00-000Z_019f8888-aaaa-7bbb-8ccc-000000000002.jsonl');
+  writeFileSync(
+    file,
+    jsonl([
+      { type: 'session', version: 3, id: 'pi-fail-1', timestamp: at(0), cwd: '/tmp/errproj' },
+      { type: 'message', id: 'u1', parentId: null, timestamp: at(1), message: { role: 'user', content: [{ type: 'text', text: 'build it' }] } },
+      { type: 'message', id: 'a1', parentId: 'u1', timestamp: at(2), message: {
+        role: 'assistant', model: 'gpt-5.4-mini', provider: 'openai-codex',
+        content: [{ type: 'toolCall', id: 'call_X|fc_x', name: 'bash', arguments: { command: 'npm run build' } }],
+      } },
+      { type: 'message', id: 'tr1', parentId: 'a1', timestamp: at(3), message: { role: 'toolResult', toolCallId: 'call_X|fc_x', toolName: 'bash', isError: true, content: [{ type: 'text', text: 'sh: vitest: command not found' }] } },
+    ]),
+  );
+  const { parsePiSession, toCanonicalRows } = await import('../src/connectors/pi/normalize.js');
+  return toCanonicalRows(parsePiSession(file)!, file);
+}
+
+/** opencode: a `tool` part whose state reports `status: 'error'`. */
+async function opencodeRows(): Promise<CanonicalRow[]> {
+  const { toCanonicalRows } = await import('../src/connectors/opencode/normalize.js');
+  const session = {
+    id: 'ses_fail1',
+    directory: '/tmp/errproj',
+    title: 'Failing build',
+    parentId: null,
+    rootId: 'ses_fail1',
+    messages: [
+      { id: 'a1', data: JSON.stringify({ role: 'assistant', modelID: 'gpt-5.4-mini-fast', providerID: 'openai', time: { created: 2000 } }) },
+    ],
+    partsByMessage: new Map([
+      ['a1', [
+        JSON.stringify({
+          type: 'tool', tool: 'bash', callID: 'call_b',
+          state: { status: 'error', input: { command: 'npm run build' }, error: 'exit 1', output: 'sh: vitest: command not found' },
+        }),
+      ]],
+    ]),
+  };
+  return toCanonicalRows(session, `${join(work, 'opencode.db')}#ses_fail1`);
+}
+
+/** Copilot: a `tool.execution_complete` with `success: false`. */
+async function copilotRows(): Promise<CanonicalRow[]> {
+  const dir = join(copilotDir, 'se');
+  mkdirSync(dir, { recursive: true });
+  const file = join(dir, 'events.jsonl');
+  let n = 0;
+  const ev = (type: string, data: unknown) => ({ type, data, id: `e${n++}`, timestamp: at(n), parentId: null });
+  writeFileSync(
+    file,
+    jsonl([
+      ev('session.start', { sessionId: 'copilot-fail-1', context: { cwd: '/tmp/errproj', branch: 'main' } }),
+      ev('session.model_change', { newModel: 'gpt-5-mini' }),
+      ev('user.message', { content: 'build it' }),
+      ev('assistant.message', { messageId: 'm1', model: 'gpt-5-mini', content: 'Building.', toolRequests: [
+        { toolCallId: 'call-bash', name: 'bash', arguments: { command: 'npm run build' } },
+      ] }),
+      ev('tool.execution_start', { toolCallId: 'call-bash', toolName: 'bash', arguments: { command: 'npm run build' } }),
+      ev('tool.execution_complete', { toolCallId: 'call-bash', success: false, result: { content: 'sh: vitest: command not found' } }),
+    ]),
+  );
+  const { parseCopilotSession, toCanonicalRows } = await import('../src/connectors/copilot/normalize.js');
+  return toCanonicalRows(parseCopilotSession(file)!, file);
+}
+
+/** Junie: a terminal step whose details read like a failure — no error signal. */
+async function junieRows(): Promise<CanonicalRow[]> {
+  const sessionId = 'session-260801-090000-err';
+  const dir = join(junieDir, sessionId);
+  mkdirSync(dir, { recursive: true });
+  const a2ux = (agentEvent: unknown, sec: number) => ({
+    kind: 'SessionA2uxEvent',
+    event: { state: 'IN_PROGRESS', agentEvent },
+    timestampMs: Date.UTC(2026, 7, 1, 9, 0, sec),
+  });
+  writeFileSync(
+    join(junieDir, 'index.jsonl'),
+    jsonl([{ sessionId, createdAt: Date.UTC(2026, 7, 1, 9, 0, 0), updatedAt: Date.UTC(2026, 7, 1, 9, 0, 9), projectDir: '/tmp/errproj', taskName: 'Build it' }]),
+  );
+  const file = join(dir, 'events.jsonl');
+  writeFileSync(
+    file,
+    jsonl([
+      { kind: 'UserPromptEvent', prompt: 'build it' },
+      { kind: 'SendToAgentEvent' },
+      a2ux({ kind: 'TerminalBlockUpdatedEvent', stepId: 'step-A', status: 'IN_PROGRESS', command: 'npm run build' }, 2),
+      a2ux({ kind: 'TerminalBlockUpdatedEvent', stepId: 'step-A', status: 'COMPLETED', details: 'sh: vitest: command not found' }, 3),
+      a2ux({ kind: 'ResultBlockUpdatedEvent', stepId: 'step-R', cancelled: false, result: 'the build failed', changes: [] }, 4),
+    ]),
+  );
+  const { parseSession, toCanonicalRows } = await import('../src/connectors/junie/normalize.js');
+  return toCanonicalRows(parseSession(file)!, file);
+}
+
+/** Antigravity: a typed result record for a failed command — no error signal. */
+async function antigravityRows(): Promise<CanonicalRow[]> {
+  const conv = '55555555-5555-5555-5555-555555555555';
+  const dir = join(antigravityDir, 'brain', conv, '.system_generated', 'logs');
+  mkdirSync(dir, { recursive: true });
+  const file = join(dir, 'transcript_full.jsonl');
+  const step = (stepIndex: number, source: string, type: string, extra: Record<string, unknown> = {}) => ({
+    step_index: stepIndex, source, type, status: 'DONE', created_at: at(stepIndex), ...extra,
+  });
+  writeFileSync(
+    file,
+    jsonl([
+      step(0, 'USER_EXPLICIT', 'USER_INPUT', { content: '<USER_REQUEST>\nbuild it\n</USER_REQUEST>' }),
+      step(1, 'MODEL', 'PLANNER_RESPONSE', {
+        content: 'Reading the build script.',
+        tool_calls: [{ name: 'view_file', args: { AbsolutePath: '/tmp/errproj/missing.ts', toolAction: 'View', toolSummary: 'View' } }],
+      }),
+      step(2, 'MODEL', 'VIEW_FILE', { content: 'Error: no such file or directory' }),
+    ]),
+  );
+  const { parseAntigravitySession, toCanonicalRows } = await import('../src/connectors/antigravity/normalize.js');
+  return toCanonicalRows(parseAntigravitySession(file), file);
+}
+
+/** Grok: a `tool_result` whose body is an error string — no error signal. */
+async function grokRows(): Promise<CanonicalRow[]> {
+  const dir = join(grokDir, '%2Ftmp%2Ferrproj', 'grok-fail-1');
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(
+    join(dir, 'summary.json'),
+    JSON.stringify({ info: { id: 'grok-fail-1', cwd: '/tmp/errproj' }, created_at: at(0), updated_at: at(9), current_model_id: 'grok-4.5', generated_title: 'Build it' }),
+  );
+  const file = join(dir, 'chat_history.jsonl');
+  writeFileSync(
+    file,
+    jsonl([
+      { type: 'user', prompt_index: 0, content: [{ type: 'text', text: '<user_query>\nbuild it\n</user_query>' }] },
+      { type: 'assistant', content: 'Building.', model_id: 'grok-4.5', tool_calls: [
+        { id: 'call-g0', name: 'run_terminal_command', arguments: JSON.stringify({ command: 'npm run build' }) },
+      ] },
+      { type: 'tool_result', tool_call_id: 'call-g0', content: 'sh: vitest: command not found' },
+    ]),
+  );
+  const { parseGrokSession, toCanonicalRows } = await import('../src/connectors/grok/normalize.js');
+  return toCanonicalRows(parseGrokSession(file)!, file);
+}
+
+/** Every connector whose canonical rows come from a TypeScript normalizer. */
+const NORMALIZER_FIXTURES: Record<string, () => Promise<CanonicalRow[]>> = {
+  codex: codexRows,
+  pi: piRows,
+  opencode: opencodeRows,
+  copilot: copilotRows,
+  junie: junieRows,
+  antigravity: antigravityRows,
+  grok: grokRows,
+};
+
+let registryIds: string[];
+let withSignal: string[];
+let withoutSignal: string[];
+let hasToolErrorSignal: (id: string) => boolean;
+
+beforeAll(async () => {
+  const capabilities = await import('../src/data/agent-capabilities.js');
+  const { connectors } = await import('../src/connectors/registry.js');
+  registryIds = connectors.map((c) => c.id);
+  withSignal = capabilities.connectorsWithToolErrorSignal();
+  withoutSignal = capabilities.connectorsWithoutToolErrorSignal();
+  hasToolErrorSignal = capabilities.hasToolErrorSignal;
+
+  for (const [id, build] of Object.entries(NORMALIZER_FIXTURES)) {
+    rowsByConnector.set(id, await build());
+  }
+});
+
+afterAll(() => {
+  rmSync(work, { recursive: true, force: true });
+});
+
+describe('tool-error signal declaration', () => {
+  it('classifies every registered connector exactly once', () => {
+    expect([...withSignal, ...withoutSignal].sort()).toEqual([...registryIds].sort());
+    for (const id of withSignal) expect(hasToolErrorSignal(id)).toBe(true);
+    for (const id of withoutSignal) expect(hasToolErrorSignal(id)).toBe(false);
+  });
+
+  it('declares a signal for Claude Code, whose column is derived in SQL', () => {
+    // The only connector with no TypeScript normalizer — its projection is
+    // covered by analytics-errors.integration.test.ts.
+    expect(hasToolErrorSignal('claude-code')).toBe(true);
+    expect(Object.keys(NORMALIZER_FIXTURES)).not.toContain('claude-code');
+  });
+
+  it('covers every TypeScript normalizer with a fixture', () => {
+    const normalizerIds = registryIds.filter((id) => id !== 'claude-code');
+    expect(Object.keys(NORMALIZER_FIXTURES).sort()).toEqual([...normalizerIds].sort());
+  });
+});
+
+describe('connectors that declare a tool-error signal', () => {
+  it.each(['codex', 'pi', 'opencode', 'copilot'])('counts a failed tool call (%s)', (id) => {
+    expect(hasToolErrorSignal(id)).toBe(true);
+    const rows = rowsByConnector.get(id)!;
+    expect(rows.length).toBeGreaterThan(0);
+    const failed = rows.filter((r) => (r.tool_error_count ?? 0) >= 1);
+    expect(failed.length).toBeGreaterThan(0);
+    expect(failed.every((r) => r.tool_error_text !== null && r.tool_error_text !== '')).toBe(true);
+  });
+});
+
+describe('connectors whose format records no tool-error signal', () => {
+  it.each(['junie', 'antigravity', 'grok'])('leaves every row NULL (%s)', (id) => {
+    expect(hasToolErrorSignal(id)).toBe(false);
+    const rows = rowsByConnector.get(id)!;
+    expect(rows.length).toBeGreaterThan(0);
+    // NULL, never 0: "no errors" and "can't know" must stay distinguishable.
+    expect(rows.every((r) => r.tool_error_count === null)).toBe(true);
+    expect(rows.every((r) => r.tool_error_text === null)).toBe(true);
+  });
+});

--- a/packages/server/test/duckdb-lock-holder.mjs
+++ b/packages/server/test/duckdb-lock-holder.mjs
@@ -1,0 +1,29 @@
+/**
+ * Test helper: hold a read-write DuckDB file lock from a SEPARATE process.
+ *
+ * DuckDB's single-writer lock is per-process, so an in-process open can never
+ * reproduce the "Conflicting lock is held in …" failure that a second server
+ * (a stray `npm run dev` next to the global daemon, or a racing `claudescope
+ * mcp`) hits. Spawned as `node duckdb-lock-holder.mjs <dbPath>`: prints
+ * `locked` once the lock is held, then blocks until stdin closes (i.e. until
+ * the test kills it), releasing the lock on exit.
+ */
+
+import { DuckDBInstance } from '@duckdb/node-api';
+
+const dbPath = process.argv[2];
+if (!dbPath) {
+  console.error('usage: duckdb-lock-holder.mjs <dbPath>');
+  process.exit(2);
+}
+
+const instance = await DuckDBInstance.create(dbPath);
+const connection = await instance.connect();
+// Touch the DB so the lock is definitely materialized before we report ready.
+await connection.run('SELECT 1');
+process.stdout.write('locked\n');
+
+// Park until the parent closes our stdin (or kills us outright).
+process.stdin.resume();
+process.stdin.on('end', () => process.exit(0));
+process.stdin.on('close', () => process.exit(0));

--- a/packages/server/test/duckdb-open.test.ts
+++ b/packages/server/test/duckdb-open.test.ts
@@ -1,0 +1,88 @@
+/**
+ * Open-failure classification (db/duckdb.ts). getConnection() deletes the index
+ * on a failed open, so what counts as "corrupt" is a destructive decision: a
+ * lock conflict once wiped the running daemon's database from under it, because
+ * a second process (a stray `npm run dev`, a racing `claudescope mcp`) shares
+ * the same state dir. These cases pin down which failures may trigger that
+ * discard and which must be rethrown untouched — with the REAL DuckDB messages.
+ */
+
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterAll, describe, expect, it, vi } from 'vitest';
+import { isNonCorruptionOpenError } from '../src/db/duckdb.js';
+
+/** Verbatim from a second process opening the daemon's index (DuckDB v1.5). */
+const LOCK_CONFLICT =
+  'IO Error: Could not set lock on file "/Users/u/.claudescope/index.duckdb": ' +
+  'Conflicting lock is held in /opt/homebrew/bin/node (PID 66590) by user u. ' +
+  'See also https://duckdb.org/docs/stable/connect/concurrency';
+
+describe('isNonCorruptionOpenError', () => {
+  it('never discards on a lock conflict — another process owns a healthy index', () => {
+    expect(isNonCorruptionOpenError(new Error(LOCK_CONFLICT))).toBe(true);
+  });
+
+  it('never discards when the json/fts extensions cannot be installed', () => {
+    const cases = [
+      // Verbatim shape of a failed INSTALL (DuckDB v1.5, unreachable repository).
+      'HTTP Error: Failed to download extension "fts" at URL ' +
+        '"http://extensions.duckdb.org/v1.5.3/osx_arm64/fts.duckdb_extension.gz" (HTTP 404)',
+      'IO Error: Extension "json" not found. Extension "json" is an existing extension.',
+      'Extension "fts" could not be loaded: the file was not found',
+      "HTTP Error: HTTP GET error on " +
+        "'http://extensions.duckdb.org/v1.5.3/linux_amd64/json.duckdb_extension.gz' (HTTP 403)",
+      'IO Error: Could not establish connection to extensions.duckdb.org',
+    ];
+    for (const message of cases) {
+      expect(isNonCorruptionOpenError(new Error(message)), message).toBe(true);
+    }
+  });
+
+  it('never discards on an OS permission/disk failure, by code or by message', () => {
+    const denied = Object.assign(new Error('permission denied'), { code: 'EACCES' });
+    expect(isNonCorruptionOpenError(denied)).toBe(true);
+    expect(isNonCorruptionOpenError(Object.assign(new Error('x'), { code: 'EPERM' }))).toBe(true);
+    const full = new Error("ENOSPC: no space left on device, write '/x/index.duckdb'");
+    expect(isNonCorruptionOpenError(full)).toBe(true);
+  });
+
+  it('still rebuilds on the stale-schema sentinel and on real corruption', () => {
+    const rebuildable = [
+      'index schema is stale (expected v21); rebuilding',
+      'IO Error: The file "/Users/u/.claudescope/index.duckdb" exists, ' +
+        'but it is not a valid DuckDB database file!',
+      // An unreplayable WAL is the original reason the discard path exists.
+      'IO Error: Failure while replaying WAL file "index.duckdb.wal"',
+    ];
+    for (const message of rebuildable) {
+      expect(isNonCorruptionOpenError(new Error(message)), message).toBe(false);
+    }
+    expect(isNonCorruptionOpenError(undefined)).toBe(false);
+  });
+});
+
+describe('DUCKDB_EXTENSION_DIR', () => {
+  // No DuckDB instance is opened here on purpose: that would download the
+  // extensions into this throwaway home.
+  const home = mkdtempSync(join(tmpdir(), 'claudescope-extdir-'));
+  afterAll(() => rmSync(home, { recursive: true, force: true }));
+
+  it('defaults under CLAUDESCOPE_HOME when the override is unset', async () => {
+    const saved = { ext: process.env.DUCKDB_EXTENSION_DIR, home: process.env.CLAUDESCOPE_HOME };
+    delete process.env.DUCKDB_EXTENSION_DIR;
+    process.env.CLAUDESCOPE_HOME = home;
+    try {
+      vi.resetModules();
+      const config = await import('../src/config.js');
+      expect(config.DUCKDB_EXTENSION_DIR).toBe(join(home, 'duckdb-extensions'));
+    } finally {
+      if (saved.ext === undefined) delete process.env.DUCKDB_EXTENSION_DIR;
+      else process.env.DUCKDB_EXTENSION_DIR = saved.ext;
+      if (saved.home === undefined) delete process.env.CLAUDESCOPE_HOME;
+      else process.env.CLAUDESCOPE_HOME = saved.home;
+      vi.resetModules();
+    }
+  });
+});

--- a/packages/server/test/index-durability.integration.test.ts
+++ b/packages/server/test/index-durability.integration.test.ts
@@ -79,6 +79,59 @@ const row = (session: string, uuid: string, cwd = '/tmp/projD'): string =>
     },
   }) + '\n';
 
+/** Unique term for the FTS assertion below — must not collide with any other
+ *  fixture's prose in this file. */
+const UNIQUE_WORD = 'zzyzxquokka';
+
+/**
+ * A user turn (carrying {@link UNIQUE_WORD}) followed by an Edit tool call and
+ * its result — exercises `sessions`, `file_edits`, and FTS in one fixture, all
+ * of which only get (re)built by `doReindex`'s finalize step.
+ */
+const editSessionLines = (session: string, cwd = '/tmp/projE'): string => {
+  const base = { sessionId: session, cwd, isSidechain: false };
+  const lines = [
+    {
+      ...base,
+      type: 'user',
+      uuid: 'eu1',
+      parentUuid: null,
+      timestamp: '2026-01-01T11:00:00.000Z',
+      message: { role: 'user', content: `please handle ${UNIQUE_WORD} now` },
+    },
+    {
+      ...base,
+      type: 'assistant',
+      uuid: 'ea1',
+      parentUuid: 'eu1',
+      timestamp: '2026-01-01T11:00:01.000Z',
+      message: {
+        role: 'assistant',
+        id: 'msg-ea1',
+        model: 'some-unlisted-model',
+        content: [
+          {
+            type: 'tool_use',
+            id: 'toolu_e1',
+            name: 'Edit',
+            input: { file_path: `${cwd}/src/app.ts`, old_string: 'one', new_string: 'ONE' },
+          },
+        ],
+        usage: { input_tokens: 100, output_tokens: 10 },
+      },
+    },
+    {
+      ...base,
+      type: 'user',
+      uuid: 'eu2',
+      parentUuid: 'ea1',
+      timestamp: '2026-01-01T11:00:02.000Z',
+      message: { role: 'user', content: [{ type: 'tool_result', tool_use_id: 'toolu_e1', content: 'ok' }] },
+    },
+  ];
+  return lines.map((l) => JSON.stringify(l)).join('\n') + '\n';
+};
+
 /** `default.input` is injectable so a test can make it unusable. */
 const pricingWith = (defaultInput: unknown): string =>
   JSON.stringify(
@@ -94,13 +147,27 @@ const pricingWith = (defaultInput: unknown): string =>
   );
 
 let reindex: () => Promise<ReindexResponse>;
+let failNextFinalizeForTests: () => void;
 let conn: DuckDBConnection;
 let queryRows: typeof import('../src/db/duckdb.js').queryRows;
+let sqlString: typeof import('../src/db/duckdb.js').sqlString;
 let closeConnection: () => Promise<void>;
 
 const countEvents = async (file?: string): Promise<number> => {
   const where = file ? ` WHERE file_path = '${file}'` : '';
   return Number((await queryRows(conn, `SELECT count(*) AS n FROM events${where}`))[0]?.n ?? 0);
+};
+
+/** Whether the BM25 index over `events.text_content` finds `term` in `sessionId`. */
+const ftsFinds = async (term: string, sessionId: string): Promise<boolean> => {
+  const rows = await queryRows(
+    conn,
+    `SELECT session_id FROM (
+       SELECT session_id, fts_main_events.match_bm25(uuid, ${sqlString(term)}) AS score
+       FROM events WHERE text_content IS NOT NULL
+     ) WHERE score IS NOT NULL AND session_id = ${sqlString(sessionId)}`,
+  );
+  return rows.length > 0;
 };
 
 beforeAll(async () => {
@@ -109,9 +176,9 @@ beforeAll(async () => {
   writeFileSync(pricingPath, pricingWith(3));
   writeFileSync(keepFile, row('sessKeep', 'k1') + row('sessKeep', 'k2') + row('sessKeep', 'k3'));
 
-  ({ reindex } = await import('../src/data/index.js'));
+  ({ reindex, failNextFinalizeForTests } = await import('../src/data/index.js'));
   const duck = await import('../src/db/duckdb.js');
-  ({ queryRows, closeConnection } = duck);
+  ({ queryRows, sqlString, closeConnection } = duck);
   conn = await duck.getConnection();
 });
 
@@ -219,6 +286,36 @@ describe('a projection failure validation cannot foresee', () => {
       await reindex();
     },
   );
+});
+
+describe('a finalize failure after `files` bookkeeping already advanced', () => {
+  it('is repaired by the next pass even with no further file changes', async () => {
+    const editFile = join(projDir, 'sessEdit.jsonl');
+    writeFileSync(editFile, editSessionLines('sessEdit'));
+
+    failNextFinalizeForTests();
+    await expect(reindex()).rejects.toThrow('injected finalize failure');
+
+    // `files`/`events` already reflect the new file (staged before finalize
+    // ran), but the derived tables the finalize step owns do not yet.
+    expect(await countEvents(editFile)).toBe(3);
+    const beforeSessions = await queryRows(conn, "SELECT count(*) AS n FROM sessions WHERE id = 'sessEdit'");
+    expect(Number(beforeSessions[0]?.n ?? 0)).toBe(0);
+
+    // No further file changes on disk — this must NOT read as an idle pass.
+    const recovered = await reindex();
+    expect(recovered.reindexed).toBe(0);
+    expect(recovered.failed).toBe(0);
+
+    const sessions = await queryRows(conn, "SELECT count(*) AS n FROM sessions WHERE id = 'sessEdit'");
+    expect(Number(sessions[0]?.n ?? 0)).toBe(1);
+    const edits = await queryRows(
+      conn,
+      "SELECT count(*) AS n FROM file_edits WHERE session_id = 'sessEdit' AND edit_canonical",
+    );
+    expect(Number(edits[0]?.n ?? 0)).toBe(1);
+    expect(await ftsFinds(UNIQUE_WORD, 'sessEdit')).toBe(true);
+  });
 });
 
 describe('modal project cwd', () => {

--- a/packages/server/test/index-durability.integration.test.ts
+++ b/packages/server/test/index-durability.integration.test.ts
@@ -163,7 +163,7 @@ const ftsFinds = async (term: string, sessionId: string): Promise<boolean> => {
   const rows = await queryRows(
     conn,
     `SELECT session_id FROM (
-       SELECT session_id, fts_main_events.match_bm25(uuid, ${sqlString(term)}) AS score
+       SELECT session_id, fts_main_events.match_bm25(doc_id, ${sqlString(term)}) AS score
        FROM events WHERE text_content IS NOT NULL
      ) WHERE score IS NOT NULL AND session_id = ${sqlString(sessionId)}`,
   );

--- a/packages/server/test/index-recovery.integration.test.ts
+++ b/packages/server/test/index-recovery.integration.test.ts
@@ -7,6 +7,11 @@
  *  - (2b) a valid DB whose persisted schema signature no longer matches →
  *         isStaleSchema throws → discarded → rebuilt.
  *
+ * Plus the boundary of that contract: a failure the index is NOT to blame for
+ * must never reach the discard. A second process holding the DuckDB write lock
+ * (the real-world case: `npm run dev` next to the installed daemon) used to be
+ * read as corruption and deleted the live daemon's database.
+ *
  * Each scenario uses its own DUCKDB_PATH and re-imports the db/index modules
  * after vi.resetModules(), because DUCKDB_PATH / SCHEMA_SIGNATURE / the
  * connection singleton are all frozen at module import. closeConnection() fully
@@ -15,10 +20,12 @@
  */
 
 import { afterAll, describe, expect, it, vi } from 'vitest';
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdirSync, mkdtempSync, rmSync, statSync, writeFileSync } from 'node:fs';
 import { randomBytes } from 'node:crypto';
+import { type ChildProcess, spawn } from 'node:child_process';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
 
 // --- temp locations (decided before any server module is imported) ----------
 const work = mkdtempSync(join(tmpdir(), 'claudescope-recovery-'));
@@ -77,6 +84,40 @@ async function snapshot(db: DbModules): Promise<{ ids: unknown[]; events: number
 
 /** The catch in getConnection logs this when it discards a bad DB. */
 const RECOVERY_LOG = 'discarding and rebuilding';
+
+/** Standalone script that holds the DuckDB write lock from another process —
+ *  DuckDB's lock is per-process, so an in-process open can't reproduce it. */
+const LOCK_HOLDER = fileURLToPath(new URL('./duckdb-lock-holder.mjs', import.meta.url));
+
+/** Spawn the lock holder and resolve once it reports the lock is held. */
+async function holdLock(dbPath: string): Promise<ChildProcess> {
+  const child = spawn(process.execPath, [LOCK_HOLDER, dbPath], {
+    stdio: ['pipe', 'pipe', 'inherit'],
+  });
+  await new Promise<void>((resolve, reject) => {
+    const timer = setTimeout(() => reject(new Error('lock holder never reported ready')), 20_000);
+    child.stdout?.setEncoding('utf8');
+    child.stdout?.on('data', (chunk: string) => {
+      if (chunk.includes('locked')) {
+        clearTimeout(timer);
+        resolve();
+      }
+    });
+    child.once('exit', (code) => {
+      clearTimeout(timer);
+      reject(new Error(`lock holder exited early (${code})`));
+    });
+  });
+  return child;
+}
+
+/** Release the lock and wait for the holder to actually be gone. */
+async function releaseLock(child: ChildProcess): Promise<void> {
+  const exited = new Promise<void>((resolve) => child.once('exit', () => resolve()));
+  child.stdin?.end();
+  child.kill();
+  await exited;
+}
 
 afterAll(() => rmSync(work, { recursive: true, force: true }));
 
@@ -141,6 +182,64 @@ describe('stale schema signature', () => {
     const rows = await db.queryRows(conn2, "SELECT value FROM meta WHERE key = 'schema_signature'");
     expect(rows[0]?.value).not.toBe('STALE-DOES-NOT-MATCH');
     expect(String(rows[0]?.value)).toMatch(/^[0-9a-f]{40}$/);
+    await db.closeConnection();
+  });
+});
+
+// Windows: DuckDB's Windows build let a second read-write open through in CI
+// (no "Could not set lock" error was raised), so the conflict this scenario
+// provokes never happens there. The classification itself is platform-neutral
+// and covered by duckdb-open.test.ts; this proves the end-to-end behaviour on
+// the POSIX builds that do enforce the single-writer lock.
+describe.skipIf(process.platform === 'win32')('index locked by another process', () => {
+  it('reports the conflict and leaves the database on disk', async () => {
+    const dbPath = join(work, 'locked.duckdb');
+
+    // Build a valid index, then fully flush + close so the holder sees a
+    // settled file (nothing left for it to replay and rewrite).
+    let db = await loadDbModules(dbPath);
+    await db.reindex();
+    const before = await snapshot(db);
+    expect(before.ids).toEqual(['sessR']);
+    const conn = await db.getConnection();
+    await conn.run('CHECKPOINT');
+    await db.closeConnection();
+    const sizeBefore = statSync(dbPath).size;
+
+    const holder = await holdLock(dbPath);
+    try {
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      db = await loadDbModules(dbPath);
+      // The old behaviour: treat this as corruption, delete the daemon's index.
+      await expect(db.getConnection()).rejects.toThrow(/lock/i);
+      expect(warn).not.toHaveBeenCalledWith(
+        expect.stringContaining(RECOVERY_LOG),
+        expect.anything(),
+      );
+      warn.mockRestore();
+
+      expect(existsSync(dbPath)).toBe(true);
+      expect(statSync(dbPath).size).toBe(sizeBefore);
+    } finally {
+      await releaseLock(holder);
+    }
+
+    // `connecting` was reset in the finally, so the next call really retries —
+    // and finds the same index, never rebuilt.
+    expect(await snapshot(db)).toEqual(before);
+    await db.closeConnection();
+  });
+});
+
+describe('DuckDB extension directory', () => {
+  it('is redirected to the configured dir, not DuckDB’s default', async () => {
+    const dbPath = join(work, 'extdir.duckdb');
+    const db = await loadDbModules(dbPath);
+    const { DUCKDB_EXTENSION_DIR } = await import('../src/config.js');
+
+    const conn = await db.getConnection();
+    const rows = await db.queryRows(conn, "SELECT current_setting('extension_directory') AS dir");
+    expect(rows[0]?.dir).toBe(DUCKDB_EXTENSION_DIR);
     await db.closeConnection();
   });
 });

--- a/packages/server/test/parser.test.ts
+++ b/packages/server/test/parser.test.ts
@@ -29,7 +29,7 @@ function user(uuid: string, content: unknown, isSidechain = false): RawEvent {
 function assistant(
   uuid: string,
   content: unknown,
-  opts: { usage?: Record<string, number>; model?: string; isSidechain?: boolean } = {},
+  opts: { usage?: Record<string, number>; model?: string; isSidechain?: boolean; id?: string } = {},
 ): RawEvent {
   return {
     type: 'assistant',
@@ -44,6 +44,7 @@ function assistant(
       content,
       ...(opts.model ? { model: opts.model } : {}),
       ...(opts.usage ? { usage: opts.usage } : {}),
+      ...(opts.id ? { id: opts.id } : {}),
     },
   } as unknown as RawEvent;
 }
@@ -461,6 +462,44 @@ describe('buildSubagentRuns', () => {
     expect(run?.toolCallCount).toBe(1);
     expect(run?.totalTokens).toBe(17); // 10 + 5 + 2
     expect(run?.messageCount).toBe(2);
+  });
+
+  it('elects the max-output row per message id instead of summing every block row', () => {
+    // Claude Code writes one row per content block of an assistant message,
+    // all sharing `message.id` and repeating the FULL usage object.
+    const blockUsage = (output: number) => ({
+      input_tokens: 100,
+      output_tokens: output,
+      cache_read_input_tokens: 10,
+      cache_creation_input_tokens: 5,
+    });
+    const events: RawEvent[] = [
+      user('su', 'do it', true),
+      assistant('sa1', [{ type: 'text', text: 'thinking' }], {
+        usage: blockUsage(5),
+        id: 'msg1',
+        isSidechain: true,
+      }),
+      assistant('sa2', [{ type: 'tool_use', id: 't1', name: 'Bash', input: {} }], {
+        usage: blockUsage(20),
+        id: 'msg1',
+        isSidechain: true,
+      }),
+      assistant('sa3', [{ type: 'tool_use', id: 't2', name: 'Bash', input: {} }], {
+        usage: blockUsage(30),
+        id: 'msg1',
+        isSidechain: true,
+      }),
+      assistant('sa4', [{ type: 'text', text: 'done' }], {
+        usage: { input_tokens: 7, output_tokens: 3, cache_read_input_tokens: 1, cache_creation_input_tokens: 2 },
+        isSidechain: true,
+      }),
+    ];
+    const [run] = buildSubagentRuns(mainThreadWithSpawns(), [
+      source({ agentId: 'a', agentType: 'Explore', description: 'Explore X', events }),
+    ]);
+    // max-output row of msg1 (100 + 30 + 10 + 5 = 145) + the id-less row (7 + 3 + 1 + 2 = 13).
+    expect(run?.totalTokens).toBe(158);
   });
 
   it('consumes each Agent spawn at most once for duplicate descriptions', () => {

--- a/packages/server/test/pi.integration.test.ts
+++ b/packages/server/test/pi.integration.test.ts
@@ -49,6 +49,7 @@ const ts4 = (s: number) => `2026-06-15T14:00:${String(s).padStart(2, '0')}.000Z`
 const CALL_A = 'call_AAA|fc_aaa';
 const CALL_B = 'call_BBB|fc_bbb';
 const CALL_C = 'call_CCC|fc_ccc';
+const CALL_D = 'call_DDD|fc_ddd'; // the FAILED call (`isError: true` on its result)
 const CALL_M = 'call_MMM|fc_mmm'; // management-mode subagent call
 const CALL_S = 'call_SSS|fc_sss'; // spawning subagent call
 // The dispatched task; the run must anchor on its FIRST LINE (subagentLabel).
@@ -80,13 +81,17 @@ function writeSession(): string {
           { type: 'toolCall', id: CALL_B, name: 'edit', arguments: { path: '/tmp/piproj/hay.txt', edits: [{ oldText: 'hay', newText: 'needle' }] } },
           // pi reads a pasted screenshot from a temp file; the image rides the RESULT.
           { type: 'toolCall', id: CALL_C, name: 'read', arguments: { path: '/tmp/pi-clipboard-x.png' } },
+          { type: 'toolCall', id: CALL_D, name: 'bash', arguments: { command: 'npm run build' } },
         ],
         usage: { input: 1000, output: 300, cacheRead: 200, cacheWrite: 0, totalTokens: 1500 },
       } },
-      // Three consecutive tool results → coalesce into ONE user turn carrying all.
+      // Four consecutive tool results → coalesce into ONE user turn carrying all.
       { type: 'message', id: 'tr1', parentId: 'a1', timestamp: ts(3), message: { role: 'toolResult', toolCallId: CALL_A, toolName: 'bash', content: [{ type: 'text', text: 'needle found at line 42' }] } },
       { type: 'message', id: 'tr2', parentId: 'a1', timestamp: ts(3), message: { role: 'toolResult', toolCallId: CALL_B, toolName: 'edit', content: [{ type: 'text', text: 'edited hay.txt' }] } },
       { type: 'message', id: 'tr3', parentId: 'a1', timestamp: ts(3), message: { role: 'toolResult', toolCallId: CALL_C, toolName: 'read', content: [{ type: 'text', text: 'Read image file [image/png]' }, { type: 'image', data: PNG_B64, mimeType: 'image/png' }] } },
+      // The ONE failed result: pi-ai's `ToolResultMessage.isError` is the only
+      // failure signal in the format, so tr1–tr3 (no flag) must stay uncounted.
+      { type: 'message', id: 'tr4', parentId: 'a1', timestamp: ts(3), message: { role: 'toolResult', toolCallId: CALL_D, toolName: 'bash', isError: true, content: [{ type: 'text', text: 'sh: vitest: command not found' }] } },
       { type: 'message', id: 'a2', parentId: 'tr2', timestamp: ts(4), message: {
         role: 'assistant', model: 'gpt-5.4-mini', provider: 'openai-codex',
         content: [{ type: 'text', text: 'Found the needle.' }],
@@ -261,6 +266,8 @@ function writeCompactionSession(): void {
 
 let app: FastifyInstance;
 let closeConnection: () => Promise<void>;
+let getConnection: typeof import('../src/db/duckdb.js').getConnection;
+let queryRows: typeof import('../src/db/duckdb.js').queryRows;
 
 beforeAll(async () => {
   mkdirSync(claudeDir, { recursive: true });
@@ -273,7 +280,7 @@ beforeAll(async () => {
   const Fastify = (await import('fastify')).default;
   const { registerRoutes } = await import('../src/routes/index.js');
   const { reindex } = await import('../src/data/index.js');
-  ({ closeConnection } = await import('../src/db/duckdb.js'));
+  ({ getConnection, queryRows, closeConnection } = await import('../src/db/duckdb.js'));
 
   app = Fastify();
   await registerRoutes(app);
@@ -362,9 +369,11 @@ describe('pi session detail', () => {
     expect(thinking).toBeTruthy();
     expect(thinking.thinking).toContain('let me search the haystack');
 
-    // All three tool calls pair to their results by the verbatim composite id.
+    // All four tool calls pair to their results by the verbatim composite id.
     const tools = flat.filter((b: Record<string, unknown>) => b.kind === 'tool');
-    expect(tools.map((t: { id: string }) => t.id).sort()).toEqual([CALL_A, CALL_B, CALL_C].sort());
+    expect(tools.map((t: { id: string }) => t.id).sort()).toEqual(
+      [CALL_A, CALL_B, CALL_C, CALL_D].sort(),
+    );
 
     // pi `bash` → canonical `Bash` (renders command + output).
     const bash = tools.find((t: { name: string }) => t.name === 'Bash');
@@ -478,6 +487,24 @@ describe('pi provider-aware cost', () => {
     expect(s.totalCostUsd).toBeCloseTo(0.0006, 6);
     // A zero-rated provider on the session sets the local marker.
     expect(s.hasLocalProvider).toBe(true);
+  });
+});
+
+describe('pi tool errors', () => {
+  it('counts only the `isError` result, never the unflagged ones', async () => {
+    const conn = await getConnection();
+    const [row] = await queryRows(
+      conn,
+      `SELECT COALESCE(sum(tool_error_count), 0) AS errors,
+              count(*) FILTER (WHERE tool_error_count IS NULL) AS unknowns,
+              max(tool_error_text) AS text
+         FROM events WHERE session_id = 'pi-sess-1'`,
+    );
+    // One flagged result out of four — a format WITH a signal must never report
+    // NULL, and the three unflagged results must not inflate the count.
+    expect(Number(row!.errors)).toBe(1);
+    expect(Number(row!.unknowns)).toBe(0);
+    expect(row!.text).toBe('sh: vitest: command not found');
   });
 });
 

--- a/packages/server/test/search-forked.integration.test.ts
+++ b/packages/server/test/search-forked.integration.test.ts
@@ -3,16 +3,15 @@
  *
  * `events.uuid` is NOT unique: forking or resuming a session copies the whole
  * history into a new file with the uuids preserved, so the same uuid exists under
- * two session ids. `fts_main_events.match_bm25(uuid, …)` looks the document up by
- * that key with a scalar subquery, which therefore returns multiple rows — and
- * newer DuckDB raises `More than one row returned by a subquery` for that.
+ * two session ids. `match_bm25` looks its document up by the FTS key with a
+ * scalar subquery, so a uuid-keyed index returned multiple rows there — which
+ * newer DuckDB raises `More than one row returned by a subquery` for.
  *
- * The search route relies on `scalar_subquery_error_on_multiple_rows = false` to
- * keep working (the duplicates are identical copies, so picking either is fine).
- * Nothing tested that: deleting the setting outright left the whole suite green,
- * which meant the one reason it exists was unverified — and it is a
- * connection-level setting on the connection the indexer shares, so where it gets
- * applied matters.
+ * The fix is a key that really is unique per row (`events.doc_id`), not a
+ * connection-wide `scalar_subquery_error_on_multiple_rows = false` that would
+ * turn every genuine multi-row scalar subquery in the app into a silent
+ * arbitrary pick. This asserts both halves: the key is distinct per row, the
+ * shared connection keeps the strict default, and search still crosses forks.
  */
 
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
@@ -123,6 +122,27 @@ describe('a duplicated events.uuid', () => {
     );
     expect(Number(rows[0]?.n)).toBe(2);
   });
+
+  it('still yields a doc_id that is unique per row — the FTS key', async () => {
+    const conn = await (await import('../src/db/duckdb.js')).getConnection();
+    const rows = await queryRows(
+      conn,
+      'SELECT count(*) AS n, count(DISTINCT doc_id) AS distinct_ids FROM events',
+    );
+    expect(Number(rows[0]?.n)).toBeGreaterThan(0);
+    expect(Number(rows[0]?.distinct_ids)).toBe(Number(rows[0]?.n));
+  });
+});
+
+describe('the shared connection', () => {
+  it('keeps scalar subqueries strict — no connection-wide relaxation', async () => {
+    const conn = await (await import('../src/db/duckdb.js')).getConnection();
+    const rows = await queryRows(
+      conn,
+      "SELECT current_setting('scalar_subquery_error_on_multiple_rows') AS strict",
+    );
+    expect(rows[0]?.strict).toBe(true);
+  });
 });
 
 describe('GET /api/search over forked sessions', () => {
@@ -134,14 +154,16 @@ describe('GET /api/search over forked sessions', () => {
     // broken FTS lookup shows up here — assert we actually got hits.
     expect(body.sessions.length).toBeGreaterThan(0);
     expect(body.sessions[0].snippet).toContain('<mark>');
+    // Both copies are their own documents under the per-row key, so neither the
+    // original nor the fork is swallowed by the other.
+    const hitSessions = new Set(body.sessions.map((s: { sessionId: string }) => s.sessionId));
+    expect(hitSessions).toEqual(new Set(['sessOrig', 'sessFork']));
   });
 
   it('works on a connection that has served no prior search', async () => {
-    // The setting used to be applied inside the search handler, so the FIRST
-    // search on a fresh process was the one that armed it. Sequencing that way
-    // means a different first query could have hit the error instead. Search from
-    // a second app on the same (already-open) connection to make the point that
-    // the setting is a property of the connection, not of having searched before.
+    // A search must never depend on some earlier query having prepared the
+    // connection for it. Search from a second app on the same (already-open)
+    // connection, which the first test has since used, to keep that honest.
     const Fastify = (await import('fastify')).default;
     const { registerRoutes } = await import('../src/routes/index.js');
     const fresh = Fastify();

--- a/packages/server/test/security.test.ts
+++ b/packages/server/test/security.test.ts
@@ -42,6 +42,9 @@ describe('security headers', () => {
     expect(csp).not.toMatch(/script-src[^;]*'unsafe-inline'/);
     expect(csp).not.toContain("'unsafe-eval'"); // bare unsafe-eval (note: != wasm-unsafe-eval)
 
+    expect(res.headers['x-content-type-options']).toBe('nosniff');
+    expect(res.headers['referrer-policy']).toBe('no-referrer');
+
     await app.close();
   });
 

--- a/packages/server/test/shutdown.test.ts
+++ b/packages/server/test/shutdown.test.ts
@@ -1,0 +1,130 @@
+/**
+ * Graceful-shutdown tests (src/shutdown.ts). The point of the handler is that a
+ * `claudescope stop` never kills the process mid-write, so what is pinned here
+ * is the ordering that makes that true — stop the poller, let an index pass
+ * drain, close the server, close the index — plus the two cases where it must
+ * NOT close the index: a pass that outlives the drain budget (closing under a
+ * live statement is unsafe), and every failing step still reaching the exit,
+ * because the CLI is timing us (daemon.ts EXIT_WAIT_MS).
+ *
+ * The last case is the observable property the whole path exists for: a clean
+ * closeConnection() checkpoints and removes the WAL, so the next open needs no
+ * replay — the replay that corrupts a file killed between the FTS index DDL and
+ * its CHECKPOINT (data/index.ts).
+ *
+ * CLAUDESCOPE_HOME / DUCKDB_PATH are set before any server module is imported
+ * (config.ts freezes them at import); no real agent source or state dir is
+ * touched.
+ */
+
+import { afterAll, afterEach, describe, expect, it, vi } from 'vitest';
+import { existsSync, mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import type { FastifyInstance } from 'fastify';
+
+const work = mkdtempSync(join(tmpdir(), 'claudescope-shutdown-'));
+process.env.CLAUDESCOPE_HOME = join(work, 'home');
+process.env.DUCKDB_PATH = join(work, 'home', 'index.duckdb');
+process.env.CLAUDE_PROJECTS_DIR = join(work, 'projects-empty');
+process.env.REINDEX_INTERVAL_MS = '0';
+process.env.PRICING_REFRESH_INTERVAL_MS = '0';
+
+const { installShutdownHandlers, shutdown } = await import('../src/shutdown.js');
+type ShutdownDeps = Parameters<typeof shutdown>[0];
+
+afterAll(() => rmSync(work, { recursive: true, force: true }));
+
+/** Recording deps: every step appends its name to `calls`. */
+function makeDeps(over: Partial<ShutdownDeps> = {}): {
+  deps: ShutdownDeps;
+  calls: string[];
+  logs: string[];
+} {
+  const calls: string[] = [];
+  const logs: string[] = [];
+  const deps: ShutdownDeps = {
+    log: (msg) => void logs.push(msg),
+    stopTimers: () => void calls.push('stopTimers'),
+    inFlightPass: () => null,
+    closeApp: async () => void calls.push('closeApp'),
+    closeDb: async () => void calls.push('closeDb'),
+    exit: (code) => void calls.push(`exit:${code}`),
+    ...over,
+  };
+  return { deps, calls, logs };
+}
+
+const after = (ms: number): Promise<void> => new Promise((r) => setTimeout(r, ms));
+
+describe('shutdown', () => {
+  it('stops the poller, closes the server, then the index — in that order', async () => {
+    const { deps, calls } = makeDeps();
+    await shutdown(deps, 50);
+    expect(calls).toEqual(['stopTimers', 'closeApp', 'closeDb', 'exit:0']);
+  });
+
+  it('waits for an in-flight pass and closes the index once it finished', async () => {
+    const { deps, calls } = makeDeps({
+      inFlightPass: () => after(20).then(() => void calls.push('pass')),
+    });
+    await shutdown(deps, 1000);
+    expect(calls).toEqual(['stopTimers', 'pass', 'closeApp', 'closeDb', 'exit:0']);
+  });
+
+  it('leaves the index open when the pass outlives the drain budget', async () => {
+    const { deps, calls, logs } = makeDeps({ inFlightPass: () => after(300) });
+    await shutdown(deps, 20);
+    expect(calls).toEqual(['stopTimers', 'closeApp', 'exit:0']);
+    expect(logs.join('\n')).toMatch(/pass still running/);
+  });
+
+  it('still exits when a step throws', async () => {
+    const { deps, calls, logs } = makeDeps({
+      closeApp: async () => {
+        throw new Error('server close blew up');
+      },
+    });
+    await shutdown(deps, 50);
+    expect(calls).toEqual(['stopTimers', 'closeDb', 'exit:0']);
+    expect(logs.join('\n')).toMatch(/server close blew up/);
+  });
+});
+
+describe('installShutdownHandlers', () => {
+  let uninstall: (() => void) | null = null;
+  afterEach(() => {
+    uninstall?.();
+    uninstall = null;
+  });
+
+  it('exits immediately on a second signal instead of waiting out the drain', async () => {
+    const { deps, calls, logs } = makeDeps({ inFlightPass: () => after(50) });
+    const app = { log: { info: deps.log }, close: deps.closeApp } as unknown as FastifyInstance;
+    const handle = installShutdownHandlers(app, deps);
+    uninstall = handle.uninstall;
+
+    handle.handler('SIGTERM');
+    handle.handler('SIGTERM');
+    // Synchronous: the impatient second signal must not queue behind the drain.
+    expect(calls).toEqual(['stopTimers', 'exit:1']);
+    expect(logs.join('\n')).toMatch(/during shutdown/);
+  });
+});
+
+describe('closeConnection', () => {
+  it('leaves no WAL behind, so the next open needs no replay', async () => {
+    const dbPath = join(work, 'wal', 'index.duckdb');
+    process.env.DUCKDB_PATH = dbPath;
+    vi.resetModules();
+    const { getConnection, closeConnection } = await import('../src/db/duckdb.js');
+
+    const conn = await getConnection();
+    await conn.run('CREATE TABLE wal_probe (i INTEGER, s VARCHAR)');
+    await conn.run("INSERT INTO wal_probe SELECT i, repeat('x', 512) FROM range(2000) t(i)");
+    expect(existsSync(`${dbPath}.wal`)).toBe(true);
+
+    await closeConnection();
+    expect(existsSync(`${dbPath}.wal`)).toBe(false);
+  });
+});

--- a/packages/web/src/pages/search/SearchPage.tsx
+++ b/packages/web/src/pages/search/SearchPage.tsx
@@ -238,10 +238,10 @@ export function SearchPage() {
     }
 
     const controller = new AbortController();
-    setLoading(true);
     setError(null);
 
     debounceRef.current = setTimeout(() => {
+      setLoading(true);
       api
         .search(
           { q: trimmed, project: project || undefined, type, scope, literal: exact },
@@ -376,10 +376,12 @@ export function SearchPage() {
 
       {error ? (
         <ErrorBox error={error} title="Search failed" onRetry={() => patchParams({ q: query })} />
-      ) : loading ? (
-        <Spinner label="Searching…" />
       ) : !hasQuery ? (
         <p className="tv-search__empty">Type a query above to search across all transcripts.</p>
+      ) : loading && totalCount === 0 ? (
+        // Nothing to show yet (first search, or the last one came back empty):
+        // the full spinner is the only useful thing on screen.
+        <Spinner label="Searching…" />
       ) : searched && totalCount === 0 ? (
         <p className="tv-search__empty">
           No {exact ? 'exact ' : ''}matches for <strong>{query}</strong>
@@ -387,6 +389,9 @@ export function SearchPage() {
         </p>
       ) : (
         <>
+          {/* A new query is in flight: keep the previous results on screen and
+              surface progress as a small indicator instead of blanking them. */}
+          {loading ? <Spinner label="Searching…" /> : null}
           <div className="tv-search__meta">
             {showSessions && sessions.length > 0 ? (
               <>

--- a/packages/web/src/status/StatusProvider.tsx
+++ b/packages/web/src/status/StatusProvider.tsx
@@ -65,6 +65,8 @@ export function StatusProvider({ children }: { children: ReactNode }) {
     let timer: number | undefined;
 
     const tick = async () => {
+      // Hidden tab: go idle without fetching — visibilitychange re-kicks below.
+      if (document.hidden) return;
       try {
         const h = await api.health();
         if (cancelled) return;
@@ -85,11 +87,22 @@ export function StatusProvider({ children }: { children: ReactNode }) {
         timer = window.setTimeout(() => void tick(), UNREACHABLE_POLL_MS);
       }
     };
+
+    // Returning to the tab probes once, catching up on anything missed while
+    // hidden and reviving the poll loop.
+    const onVisibility = () => {
+      if (!document.hidden) {
+        window.clearTimeout(timer);
+        void tick();
+      }
+    };
+    document.addEventListener('visibilitychange', onVisibility);
     void tick();
 
     return () => {
       cancelled = true;
       window.clearTimeout(timer);
+      document.removeEventListener('visibilitychange', onVisibility);
     };
   }, []);
 

--- a/scripts/bundle.mjs
+++ b/scripts/bundle.mjs
@@ -64,7 +64,7 @@ await build({
   bundle: true,
   platform: 'node',
   format: 'esm',
-  target: 'node20',
+  target: 'node22',
   external: ['@duckdb/node-api'],
   // Ship a compact, non-source-mapped bundle: smaller, and it doesn't expose
   // readable source. No .map files are emitted (sourcemap defaults off; set

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,4 +1,5 @@
-import { dirname, resolve } from 'node:path';
+import { homedir } from 'node:os';
+import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { defineConfig } from 'vitest/config';
 
@@ -16,12 +17,19 @@ export default defineConfig({
   test: {
     environment: 'node',
     include: ['packages/*/test/**/*.test.ts'],
+    env: {
+      // In production the json/fts extensions are downloaded into the state dir
+      // (see DUCKDB_EXTENSION_DIR in config.ts), but tests spin up a throwaway
+      // CLAUDESCOPE_HOME per file — which would re-download ~31 MB every time.
+      // Pin them to the machine's own shared DuckDB cache instead.
+      DUCKDB_EXTENSION_DIR: join(homedir(), '.duckdb', 'extensions'),
+    },
     // Integration tests build a DuckDB index from fixtures; give them room.
     testTimeout: 30_000,
     hookTimeout: 30_000,
     // On Windows, parallel workers concurrently `INSTALL` DuckDB extensions into
-    // the shared ~/.duckdb dir, and the OS file-locking fails the simultaneous
-    // move ("Access is denied"). The app is single-process in production, so this
+    // that shared cache, and the OS file-locking fails the simultaneous move
+    // ("Access is denied"). The app is single-process in production, so this
     // is purely a test-concurrency artifact — serialize test files on Windows
     // only; Linux/macOS keep full parallelism.
     fileParallelism: process.platform !== 'win32',


### PR DESCRIPTION
Implements [plan 0086](docs/plans/0086-audit-fixes-and-fitness-functions.md): every finding of the codebase audit except the shared-connection design, each fix paired with a *fitness function* that encodes the rule the bug broke (run red against the pre-fix code, then green).

## What changes

- **Analytics counting rules** — tool calls are per-row counts excluding fork copies, never filtered through the usage election (errors, agents, efficiency, digest, `sessions.tool_call_count`). Real index: errors route showed 2728 Claude Code calls vs the tools route's 4974; error rate 4.8% vs a true 2.7%.
- **Parser** — subagent run totals elect one row per `message.id` (was 3.84× inflated).
- **Connectors** — Codex flags non-zero exec exits; pi reads `isError`; tool-error signal is a declared capability.
- **DuckDB** — lock conflicts, extension failures, and OS errors rethrow with guidance instead of deleting the index; extensions install under the state dir (`DUCKDB_EXTENSION_DIR`).
- **Indexer / server** — a failed finalize is remembered and repaired; SIGTERM/SIGINT drain and close DuckDB cleanly.
- **Seam** — agent facts live in `agent-capabilities.ts`; Codex title stripping and Claude memory slugs are connector hooks; an architecture test forbids connector ids under `data/`/`routes/`.
- **Search** — FTS keyed by a unique `doc_id` (schema v22); the connection-wide `scalar_subquery_error_on_multiple_rows` relaxation is gone.
- **CLI / config / web** — interval env validation, usage errors instead of stack traces, multi-agent wording, search keeps results while loading, hidden-tab polling paused, `nosniff` + `Referrer-Policy`.

## Behaviour changes on upgrade

- Schema v22 → one-time index rebuild.
- Extensions re-download once (~30 MB, plain HTTP per DuckDB's endpoint; documented in README and SECURITY).
- A second server on the same state dir now fails loudly instead of silently rebuilding the live daemon's index.

## Definition of done

- [x] `npm run typecheck`, `npm run build` clean
- [x] `npm test`: 78 files / 807 tests (was 72 / 759); every new test verified red pre-fix
- [x] markdownlint clean on changed docs
- [x] Plan 0086 committed, status done, linked here
- [x] CI green on Linux, Windows, and both Nix legs (the second-process lock scenario is skipped on Windows, where DuckDB did not raise the lock conflict in CI; the classifier's unit test covers it)
- [ ] Deferred to a follow-up plan: sessions-list pagination, Codex incremental prepare, FTS rebuild debouncing
