### PR TITLE
feat: sessions pagination, Codex walk reuse, and FTS rebuild debounce

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -389,6 +389,29 @@ The CLI `update` command (`cli.ts`) detects the install method and defers to
   row). `uuid` repeats across fork copies, and the old fix — relaxing
   `scalar_subquery_error_on_multiple_rows` connection-wide — masked genuine
   multi-row scalar-subquery bugs everywhere; never reintroduce it.
+- **Sessions paging is stable by construction.** `GET /api/sessions` clamps
+  `limit` (default 50, max 500), takes `offset`, and every sort order carries
+  an `, id` tie-break so pages never overlap or skip on tied values. The
+  unpaged match count travels in the `X-Total-Count` header
+  (`SESSIONS_TOTAL_HEADER` in `shared`); the body stays `SessionMeta[]` so the
+  CLI `--json` shape and the MCP tool are unchanged. `q` matches title, git
+  branch, id, or model on the server — the web list sends it instead of
+  filtering client-side, so a filter can find a session beyond the loaded page.
+- **The FTS rebuild is debounced; derived tables never are.** A pass rebuilds
+  the FTS index only if the last rebuild is older than
+  `FTS_REBUILD_MIN_INTERVAL_MS` (default 60 s; `0` = every pass, which
+  `vitest.config.ts` pins), otherwise it records `fts_stale` in the `meta`
+  table. The flag is persisted because a restart mid-session would otherwise
+  leave ranked search stale until the next file change. An idle pass that
+  finds the flag rebuilds FTS only and does not bump `dataVersion`;
+  `POST /api/reindex` always flushes. `sessions`/`file_edits` stay per pass —
+  the list page is what people watch live. Literal search is a `LIKE` over
+  `events`, so it never lags.
+- **Codex walks its sessions dir once per pass.** `listRollouts()` remembers
+  its last walk and `getCodexContext()` fingerprints that list instead of
+  walking again per subagent rollout. Whole-file re-normalization of a
+  changed rollout is deliberate: rows depend on cross-record correlation, and
+  DuckDB re-reads the whole cache anyway.
 - **Release is maintainer-only** and tag-triggered (npm Trusted Publishing /
   OIDC). See `CONTRIBUTING.md`.
 

--- a/README.md
+++ b/README.md
@@ -262,7 +262,9 @@ ranking) — the way to find an error message the agent never restated in prose.
 
 `sessions --cwd <path>` resolves to the project for that working directory
 locally, without a separate `projects` lookup, and is exclusive with
-`--project`; `--branch <name>` filters to that git branch. `session` prints a
+`--project`; `--branch <name>` filters to that git branch; `--q <text>` matches
+the title, branch, id, or model; `--limit/--offset` page the list (20 rows by
+default). `session` prints a
 pageable window of turns as Markdown (`--offset/--limit`, `--redact` to mask
 paths/secrets); `--tail N` prints only the last N turns and is exclusive with
 `--offset/--limit/--around`. `--json` returns the raw API response unredacted.
@@ -300,6 +302,7 @@ All optional — set via environment variables.
 | `CLAUDESCOPE_HOME`    | `~/.claudescope`       | Where the app keeps its own state (index, pricing copy, logs, PID).    |
 | `DUCKDB_EXTENSION_DIR`| `~/.claudescope/duckdb-extensions` | Where DuckDB keeps its `json`/`fts` extensions. Point it at `~/.duckdb/extensions` to reuse a machine-wide cache. |
 | `REINDEX_INTERVAL_MS` | `15000`                | How often to auto-pick-up new/updated sessions. Set `0` to disable.    |
+| `FTS_REBUILD_MIN_INTERVAL_MS` | `60000`       | Minimum gap between full-text index rebuilds while sessions keep changing; the first quiet scan catches up. Set `0` to rebuild on every scan. |
 
 Each agent source is optional — if a directory doesn't exist it's simply skipped,
 so the app works whether you use one agent or all eight.
@@ -432,6 +435,11 @@ served from cache (legitimately high for Claude Code, which re-reads cached cont
   restart. In an open session, hit **⟳ Refresh** (or ⌘R / Ctrl+R) to pull the
   latest messages in place without losing your scroll position. Each scan is
   near-free when nothing changed; you can also force one with `POST /api/reindex`.
+- **Ranked search trails a live session by up to a minute.** Rebuilding the
+  full-text index is the expensive part of a scan, so while a session keeps
+  changing it is rebuilt at most every `FTS_REBUILD_MIN_INTERVAL_MS` and the
+  first quiet scan (or `POST /api/reindex`) catches up. Session lists and
+  analytics update on every scan, and **Exact** search is always current.
 - **Thinking blocks** appear empty because Claude Code stores only a signature
   (and Codex only encrypted reasoning), not the plaintext — the app notes this
   explicitly. (Not a bug.)

--- a/docs/plans/0087-sessions-pagination-and-fts-debounce.md
+++ b/docs/plans/0087-sessions-pagination-and-fts-debounce.md
@@ -1,0 +1,175 @@
+# 0087 — Sessions pagination, Codex walk reuse, and FTS rebuild debounce
+
+- **Status:** done
+- **Date:** 2026-09-06
+- **PR:** <https://github.com/vladar107/claudescope/pull/111>
+
+## Context
+
+Plan 0086 fixed every finding of the codebase audit except three it deferred
+to a follow-up. Re-measured on this machine before planning:
+
+- **No default limit or pagination on the sessions list.** `GET /api/sessions`
+  returns every matching row unless the caller passes `limit`; the web list
+  never does, and refetches the entire list on every data-version bump. The
+  client-side text filter covers title, branch, id, and models, so any paging
+  scheme has to keep that filter honest across pages.
+- **Codex prepare re-walks the sessions dir per file.** `getCodexContext()`
+  calls `listRollouts()` (recursive readdir + stat) on every call to compute
+  its fingerprint, and it is called once per subagent rollout parsed. Measured:
+  158 rollouts walk in 3 ms, so the re-walk is negligible today (85 subagent
+  rollouts × 3 ms on a first build). The other half of the finding — whole-file
+  re-normalization of a growing rollout — costs 353 ms and a 270 MB heap spike
+  per pass for the largest (68 MB) rollout, and only while that rollout is
+  being appended to.
+- **The FTS index is rebuilt from scratch, plus a CHECKPOINT, on every pass
+  that loaded a file.** With a 15 s poll and an active agent that is every
+  pass; the audit measured a 615 ms median incremental pass, and every route
+  query stalls behind it on the shared connection.
+
+## Goal
+
+Land the three deferred items with the same discipline as 0086: each fix
+carries a fitness function that encodes the rule, and the sessions list stays
+correct under paging for the web, the CLI, and the MCP tool.
+
+## Decisions
+
+- **Paging is `offset` + `limit` with a deterministic order; the total rides
+  in an `X-Total-Count` header and the body stays `SessionMeta[]`.** Every
+  `ORDER BY` gets an `, id` tie-break so pages never overlap or skip on tied
+  values. Rejected: a `{ rows, total }` envelope — it would ripple through the
+  CLI `--json` shape, the MCP tool, and ten test files for one number.
+- **`limit` defaults to 50 and clamps to 500** (`clampInt`, as
+  `analytics-sessions.ts` does). "Absent = all rows" goes away; that was the
+  audit finding. The CLI and MCP keep their own default of 20.
+- **`q` matches title, branch, id, or model on the server** — the exact
+  haystack the web filter applied client-side. The web sends `q` (debounced
+  300 ms, as the search page does) and drops the client-side filter, so a
+  filter can find a session on page three. CLI/MCP descriptions change from
+  "title" to "title, branch, id, or model"; matches only widen.
+- **The web pages with a "Load more" button, 50 rows per page, and a
+  "Showing X of Y" line.** A data-version bump refetches the loaded window
+  (offset 0, limit = rows loaded) so a live session's row updates without
+  collapsing the list. Rejected: infinite scroll — an observer adds plumbing
+  for no gain on a list this size, and a button is predictable and keyboard
+  reachable.
+- **Codex reuses the walk `discover()` already did.** `listRollouts()`
+  remembers its last result; `getCodexContext()` fingerprints that list
+  instead of walking again, so a pass walks the sessions dir exactly once.
+  The read path (`loadSession`) sees at most one poll interval of staleness,
+  which only matters for a grandchild spawned within the last 15 s and is
+  corrected by the next pass. **Whole-file normalization stays.** Rejected:
+  append-incremental parsing — a rollout's rows depend on cross-record
+  correlation (call/output pairing, the spawn map, the synthesized uuid
+  chain), so incremental parsing means persisting the parser's state machine
+  between passes; DuckDB re-reads the whole cache file anyway; and the cost
+  exists only while a very large rollout is actively growing.
+- **The FTS rebuild is debounced with a trailing edge and a staleness cap.**
+  After `rebuildSessions`, the pass rebuilds FTS only if the last rebuild is
+  older than `FTS_REBUILD_MIN_INTERVAL_MS` (default 60 000; `0` = every pass,
+  which the vitest config pins so the existing suite is unchanged). Otherwise
+  it records `fts_stale` in the `meta` table and moves on. An idle pass that
+  finds the flag rebuilds FTS only — not the whole finalize. `POST
+  /api/reindex` always flushes: a user-initiated pass expects fresh search.
+  Derived tables (`sessions`, `file_edits`) are never debounced: the list page
+  is what people watch live.
+- **The stale flag is persisted, not in-memory.** A restart mid-session
+  (`claudescope update`, the version-skew self-restart) would otherwise leave
+  ranked search stale until the next file change, because the idle
+  early-return sees no work. The first pass after boot reads the flag.
+- **Ranked search may lag up to a minute during continuous activity; literal
+  search never does.** `searchLiteral` is a `LIKE` over `events`, so it is
+  always current. Documented in the README. An FTS-only pass does not bump
+  `dataVersion`: nothing the list consumers watch changed.
+
+## Approach
+
+Waves keep parallel work on disjoint files; at most three agents per wave.
+
+1. **Wave 1** — three independent chunks.
+   - **C1 Sessions API paging (complex).** `offset` in `SessionsQuery`;
+     route clamps `limit`, adds `OFFSET`, the `, id` tie-break, the widened
+     `q`, and the `X-Total-Count` header (constant exported from `shared`);
+     `ApiClient.sessions`, `querySessions` (`--offset`), the MCP
+     `list_sessions` schema, and the CLI help. Fitness test 1.
+   - **C2 FTS debounce (complex).** `ftsStale` + `lastFtsRebuildAt` in
+     `data/index.ts`, the `meta.fts_stale` read on the first pass and write
+     on skip/clear, the idle-pass FTS-only branch, `reindex({ flushFts })`
+     from the reindex route, the env pin in `vitest.config.ts`. Fitness
+     test 3.
+   - **C3 Codex walk reuse (simple).** `listRollouts()` remembers its last
+     result; `getCodexContext()` uses it. Fitness test 2.
+2. **Wave 2** — **C4 Web list paging (complex)**, after C1: `client.ts`
+   gains `limit`/`offset` and reads the total header; `SessionList.tsx` gets
+   the page state, "Load more", the count line, debounced server-side `q`,
+   and the windowed data-version refetch. Verified against fixtures with the
+   `verify` skill (load more, filter across pages, live row update).
+3. **Wave 3** — README (env table row, search staleness note), CLAUDE.md
+   gotchas (paging tie-break, FTS debounce and the persisted flag, Codex walk
+   reuse), this plan's status, `/review`, `npm test`, `npm run typecheck`,
+   markdownlint.
+
+## Fitness functions
+
+1. **Paging is stable.** For every sort key, pages of 2 over a fixture with
+   tied sort values cover the unpaged set exactly once; `X-Total-Count`
+   equals the unpaged count; `q` finds a session by branch, by id, and by
+   model; an absent `limit` never returns more than the default.
+2. **One walk per pass.** After `discover()`, preparing N subagent rollouts
+   triggers no further `readdirSync` of the sessions dir; the parent map
+   still resolves a grandchild to its root.
+3. **Debounce never loses a rebuild.** Within the window, a second change
+   leaves `sessions` fresh, FTS stale, and `meta.fts_stale` set; the next
+   idle pass rebuilds FTS and clears the flag; a simulated restart with the
+   flag set rebuilds on its first idle pass; `POST /api/reindex` flushes
+   immediately; with the interval at 0 every pass rebuilds (the existing
+   suite).
+
+## Files affected
+
+- `packages/shared/src/api.ts` — `offset`, the total-count header constant,
+  `q` doc.
+- `packages/server/src/routes/sessions.ts` — clamp, offset, tie-break,
+  widened `q`, header.
+- `packages/server/src/agent/api-client.ts`, `agent/query.ts`, `agent/mcp.ts`,
+  `cli.ts` — `offset` through the CLI and MCP.
+- `packages/server/src/data/index.ts`, `routes/index.ts` — FTS debounce,
+  persisted flag, flush on manual reindex.
+- `packages/server/src/connectors/codex/normalize.ts` — walk reuse.
+- `packages/web/src/api/client.ts`, `pages/browse/SessionList.tsx` — paging
+  UI.
+- `vitest.config.ts` — pin `FTS_REBUILD_MIN_INTERVAL_MS=0`.
+- `packages/server/test/sessions-pagination.integration.test.ts`,
+  `fts-debounce.integration.test.ts`, an addition to
+  `codex.integration.test.ts` — the fitness functions.
+- `README.md`, `CLAUDE.md`, `docs/plans/README.md` — docs and the index row.
+
+## Testing
+
+`npm test` and `npm run typecheck` green (final: 81 files / 833 tests, up
+from 78 / 807); each new test was run against the pre-fix code and failed
+there first — the paging walk additionally fails with only the `, id`
+tie-break reverted (36 distinct ids out of 52 rows), and the debounce test
+fails with only the `meta` write removed. markdownlint clean on changed
+docs. The `verify` skill drove the built app against 63 fixture sessions:
+"Showing 50 of 63", Load more to 63 unique rows, a branch filter finding
+three sessions that were never on page one, the empty state, and a session
+dropped in live updating the loaded window without a reload. Not done: a
+timing check against the live daemon, which runs the released build.
+
+## Risks / open questions
+
+- Ranked search lags up to `FTS_REBUILD_MIN_INTERVAL_MS` during continuous
+  activity. Set it to `0` to restore per-pass rebuilds.
+- `q` widening changes CLI/MCP results only by adding matches.
+- A session landing live re-fetches the same-size window, so the last row of
+  the window drops out and the count line flips from "Y sessions" back to
+  "Showing …" with Load more; the list never grows on its own.
+- A manual reindex arriving during a pass now waits for it and runs its own
+  pass rather than joining one that may have skipped the rebuild.
+- Page size, default cap, and the 60 s window are defaults chosen here;
+  all three are one-line changes.
+- Still deferred: a second DuckDB connection for the indexer (the
+  shared-connection topic excluded from 0086) and sessions-list virtualization
+  if lists ever exceed a few thousand rows.

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -111,3 +111,4 @@ decision, or a change worth explaining before doing. Skip it for one-line fixes.
 | 0084 | [Nested subagents (a subagent spawning a subagent)](./0084-nested-subagents.md) | done |
 | 0085 | [Security review hardening](./0085-security-review-hardening.md) | done |
 | 0086 | [Audit fixes and fitness functions](./0086-audit-fixes-and-fitness-functions.md) | done |
+| 0087 | [Sessions pagination, Codex walk reuse, and FTS rebuild debounce](./0087-sessions-pagination-and-fts-debounce.md) | done |

--- a/packages/server/src/agent/mcp.ts
+++ b/packages/server/src/agent/mcp.ts
@@ -182,11 +182,12 @@ export function createMcpServer(deps: McpDeps): McpServer {
           .describe('Agent connector id, e.g. claude-code, codex, junie, pi, opencode, copilot, antigravity'),
         branch: z.string().optional().describe('Exact git branch the session recorded, e.g. main'),
         sort: z.enum(['recent', 'oldest', 'tokens', 'cost', 'messages']).optional(),
-        q: z.string().optional().describe('Substring filter on the session title'),
+        q: z.string().optional().describe('Substring filter on the session title, git branch, id, or model'),
         limit: z.number().int().min(1).max(200).optional().describe(`Max rows (default ${DEFAULT_LIMIT})`),
+        offset: z.number().int().min(0).optional().describe('Rows to skip (page with limit)'),
       }),
     },
-    guarded(async (client, args: { project?: string; cwd?: string; agent?: string; branch?: string; sort?: 'recent' | 'oldest' | 'tokens' | 'cost' | 'messages'; q?: string; limit?: number }) => {
+    guarded(async (client, args: { project?: string; cwd?: string; agent?: string; branch?: string; sort?: 'recent' | 'oldest' | 'tokens' | 'cost' | 'messages'; q?: string; limit?: number; offset?: number }) => {
       const rows = await client.sessions({
         project: args.project ?? (args.cwd ? projectIdForCwd(args.cwd) : undefined),
         agent: args.agent,
@@ -194,6 +195,7 @@ export function createMcpServer(deps: McpDeps): McpServer {
         sort: args.sort,
         q: args.q,
         limit: args.limit ?? DEFAULT_LIMIT,
+        offset: args.offset,
       });
       if (rows.length === 0) return 'No sessions match.';
       return frameRecorded(rows.map(sessionLine).join('\n'));

--- a/packages/server/src/agent/query.ts
+++ b/packages/server/src/agent/query.ts
@@ -74,6 +74,7 @@ export interface SessionsArgs {
   sort?: SessionSort;
   q?: string;
   limit?: number;
+  offset?: number;
   json?: boolean;
 }
 
@@ -86,6 +87,7 @@ export async function querySessions(client: ApiClient, args: SessionsArgs): Prom
     sort: args.sort,
     q: args.q,
     limit: args.limit ?? DEFAULT_LIMIT,
+    offset: args.offset,
   });
   if (args.json) return json(rows);
   if (rows.length === 0) return 'No sessions match.';

--- a/packages/server/src/cli.ts
+++ b/packages/server/src/cli.ts
@@ -472,7 +472,8 @@ Query commands (read-only; start the background server on first use):
                    [--project id] [--role user|assistant] [--scope sessions|memory|all] [--limit N]
                    [--literal] (exact substring, for errors/identifiers)
   sessions         List sessions [--project id] [--cwd path] [--agent id] [--branch name]
-                   [--sort recent|oldest|tokens|cost|messages] [--q substr] [--limit N]
+                   [--sort recent|oldest|tokens|cost|messages] [--q substr]
+                   [--limit N] [--offset N]
   session <id>     One session as Markdown — a window of turns, pageable
                    [--offset N] [--limit N] [--around uuid] [--radius N] [--tail N]
                    [--max-tool-chars N] [--redact]
@@ -615,6 +616,7 @@ export async function main(): Promise<void> {
           sort: enumFlag('sort', values.sort, ['recent', 'oldest', 'tokens', 'cost', 'messages'] as const),
           q: values.q,
           limit: intFlag('limit', values.limit),
+          offset: intFlag('offset', values.offset),
           json: values.json,
         };
         return (client) => querySessions(client, args);

--- a/packages/server/src/connectors/codex/codex.ts
+++ b/packages/server/src/connectors/codex/codex.ts
@@ -30,6 +30,8 @@ const cache = ndjsonCache('codex');
  * included as ordinary files — they re-key to their root session at prepare time.
  * Unlike antigravity, no mtime folding is needed: a child's parent link lives in
  * its OWN `session_meta` from creation, so it never changes after the fact.
+ * This walk also feeds `getCodexContext()` for the rest of the pass — see
+ * `listRollouts` in `normalize.ts`.
  */
 function discover(): DiscoveredFile[] {
   return listRollouts();

--- a/packages/server/src/connectors/codex/normalize.ts
+++ b/packages/server/src/connectors/codex/normalize.ts
@@ -102,6 +102,10 @@ export interface RolloutFile {
   size: number;
 }
 
+/** The result of the most recent {@link listRollouts} walk in this process,
+ *  reused by {@link getCodexContext} so a pass walks the sessions dir once. */
+let lastRollouts: RolloutFile[] | null = null;
+
 /** Recursively collect every `rollout-*.jsonl` under the Codex sessions dir. */
 export function listRollouts(): RolloutFile[] {
   const out: RolloutFile[] = [];
@@ -127,6 +131,7 @@ export function listRollouts(): RolloutFile[] {
     }
   };
   walk(codexSessionsDir());
+  lastRollouts = out;
   return out;
 }
 
@@ -180,11 +185,17 @@ function fingerprint(files: RolloutFile[]): string {
 /**
  * The memoized subagent parent-map for the sessions dir, built by reading only
  * each rollout's first line (`session_meta` carries `thread_source` and
- * `source.subagent.thread_spawn.parent_thread_id`). Rebuilt only when a rollout
- * changes, so per-file `prepare`/`loadSession` calls in one reindex reuse one scan.
+ * `source.subagent.thread_spawn.parent_thread_id`). Rebuilt only when the file
+ * list changes. Fingerprints {@link lastRollouts} (the walk `discover()`
+ * already did this pass) instead of walking again — falling back to its own
+ * walk only when nothing has been remembered yet in this process — so a pass
+ * preparing N subagent rollouts still walks the sessions dir exactly once.
+ * The read path (`loadSession`) therefore sees at most one poll interval of
+ * staleness, which only affects a grandchild spawned within that interval and
+ * is corrected by the next pass's `discover()`.
  */
 export function getCodexContext(): CodexContext {
-  const files = listRollouts();
+  const files = lastRollouts ?? listRollouts();
   const fp = fingerprint(files);
   if (ctxCache && ctxCache.fp === fp) return ctxCache.ctx;
   const parents = new Map<string, string>();

--- a/packages/server/src/data/index.ts
+++ b/packages/server/src/data/index.ts
@@ -8,9 +8,9 @@
  * reindex only touches what changed.
  *
  * After loading, derived `sessions` rows are recomputed and the FTS index over
- * `events.text_content` is rebuilt (cheap at this scale). Everything below the
- * connector boundary — the canonical schema, cost, derived tables, FTS — is
- * agent-agnostic.
+ * `events.text_content` is rebuilt — the latter debounced, see
+ * {@link FTS_REBUILD_MIN_INTERVAL_MS}. Everything below the connector boundary
+ * — the canonical schema, cost, derived tables, FTS — is agent-agnostic.
  *
  * STRICTLY READ-ONLY with respect to the source transcripts — files are only read.
  */
@@ -40,11 +40,12 @@ let dataVersion = 0;
 
 /** True from the moment a pass finds file changes until its finalize step
  *  (electCanonicalUsage → refreshFileEdits → electCanonicalEdits →
- *  rebuildSessions → rebuildFtsIndex) actually completes. Files bookkeeping
- *  (the `files`/`events` tables) advances per file *before* finalize runs, so
- *  a failed finalize must be remembered — otherwise the next pass would see
- *  no changed files, take the idle early-return, and leave `sessions`,
- *  `file_edits`, and the FTS index permanently stale versus `events`. */
+ *  rebuildSessions → the debounced rebuildFtsIndex) actually completes. Files
+ *  bookkeeping (the `files`/`events` tables) advances per file *before*
+ *  finalize runs, so a failed finalize must be remembered — otherwise the next
+ *  pass would see no changed files, take the idle early-return, and leave
+ *  `sessions`, `file_edits`, and the FTS index permanently stale versus
+ *  `events`. */
 let derivedDirty = false;
 /** Sessions whose `file_edits` are owed a refresh, carried across a failed
  *  finalize so a later pass with no file changes still repairs them. */
@@ -59,6 +60,28 @@ export function failNextFinalizeForTests(): void {
 /** Min interval between mid-first-build partial `sessions` rebuilds (ms).
  *  Env-overridable so tests can force a rebuild after every file. */
 const PARTIAL_REBUILD_MS = Number(process.env.PARTIAL_REBUILD_MS ?? 3000);
+
+/** Min interval between FTS rebuilds (ms). The rebuild re-indexes every row and
+ *  must CHECKPOINT afterwards (see {@link rebuildFtsIndex}), and every route
+ *  query stalls behind it on the shared connection — so with an active agent and
+ *  a 15 s poll it is the dominant cost of a pass. Debounced with a trailing edge:
+ *  within the window a pass records `meta.fts_stale` and moves on, and the next
+ *  idle pass (or an explicit flush) rebuilds. `0` rebuilds on every pass; a
+ *  non-finite or negative override falls back to the default. Ranked search may
+ *  therefore lag by up to this much during continuous activity — literal
+ *  (`LIKE`) search never does. */
+const FTS_REBUILD_MIN_INTERVAL_MS = (() => {
+  const raw = Number(process.env.FTS_REBUILD_MIN_INTERVAL_MS);
+  return Number.isFinite(raw) && raw >= 0 ? raw : 60_000;
+})();
+/** When the FTS index was last rebuilt in THIS process (epoch ms; 0 = never). */
+let lastFtsRebuildAt = 0;
+/** Whether the FTS index is behind `events`. Persisted in `meta.fts_stale`, so a
+ *  restart mid-session (`claudescope update`, the version-skew self-restart)
+ *  cannot strand ranked search: an in-memory-only flag would be lost and the
+ *  idle early-return would see no work until the next file change. `null` until
+ *  the first pass of the process reads it back. */
+let ftsStale: boolean | null = null;
 
 export function isIndexReady(): boolean {
   return ready;
@@ -600,7 +623,11 @@ async function applyFallbackTitles(conn: DuckDBConnection): Promise<void> {
   }
 }
 
-/** (Re)build the BM25 full-text index over event text. */
+/**
+ * (Re)build the BM25 full-text index over event text, and clear the staleness
+ * debt the debounce may have recorded. On a throw the flag is left as it is —
+ * still set if a skipped pass had recorded it — so a later pass retries.
+ */
 async function rebuildFtsIndex(conn: DuckDBConnection): Promise<void> {
   // Keyed by `doc_id`, not `uuid`: the generated match_bm25 macro looks a
   // document up with a scalar subquery on that column, so it must be unique per
@@ -614,22 +641,36 @@ async function rebuildFtsIndex(conn: DuckDBConnection): Promise<void> {
       'events', 'doc_id', 'text_content', ignore='[^a-z0-9]+', overwrite=1
     )
   `);
+  // Cleared before the CHECKPOINT below, so the flag and the index it describes
+  // land in the main DB file together.
+  await conn.run(`DELETE FROM meta WHERE key = 'fts_stale'`);
   // Force a CHECKPOINT so the FTS index DDL is merged into the main DB file
   // instead of lingering in the WAL. DuckDB cannot replay the FTS schema's
   // DROP/CREATE from a WAL on the next open (the `fts_main_events`.`terms`
   // dependency fails), so an unflushed WAL would corrupt the file if the
   // process is killed. Checkpointing keeps reopen clean.
   await conn.run('CHECKPOINT');
+  ftsStale = false;
+  lastFtsRebuildAt = Date.now();
 }
 
 /**
  * Run an incremental index pass. Only files whose (mtime, size) differ from the
  * recorded `files` row are (re)loaded. Returns the number of files (re)indexed
  * and the elapsed wall-clock time.
+ *
+ * `flushFts` bypasses the FTS debounce — a user-initiated reindex expects fresh
+ * ranked search. A flush arriving while a pass is already running waits for it
+ * and then runs its own pass (idle by then, so it costs the FTS rebuild alone),
+ * because joining a pass that may have skipped its rebuild would resolve with
+ * the index still stale. Plain calls keep coalescing onto the in-flight pass.
  */
-export async function reindex(): Promise<ReindexResponse> {
-  if (inFlight) return inFlight;
-  const pass = doReindex().then(stampLastPass);
+export async function reindex(opts?: { flushFts?: boolean }): Promise<ReindexResponse> {
+  if (inFlight) {
+    if (opts?.flushFts) return inFlight.then(() => reindex(opts), () => reindex(opts));
+    return inFlight;
+  }
+  const pass = doReindex(opts).then(stampLastPass);
   inFlight = pass;
   try {
     return await pass;
@@ -665,6 +706,10 @@ export async function rebuildIndex(): Promise<ReindexResponse> {
       await closeConnection();
       discardDbFiles();
       await getConnection();
+      // The discarded file took the FTS index and the persisted flag with it, so
+      // the rebuild's own pass must create the index rather than debounce it.
+      ftsStale = false;
+      lastFtsRebuildAt = 0;
       // Empty `files` table ⇒ doReindex reloads everything from the sources.
       return stampLastPass(await doReindex());
     } finally {
@@ -679,9 +724,16 @@ export async function rebuildIndex(): Promise<ReindexResponse> {
   }
 }
 
-async function doReindex(): Promise<ReindexResponse> {
+async function doReindex(opts?: { flushFts?: boolean }): Promise<ReindexResponse> {
   const start = Date.now();
   const conn = await getConnection();
+  const flushFts = opts?.flushFts === true;
+  // Read the persisted staleness flag once per process, before anything can
+  // take the idle early-return on it (see {@link ftsStale}).
+  if (ftsStale === null) {
+    const staleRows = await queryRows(conn, `SELECT value FROM meta WHERE key = 'fts_stale'`);
+    ftsStale = staleRows.length > 0 && String(staleRows[0]?.value ?? '') === '1';
+  }
   const pricing = loadPricing();
   const costExpr = buildCostExpr(pricing);
   // The pricing join table is only read by loadFile (its exact-id LEFT JOIN), so
@@ -847,9 +899,9 @@ async function doReindex(): Promise<ReindexResponse> {
       }
     }
 
-    // Nothing changed on disk: skip the (relatively expensive) derived-table and
-    // FTS rebuild + CHECKPOINT entirely. This keeps periodic auto-reindex polls
-    // cheap — they only stat files and bail when there's no new data.
+    // Nothing changed on disk: skip the (relatively expensive) derived-table
+    // rebuild entirely. This keeps periodic auto-reindex polls cheap — they only
+    // stat files and bail when there's no new data.
     //
     // `failed === 0` guard: loadFile is atomic, so a failed file leaves the
     // tables untouched and skipping the rebuild is correct today. The guard is
@@ -859,6 +911,14 @@ async function doReindex(): Promise<ReindexResponse> {
     // already advanced — this pass must still run finalize even though it
     // sees no changes of its own.
     if (reindexed === 0 && removed === 0 && failed === 0 && !derivedDirty) {
+      // The one thing an idle pass still owes: an FTS rebuild the debounce
+      // skipped, possibly in an earlier process (the flag is persisted). This is
+      // the debounce's trailing edge, so it runs regardless of the window. Only
+      // the index — the rest of finalize is already current — and no
+      // `dataVersion` bump: nothing the list consumers watch changed, and search
+      // reads the index directly. A flush request needs no special case here: a
+      // fresh index has nothing to rebuild.
+      if (ftsStale) await rebuildFtsIndex(conn);
       ready = true;
       return { reindexed, failed, durationMs: Date.now() - start };
     }
@@ -884,7 +944,15 @@ async function doReindex(): Promise<ReindexResponse> {
     await refreshFileEdits(conn, pendingEditSessions);
     await electCanonicalEdits(conn);
     await rebuildSessions(conn);
-    await rebuildFtsIndex(conn);
+    // The FTS rebuild is the expensive half of finalize, so it — and only it —
+    // is debounced: inside the window the pass records the debt and moves on,
+    // leaving the derived tables (what the list page watches live) current.
+    if (flushFts || Date.now() - lastFtsRebuildAt >= FTS_REBUILD_MIN_INTERVAL_MS) {
+      await rebuildFtsIndex(conn);
+    } else {
+      await conn.run(`INSERT OR REPLACE INTO meta (key, value) VALUES ('fts_stale', '1')`);
+      ftsStale = true;
+    }
 
     // Only clear once finalize has fully succeeded.
     derivedDirty = false;

--- a/packages/server/src/routes/index.ts
+++ b/packages/server/src/routes/index.ts
@@ -100,6 +100,7 @@ export async function registerRoutes(app: FastifyInstance): Promise<void> {
   await registerSystemRoute(app);
 
   app.post('/api/reindex', async (): Promise<ReindexResponse> => {
-    return reindex();
+    // Flush the FTS debounce: a user-initiated pass expects fresh ranked search.
+    return reindex({ flushFts: true });
   });
 }

--- a/packages/server/src/routes/sessions.ts
+++ b/packages/server/src/routes/sessions.ts
@@ -1,6 +1,9 @@
 /**
- * GET /api/sessions — list sessions with optional project filter, sort, and a
- * lightweight title query (`q`).
+ * GET /api/sessions — one page of sessions: optional project/agent/branch
+ * filters, a sort key, and a lightweight text query (`q`, matching the title,
+ * git branch, session id, or model). Paged with `limit` (default 50, max 500)
+ * and `offset`; the unpaged match count rides in the `X-Total-Count` header
+ * while the body stays `SessionMeta[]`.
  *
  * GET /api/sessions/:id — full session detail: derived meta + the assembled
  * thread (parsed directly from the session's JSONL on disk).
@@ -16,7 +19,7 @@ import type {
   SessionMeta,
   SessionSort,
 } from '@claudescope/shared';
-import { isZeroRated } from '@claudescope/shared';
+import { isZeroRated, SESSIONS_TOTAL_HEADER } from '@claudescope/shared';
 import { getConnection, queryRows, sqlLikeEscape, sqlString } from '../db/duckdb.js';
 import { readRow } from '../db/row.js';
 import { displayNameFromCwd, projectIdFromCwd } from '../data/project-id.js';
@@ -43,13 +46,28 @@ function intParam(v: string | undefined): number | undefined {
   return Number.isInteger(n) && n >= 0 ? n : undefined;
 }
 
+/** Parse an int query param and clamp it into range; junk falls back to `dflt`. */
+function clampInt(raw: string | undefined, dflt: number, min: number, max: number): number {
+  const n = raw === undefined ? dflt : Number.parseInt(raw, 10);
+  if (!Number.isFinite(n)) return dflt;
+  return Math.min(max, Math.max(min, n));
+}
+
+const DEFAULT_SESSIONS_LIMIT = 50;
+const MAX_SESSIONS_LIMIT = 500;
+// A page beyond this is a client bug, not a scroll; keeps OFFSET bounded.
+const MAX_SESSIONS_OFFSET = 1_000_000;
+
+// Every key ends in `, id`: the sort values tie constantly (same-second
+// sessions, identical short runs), and without a total order LIMIT/OFFSET may
+// repeat a row on one page and skip another, so a paging walk loses sessions.
 const SORT_SQL: Record<SessionSort, string> = {
-  recent: 'ended_at DESC NULLS LAST',
-  oldest: 'started_at ASC NULLS LAST',
-  tokens: 'total_tokens DESC',
-  cost: 'total_cost_usd DESC',
-  messages: 'message_count DESC',
-  context: 'context_tokens DESC NULLS LAST',
+  recent: 'ended_at DESC NULLS LAST, id',
+  oldest: 'started_at ASC NULLS LAST, id',
+  tokens: 'total_tokens DESC, id',
+  cost: 'total_cost_usd DESC, id',
+  messages: 'message_count DESC, id',
+  context: 'context_tokens DESC NULLS LAST, id',
 };
 
 function rowToSessionMeta(r: Record<string, unknown>): SessionMeta {
@@ -107,11 +125,13 @@ export async function registerSessionsRoutes(app: FastifyInstance): Promise<void
       agent?: string;
       branch?: string;
       limit?: string;
+      offset?: string;
     };
-  }>('/api/sessions', async (req): Promise<SessionMeta[]> => {
+  }>('/api/sessions', async (req, reply): Promise<SessionMeta[]> => {
     const conn = await getConnection();
     const { project, sort, q, agent, branch } = req.query;
-    const limit = intParam(req.query.limit);
+    const limit = clampInt(req.query.limit, DEFAULT_SESSIONS_LIMIT, 1, MAX_SESSIONS_LIMIT);
+    const offset = clampInt(req.query.offset, 0, 0, MAX_SESSIONS_OFFSET);
 
     const where: string[] = [];
     if (agent) {
@@ -124,9 +144,12 @@ export async function registerSessionsRoutes(app: FastifyInstance): Promise<void
     // with /api/search and the analytics routes.
     if (project) where.push(await projectFilter(conn, project));
     if (q && q.trim()) {
-      where.push(
-        `(lower(title) LIKE ${sqlString('%' + sqlLikeEscape(q.toLowerCase()) + '%')} ESCAPE '\\')`,
-      );
+      // The haystack the web list used to filter client-side. COALESCE keeps it
+      // NULL-safe: a session with no recorded branch would otherwise make the
+      // whole OR chain NULL and vanish from its own title match.
+      const pattern = sqlString('%' + sqlLikeEscape(q.toLowerCase()) + '%');
+      const like = (col: string): string => `lower(COALESCE(${col}, '')) LIKE ${pattern} ESCAPE '\\'`;
+      where.push(`(${['title', 'git_branch', 'id', 'models'].map(like).join(' OR ')})`);
     }
 
     // Object.hasOwn, NOT `in`: `in` walks Object.prototype, so ?sort=toString
@@ -137,10 +160,12 @@ export async function registerSessionsRoutes(app: FastifyInstance): Promise<void
       : 'recent';
     const whereSql = where.length ? `WHERE ${where.join(' AND ')}` : '';
 
-    const limitSql = limit !== undefined && limit > 0 ? ` LIMIT ${limit}` : '';
+    const [countRow] = await queryRows(conn, `SELECT count(*) AS total FROM sessions ${whereSql}`);
+    reply.header(SESSIONS_TOTAL_HEADER, countRow ? readRow(countRow, 'sessions total').num('total') : 0);
+
     const rows = await queryRows(
       conn,
-      `SELECT * FROM sessions ${whereSql} ORDER BY ${SORT_SQL[sortKey]}${limitSql}`,
+      `SELECT * FROM sessions ${whereSql} ORDER BY ${SORT_SQL[sortKey]} LIMIT ${limit} OFFSET ${offset}`,
     );
     return rows.map(rowToSessionMeta);
   });

--- a/packages/server/test/codex-walk-reuse.test.ts
+++ b/packages/server/test/codex-walk-reuse.test.ts
@@ -1,0 +1,180 @@
+/**
+ * Fitness function: one sessions-dir walk per indexer pass.
+ *
+ * `discover()` walks the Codex sessions dir once at the start of a pass;
+ * `getCodexContext()` (used to resolve a subagent's root thread while
+ * preparing it) must reuse that same walk instead of re-`readdirSync`-ing for
+ * every subagent rollout it prepares. See `listRollouts`/`getCodexContext` in
+ * `connectors/codex/normalize.ts`.
+ */
+
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
+import { mkdirSync, mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import type { CanonicalRow } from '../src/connectors/canonical.js';
+
+vi.mock('node:fs', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:fs')>();
+  return { ...actual, readdirSync: vi.fn(actual.readdirSync) };
+});
+
+const work = mkdtempSync(join(tmpdir(), 'claudescope-codex-walk-'));
+const codexDir = join(work, 'codex');
+
+// Isolate every other source dir so this suite touches nothing but its own
+// fixtures, and set CLAUDESCOPE_HOME before any server module is imported.
+process.env.CLAUDE_PROJECTS_DIR = join(work, 'claude-empty');
+process.env.CODEX_SESSIONS_DIR = codexDir;
+process.env.JUNIE_SESSIONS_DIR = join(work, 'junie-empty');
+process.env.PI_SESSIONS_DIR = join(work, 'pi-empty');
+process.env.OPENCODE_DATA_DIR = join(work, 'opencode-empty');
+process.env.COPILOT_SESSIONS_DIR = join(work, 'copilot-empty');
+process.env.ANTIGRAVITY_CLI_DIR = join(work, 'antigravity-empty');
+process.env.ANTIGRAVITY_DIR = join(work, 'antigravity-empty-desktop');
+process.env.GROK_SESSIONS_DIR = join(work, 'grok-empty');
+process.env.CLAUDESCOPE_HOME = join(work, 'home');
+
+const jsonl = (events: unknown[]): string => events.map((e) => JSON.stringify(e)).join('\n') + '\n';
+const ts = (s: number) => `2026-01-01T10:00:${String(s).padStart(2, '0')}.000Z`;
+
+const rootId = 'codex-sess-root';
+const childId = '019f2222-aaaa-7bbb-8ccc-000000000001';
+const grandchildId = '019f2222-aaaa-7bbb-8ccc-000000000002';
+const lateChildId = '019f2222-aaaa-7bbb-8ccc-000000000003';
+
+const rolloutsDir = join(codexDir, '2026', '01', '01');
+
+/** A root rollout: no `thread_source`, so it stays a top-level session. */
+function writeRootRollout(): string {
+  mkdirSync(rolloutsDir, { recursive: true });
+  const file = join(rolloutsDir, `rollout-2026-01-01T10-00-00-${rootId}.jsonl`);
+  writeFileSync(
+    file,
+    jsonl([
+      { type: 'session_meta', timestamp: ts(0), payload: { id: rootId, cwd: '/tmp/codexproj', git: { branch: 'main' } } },
+      { type: 'turn_context', timestamp: ts(1), payload: { model: 'gpt-5.4', cwd: '/tmp/codexproj' } },
+      { type: 'response_item', timestamp: ts(2), payload: { type: 'message', role: 'user', content: [{ type: 'input_text', text: 'walk once please' }] } },
+      { type: 'response_item', timestamp: ts(3), payload: { type: 'message', role: 'assistant', content: [{ type: 'output_text', text: 'on it' }] } },
+    ]),
+  );
+  return file;
+}
+
+/** A depth-1 subagent rollout, parented directly under the root. */
+function writeChildRollout(): string {
+  mkdirSync(rolloutsDir, { recursive: true });
+  const file = join(rolloutsDir, `rollout-2026-01-01T10-01-00-${childId}.jsonl`);
+  writeFileSync(
+    file,
+    jsonl([
+      { type: 'session_meta', timestamp: ts(10), payload: { id: childId, cwd: '/tmp/codexproj', thread_source: 'subagent', source: { subagent: { thread_spawn: { parent_thread_id: rootId, depth: 1, agent_nickname: 'Linnaeus', agent_role: 'explorer' } } }, git: { branch: 'main' } } },
+      { type: 'turn_context', timestamp: ts(11), payload: { model: 'gpt-5.4' } },
+      { type: 'response_item', timestamp: ts(12), payload: { type: 'message', role: 'user', content: [{ type: 'input_text', text: 'scan the repo' }] } },
+      { type: 'response_item', timestamp: ts(13), payload: { type: 'message', role: 'assistant', content: [{ type: 'output_text', text: 'scanning' }] } },
+    ]),
+  );
+  return file;
+}
+
+/** A depth-2 subagent rollout: `parent_thread_id` names the depth-1 child. */
+function writeGrandchildRollout(): string {
+  mkdirSync(rolloutsDir, { recursive: true });
+  const file = join(rolloutsDir, `rollout-2026-01-01T10-02-00-${grandchildId}.jsonl`);
+  writeFileSync(
+    file,
+    jsonl([
+      { type: 'session_meta', timestamp: ts(20), payload: { id: grandchildId, cwd: '/tmp/codexproj', thread_source: 'subagent', source: { subagent: { thread_spawn: { parent_thread_id: childId, depth: 2, agent_nickname: 'Chronicler', agent_role: 'summarizer' } } }, git: { branch: 'main' } } },
+      { type: 'turn_context', timestamp: ts(21), payload: { model: 'gpt-5.4' } },
+      { type: 'response_item', timestamp: ts(22), payload: { type: 'message', role: 'user', content: [{ type: 'input_text', text: 'summarize findings' }] } },
+      { type: 'response_item', timestamp: ts(23), payload: { type: 'message', role: 'assistant', content: [{ type: 'output_text', text: 'summary done' }] } },
+    ]),
+  );
+  return file;
+}
+
+/** A depth-1 rollout written AFTER the initial walk, to probe staleness. */
+function writeLateChildRollout(): string {
+  mkdirSync(rolloutsDir, { recursive: true });
+  const file = join(rolloutsDir, `rollout-2026-01-01T10-03-00-${lateChildId}.jsonl`);
+  writeFileSync(
+    file,
+    jsonl([
+      { type: 'session_meta', timestamp: ts(30), payload: { id: lateChildId, cwd: '/tmp/codexproj', thread_source: 'subagent', source: { subagent: { thread_spawn: { parent_thread_id: rootId, depth: 1, agent_nickname: 'Latecomer', agent_role: 'explorer' } } }, git: { branch: 'main' } } },
+      { type: 'turn_context', timestamp: ts(31), payload: { model: 'gpt-5.4' } },
+      { type: 'response_item', timestamp: ts(32), payload: { type: 'message', role: 'user', content: [{ type: 'input_text', text: 'joined late' }] } },
+      { type: 'response_item', timestamp: ts(33), payload: { type: 'message', role: 'assistant', content: [{ type: 'output_text', text: 'noted' }] } },
+    ]),
+  );
+  return file;
+}
+
+let codexConnector: typeof import('../src/connectors/codex/codex.js')['codexConnector'];
+let getCodexContext: typeof import('../src/connectors/codex/normalize.js')['getCodexContext'];
+let ndjsonCache: typeof import('../src/connectors/ndjson-cache.js')['ndjsonCache'];
+let childPath: string;
+let grandchildPath: string;
+
+beforeAll(async () => {
+  writeRootRollout();
+  childPath = writeChildRollout();
+  grandchildPath = writeGrandchildRollout();
+  ({ codexConnector } = await import('../src/connectors/codex/codex.js'));
+  ({ getCodexContext } = await import('../src/connectors/codex/normalize.js'));
+  ({ ndjsonCache } = await import('../src/connectors/ndjson-cache.js'));
+});
+
+afterAll(() => {
+  rmSync(work, { recursive: true, force: true });
+});
+
+describe('codex walk reuse', () => {
+  it('reuses discover()\'s walk instead of re-walking per subagent prepare', async () => {
+    const discovered = codexConnector.discover();
+    expect(discovered.length).toBe(3);
+
+    vi.mocked(readdirSync).mockClear();
+    await codexConnector.prepare(childPath);
+    await codexConnector.prepare(grandchildPath);
+
+    const underSessionsDir = vi
+      .mocked(readdirSync)
+      .mock.calls.filter((call) => String(call[0]).startsWith(codexDir));
+    expect(underSessionsDir).toHaveLength(0);
+  });
+
+  it('still resolves a multi-level subagent to its root after reuse', () => {
+    const cache = ndjsonCache('codex');
+    const raw = readFileSync(cache.path(grandchildPath), 'utf8');
+    const rows: CanonicalRow[] = raw
+      .trim()
+      .split('\n')
+      .map((line) => JSON.parse(line) as CanonicalRow);
+    expect(rows.length).toBeGreaterThan(0);
+    for (const row of rows) {
+      expect(row.session_id).toBe(rootId);
+      expect(row.is_sidechain).toBe(true);
+    }
+  });
+
+  it('resolves a rollout added after the last discover(), and picks it up on the next one', async () => {
+    const latePath = writeLateChildRollout();
+
+    // No discover() call in between: getCodexContext() must still be usable —
+    // a direct child of an already-known root resolves without needing the
+    // memo to include the new file at all.
+    await codexConnector.prepare(latePath);
+    const cache = ndjsonCache('codex');
+    const raw = readFileSync(cache.path(latePath), 'utf8');
+    const rows: CanonicalRow[] = raw
+      .trim()
+      .split('\n')
+      .map((line) => JSON.parse(line) as CanonicalRow);
+    expect(rows.length).toBeGreaterThan(0);
+    for (const row of rows) expect(row.session_id).toBe(rootId);
+
+    // The next discover() re-walks and refreshes the memo with the new file.
+    codexConnector.discover();
+    expect(getCodexContext().parents.get(lateChildId)).toBe(rootId);
+  });
+});

--- a/packages/server/test/fts-debounce.integration.test.ts
+++ b/packages/server/test/fts-debounce.integration.test.ts
@@ -1,0 +1,219 @@
+/**
+ * FTS rebuild debounce — the rule is "a debounce never loses a rebuild".
+ *
+ * Rebuilding the BM25 index from scratch plus a CHECKPOINT on every pass that
+ * loaded a file makes an active agent stall every route query on the shared
+ * connection once per poll. The rebuild is therefore debounced with a trailing
+ * edge (`FTS_REBUILD_MIN_INTERVAL_MS`) and a PERSISTED `meta.fts_stale` flag.
+ * Persisted, because an in-memory flag is lost by a restart mid-session
+ * (`claudescope update`, the version-skew self-restart) and the idle
+ * early-return would then never notice the index is behind.
+ *
+ * What is asserted here is only the skip path: the derived tables stay fresh
+ * while FTS is skipped, the flag records the debt, and every route back to a
+ * rebuild pays it — an idle pass, a pass in a fresh process, and an explicit
+ * flush. With the interval at `0` (the vitest default) every pass rebuilds, and
+ * the rest of the suite already asserts search right after a pass; that case is
+ * deliberately not duplicated here.
+ *
+ * Uses a throwaway projects dir + DuckDB in a temp dir; never touches any real
+ * agent source.
+ */
+
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import type { DuckDBConnection } from '@duckdb/node-api';
+import type { FastifyInstance } from 'fastify';
+import type { ReindexResponse } from '@claudescope/shared';
+
+// --- temp locations (decided before any server module is imported) ----------
+const work = mkdtempSync(join(tmpdir(), 'claudescope-fts-debounce-'));
+const projectsDir = join(work, 'projects');
+
+process.env.CLAUDE_PROJECTS_DIR = projectsDir;
+for (const v of [
+  'CODEX_SESSIONS_DIR',
+  'JUNIE_SESSIONS_DIR',
+  'PI_SESSIONS_DIR',
+  'OPENCODE_DATA_DIR',
+  'COPILOT_SESSIONS_DIR',
+  'ANTIGRAVITY_CLI_DIR',
+  'ANTIGRAVITY_DIR',
+  'GROK_SESSIONS_DIR',
+]) {
+  process.env[v] = join(work, `${v.toLowerCase()}-empty`);
+}
+process.env.DUCKDB_PATH = join(work, 'index.duckdb');
+process.env.CLAUDESCOPE_HOME = join(work, 'home');
+process.env.REINDEX_INTERVAL_MS = '0';
+// A window no test can cross by elapsing, so every rebuild after the first is
+// one the debounce had to be told about. Read at module load, so it must be set
+// before the first dynamic import below (and it overrides the vitest env pin).
+process.env.FTS_REBUILD_MIN_INTERVAL_MS = '3600000';
+
+const projDir = join(projectsDir, 'enc-projFts');
+
+/** Distinct nonsense terms, one per session, so a hit names its session. */
+const WORDS = { a: 'quokkazero', b: 'quokkaone', c: 'quokkatwo', d: 'quokkathree' } as const;
+
+/** A one-turn Claude Code transcript whose prose carries `word`. */
+const writeSession = (session: string, word: string): void => {
+  const base = { sessionId: session, cwd: '/tmp/projFts', isSidechain: false };
+  const lines = [
+    {
+      ...base,
+      type: 'user',
+      uuid: `${session}-u1`,
+      parentUuid: null,
+      timestamp: '2026-01-01T10:00:00.000Z',
+      message: { role: 'user', content: `please handle ${word} now` },
+    },
+    {
+      ...base,
+      type: 'assistant',
+      uuid: `${session}-a1`,
+      parentUuid: `${session}-u1`,
+      timestamp: '2026-01-01T10:00:01.000Z',
+      message: {
+        role: 'assistant',
+        id: `msg-${session}-a1`,
+        model: 'some-unlisted-model',
+        content: [{ type: 'text', text: `done with ${word}` }],
+        usage: { input_tokens: 100, output_tokens: 10 },
+      },
+    },
+  ];
+  writeFileSync(join(projDir, `${session}.jsonl`), lines.map((l) => JSON.stringify(l)).join('\n') + '\n');
+};
+
+let reindex: (opts?: { flushFts?: boolean }) => Promise<ReindexResponse>;
+let conn: DuckDBConnection;
+let queryRows: typeof import('../src/db/duckdb.js').queryRows;
+let sqlString: typeof import('../src/db/duckdb.js').sqlString;
+let closeConnection: () => Promise<void>;
+
+/** (Re)import the indexer + db modules, as a fresh process would. */
+async function loadServerModules(): Promise<void> {
+  ({ reindex } = await import('../src/data/index.js'));
+  const duck = await import('../src/db/duckdb.js');
+  ({ queryRows, sqlString, closeConnection } = duck);
+  conn = await duck.getConnection();
+}
+
+/** Whether the BM25 index over `events.text_content` finds `term` in `sessionId`. */
+const ftsFinds = async (term: string, sessionId: string): Promise<boolean> => {
+  const rows = await queryRows(
+    conn,
+    `SELECT session_id FROM (
+       SELECT session_id, fts_main_events.match_bm25(doc_id, ${sqlString(term)}) AS score
+       FROM events WHERE text_content IS NOT NULL
+     ) WHERE score IS NOT NULL AND session_id = ${sqlString(sessionId)}`,
+  );
+  return rows.length > 0;
+};
+
+/** The persisted staleness flag, or null when the key is absent. */
+const ftsStaleFlag = async (): Promise<string | null> => {
+  const rows = await queryRows(conn, "SELECT value FROM meta WHERE key = 'fts_stale'");
+  return rows.length > 0 ? String(rows[0]?.value) : null;
+};
+
+/** Whether the derived `sessions` table (never debounced) has the row. */
+const sessionIndexed = async (id: string): Promise<boolean> => {
+  const rows = await queryRows(conn, `SELECT id FROM sessions WHERE id = ${sqlString(id)}`);
+  return rows.length > 0;
+};
+
+beforeAll(async () => {
+  mkdirSync(projDir, { recursive: true });
+  mkdirSync(join(work, 'home'), { recursive: true });
+  await loadServerModules();
+});
+
+afterAll(async () => {
+  await closeConnection?.();
+  rmSync(work, { recursive: true, force: true });
+});
+
+describe('the FTS rebuild debounce', () => {
+  it('rebuilds on the first pass of a process', async () => {
+    writeSession('ftsA', WORDS.a);
+    const pass = await reindex();
+    expect(pass.reindexed).toBe(1);
+    expect(await ftsFinds(WORDS.a, 'ftsA')).toBe(true);
+    expect(await ftsStaleFlag()).toBeNull();
+  });
+
+  it('skips the rebuild inside the window but keeps the derived tables fresh', async () => {
+    writeSession('ftsB', WORDS.b);
+    const pass = await reindex();
+    expect(pass.reindexed).toBe(1);
+
+    // `sessions` is what the list page watches live — never debounced.
+    expect(await sessionIndexed('ftsB')).toBe(true);
+    // Ranked search lags; the debt is recorded rather than forgotten.
+    expect(await ftsFinds(WORDS.b, 'ftsB')).toBe(false);
+    expect(await ftsStaleFlag()).toBe('1');
+  });
+
+  it('pays the debt on the next idle pass and clears the flag', async () => {
+    const pass = await reindex();
+    expect(pass.reindexed).toBe(0);
+    expect(pass.failed).toBe(0);
+    expect(await ftsFinds(WORDS.b, 'ftsB')).toBe(true);
+    expect(await ftsStaleFlag()).toBeNull();
+  });
+
+  it('pays a debt recorded before a restart, on the first pass after it', async () => {
+    writeSession('ftsC', WORDS.c);
+    await reindex();
+    expect(await ftsFinds(WORDS.c, 'ftsC')).toBe(false);
+    expect(await ftsStaleFlag()).toBe('1');
+
+    // Simulate `claudescope update` / the version-skew self-restart: the
+    // in-memory flag is gone, and nothing on disk has changed since.
+    await closeConnection();
+    vi.resetModules();
+    await loadServerModules();
+
+    const pass = await reindex();
+    expect(pass.reindexed).toBe(0);
+    expect(await ftsFinds(WORDS.c, 'ftsC')).toBe(true);
+    expect(await ftsStaleFlag()).toBeNull();
+  });
+
+  it('flushes on request, without waiting for the window', async () => {
+    writeSession('ftsD', WORDS.d);
+    await reindex();
+    expect(await ftsFinds(WORDS.d, 'ftsD')).toBe(false);
+
+    await reindex({ flushFts: true });
+    expect(await ftsFinds(WORDS.d, 'ftsD')).toBe(true);
+    expect(await ftsStaleFlag()).toBeNull();
+  });
+
+  it('flushes for POST /api/reindex — a user-initiated pass expects fresh search', async () => {
+    const session = 'ftsE';
+    const word = 'quokkafour';
+    writeSession(session, word);
+    await reindex();
+    expect(await ftsFinds(word, session)).toBe(false);
+
+    const Fastify = (await import('fastify')).default;
+    const { registerRoutes } = await import('../src/routes/index.js');
+    const app: FastifyInstance = Fastify();
+    await registerRoutes(app);
+    await app.ready();
+    try {
+      const res = await app.inject({ method: 'POST', url: '/api/reindex' });
+      expect(res.statusCode).toBe(200);
+    } finally {
+      await app.close();
+    }
+
+    expect(await ftsFinds(word, session)).toBe(true);
+    expect(await ftsStaleFlag()).toBeNull();
+  });
+});

--- a/packages/server/test/sessions-pagination.integration.test.ts
+++ b/packages/server/test/sessions-pagination.integration.test.ts
@@ -1,0 +1,289 @@
+/**
+ * Fitness function: the sessions list pages correctly.
+ *
+ * The rule this file encodes is **paging is stable under ties**. Sort keys on
+ * the sessions list are session-level aggregates (timestamps, tokens, cost,
+ * message counts, context size), and real fixtures tie on all of them —
+ * identical short sessions, replays of the same prompt, a whole afternoon of
+ * runs stamped in the same second. Without a total order, `LIMIT`/`OFFSET` is
+ * free to return the same row on two pages and never return another, so a
+ * "Load more" walk would silently drop sessions. The fixture is built to tie
+ * deliberately (48 of 52 sessions are identical on every sort key) so a missing
+ * `, id` tie-break shows up as duplicated or skipped ids, not as a flake.
+ *
+ * It also pins the paging contract itself: the `X-Total-Count` header carries
+ * the unpaged match count, an absent `limit` never returns more than the
+ * default page, and `q` matches the same haystack the web filter used to apply
+ * client-side (title, branch, id, model) — NULL-safely, so a session with no
+ * recorded branch can still be found by its title.
+ */
+
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import type { FastifyInstance } from 'fastify';
+import type { SessionSort } from '@claudescope/shared';
+import { SESSIONS_TOTAL_HEADER } from '@claudescope/shared';
+
+// --- temp locations (decided before any server module is imported) ----------
+const work = mkdtempSync(join(tmpdir(), 'claudescope-paging-'));
+const projectsDir = join(work, 'projects');
+
+process.env.CLAUDE_PROJECTS_DIR = projectsDir;
+for (const v of [
+  'CODEX_SESSIONS_DIR',
+  'JUNIE_SESSIONS_DIR',
+  'PI_SESSIONS_DIR',
+  'OPENCODE_DATA_DIR',
+  'COPILOT_SESSIONS_DIR',
+  'ANTIGRAVITY_CLI_DIR',
+  'ANTIGRAVITY_DIR',
+  'GROK_SESSIONS_DIR',
+]) {
+  process.env[v] = join(work, `${v.toLowerCase()}-empty`);
+}
+process.env.DUCKDB_PATH = join(work, 'index.duckdb');
+process.env.CLAUDESCOPE_HOME = join(work, 'home');
+process.env.REINDEX_INTERVAL_MS = '0';
+
+const CWD = '/tmp/pagingProj';
+const TIED_COUNT = 48;
+const TOTAL = TIED_COUNT + 4;
+
+const jsonl = (events: unknown[]): string => events.map((e) => JSON.stringify(e)).join('\n') + '\n';
+
+interface Fixture {
+  id: string;
+  title: string;
+  branch?: string;
+  model: string;
+  /** Start of the session; each turn is +5s. */
+  startedAt: string;
+  usage: { input_tokens: number; output_tokens: number };
+  /** User/assistant pairs written into the file. */
+  turns: number;
+}
+
+function writeSession(f: Fixture): void {
+  const base: Record<string, unknown> = { sessionId: f.id, cwd: CWD, version: '2.1.0' };
+  if (f.branch !== undefined) base.gitBranch = f.branch;
+  const start = Date.parse(f.startedAt);
+  const at = (n: number): string => new Date(start + n * 5000).toISOString();
+
+  const rows: unknown[] = [{ type: 'ai-title', sessionId: f.id, aiTitle: f.title }];
+  for (let t = 0; t < f.turns; t++) {
+    rows.push({
+      ...base,
+      type: 'user',
+      uuid: `${f.id}-u${t}`,
+      parentUuid: t === 0 ? null : `${f.id}-a${t - 1}`,
+      timestamp: at(t * 2),
+      isSidechain: false,
+      message: { role: 'user', content: `turn ${t}` },
+    });
+    rows.push({
+      ...base,
+      type: 'assistant',
+      uuid: `${f.id}-a${t}`,
+      parentUuid: `${f.id}-u${t}`,
+      timestamp: at(t * 2 + 1),
+      isSidechain: false,
+      message: {
+        role: 'assistant',
+        model: f.model,
+        content: [{ type: 'text', text: 'ok' }],
+        usage: {
+          ...f.usage,
+          cache_read_input_tokens: 10,
+          cache_creation_input_tokens: 5,
+        },
+      },
+    });
+  }
+  writeFileSync(join(projectsDir, 'enc-paging', `${f.id}.jsonl`), jsonl(rows));
+}
+
+/**
+ * 48 sessions that tie on every sort key (same timestamps, usage, model and
+ * message count) plus 4 deliberately distinct ones that carry the `q` probes:
+ * a unique branch, a unique id token, a unique model, and — with NO recorded
+ * branch — a unique title token.
+ */
+function writeFixtures(): void {
+  mkdirSync(join(projectsDir, 'enc-paging'), { recursive: true });
+
+  for (let i = 0; i < TIED_COUNT; i++) {
+    const n = String(i).padStart(2, '0');
+    writeSession({
+      id: `sess-tied-${n}`,
+      title: `Tied session ${n}`,
+      branch: 'main',
+      model: 'claude-opus-4-8',
+      startedAt: '2026-05-01T10:00:00.000Z',
+      usage: { input_tokens: 100, output_tokens: 50 },
+      turns: 1,
+    });
+  }
+
+  writeSession({
+    id: 'sess-zebra-unique',
+    title: 'Distinct alpha',
+    branch: 'main',
+    model: 'claude-opus-4-8',
+    startedAt: '2026-05-02T10:00:00.000Z',
+    usage: { input_tokens: 1000, output_tokens: 500 },
+    turns: 2,
+  });
+  writeSession({
+    id: 'sess-distinct-b',
+    title: 'Distinct bravo',
+    branch: 'feat/paging-probe',
+    model: 'claude-sonnet-4-9',
+    startedAt: '2026-05-03T10:00:00.000Z',
+    usage: { input_tokens: 2000, output_tokens: 800 },
+    turns: 3,
+  });
+  writeSession({
+    id: 'sess-distinct-c',
+    title: 'Distinct charlie',
+    branch: 'main',
+    model: 'claude-haiku-9-uniquemodel',
+    startedAt: '2026-04-28T10:00:00.000Z',
+    usage: { input_tokens: 300, output_tokens: 150 },
+    turns: 4,
+  });
+  // No gitBranch at all: a NULL branch must not make the whole `q` OR chain
+  // NULL and hide this row from a title match.
+  writeSession({
+    id: 'sess-distinct-d',
+    title: 'Distinct delta nullbranch',
+    model: 'claude-opus-4-8',
+    startedAt: '2026-04-29T10:00:00.000Z',
+    usage: { input_tokens: 5, output_tokens: 2 },
+    turns: 5,
+  });
+}
+
+let app: FastifyInstance;
+let closeConnection: () => Promise<void>;
+
+beforeAll(async () => {
+  writeFixtures();
+  const Fastify = (await import('fastify')).default;
+  const { registerRoutes } = await import('../src/routes/index.js');
+  const { reindex } = await import('../src/data/index.js');
+  ({ closeConnection } = await import('../src/db/duckdb.js'));
+  app = Fastify();
+  await registerRoutes(app);
+  await reindex();
+  await app.ready();
+});
+
+afterAll(async () => {
+  await app?.close();
+  await closeConnection?.();
+  rmSync(work, { recursive: true, force: true });
+});
+
+const get = (url: string) => app.inject({ method: 'GET', url });
+const ids = (body: unknown): string[] => (body as { id: string }[]).map((s) => s.id);
+const total = (res: { headers: Record<string, unknown> }): number =>
+  Number(res.headers[SESSIONS_TOTAL_HEADER]);
+
+const SORTS: SessionSort[] = ['recent', 'oldest', 'tokens', 'cost', 'messages', 'context'];
+
+describe('sessions paging is stable under ties', () => {
+  it.each(SORTS)('sort=%s: pages of 2 cover the unpaged list exactly once', async (sort) => {
+    const unpaged = await get(`/api/sessions?sort=${sort}&limit=500`);
+    const all = ids(unpaged.json());
+    expect(all).toHaveLength(TOTAL);
+
+    const walked: string[] = [];
+    for (let offset = 0; offset < TOTAL + 4; offset += 2) {
+      const res = await get(`/api/sessions?sort=${sort}&limit=2&offset=${offset}`);
+      expect(res.statusCode).toBe(200);
+      // Every page reports the same unpaged total.
+      expect(total(res)).toBe(TOTAL);
+      const page = ids(res.json());
+      if (page.length === 0) break;
+      walked.push(...page);
+    }
+
+    expect(new Set(walked).size).toBe(walked.length);
+    expect([...walked].sort()).toEqual([...all].sort());
+    // The order is total, so the walk reproduces the unpaged sequence exactly.
+    expect(walked).toEqual(all);
+  });
+});
+
+describe('X-Total-Count and the default page size', () => {
+  it('an absent limit returns the default page, not the whole table', async () => {
+    const res = await get('/api/sessions');
+    expect(res.statusCode).toBe(200);
+    expect(ids(res.json())).toHaveLength(50);
+    expect(total(res)).toBe(TOTAL);
+  });
+
+  it('reports the filtered count when q or agent narrows', async () => {
+    const filtered = await get('/api/sessions?q=nullbranch');
+    expect(total(filtered)).toBe(1);
+    const none = await get('/api/sessions?agent=codex');
+    expect(ids(none.json())).toEqual([]);
+    expect(total(none)).toBe(0);
+    const all = await get('/api/sessions?agent=claude-code&limit=500');
+    expect(total(all)).toBe(TOTAL);
+  });
+});
+
+describe('q matches title, branch, id, or model', () => {
+  it('finds a session by its git branch', async () => {
+    const res = await get('/api/sessions?q=paging-probe');
+    expect(ids(res.json())).toEqual(['sess-distinct-b']);
+    expect(total(res)).toBe(1);
+  });
+
+  it('finds a session by a substring of its id', async () => {
+    const res = await get('/api/sessions?q=zebra');
+    expect(ids(res.json())).toEqual(['sess-zebra-unique']);
+  });
+
+  it('finds a session by model name', async () => {
+    const res = await get('/api/sessions?q=uniquemodel');
+    expect(ids(res.json())).toEqual(['sess-distinct-c']);
+  });
+
+  it('a NULL branch does not hide a title match', async () => {
+    const res = await get('/api/sessions?q=nullbranch');
+    expect(ids(res.json())).toEqual(['sess-distinct-d']);
+  });
+
+  it('no match returns an empty page and a zero total', async () => {
+    const res = await get('/api/sessions?q=no-such-token-anywhere');
+    expect(res.statusCode).toBe(200);
+    expect(res.json()).toEqual([]);
+    expect(total(res)).toBe(0);
+  });
+});
+
+describe('malformed paging params clamp instead of erroring', () => {
+  it('a bogus limit falls back to the default page', async () => {
+    const res = await get('/api/sessions?limit=abc');
+    expect(res.statusCode).toBe(200);
+    expect(ids(res.json())).toHaveLength(50);
+    expect(total(res)).toBe(TOTAL);
+  });
+
+  it('limit=0 clamps to the minimum page rather than returning everything', async () => {
+    const res = await get('/api/sessions?limit=0');
+    expect(res.statusCode).toBe(200);
+    expect(ids(res.json())).toHaveLength(1);
+  });
+
+  it.each(['-1', 'abc'])('offset=%s is treated as the first page', async (bad) => {
+    const res = await get(`/api/sessions?limit=3&offset=${bad}`);
+    expect(res.statusCode).toBe(200);
+    const first = await get('/api/sessions?limit=3');
+    expect(ids(res.json())).toEqual(ids(first.json()));
+  });
+});

--- a/packages/shared/src/api.ts
+++ b/packages/shared/src/api.ts
@@ -131,14 +131,24 @@ export type SessionSort = 'recent' | 'oldest' | 'tokens' | 'cost' | 'messages' |
 export interface SessionsQuery {
   project?: string;
   sort?: SessionSort;
+  /** Case-insensitive substring match on the title, git branch, id, or model. */
   q?: string;
   /** Filter to a single agent connector id, e.g. `codex`. */
   agent?: string;
   /** Exact match on the session's recorded git branch. */
   branch?: string;
-  /** Max rows returned (positive int). Absent = all rows (the web UI's default). */
+  /** Max rows returned (default 50, max 500). */
   limit?: number;
+  /** Rows to skip before the page (default 0). */
+  offset?: number;
 }
+
+/**
+ * Response header on GET /api/sessions carrying the number of rows that match
+ * the query before `limit`/`offset` — the body stays `SessionMeta[]`, so a
+ * paging client reads the total from here.
+ */
+export const SESSIONS_TOTAL_HEADER = 'x-total-count';
 
 /**
  * Windowing params for GET /api/sessions/:id — agent/CLI consumers slice large

--- a/packages/web/src/api/client.ts
+++ b/packages/web/src/api/client.ts
@@ -4,6 +4,7 @@
  * the Fastify backend on :4317; in prod Fastify serves both).
  */
 
+import { SESSIONS_TOTAL_HEADER } from '@claudescope/shared';
 import type {
   ActivityResponse,
   AgentComparisonResponse,
@@ -24,6 +25,7 @@ import type {
   SessionEfficiencyResponse,
   SessionFingerprintResponse,
   SessionEfficiencySort,
+  SessionMeta,
   SettingsResponse,
   SettingsUpdateRequest,
   SettingsUpdateResponse,
@@ -61,15 +63,21 @@ function qs(params: Record<string, string | number | undefined | null>): string 
   return s ? `?${s}` : '';
 }
 
+interface RequestInitLite {
+  method?: string;
+  body?: unknown;
+  signal?: AbortSignal;
+}
+
 /**
  * Core fetch wrapper: prefixes `/api`, parses JSON, and raises {@link ApiError}
- * on non-2xx. `signal` lets callers cancel in-flight requests (e.g. on unmount
- * or rapid search typing).
+ * on non-2xx. Returns the response headers alongside the body for the few
+ * endpoints that carry metadata there (e.g. the sessions total count).
  */
-async function request<T>(
+async function requestWithHeaders<T>(
   path: string,
-  init?: { method?: string; body?: unknown; signal?: AbortSignal },
-): Promise<T> {
+  init?: RequestInitLite,
+): Promise<{ data: T; headers: Headers }> {
   const headers: Record<string, string> = { Accept: 'application/json' };
   const hasBody = init?.body !== undefined;
   if (hasBody) headers['Content-Type'] = 'application/json';
@@ -86,7 +94,15 @@ async function request<T>(
     throw new ApiError(res.status, res.statusText, text);
   }
 
-  return (await res.json()) as T;
+  return { data: (await res.json()) as T, headers: res.headers };
+}
+
+/**
+ * Body-only fetch wrapper. `signal` lets callers cancel in-flight requests
+ * (e.g. on unmount or rapid search typing).
+ */
+async function request<T>(path: string, init?: RequestInitLite): Promise<T> {
+  return (await requestWithHeaders<T>(path, init)).data;
 }
 
 export interface ListSessionsParams {
@@ -94,6 +110,14 @@ export interface ListSessionsParams {
   sort?: SessionSort;
   q?: string;
   agent?: string;
+  limit?: number;
+  offset?: number;
+}
+
+/** One page of sessions plus the unpaged match count from `X-Total-Count`. */
+export interface ListSessionsResult {
+  rows: SessionMeta[];
+  total: number;
 }
 
 export interface SearchParams {
@@ -134,17 +158,28 @@ export const api = {
     return request<ProjectsResponse>('/projects', { signal });
   },
 
-  /** GET /api/sessions?project=&sort=&q=&agent= */
-  listSessions(params: ListSessionsParams = {}, signal?: AbortSignal): Promise<SessionsResponse> {
-    return request<SessionsResponse>(
+  /** GET /api/sessions?project=&sort=&q=&agent=&limit=&offset= — one page + the total. */
+  async listSessions(
+    params: ListSessionsParams = {},
+    signal?: AbortSignal,
+  ): Promise<ListSessionsResult> {
+    const { data, headers } = await requestWithHeaders<SessionsResponse>(
       `/sessions${qs({
         project: params.project,
         sort: params.sort,
         q: params.q,
         agent: params.agent,
+        limit: params.limit,
+        offset: params.offset,
       })}`,
       { signal },
     );
+    // An older server (or a proxy that strips the header) reports no total; the
+    // page we did get is then the only truth we have. `Number('')` and
+    // `Number(null)` are 0, so the header has to be checked before parsing.
+    const raw = headers.get(SESSIONS_TOTAL_HEADER);
+    const total = raw && raw.trim() ? Number(raw) : Number.NaN;
+    return { rows: data, total: Number.isFinite(total) ? total : data.length };
   },
 
   /** GET /api/sessions/:id */

--- a/packages/web/src/pages/browse/SessionList.tsx
+++ b/packages/web/src/pages/browse/SessionList.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { Link } from 'react-router';
 import { RotateCcw } from 'lucide-react';
 import type { SessionMeta, SessionSort } from '@claudescope/shared';
@@ -17,6 +17,12 @@ const SORT_OPTIONS: { value: SessionSort; label: string }[] = [
   { value: 'context', label: 'Context' },
 ];
 
+/** Rows per page — matches the server's own default `limit`. */
+const PAGE_SIZE = 50;
+/** The server clamps `limit` here; a wide refetch must not ask for more. */
+const MAX_LIMIT = 500;
+const FILTER_DEBOUNCE_MS = 300;
+
 /** Ignore aborted/offline fetch errors that are not user-actionable. */
 function isBenignError(err: unknown): boolean {
   if (err instanceof DOMException && err.name === 'AbortError') return true;
@@ -28,28 +34,60 @@ function isBenignError(err: unknown): boolean {
  * The Sessions tab of a project (`/projects/:projectId`). The breadcrumb, name,
  * cwd, and the Sessions | Memory tab bar live in {@link ProjectLayout}; this
  * renders the tab body — sort/filter controls, the agent filter, and the list.
- * Sort and agent filter are server-driven (re-fetch on change); the text filter
- * is applied client-side against title / branch / id.
+ * Sort, agent filter, and the text filter are all server-driven: the filter is
+ * debounced and sent as `q` (matching title / branch / id / model), so it finds
+ * sessions beyond the loaded page. The list pages with "Load more".
  */
 export function SessionListPage() {
   const { projectId, project } = useProjectContext();
 
-  const [sessions, setSessions] = useState<SessionMeta[]>([]);
+  const [rows, setRows] = useState<SessionMeta[]>([]);
+  const [total, setTotal] = useState(0);
   const [sort, setSort] = useState<SessionSort>('recent');
   const [filter, setFilter] = useState('');
+  const [debouncedQ, setDebouncedQ] = useState('');
   const [agent, setAgent] = useState<string | undefined>(undefined);
   const [loading, setLoading] = useState(true);
+  const [loadingMore, setLoadingMore] = useState(false);
   const [error, setError] = useState<unknown>(null);
+  const [moreError, setMoreError] = useState<unknown>(null);
   const [reloadKey, setReloadKey] = useState(0);
 
+  // Typing restarts the wait, so the server sees one query per pause.
   useEffect(() => {
+    const timer = setTimeout(() => setDebouncedQ(filter.trim()), FILTER_DEBOUNCE_MS);
+    return () => clearTimeout(timer);
+  }, [filter]);
+
+  // A load-more request in flight when the query changes is stale by then: the
+  // first-page effect below owns the result, so cancel it rather than let it
+  // append rows from the previous sort/filter.
+  const moreRef = useRef<AbortController | null>(null);
+  useEffect(() => () => moreRef.current?.abort(), []);
+
+  useEffect(() => {
+    moreRef.current?.abort();
+    moreRef.current = null;
     const controller = new AbortController();
     setLoading(true);
+    setLoadingMore(false);
     setError(null);
+    setMoreError(null);
     api
-      .listSessions({ project: projectId, sort, agent }, controller.signal)
-      .then((data) => {
-        setSessions(data);
+      .listSessions(
+        {
+          project: projectId,
+          sort,
+          agent,
+          q: debouncedQ || undefined,
+          limit: PAGE_SIZE,
+          offset: 0,
+        },
+        controller.signal,
+      )
+      .then((page) => {
+        setRows(page.rows);
+        setTotal(page.total);
         setLoading(false);
       })
       .catch((err: unknown) => {
@@ -58,32 +96,72 @@ export function SessionListPage() {
         setLoading(false);
       });
     return () => controller.abort();
-  }, [projectId, sort, agent, reloadKey]);
+  }, [projectId, sort, agent, debouncedQ, reloadKey]);
+
+  function loadMore() {
+    moreRef.current?.abort();
+    const controller = new AbortController();
+    moreRef.current = controller;
+    setLoadingMore(true);
+    setMoreError(null);
+    api
+      .listSessions(
+        {
+          project: projectId,
+          sort,
+          agent,
+          q: debouncedQ || undefined,
+          limit: PAGE_SIZE,
+          offset: rows.length,
+        },
+        controller.signal,
+      )
+      .then((page) => {
+        // The index moves under us: a row indexed since the first page can
+        // shift a session across the boundary, and a repeated id would collide
+        // as a React key.
+        setRows((prev) => {
+          const seen = new Set(prev.map((s) => s.id));
+          return [...prev, ...page.rows.filter((s) => !seen.has(s.id))];
+        });
+        setTotal(page.total);
+        setLoadingMore(false);
+      })
+      .catch((err: unknown) => {
+        if (isBenignError(err)) return;
+        setMoreError(err);
+        setLoadingMore(false);
+      });
+  }
 
   // Steady-state freshness: silently refetch (no spinner, keep scroll) when a
   // reindex pass lands new data — a live session's row updates and new
-  // sessions appear without a manual reload.
+  // sessions appear without a manual reload. Refetching the whole loaded
+  // window (not just the first page) keeps the pages already opened.
   useDataVersionRefetch((signal) => {
     api
-      .listSessions({ project: projectId, sort, agent }, signal)
-      .then(setSessions)
+      .listSessions(
+        {
+          project: projectId,
+          sort,
+          agent,
+          q: debouncedQ || undefined,
+          limit: Math.min(MAX_LIMIT, Math.max(PAGE_SIZE, rows.length)),
+          offset: 0,
+        },
+        signal,
+      )
+      .then((page) => {
+        setRows(page.rows);
+        setTotal(page.total);
+      })
       .catch(() => {
         /* transient — the next change retries */
       });
   });
 
-  const filtered = useMemo(() => {
-    const q = filter.trim().toLowerCase();
-    if (!q) return sessions;
-    return sessions.filter((s) => {
-      const haystack = [s.title, s.gitBranch ?? '', s.id, s.models.join(' ')]
-        .join(' ')
-        .toLowerCase();
-      return haystack.includes(q);
-    });
-  }, [sessions, filter]);
-
   const agents = project?.agents ?? [];
+  const hasMore = rows.length < total;
 
   return (
     <>
@@ -134,25 +212,50 @@ export function SessionListPage() {
         </div>
       ) : null}
 
-      {loading ? (
+      {loading && rows.length === 0 ? (
         <Spinner size="lg" label="Loading sessions…" />
       ) : error ? (
         <ErrorBox error={error} onRetry={() => setReloadKey((k) => k + 1)} />
-      ) : filtered.length === 0 ? (
+      ) : rows.length === 0 ? (
         <p className="tv-muted">
-          {sessions.length === 0 ? 'No sessions.' : 'No sessions match the filter.'}
+          {debouncedQ ? 'No sessions match the filter.' : 'No sessions.'}
         </p>
       ) : (
         <>
-          <div className="tv-muted" style={{ marginBottom: 'var(--tv-space-3)' }}>
-            {filtered.length} session{filtered.length === 1 ? '' : 's'}
-            {filter ? ` (of ${sessions.length})` : ''}
+          {/* A new sort/filter is in flight: keep the previous rows on screen and
+              surface progress as a small indicator instead of blanking them. */}
+          <div
+            className="tv-muted"
+            style={{ display: 'flex', alignItems: 'center', gap: 'var(--tv-space-2)', marginBottom: 'var(--tv-space-3)' }}
+          >
+            <span>
+              {hasMore
+                ? `Showing ${rows.length} of ${total} sessions`
+                : `${total} session${total === 1 ? '' : 's'}`}
+            </span>
+            {loading ? <Spinner label="Loading…" /> : null}
           </div>
           <ul className="tv-list">
-            {filtered.map((s) => (
+            {rows.map((s) => (
               <SessionRow key={s.id} session={s} />
             ))}
           </ul>
+          {moreError ? (
+            <div className="tv-browse__more">
+              <ErrorBox error={moreError} onRetry={loadMore} />
+            </div>
+          ) : hasMore ? (
+            <div className="tv-browse__more">
+              <button
+                type="button"
+                className="tv-btn tv-btn--secondary"
+                onClick={loadMore}
+                disabled={loadingMore || loading}
+              >
+                {loadingMore ? <Spinner label="Loading…" /> : 'Load more'}
+              </button>
+            </div>
+          ) : null}
         </>
       )}
     </>

--- a/packages/web/src/pages/browse/browse.css
+++ b/packages/web/src/pages/browse/browse.css
@@ -185,6 +185,13 @@
   gap: var(--tv-space-2);
 }
 
+/* "Load more" row (or its error) under a paged session list. */
+.tv-browse__more {
+  display: flex;
+  justify-content: center;
+  margin-top: var(--tv-space-3);
+}
+
 .tv-session-row {
   position: relative;
   display: flex;

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -23,6 +23,9 @@ export default defineConfig({
       // CLAUDESCOPE_HOME per file — which would re-download ~31 MB every time.
       // Pin them to the machine's own shared DuckDB cache instead.
       DUCKDB_EXTENSION_DIR: join(homedir(), '.duckdb', 'extensions'),
+      // The suite asserts search right after a pass, so rebuild FTS every pass;
+      // the debounce itself has its own test, which sets its own window.
+      FTS_REBUILD_MIN_INTERVAL_MS: '0',
     },
     // Integration tests build a DuckDB index from fixtures; give them room.
     testTimeout: 30_000,


### PR DESCRIPTION
Implements [plan 0087](docs/plans/0087-sessions-pagination-and-fts-debounce.md): the three items plan 0086 deferred, each re-measured before planning and landed with a fitness function that was run red against the pre-fix code first.

## What changes

- **Sessions paging** — `GET /api/sessions` clamps `limit` (default 50, max 500), takes `offset`, and every sort order carries an `, id` tie-break so pages never overlap or skip on tied values. The unpaged match count rides in `X-Total-Count`; the body stays `SessionMeta[]`, so the CLI `--json` shape and the MCP tool are unchanged (both gain an offset). `q` now matches title, git branch, id, or model server-side.
- **Web list** — 50 rows per page behind **Load more**, "Showing X of Y sessions", the filter debounced and sent as `q` so it finds sessions beyond the loaded page; a data-version bump refetches the loaded window rather than collapsing it. Previous rows stay on screen while a new sort/filter loads.
- **FTS rebuild debounce** — the rebuild plus CHECKPOINT ran on every pass that loaded a file (every 15 s with an active agent, stalling every route query on the shared connection). It now runs only when the last rebuild is older than `FTS_REBUILD_MIN_INTERVAL_MS` (default 60 s, `0` = every pass); otherwise the pass records `fts_stale` in the `meta` table and the next idle pass rebuilds the index alone. The flag is persisted so a restart mid-session cannot leave ranked search stale. `POST /api/reindex` always flushes, waiting for an in-flight pass first. Derived tables stay per pass; literal search never lags.
- **Codex** — `listRollouts()` remembers its last walk so `getCodexContext()` no longer re-walks the sessions dir per subagent rollout. Whole-file re-normalization stays, deliberately: measured at 353 ms / 270 MB heap per pass for a 68 MB rollout and only while it grows, versus persisting the parser's cross-record state.

## Behaviour changes

- `GET /api/sessions` without `limit` returns 50 rows, not all.
- Ranked search can trail a continuously changing session by up to a minute; **Exact** search is always current. Set `FTS_REBUILD_MIN_INTERVAL_MS=0` to restore per-pass rebuilds.
- CLI/MCP `q` matches more fields than the title; results only widen.

## Definition of done

- [x] `npm run typecheck`, `npm run build` clean
- [x] `npm test`: 81 files / 833 tests (was 78 / 807); every new test verified red pre-fix
- [x] markdownlint clean on changed docs
- [x] Web paging driven end to end against 63 fixture sessions with Playwright (load more, filter beyond page one, live window update)
- [x] Plan 0087 committed, status done, linked here
- [x] CI green on Linux, Windows, and both Nix legs

